### PR TITLE
Remove zend json from data object

### DIFF
--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -325,19 +325,21 @@ class DataObject implements \ArrayAccess
      * Convert object data to JSON
      *
      * @param array $keys array of required keys
-     * @return string
+     * @return bool|string
+     * @throws \InvalidArgumentException
      */
     public function toJson(array $keys = [])
     {
         $data = $this->toArray($keys);
-        return \Zend_Json::encode($data);
+        return \Magento\Framework\Serialize\JsonConverter::convert($data);
     }
 
     /**
      * The "__" style wrapper for toJson
      *
-     * @param  array $keys
-     * @return string
+     * @param array $keys
+     * @return bool|string
+     * @throws \InvalidArgumentException
      */
     public function convertToJson(array $keys = [])
     {

--- a/lib/internal/Magento/Framework/Serialize/JsonConverter.php
+++ b/lib/internal/Magento/Framework/Serialize/JsonConverter.php
@@ -6,14 +6,17 @@
 namespace Magento\Framework\Serialize;
 
 /**
- * Used to convert \Magento\Framework\DataObject to Json
- *
- * @deprecated @see \Magento\Framework\Serialize\Serializer\Json::serialize
+ * This class was introducted only for usage in the \Magento\Framework\DataObject::toJson method.
+ * It should not be used in other cases and instead \Magento\Framework\Serialize\Serializer\Json::serialize
+ * should be used.
  */
 class JsonConverter
 {
     /**
-     * @param $data
+     * This method should only be used by \Magento\Framework\DataObject::toJson
+     * All other cases should use \Magento\Framework\Serialize\Serializer\Json::serialize directly
+     *
+     * @param string|int|float|bool|array|null $data
      * @return bool|string
      * @throws \InvalidArgumentException
      */

--- a/lib/internal/Magento/Framework/Serialize/JsonConverter.php
+++ b/lib/internal/Magento/Framework/Serialize/JsonConverter.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Serialize;
+
+/**
+ * Used to convert \Magento\Framework\DataObject to Json
+ *
+ * @deprecated @see \Magento\Framework\Serialize\Serializer\Json::serialize
+ */
+class JsonConverter
+{
+    /**
+     * @param $data
+     * @return bool|string
+     * @throws \InvalidArgumentException
+     */
+    public static function convert($data)
+    {
+        $serializer = new \Magento\Framework\Serialize\Serializer\Json();
+        return $serializer->serialize($data);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The DataObject class has a method `toJson` that uses `Zend_Json`. Since this at EOF we should replace the usage. Unfortunately in this case that is not so "simple" after some discussion with @okorshenko it was decided to create a new static class for this single case. This should not be used in other places but for this case it is "ok".

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
