### PR TITLE
Fix getImage method when sending product alert email

### DIFF
--- a/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
+++ b/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
@@ -3,24 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
-// @codingStandardsIgnoreFile
-
 namespace Magento\ProductAlert\Block\Email;
 
 use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\ProductAlert\Block\Product\ImageProvider;
 
 /**
  * Product Alert Abstract Email Block
- *
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
 {
     /**
      * Product collection array
      *
-     * @var array
+     * @var \Magento\Catalog\Model\Product[]
      */
     protected $_products = [];
 
@@ -42,14 +39,14 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
     protected $priceCurrency;
 
     /**
-     * @var \Magento\Catalog\Helper\Image
+     * @var \Magento\Catalog\Block\Product\ImageBuilder
      */
     protected $imageBuilder;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation
+     * @var ImageProvider
      */
-    private $appEmulation;
+    private $imageProvider;
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
@@ -57,7 +54,7 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
      * @param PriceCurrencyInterface $priceCurrency
      * @param \Magento\Catalog\Block\Product\ImageBuilder $imageBuilder
      * @param array $data
-     * @param \Magento\Store\Model\App\Emulation $appEmulation
+     * @param ImageProvider $imageProvider
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
@@ -65,21 +62,20 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
         PriceCurrencyInterface $priceCurrency,
         \Magento\Catalog\Block\Product\ImageBuilder $imageBuilder,
         array $data = [],
-        \Magento\Store\Model\App\Emulation $appEmulation = null
+        ImageProvider $imageProvider = null
     ) {
         $this->imageBuilder = $imageBuilder;
         $this->priceCurrency = $priceCurrency;
         $this->_maliciousCode = $maliciousCode;
-        $this->appEmulation = $appEmulation
-            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Store\Model\App\Emulation::class);
+        $this->imageProvider = $imageProvider ?: ObjectManager::getInstance()->get(ImageProvider::class);
 
         parent::__construct($context, $data);
     }
 
-    /**
+   /**
     * Filter malicious code before insert content to email
     *
-    * @param  string|array $content
+    * @param string|array $content
     * @return string|array
     */
     public function getFilteredContent($content)
