### PR TITLE
getItems from order if already provided.

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1244,25 +1244,29 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * @param array $filterByTypes
      * @param bool $nonChildrenOnly
-     * @return ImportCollection
+     * @return \Magento\Sales\Api\Data\OrderItemInterface[]
      */
     public function getItemsCollection($filterByTypes = [], $nonChildrenOnly = false)
     {
-        $collection = $this->_orderItemCollectionFactory->create()->setOrderFilter($this);
+        if (!$this->hasData(OrderInterface::ITEMS)) {
+            $collection = $this->_orderItemCollectionFactory->create()->setOrderFilter($this);
 
-        if ($filterByTypes) {
-            $collection->filterByTypes($filterByTypes);
-        }
-        if ($nonChildrenOnly) {
-            $collection->filterByParent();
-        }
-
-        if ($this->getId()) {
-            foreach ($collection as $item) {
-                $item->setOrder($this);
+            if ($filterByTypes) {
+                $collection->filterByTypes($filterByTypes);
             }
+            if ($nonChildrenOnly) {
+                $collection->filterByParent();
+            }
+            $this->setItems($collection);
+
+            if ($this->getId()) {
+                foreach ($collection as $item) {
+                    $item->setOrder($this);
+                }
+            }
+
         }
-        return $collection;
+        return $this->getItems();
     }
 
     /**


### PR DESCRIPTION
fixes issue #6267

This is a replication of PR https://github.com/magento/magento2/pull/6268 that was closed because of a removed repository

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6267: Order getitemscollection Missing items when loading

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. See https://github.com/magento/magento2/issues/6267

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
