### PR TITLE
Remove zend json from customer data

### DIFF
--- a/app/code/Magento/Customer/Block/CustomerScopeData.php
+++ b/app/code/Magento/Customer/Block/CustomerScopeData.php
@@ -25,15 +25,16 @@ class CustomerScopeData extends \Magento\Framework\View\Element\Template
     private $serializer;
 
     /**
+     * CustomerScopeData constructor.
      * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param $jsonEncoder
+     * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
-        $jsonEncoder,
+        \Magento\Framework\Json\EncoderInterface $jsonEncoder,
         array $data = [],
         \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {

--- a/app/code/Magento/Customer/Block/CustomerScopeData.php
+++ b/app/code/Magento/Customer/Block/CustomerScopeData.php
@@ -50,4 +50,30 @@ class CustomerScopeData extends \Magento\Framework\View\Element\Template
     {
         return (int)$this->_storeManager->getStore()->getWebsiteId();
     }
+
+    /**
+     * Get the invalidation rules json encoded
+     *
+     * @return string
+     */
+    public function getInvalidationRulesJson()
+    {
+        return $this->jsonEncoder->encode(
+            [
+                '*' => [
+                    'Magento_Customer/js/invalidation-processor' => [
+                        'invalidationRules' => [
+                            'website-rule' => [
+                                'Magento_Customer/js/invalidation-rules/website-rule' => [
+                                    'scopeConfig' => [
+                                        'websiteId' => $this->getWebsiteId(),
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+            ]
+        );
+    }
 }

--- a/app/code/Magento/Customer/Block/CustomerScopeData.php
+++ b/app/code/Magento/Customer/Block/CustomerScopeData.php
@@ -25,12 +25,12 @@ class CustomerScopeData extends \Magento\Framework\View\Element\Template
     private $serializer;
 
     /**
-     * CustomerScopeData constructor.
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @throws \RuntimeException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,

--- a/app/code/Magento/Customer/Block/CustomerScopeData.php
+++ b/app/code/Magento/Customer/Block/CustomerScopeData.php
@@ -20,23 +20,23 @@ class CustomerScopeData extends \Magento\Framework\View\Element\Template
     private $storeManager;
 
     /**
-     * @var \Magento\Framework\Json\EncoderInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
-    private $jsonEncoder;
+    private $serializer;
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
+     * @param \Magento\Framework\Serialize\Serializer\Json $serializer
      * @param array $data
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
-        \Magento\Framework\Json\EncoderInterface $jsonEncoder,
+        \Magento\Framework\Serialize\Serializer\Json $serializer,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->storeManager = $context->getStoreManager();
-        $this->jsonEncoder = $jsonEncoder;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -54,11 +54,12 @@ class CustomerScopeData extends \Magento\Framework\View\Element\Template
     /**
      * Get the invalidation rules json encoded
      *
-     * @return string
+     * @return bool|string
+     * @throws \InvalidArgumentException
      */
-    public function getInvalidationRulesJson()
+    public function getSerializedInvalidationRules()
     {
-        return $this->jsonEncoder->encode(
+        return $this->serializer->serialize(
             [
                 '*' => [
                     'Magento_Customer/js/invalidation-processor' => [

--- a/app/code/Magento/Customer/Test/Unit/Block/CustomerScopeDataTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/CustomerScopeDataTest.php
@@ -54,8 +54,9 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
 
         $this->model = new CustomerScopeData(
             $this->contextMock,
-            $this->serializerMock,
-            []
+            null,
+            [],
+            $this->serializerMock
         );
     }
 
@@ -77,5 +78,85 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
             ->willReturn($storeMock);
 
         $this->assertEquals($storeId, $this->model->getWebsiteId());
+    }
+
+    public function testGetInvalidationRules()
+    {
+        $storeId = 1;
+
+        $storeMock = $this->getMockBuilder(StoreInterface::class)
+            ->setMethods(['getWebsiteId'])
+            ->getMockForAbstractClass();
+
+        $storeMock->expects($this->any())
+            ->method('getWebsiteId')
+            ->willReturn($storeId);
+
+        $this->storeManagerMock->expects($this->any())
+            ->method('getStore')
+            ->with(null)
+            ->willReturn($storeMock);
+
+        $this->assertEquals(
+            [
+                '*' => [
+                    'Magento_Customer/js/invalidation-processor' => [
+                        'invalidationRules' => [
+                            'website-rule' => [
+                                'Magento_Customer/js/invalidation-rules/website-rule' => [
+                                    'scopeConfig' => [
+                                        'websiteId' => 1,
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+            ],
+            $this->model->getInvalidationRules()
+        );
+    }
+
+    public function testGetSerializedInvalidationRules()
+    {
+        $storeId = 1;
+        $rules = [
+            '*' => [
+                'Magento_Customer/js/invalidation-processor' => [
+                    'invalidationRules' => [
+                        'website-rule' => [
+                            'Magento_Customer/js/invalidation-rules/website-rule' => [
+                                'scopeConfig' => [
+                                    'websiteId' => 1,
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+        ];
+
+        $storeMock = $this->getMockBuilder(StoreInterface::class)
+            ->setMethods(['getWebsiteId'])
+            ->getMockForAbstractClass();
+
+        $storeMock->expects($this->any())
+            ->method('getWebsiteId')
+            ->willReturn($storeId);
+
+        $this->storeManagerMock->expects($this->any())
+            ->method('getStore')
+            ->with(null)
+            ->willReturn($storeMock);
+
+        $this->serializerMock->expects($this->any())
+            ->method('serialize')
+            ->with($rules)
+            ->willReturn(json_encode($rules));
+
+        $this->assertEquals(
+            json_encode($rules),
+            $this->model->getSerializedInvalidationRules()
+        );
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Block/CustomerScopeDataTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/CustomerScopeDataTest.php
@@ -10,7 +10,6 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Customer\Block\CustomerScopeData;
-use Magento\Framework\Json\EncoderInterface;
 
 class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,6 +24,9 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
 
     /** @var ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $scopeConfigMock;
+
+    /** @var \Magento\Framework\Json\EncoderInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $encoderMock;
 
     /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
     private $serializerMock;
@@ -41,6 +43,9 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
         $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
             ->getMock();
 
+        $this->encoderMock = $this->getMockBuilder(\Magento\Framework\Json\EncoderInterface::class)
+            ->getMock();
+
         $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
             ->getMock();
 
@@ -54,7 +59,7 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
 
         $this->model = new CustomerScopeData(
             $this->contextMock,
-            null,
+            $this->encoderMock,
             [],
             $this->serializerMock
         );

--- a/app/code/Magento/Customer/Test/Unit/Block/CustomerScopeDataTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/CustomerScopeDataTest.php
@@ -26,8 +26,8 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
     /** @var ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $scopeConfigMock;
 
-    /** @var \Magento\Framework\Json\EncoderInterface|\PHPUnit_Framework_MockObject_MockObject */
-    private $encoderMock;
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serializerMock;
 
     protected function setUp()
     {
@@ -41,7 +41,7 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
         $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
             ->getMock();
 
-        $this->encoderMock = $this->getMockBuilder(EncoderInterface::class)
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
             ->getMock();
 
         $this->contextMock->expects($this->exactly(2))
@@ -54,7 +54,7 @@ class CustomerScopeDataTest extends \PHPUnit_Framework_TestCase
 
         $this->model = new CustomerScopeData(
             $this->contextMock,
-            $this->encoderMock,
+            $this->serializerMock,
             []
         );
     }

--- a/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
@@ -12,6 +12,6 @@
 <script type="text/x-magento-init">
 <?php
     /* @noEscape */
-    echo $block->getInvalidationRulesJson();
+    echo $block->getSerializedInvalidationRules();
 ?>
 </script>

--- a/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
@@ -12,18 +12,6 @@
 <script type="text/x-magento-init">
 <?php
     /* @noEscape */
-    echo \Zend_Json::encode([
-        '*' => ['Magento_Customer/js/invalidation-processor' => [
-            'invalidationRules' => [
-                'website-rule' => [
-                    'Magento_Customer/js/invalidation-rules/website-rule' => [
-                        'scopeConfig' => [
-                            'websiteId' => $block->getWebsiteId(),
-                        ]
-                    ]
-                ]
-            ]
-        ]],
-    ]);
-    ?>
+    echo $block->getInvalidationRulesJson();
+?>
 </script>


### PR DESCRIPTION
### Description
As both Zend_Json and \Magento\Framework\Json\EncoderInterface are now deprecated I have migrated the usage across the the accepted \Magento\Framework\Serialize\Serializer\Json class.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
