### PR TITLE
Fix for #4530 $product->getRatingSummary() always returns null […]

### DIFF
--- a/app/code/Magento/Review/Block/Product/ReviewRenderer.php
+++ b/app/code/Magento/Review/Block/Product/ReviewRenderer.php
@@ -57,6 +57,10 @@ class ReviewRenderer extends \Magento\Framework\View\Element\Template implements
         $templateType = self::DEFAULT_VIEW,
         $displayIfNoReviews = false
     ) {
+        if (!$product->getRatingSummary()) {
+            $this->_reviewFactory->create()->getEntitySummary($product, $this->_storeManager->getStore()->getId());
+        }
+
         if (!$product->getRatingSummary() && !$displayIfNoReviews) {
             return '';
         }
@@ -68,9 +72,6 @@ class ReviewRenderer extends \Magento\Framework\View\Element\Template implements
 
         $this->setDisplayIfEmpty($displayIfNoReviews);
 
-        if (!$product->getRatingSummary()) {
-            $this->_reviewFactory->create()->getEntitySummary($product, $this->_storeManager->getStore()->getId());
-        }
         $this->setProduct($product);
 
         return $this->toHtml();


### PR DESCRIPTION
This PR fixes the `\Magento\Review\Block\Product\ReviewRenderer` such that the reviews summary is shown although `$displayIfNoReviews` is set to `false` and reviews are in fact available.

### Description
Always retrieve relevant data before checking whether there are active reviews if `$displayIfNoReviews` is set to `false`.

### Fixed Issue
magento/magento2#4530: $product->getRatingSummary() always returns null on products with ratings

### Manual testing scenario
Change the last parameter `$displayIfNoReviews` in the `\Magento\Review\Block\Product\ReviewRenderer::getReviewsSummaryHtml` method call to `false` such that the call in the template `app/code/Magento/Catalog/view/frontend/templates/product/view/review.phtml` looks like this

```php
<?php echo $block->getReviewsSummaryHtml($block->getProduct(), false, false)?>
```

In both cases (No reviews available/at least one review is available) the reviews summary won't be shown. After applying this PR the reviews summary will be shown as expected only if there is at least one review available. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
