### PR TITLE
Treat message class as newable object to avoid reuse

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -10,7 +10,7 @@ namespace Magento\Framework\Mail\Template;
 
 use Magento\Framework\App\TemplateTypesInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Mail\MessageInterface;
+use Magento\Framework\Mail\MessageInterfaceFactory;
 use Magento\Framework\Mail\TransportInterfaceFactory;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Phrase;
@@ -70,6 +70,13 @@ class TransportBuilder
     protected $objectManager;
 
     /**
+     * Message Factory
+     *
+     * @var \Magento\Framework\Mail\MessageInterfaceFactory
+     */
+    protected $messageInterfaceFactory;
+
+    /**
      * Message
      *
      * @var \Magento\Framework\Mail\Message
@@ -90,20 +97,21 @@ class TransportBuilder
 
     /**
      * @param FactoryInterface $templateFactory
-     * @param MessageInterface $message
+     * @param MessageInterfaceFactory $messageInterfaceFactory
      * @param SenderResolverInterface $senderResolver
      * @param ObjectManagerInterface $objectManager
      * @param TransportInterfaceFactory $mailTransportFactory
      */
     public function __construct(
         FactoryInterface $templateFactory,
-        MessageInterface $message,
+        MessageInterfaceFactory $messageInterfaceFactory,
         SenderResolverInterface $senderResolver,
         ObjectManagerInterface $objectManager,
         TransportInterfaceFactory $mailTransportFactory
     ) {
         $this->templateFactory = $templateFactory;
-        $this->message = $message;
+        $this->messageInterfaceFactory = $messageInterfaceFactory;
+        $this->message = $messageInterfaceFactory->create();
         $this->objectManager = $objectManager;
         $this->_senderResolver = $senderResolver;
         $this->mailTransportFactory = $mailTransportFactory;
@@ -242,7 +250,7 @@ class TransportBuilder
      */
     protected function reset()
     {
-        $this->message = $this->objectManager->create(\Magento\Framework\Mail\Message::class);
+        $this->message = $this->messageInterfaceFactory->create();
         $this->templateIdentifier = null;
         $this->templateVars = null;
         $this->templateOptions = null;


### PR DESCRIPTION
### Description
Currently the `TransportBuilder` class constructor requests the `Message` class as a singleton. However, since this is a data object, it should be treated as a newable object. Otherwise there is the risk that it will be passed a "dirty" copy of the object when the class is instantiated.

### Manual testing scenarios
The scenario that we ran into this involves inheritance, which I know is no longer recommended by the architecture guidelines, but it is the simplest to explain. The issue could also surface in the case that another class requests a `Message` object and modifies its properties before the `TransportBuilder` class is instantiated.

1. Inject the core `TransportBuilder` class into a new class `CoreSender` and add a method `send` which sends an email using the injected class.
2. Create a new class that inherits from the core `TransportBuilder`. Call it `TransportBuilderChild`. No need to override any methods: it can be an empty class.
3. Inject the new `TransportBuilderChild` class into a new class `ExtendedSender` and add a method `send` which sends an email using the injected class, but to a different email address than in step 1.
4. Call `CoreSender::send()` after `ExtendedSender::send()`.

**Behavior Before PR:** The latter `send()` call ends up sending the email to *both* the recipient from step 1 and step 2. This is because `TransportBuilder` object reuses the dirty copy of `Message` from `TransportBuilderChild`.

**Behavior After PR:** The two `send()` calls send their respective messages only to their specified recipients. The `TransportBuilder` object gets a freshly instantiated instance of `Message`.