@@ -114,7 +110,7 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
      */
     public function getStore()
     {
-        if (is_null($this->_store)) {
+        if ($this->_store === null) {
             $this->_store = $this->_storeManager->getStore();
         }
         return $this->_store;
@@ -124,9 +120,9 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
      * Convert price from default currency to current currency
      *
      * @param float $price
-     * @param boolean $format             Format price to currency format
-     * @param boolean $includeContainer   Enclose into <span class="price"><span>
-     * @return float
+     * @param bool $format Format price to currency format
+     * @param bool $includeContainer Enclose into <span class="price"><span>
+     * @return float|string
      */
     public function formatPrice($price, $format = true, $includeContainer = true)
     {
@@ -159,7 +155,7 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
     /**
      * Retrieve product collection array
      *
-     * @return array
+     * @return \Magento\Catalog\Model\Product[]
      */
     public function getProducts()
     {
@@ -228,28 +224,9 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
      * @param string $imageId
      * @param array $attributes
      * @return \Magento\Catalog\Block\Product\Image
-     * @throws \Exception
      */
     public function getImage($product, $imageId, $attributes = [])
     {
-        $this->appEmulation->startEnvironmentEmulation(
-            $this->_storeManager->getStore()->getId(),
-            \Magento\Framework\App\Area::AREA_FRONTEND,
-            true
-        );
-
-        try {
-            $image = $this->imageBuilder->setProduct($product)
-                ->setImageId($imageId)
-                ->setAttributes($attributes)
-                ->create();
-        } catch (\Exception $e) {
-            $this->appEmulation->stopEnvironmentEmulation();
-            throw $e;
-        }
-
-        $this->appEmulation->stopEnvironmentEmulation();
-
-        return $image;
+        return $this->imageProvider->getImage($product, $imageId, $attributes);
     }
 }

--- a/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
+++ b/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
@@ -72,12 +72,12 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
         parent::__construct($context, $data);
     }
 
-   /**
-    * Filter malicious code before insert content to email
-    *
-    * @param string|array $content
-    * @return string|array
-    */
+    /**
+     * Filter malicious code before insert content to email
+     *
+     * @param string|array $content
+     * @return string|array
+     */
     public function getFilteredContent($content)
     {
         return $this->_maliciousCode->filter($content);

--- a/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
+++ b/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
@@ -52,11 +52,6 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
     private $appEmulation;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
-     */
-    private $storeManager;
-
-    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Framework\Filter\Input\MaliciousCode $maliciousCode
      * @param PriceCurrencyInterface $priceCurrency
@@ -75,7 +70,6 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
         $this->imageBuilder = $imageBuilder;
         $this->priceCurrency = $priceCurrency;
         $this->_maliciousCode = $maliciousCode;
-        $this->storeManager = $context->getStoreManager();
         $this->appEmulation = $appEmulation
             ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Store\Model\App\Emulation::class);
 
@@ -239,7 +233,7 @@ abstract class AbstractEmail extends \Magento\Framework\View\Element\Template
     public function getImage($product, $imageId, $attributes = [])
     {
         $this->appEmulation->startEnvironmentEmulation(
-            $this->storeManager->getStore()->getId(),
+            $this->_storeManager->getStore()->getId(),
             \Magento\Framework\App\Area::AREA_FRONTEND,
             true
         );

--- a/app/code/Magento/ProductAlert/Block/Product/ImageProvider.php
+++ b/app/code/Magento/ProductAlert/Block/Product/ImageProvider.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ProductAlert\Block\Product;
+
+use Magento\Store\Model\App\Emulation;
+use Magento\Catalog\Block\Product\ImageBuilder;
+use Magento\Catalog\Model\Product;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\Area;
+use Magento\Catalog\Block\Product\Image;
+
+/**
+ * Provides product image to be used in the Product Alert Email.
+ */
+class ImageProvider
+{
+    /**
+     * @var ImageBuilder
+     */
+    private $imageBuilder;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var Emulation
+     */
+    private $appEmulation;
+
+    /**
+     * @param ImageBuilder $imageBuilder
+     * @param StoreManagerInterface $storeManager
+     * @param Emulation $appEmulation
+     */
+    public function __construct(
+        ImageBuilder $imageBuilder,
+        StoreManagerInterface $storeManager,
+        Emulation $appEmulation
+    ) {
+        $this->imageBuilder = $imageBuilder;
+        $this->storeManager = $storeManager;
+        $this->appEmulation = $appEmulation;
+    }
+
+    /**
+     * @param Product $product
+     * @param string $imageId
+     * @param array $attributes
+     * @return Image
+     * @throws \Exception
+     */
+    public function getImage(Product $product, $imageId, $attributes = [])
+    {
+        $storeId = $this->storeManager->getStore()->getId();
+        $this->appEmulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
+
+        try {
+            $image = $this->imageBuilder->setProduct($product)
+                ->setImageId($imageId)
+                ->setAttributes($attributes)
+                ->create();
+        } catch (\Exception $exception) {
+            $this->appEmulation->stopEnvironmentEmulation();
+            throw $exception;
+        }
+
+        $this->appEmulation->stopEnvironmentEmulation();
+        return $image;
+    }
+}

--- a/app/code/Magento/ProductAlert/Test/Unit/Block/Email/StockTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Block/Email/StockTest.php
@@ -24,6 +24,7 @@ class StockTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Catalog\Block\Product\ImageBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $imageBuilder;
+
     /**
      * @var \Magento\ProductAlert\Block\Product\ImageProvider|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/app/code/Magento/ProductAlert/Test/Unit/Block/Email/StockTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Block/Email/StockTest.php
@@ -24,16 +24,10 @@ class StockTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Catalog\Block\Product\ImageBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $imageBuilder;
-
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\ProductAlert\Block\Product\ImageProvider|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $storeManagerMock;
-
-    /**
-     * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $appEmulationMock;
+    protected $imageProviderMock;
 
     protected function setUp()
     {
@@ -49,25 +43,17 @@ class StockTest extends \PHPUnit_Framework_TestCase
         $this->imageBuilder = $this->getMockBuilder(\Magento\Catalog\Block\Product\ImageBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->storeManagerMock = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->appEmulationMock = $this->getMockBuilder(\Magento\Store\Model\App\Emulation::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
-        $contextMock = $this->getMockBuilder(\Magento\Framework\View\Element\Template\Context::class)
+        $this->imageProviderMock = $this->getMockBuilder(\Magento\ProductAlert\Block\Product\ImageProvider::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $contextMock->expects($this->any())->method('getStoreManager')->willReturn($this->storeManagerMock);
 
         $this->_block = $objectManager->getObject(
             \Magento\ProductAlert\Block\Email\Stock::class,
             [
                 'maliciousCode' => $this->_filter,
                 'imageBuilder' => $this->imageBuilder,
-                'context' => $contextMock,
-                'appEmulation' => $this->appEmulationMock
+                'imageProvider' => $this->imageProviderMock
             ]
         );
     }
@@ -100,65 +86,15 @@ class StockTest extends \PHPUnit_Framework_TestCase
         $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
             ->getMock();
-
-        $imageMock = $this->getMockBuilder(\Magento\Catalog\Block\Product\Image::class)
+        $productImageMock = $this->getMockBuilder(\Magento\Catalog\Block\Product\Image::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $storeMock = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->appEmulationMock->expects($this->once())->method('startEnvironmentEmulation');
-        $this->storeManagerMock->expects($this->atLeastOnce())->method('getStore')->willReturn($storeMock);
-        $storeMock->expects($this->atLeastOnce())->method('getId')->willReturn(42);
-        $this->imageBuilder->expects($this->once())
-            ->method('setProduct')
-            ->with($productMock)
-            ->willReturnSelf();
-        $this->imageBuilder->expects($this->once())
-            ->method('setImageId')
-            ->with($imageId)
-            ->willReturnSelf();
-        $this->imageBuilder->expects($this->once())
-            ->method('setAttributes')
-            ->with($attributes)
-            ->willReturnSelf();
-        $this->imageBuilder->expects($this->once())
-            ->method('create')
-            ->willReturn($imageMock);
-        $this->appEmulationMock->expects($this->once())->method('stopEnvironmentEmulation');
+        $this->imageProviderMock->expects($this->atLeastOnce())->method('getImage')->willReturn($productImageMock);
 
         $this->assertInstanceOf(
             \Magento\Catalog\Block\Product\Image::class,
             $this->_block->getImage($productMock, $imageId, $attributes)
         );
-    }
-
-    /**
-     * Test that app emulation stops when exception occurs.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Image Builder Exception
-     */
-    public function testGetImageThrowsAnException()
-    {
-        $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $storeMock = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->appEmulationMock->expects($this->once())->method('startEnvironmentEmulation');
-        $this->storeManagerMock->expects($this->atLeastOnce())->method('getStore')->willReturn($storeMock);
-        $storeMock->expects($this->atLeastOnce())->method('getId')->willReturn(42);
-
-        $this->imageBuilder->expects($this->once())
-            ->method('setProduct')
-            ->willThrowException(new \Exception("Image Builder Exception"));
-        $this->appEmulationMock->expects($this->once())->method('stopEnvironmentEmulation');
-
-        $this->_block->getImage($productMock, 1, []);
     }
 }

--- a/app/code/Magento/ProductAlert/Test/Unit/Block/Product/ImageProviderTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Block/Product/ImageProviderTest.php
@@ -11,10 +11,12 @@ class ImageProviderTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Catalog\Block\Product\ImageBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
     private $imageBuilderMock;
+
     /**
      * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $storeManagerMock;
+
     /**
      * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/app/code/Magento/ProductAlert/Test/Unit/Block/Product/ImageProviderTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Block/Product/ImageProviderTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ProductAlert\Test\Unit\Block\Product;
+
+class ImageProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Catalog\Block\Product\ImageBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $imageBuilderMock;
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+    /**
+     * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $emulationMock;
+
+    /**
+     * @var \Magento\ProductAlert\Block\Product\ImageProvider
+     */
+    private $model;
+
+    protected function setUp()
+    {
+        $this->imageBuilderMock = $this->getMockBuilder(\Magento\Catalog\Block\Product\ImageBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->storeManagerMock = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->emulationMock = $this->getMockBuilder(\Magento\Store\Model\App\Emulation::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->model = new \Magento\ProductAlert\Block\Product\ImageProvider(
+            $this->imageBuilderMock,
+            $this->storeManagerMock,
+            $this->emulationMock
+        );
+    }
+
+    /**
+     * Test that image is created successfully with app emulation enabled.
+     */
+    public function testGetImage()
+    {
+        $imageId = 'test_image_id';
+        $attributes = [];
+
+        $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $imageMock = $this->getMockBuilder(\Magento\Catalog\Block\Product\Image::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $storeMock = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->storeManagerMock->expects($this->atLeastOnce())->method('getStore')->willReturn($storeMock);
+        $storeMock->expects($this->atLeastOnce())->method('getId')->willReturn(42);
+        $this->emulationMock->expects($this->once())->method('startEnvironmentEmulation');
+        $this->imageBuilderMock->expects($this->once())->method('setProduct')->with($productMock)->willReturnSelf();
+        $this->imageBuilderMock->expects($this->once())->method('setImageId')->with($imageId)->willReturnSelf();
+        $this->imageBuilderMock->expects($this->once())->method('setAttributes')->with($attributes)->willReturnSelf();
+        $this->imageBuilderMock->expects($this->once())->method('create')->willReturn($imageMock);
+        $this->emulationMock->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->assertEquals($imageMock, $this->model->getImage($productMock, $imageId, $attributes));
+    }
+
+    /**
+     * Test that app emulation stops when exception occurs.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Image Builder Exception
+     */
+    public function testGetImageThrowsAnException()
+    {
+        $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $storeMock = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->emulationMock->expects($this->once())->method('startEnvironmentEmulation');
+        $this->storeManagerMock->expects($this->atLeastOnce())->method('getStore')->willReturn($storeMock);
+        $storeMock->expects($this->atLeastOnce())->method('getId')->willReturn(42);
+
+        $this->imageBuilderMock->expects($this->once())
+            ->method('setProduct')
+            ->willThrowException(new \Exception("Image Builder Exception"));
+
+        $this->emulationMock->expects($this->once())->method('stopEnvironmentEmulation');
+        $this->model->getImage($productMock, 1);
+    }
+}


### PR DESCRIPTION
### Description
When sending product alert emails from cron jobs it will do so from the backend area. An exception is thrown `Unable to resolve the source file for 'frontend/_view/nl_NL/Magento_Catalog/images/product/placeholder/.jpg'` because the product image can't be loaded.

Although Magento will mark the subscription send, in fact it's not. To solve this I created an emulation to the product image is loaded in the fronted area.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Add yourself to the mailing list for product alerts (e.g. out of stock products).
2. Run the cron job which is responsible for sending the email if a product is back in stock.
3. Magento will mark the subscription as send but in fact it's not.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
