### PR TITLE
Fix overwrite default value image/file with NULL

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/File.php
+++ b/app/code/Magento/Config/Model/Config/Backend/File.php
@@ -110,6 +110,8 @@ class File extends \Magento\Framework\App\Config\Value
         } else {
             if (is_array($value) && !empty($value['delete'])) {
                 $this->setValue('');
+            } elseif (is_array($value) && !empty($value['value'])) {
+                $this->setValue($value['value']);
             } else {
                 $this->unsValue();
             }


### PR DESCRIPTION
If you set a default value for a config field type image/file and you save it. It won't set the default value in the database. Instead it will save NULL and so overwrite the default config.

With this change the default value will be set as value.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This is a replication of https://github.com/magento/magento2/pull/5085

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10252: Default values for system config of type image/file is not working 

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install Magento from develop branch.
2. Add config field with type image.
3. Add default config value for that field.
4. Save the config field without uploading a new file.

Before the fix:
- New record created in the database table core_config_data with value NULL.

After the fix:
- New record created in the database table core_config_data with default value.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
