### PR TITLE
Remove not used `getItemsData` functionality in Checkout

### DIFF
--- a/app/code/Magento/Checkout/Model/DefaultConfigProvider.php
+++ b/app/code/Magento/Checkout/Model/DefaultConfigProvider.php
@@ -257,7 +257,6 @@ class DefaultConfigProvider implements ConfigProviderInterface
         $output['formKey'] = $this->formKey->getFormKey();
         $output['customerData'] = $this->getCustomerData();
         $output['quoteData'] = $this->getQuoteData();
-        $output['quoteItemData'] = $this->getQuoteItemData();
         $output['isCustomerLoggedIn'] = $this->isCustomerLoggedIn();
         $output['selectedShippingMethod'] = $this->getSelectedShippingMethod();
         $output['storeCode'] = $this->getStoreCode();
@@ -371,29 +370,6 @@ class DefaultConfigProvider implements ConfigProviderInterface
 
         }
         return $quoteData;
-    }
-
-    /**
-     * Retrieve quote item data
-     *
-     * @return array
-     */
-    private function getQuoteItemData()
-    {
-        $quoteItemData = [];
-        $quoteId = $this->checkoutSession->getQuote()->getId();
-        if ($quoteId) {
-            $quoteItems = $this->quoteItemRepository->getList($quoteId);
-            foreach ($quoteItems as $index => $quoteItem) {
-                $quoteItemData[$index] = $quoteItem->toArray();
-                $quoteItemData[$index]['options'] = $this->getFormattedOptionValue($quoteItem);
-                $quoteItemData[$index]['thumbnail'] = $this->imageHelper->init(
-                    $quoteItem->getProduct(),
-                    'product_thumbnail_image'
-                )->getUrl();
-            }
-        }
-        return $quoteItemData;
     }
 
     /**

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
@@ -57,13 +57,6 @@ define([
         },
 
         /**
-         * @return {*}
-         */
-        getItems: function () {
-            return window.checkoutConfig.quoteItemData;
-        },
-
-        /**
          *
          * @return {*}
          */


### PR DESCRIPTION
These `Quote Items` are never used, so there is no need to load them. Removing this code will same some resources avoiding loading quote items and its attributes that will never be used. 

`Quote Items` used in checkout are all coming from `totalsData` as shown here:

* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/Model/DefaultConfigProvider.php#L279
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/Model/DefaultConfigProvider.php#L571
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/view/frontend/web/js/view/summary/cart-items.js#L27
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js#L15
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js#L36