### PR TITLE
Product attribute notice translation

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
@@ -537,8 +537,8 @@ class EavTest extends AbstractModifierTest
             'default_null_prod_not_new_and_not_required' => $this->defaultNullProdNotNewAndNotRequired(),
             'default_null_prod_new_and_not_required' => $this->defaultNullProdNewAndNotRequired(),
             'default_null_prod_new_and_required' => $this->defaultNullProdNewAndRequired(),
-            'default_null_prod_new_and_required_and_filled_notice' => $this->defaultNullProdNewAndRequiredAndFilledNotice(
-            )
+            'default_null_prod_new_and_required_and_filled_notice' =>
+                $this->defaultNullProdNewAndRequiredAndFilledNotice()
         ];
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav;
 use Magento\Eav\Model\Config;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\EntityManager\EventManager;
+use Magento\Framework\Phrase;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Ui\DataProvider\EavValidationRules;
@@ -452,12 +453,13 @@ class EavTest extends AbstractModifierTest
      * @param int $productId
      * @param bool $productRequired
      * @param string $attrValue
+     * @param string $note
      * @param array $expected
      * @covers \Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav::isProductExists
      * @covers \Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav::setupAttributeMeta
      * @dataProvider setupAttributeMetaDataProvider
      */
-    public function testSetupAttributeMetaDefaultAttribute($productId, $productRequired, $attrValue, $expected)
+    public function testSetupAttributeMetaDefaultAttribute($productId, $productRequired, $attrValue, $note, $expected)
     {
         $configPath =  'arguments/data/config';
         $groupCode = 'product-details';
@@ -482,6 +484,10 @@ class EavTest extends AbstractModifierTest
         $this->productAttributeMock->expects($this->any())
             ->method('getValue')
             ->willReturn('value');
+
+        $this->productAttributeMock->expects($this->any())
+            ->method('getNote')
+            ->willReturn($note);
 
         $attributeMock = $this->getMockBuilder(AttributeInterface::class)
             ->disableOriginalConstructor()
@@ -531,6 +537,7 @@ class EavTest extends AbstractModifierTest
                 'productId' => 1,
                 'productRequired' => true,
                 'attrValue' => 'val',
+                'note' => null,
                 'expected' => [
                     'dataType' => null,
                     'formElement' => null,
@@ -550,6 +557,7 @@ class EavTest extends AbstractModifierTest
                 'productId' => 1,
                 'productRequired' => false,
                 'attrValue' => 'val',
+                'note' => null,
                 'expected' => [
                     'dataType' => null,
                     'formElement' => null,
@@ -569,6 +577,7 @@ class EavTest extends AbstractModifierTest
                 'productId' => null,
                 'productRequired' => false,
                 'attrValue' => null,
+                'note' => null,
                 'expected' => [
                     'dataType' => null,
                     'formElement' => null,
@@ -588,12 +597,33 @@ class EavTest extends AbstractModifierTest
                 'productId' => null,
                 'productRequired' => false,
                 'attrValue' => null,
+                'note' => null,
                 'expected' => [
                     'dataType' => null,
                     'formElement' => null,
                     'visible' => null,
                     'required' => false,
                     'notice' => null,
+                    'default' => 'required_value',
+                    'label' => null,
+                    'code' => 'code',
+                    'source' => 'product-details',
+                    'scopeLabel' => '',
+                    'globalScope' => false,
+                    'sortOrder' => 0
+                ],
+            ],
+            'default_null_prod_new_and_required_and_filled_notice' => [
+                'productId' => null,
+                'productRequired' => false,
+                'attrValue' => null,
+                'note' => 'example notice',
+                'expected' => [
+                    'dataType' => null,
+                    'formElement' => null,
+                    'visible' => null,
+                    'required' => false,
+                    'notice' => __('example notice'),
                     'default' => 'required_value',
                     'label' => null,
                     'code' => 'code',

--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
@@ -533,106 +533,147 @@ class EavTest extends AbstractModifierTest
     public function setupAttributeMetaDataProvider()
     {
         return [
-            'default_null_prod_not_new_and_required' => [
-                'productId' => 1,
-                'productRequired' => true,
-                'attrValue' => 'val',
-                'note' => null,
-                'expected' => [
-                    'dataType' => null,
-                    'formElement' => null,
-                    'visible' => null,
-                    'required' => true,
-                    'notice' => null,
-                    'default' => null,
-                    'label' => null,
-                    'code' => 'code',
-                    'source' => 'product-details',
-                    'scopeLabel' => '',
-                    'globalScope' => false,
-                    'sortOrder' => 0
-                    ],
-                ],
-            'default_null_prod_not_new_and_not_required' => [
-                'productId' => 1,
-                'productRequired' => false,
-                'attrValue' => 'val',
-                'note' => null,
-                'expected' => [
-                    'dataType' => null,
-                    'formElement' => null,
-                    'visible' => null,
-                    'required' => false,
-                    'notice' => null,
-                    'default' => null,
-                    'label' => null,
-                    'code' => 'code',
-                    'source' => 'product-details',
-                    'scopeLabel' => '',
-                    'globalScope' => false,
-                    'sortOrder' => 0
-                    ],
-                ],
-            'default_null_prod_new_and_not_required' => [
-                'productId' => null,
-                'productRequired' => false,
-                'attrValue' => null,
-                'note' => null,
-                'expected' => [
-                    'dataType' => null,
-                    'formElement' => null,
-                    'visible' => null,
-                    'required' => false,
-                    'notice' => null,
-                    'default' => 'required_value',
-                    'label' => null,
-                    'code' => 'code',
-                    'source' => 'product-details',
-                    'scopeLabel' => '',
-                    'globalScope' => false,
-                    'sortOrder' => 0
-                ],
+            'default_null_prod_not_new_and_required' => $this->defaultNullProdNotNewAndRequired(),
+            'default_null_prod_not_new_and_not_required' => $this->defaultNullProdNotNewAndNotRequired(),
+            'default_null_prod_new_and_not_required' => $this->defaultNullProdNewAndNotRequired(),
+            'default_null_prod_new_and_required' => $this->defaultNullProdNewAndRequired(),
+            'default_null_prod_new_and_required_and_filled_notice' => $this->defaultNullProdNewAndRequiredAndFilledNotice(
+            )
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function defaultNullProdNotNewAndRequired()
+    {
+        return [
+            'productId'       => 1,
+            'productRequired' => true,
+            'attrValue'       => 'val',
+            'note'            => null,
+            'expected'        => [
+                'dataType'    => null,
+                'formElement' => null,
+                'visible'     => null,
+                'required'    => true,
+                'notice'      => null,
+                'default'     => null,
+                'label'       => null,
+                'code'        => 'code',
+                'source'      => 'product-details',
+                'scopeLabel'  => '',
+                'globalScope' => false,
+                'sortOrder'   => 0
             ],
-            'default_null_prod_new_and_required' => [
-                'productId' => null,
-                'productRequired' => false,
-                'attrValue' => null,
-                'note' => null,
-                'expected' => [
-                    'dataType' => null,
-                    'formElement' => null,
-                    'visible' => null,
-                    'required' => false,
-                    'notice' => null,
-                    'default' => 'required_value',
-                    'label' => null,
-                    'code' => 'code',
-                    'source' => 'product-details',
-                    'scopeLabel' => '',
-                    'globalScope' => false,
-                    'sortOrder' => 0
-                ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function defaultNullProdNotNewAndNotRequired()
+    {
+        return [
+            'productId'       => 1,
+            'productRequired' => false,
+            'attrValue'       => 'val',
+            'note'            => null,
+            'expected'        => [
+                'dataType'    => null,
+                'formElement' => null,
+                'visible'     => null,
+                'required'    => false,
+                'notice'      => null,
+                'default'     => null,
+                'label'       => null,
+                'code'        => 'code',
+                'source'      => 'product-details',
+                'scopeLabel'  => '',
+                'globalScope' => false,
+                'sortOrder'   => 0
             ],
-            'default_null_prod_new_and_required_and_filled_notice' => [
-                'productId' => null,
-                'productRequired' => false,
-                'attrValue' => null,
-                'note' => 'example notice',
-                'expected' => [
-                    'dataType' => null,
-                    'formElement' => null,
-                    'visible' => null,
-                    'required' => false,
-                    'notice' => __('example notice'),
-                    'default' => 'required_value',
-                    'label' => null,
-                    'code' => 'code',
-                    'source' => 'product-details',
-                    'scopeLabel' => '',
-                    'globalScope' => false,
-                    'sortOrder' => 0
-                ],
-            ]
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function defaultNullProdNewAndNotRequired()
+    {
+        return [
+            'productId'       => null,
+            'productRequired' => false,
+            'attrValue'       => null,
+            'note'            => null,
+            'expected'        => [
+                'dataType'    => null,
+                'formElement' => null,
+                'visible'     => null,
+                'required'    => false,
+                'notice'      => null,
+                'default'     => 'required_value',
+                'label'       => null,
+                'code'        => 'code',
+                'source'      => 'product-details',
+                'scopeLabel'  => '',
+                'globalScope' => false,
+                'sortOrder'   => 0
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function defaultNullProdNewAndRequired()
+    {
+        return [
+            'productId'       => null,
+            'productRequired' => false,
+            'attrValue'       => null,
+            'note'            => null,
+            'expected'        => [
+                'dataType'    => null,
+                'formElement' => null,
+                'visible'     => null,
+                'required'    => false,
+                'notice'      => null,
+                'default'     => 'required_value',
+                'label'       => null,
+                'code'        => 'code',
+                'source'      => 'product-details',
+                'scopeLabel'  => '',
+                'globalScope' => false,
+                'sortOrder'   => 0
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function defaultNullProdNewAndRequiredAndFilledNotice()
+    {
+        return [
+            'productId'       => null,
+            'productRequired' => false,
+            'attrValue'       => null,
+            'note'            => 'example notice',
+            'expected'        => [
+                'dataType'    => null,
+                'formElement' => null,
+                'visible'     => null,
+                'required'    => false,
+                'notice'      => __('example notice'),
+                'default'     => 'required_value',
+                'label'       => null,
+                'code'        => 'code',
+                'source'      => 'product-details',
+                'scopeLabel'  => '',
+                'globalScope' => false,
+                'sortOrder'   => 0
+            ],
         ];
     }
 }

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -555,7 +555,7 @@ class Eav extends AbstractModifier
             'formElement' => $this->getFormElementsMapValue($attribute->getFrontendInput()),
             'visible' => $attribute->getIsVisible(),
             'required' => $attribute->getIsRequired(),
-            'notice' => __($attribute->getNote()),
+            'notice' => $attribute->getNote() === null ? null : __($attribute->getNote()),
             'default' => (!$this->isProductExists()) ? $attribute->getDefaultValue() : null,
             'label' => $attribute->getDefaultFrontendLabel(),
             'code' => $attribute->getAttributeCode(),

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -555,7 +555,7 @@ class Eav extends AbstractModifier
             'formElement' => $this->getFormElementsMapValue($attribute->getFrontendInput()),
             'visible' => $attribute->getIsVisible(),
             'required' => $attribute->getIsRequired(),
-            'notice' => $attribute->getNote(),
+            'notice' => __($attribute->getNote()),
             'default' => (!$this->isProductExists()) ? $attribute->getDefaultValue() : null,
             'label' => $attribute->getDefaultFrontendLabel(),
             'code' => $attribute->getAttributeCode(),


### PR DESCRIPTION
When adding a note/notice to a product attribute, this is never translated in the admin.

### Description
I only added a ``__()`` to the existing variable.

### Manual testing scenarios
1. Create an attribute (``$eavSetup->addAttribute()``) with the ``note`` keyword ([example](https://github.com/magento/magento2/blob/develop/app/code/Magento/Catalog/Setup/UpgradeData.php#L372)).
2. Add a translation in the i18n folder for this ``note``.
3. It is not translated, but it should.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
