### PR TITLE
Ignore Errors With Module Versions Requiring an Upgrade

### DIFF
--- a/lib/internal/Magento/Framework/Module/Plugin/DbStatusValidator.php
+++ b/lib/internal/Magento/Framework/Module/Plugin/DbStatusValidator.php
@@ -37,7 +37,8 @@ class DbStatusValidator
 
     /**
      * @param FrontendCacheInterface $cache
-     * @param DbVersionInfo $dbVersionInfo
+     * @param DbVersionInfo $dbVersionInfo,
+     * @param DeploymentConfig $deploymentConfig
      */
     public function __construct(
         FrontendCacheInterface $cache,


### PR DESCRIPTION
### Description
At the moment, it's not possible to do a deployment without maintenance mode if a module version is being updated. If a page is loaded and the module versions are different, an exception is shown to the customer.

Although I see the purpose behind this in terms of preventing other errors, it does mean that we have to perform disruptive deployments if we want to deploy a module update. 

Very often, this is a temporary issue until the frontend servers have all got the latest version of the code. I believe flexibility should be given to allow developers to control whether this should throw an exception. 

This change introduces a new value in env.php called 'ignore_module_version_exception'. If this is set to '1' then the errors are supressed and not displayed on the frontend. If not set or set to anything other than '1', then the errors are shown as usual.

I was unable to implement this with an integration test due to the contents of env.php being validated during the tests to make sure they're not changed.

I'm very much open to other solutions rather than use env.php. It may be useful to create a console command to set this value if it is used.

### Manual testing scenarios
1. Install a clean version of Magento
2. Ensure that ignore_module_version_exception is added to env.php and set to '0' (this should be set at the same level in the data as 'MAGE_MODE'
3. Load the page
4. Locate a module in the code e.g. module-catalog and increase the version number
5. Clear the cache
6. Reload the page
7. You should now see the exception
8. Update 'ignore_module_version_exception' to '1'
9. Clear the cache
10. Reload the page
11. No exception should be visible

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
