### PR TITLE
2.1 - Allow to use text swatch 0

### DIFF
--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -430,7 +430,7 @@ class EavAttribute
             if ($this->isOptionForDelete($attribute, $optionId)) {
                 continue;
             }
-            if ($option[0] === '') {
+            if (!isset($option[0]) || $option[0] === '') {
                 return false;
             }
         }

--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -430,7 +430,7 @@ class EavAttribute
             if ($this->isOptionForDelete($attribute, $optionId)) {
                 continue;
             }
-            if (empty($option[0])) {
+            if ($option[0] === '') {
                 return false;
             }
         }


### PR DESCRIPTION
### Description
When we're trying to put "0" value into product attribute options - we're getting following error:
```Admin is a required field in the each row```.
This issue was already fixed in 2.2, but wasn't backported to 2.1.
See https://github.com/magento/magento2/issues/9619 for more detailed description.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/9619: Impossible to create Text Swatch 0 (Zero)
2. https://github.com/magento/magento2/pull/7701: Allows you to have 0 as a option
3. https://github.com/magento/magento2/issues/10266: Product Attributes - Size 0

### Manual testing scenarios
1. Try to create product attribute text swatch with value "0" (zero) 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
