### PR TITLE
Fixing issue with getSize function not recalculating after adding filters.

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -215,11 +215,14 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
      */
     public function getSize()
     {
-        if ($this->_totalRecords === null) {
+        $itemCount = count($this->_items);
+
+        if ($this->_totalRecords === null || ($itemCount > 0 && $itemCount !== $this->_totalRecords)) {
             $sql = $this->getSelectCountSql();
-            $this->_totalRecords = $this->getConnection()->fetchOne($sql, $this->_bindParams);
+            $this->_totalRecords = (int) $this->getConnection()->fetchOne($sql, $this->_bindParams);
         }
-        return intval($this->_totalRecords);
+
+        return (int) $this->_totalRecords;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -222,7 +222,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
             $this->_totalRecords = (int) $this->getConnection()->fetchOne($sql, $this->_bindParams);
         }
 
-        return (int) $this->_totalRecords;
+        return $this->_totalRecords;
     }
 
     /**


### PR DESCRIPTION
Should fix several issues with `getSize()` returning incorrect values after filters have been applied to a collection.

### Description
- Adds additional guard to check if items on collection is equal to the totalRecords on collection. 

### Fixed Issues 
1. https://github.com/magento/magento2/issues/7730

### Manual testing scenarios
1. Load a collection.
2. Apply a filter to the collection.
3. Get size of collection using `getSize()` function and validate that value is correct.
