### PR TITLE
Decrease floating precision

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -63,5 +63,5 @@ if (!empty($_SERVER['MAGE_PROFILER'])
 date_default_timezone_set('UTC');
 
 /*  Adjustment of precision value for several versions of PHP */
-ini_set('precision', 17);
-ini_set('serialize_precision', 17);
+ini_set('precision', 15);
+ini_set('serialize_precision', 15);


### PR DESCRIPTION
Relative error for PHP floats is about 10^-16 (http://php.net/manual/en/language.types.float.php).  Precision setting to 17 has the following affect:

```
    ini_set('precision', 17);
    $obj['val'] = 6.40;
    $out = json_encode($obj);
    echo $out;  // {"val":6.4000000000000004}
```