### PR TITLE
Fix order date format in Orders Grid

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -187,7 +187,6 @@
                     <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/date</item>
                     <item name="dataType" xsi:type="string">date</item>
                     <item name="label" xsi:type="string" translate="true">Purchase Date</item>
-                    <item name="dateFormat" xsi:type="string">MMM dd, YYYY, H:mm:SS A</item>
                 </item>
             </argument>
         </column>


### PR DESCRIPTION
### Description
We still have incorrect order date format in 2.1. Need to fix it. This fix removes custom date form that was defined for order grid and use default implementation:
https://github.com/magento/magento2/blob/develop/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js#L18

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/pull/6785: Fix order date format in admin grid
2. https://github.com/magento/magento2/pull/8336: fixing time format on admin sales order grid
3. https://github.com/magento/magento2/issues/5651: Purchase date on admin screen is always *:07:00

### Manual testing scenarios
1. Create customer, create product, create order
2. Go to admin, navigate to Sales->Orders grid
3. See the date, i.e. "Jan 30, 2017, **16**:01:00 PM" (should be Jan 30, 2017, **4**:01:00 PM)
4. Open the order and check the date under "Order Date"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
