### PR TITLE
check if node id exists before checking its admin

### DIFF
--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
@@ -190,7 +190,8 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
         $configResource = array_filter(
             $resources,
             function ($node) {
-                return $node['id'] == 'Magento_Backend::admin';
+                return isset($node['id'])
+                    && $node['id'] == 'Magento_Backend::admin';
             }
         );
         $configResource = reset($configResource);

--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -210,7 +210,8 @@ class Edit extends \Magento\Backend\Block\Widget\Form implements \Magento\Backen
         $configResource = array_filter(
             $resources,
             function ($node) {
-                return $node['id'] == 'Magento_Backend::admin';
+                return isset($node['id'])
+                    && $node['id'] == 'Magento_Backend::admin';
             }
         );
         $configResource = reset($configResource);


### PR DESCRIPTION
When there are nodes in the aclResources that not have a member 'id',
you will get an error on the comparison $node['id'] == 'Magento::admin'
First check if the member 'id' exists

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
