### PR TITLE
update phpserver to support versioned static urls

### DIFF
--- a/phpserver/router.php
+++ b/phpserver/router.php
@@ -61,6 +61,13 @@ if (php_sapi_name() === 'cli-server') {
     }
 
     $debug($route);
+    
+    if (strpos($route, ‘static/version’) === 0) {
+        $redirectRoute = preg_replace(‘#static/version[0–9]*/#’,’static/’, $route, 1);
+        $debug(“redirect static version string to:” . $redirectRoute);
+        header(‘Location: /’.$redirectRoute);
+        exit;
+    }
 
     if (strpos($route, 'media/') === 0 ||
         strpos($route, 'opt/') === 0 ||

--- a/phpserver/router.php
+++ b/phpserver/router.php
@@ -62,10 +62,10 @@ if (php_sapi_name() === 'cli-server') {
 
     $debug($route);
     
-    if (strpos($route, ‘static/version’) === 0) {
-        $redirectRoute = preg_replace(‘#static/version[0–9]*/#’,’static/’, $route, 1);
-        $debug(“redirect static version string to:” . $redirectRoute);
-        header(‘Location: /’.$redirectRoute);
+    if (strpos($route, 'static/version') === 0) {
+        $redirectRoute = preg_replace('#static/version[0–9]*/#','static/', $route, 1);
+        $debug("redirect static version string to:" . $redirectRoute);
+        header('Location: /'.$redirectRoute);
         exit;
     }
 

--- a/phpserver/router.php
+++ b/phpserver/router.php
@@ -63,10 +63,11 @@ if (php_sapi_name() === 'cli-server') {
     $debug($route);
     
     if (strpos($route, 'static/version') === 0) {
-        $redirectRoute = preg_replace('#static/version[0–9]*/#','static/', $route, 1);
-        $debug("redirect static version string to:" . $redirectRoute);
-        header('Location: /'.$redirectRoute);
-        exit;
+        $redirectRoute = preg_replace("/version\d+\//", "", $route, 1);
+        $redirectDebugInfo = "redirect static version string to: " . $redirectRoute;
+        $debug($redirectDebugInfo);
+        header('Location: /' . $redirectRoute);
+        exit;
     }
 
     if (strpos($route, 'media/') === 0 ||


### PR DESCRIPTION
the phpserver implementation did not support versioned static urls before, which is solved by this change

I decided to just do a redirect, as it should be enough for dev users, as they usually use no-cache or hard reloads to flush any css files used anyway.


You can reproduce this issue by following the normal setup flow (install via cli) and generate the frontend files.
Then use the php builtin server as a webserver and then load the home page.
Result without this patch will be a bunch of 404 responses for css files.
After this patch, they can get resolved correctly.