### PR TITLE
Add clarification about deprecated methods in Abstract model

### DIFF
--- a/lib/internal/Magento/Framework/Model/AbstractModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractModel.php
@@ -523,7 +523,9 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
      * @param integer $modelId
      * @param null|string $field
      * @return $this
-     * @deprecated
+     * @deprecated because entities must not be responsible for their own loading.
+     * Service contracts should persist entities. Use resource model "load" or collections to implement
+     * service contract model loading operations.
      */
     public function load($modelId, $field = null)
     {
@@ -624,7 +626,9 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
      *
      * @return $this
      * @throws \Exception
-     * @deprecated
+     * @deprecated because entities must not be responsible for their own persistence.
+     * Service contracts should persist entities. Use resource model "save" to implement
+     * service contract persistence operations.
      */
     public function save()
     {
@@ -809,7 +813,9 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
      *
      * @return $this
      * @throws \Exception
-     * @deprecated
+     * @deprecated because entities must not be responsible for their own deletion.
+     * Service contracts should delete entities. Use resource model "delete" method to implement
+     * service contract persistence operations.
      */
     public function delete()
     {


### PR DESCRIPTION
### Description
In Magento 2.1.x in  Abstract model we have deprecated load, save and delete methods, but there are no clarification why it was deprecated and what we need to use instead. This pull requests brings changes from https://github.com/magento/magento2/commit/51721324516e888467e04f0b054d70c833c62b0b to 2.1-develop branch.

### Fixed Issues (if relevant)
- 

### Manual testing scenarios
-

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
