### PR TITLE
Generating target store post data with the right uenc

### DIFF
--- a/app/code/Magento/UrlRewrite/Block/Plugin/Store/Switcher/SetRedirectUrl.php
+++ b/app/code/Magento/UrlRewrite/Block/Plugin/Store/Switcher/SetRedirectUrl.php
@@ -64,7 +64,7 @@ class SetRedirectUrl
         ]);
         if ($urlRewrite) {
             $data[ActionInterface::PARAM_NAME_URL_ENCODED] = $this->urlHelper->getEncodedUrl(
-                $this->trimSlashInPath($this->urlBuilder->getUrl($urlRewrite->getRequestPath()))
+                $this->trimSlashInPath($this->urlBuilder->getUrl($urlRewrite->getRequestPath(), ['_scope' => $store]))
             );
         }
         return [$store, $data];


### PR DESCRIPTION
The BUG:
Url is generated for the current store not target one if store id is not included in the url setting is set to no

### Description
By passing the target store in the "_scope" param,  urlBuilder generates the nice url rewrite for that target store.


### Manual testing scenarios
We need a mage store with 2 store views
1. Disable include store_id in the url in the admin
2. In the frontend navigate to a category or any url that exists in the url_rewrite
3. Switch store view from the store switcher area. The same url is being loaded after the store switch attempt.
4. After the current PR fix is applied when switching sites also updates the url for the targeted Store

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages