### PR TITLE
Updated EAV Attribute code max lenght

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute.php
@@ -23,7 +23,7 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute\AbstractAttribute im
     /**
      * Attribute code max length
      */
-    const ATTRIBUTE_CODE_MAX_LENGTH = 255;
+    const ATTRIBUTE_CODE_MAX_LENGTH = 60;
 
     /**
      * Cache tag


### PR DESCRIPTION
### Description
 - EAV attribute code will be transformed into column name for flat tables. MySQL does not support column name with more than 64 symbols

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install magento 
2. enable flat mode for catalog
3. make sure that catalog works on the frontend

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
