### PR TITLE
Remove zend json from the test suite

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -268,14 +268,10 @@ abstract class AbstractController extends \PHPUnit_Framework_TestCase
     {
         /** @var $cookieManager CookieManagerInterface */
         $cookieManager = $this->_objectManager->get(CookieManagerInterface::class);
-        try {
-            $messages = \Zend_Json::decode(
-                $cookieManager->getCookie(MessagePlugin::MESSAGES_COOKIES_NAME, \Zend_Json::encode([]))
-            );
-            if (!is_array($messages)) {
-                $messages = [];
-            }
-        } catch (\Zend_Json_Exception $e) {
+        $messages = json_decode(
+            $cookieManager->getCookie(MessagePlugin::MESSAGES_COOKIES_NAME, json_encode([]))
+        );
+        if (!is_array($messages)) {
             $messages = [];
         }
 

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -15,6 +15,7 @@ use Magento\Theme\Controller\Result\MessagePlugin;
 
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 abstract class AbstractController extends \PHPUnit_Framework_TestCase
 {

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -268,10 +268,21 @@ abstract class AbstractController extends \PHPUnit_Framework_TestCase
     {
         /** @var $cookieManager CookieManagerInterface */
         $cookieManager = $this->_objectManager->get(CookieManagerInterface::class);
-        $messages = json_decode(
-            $cookieManager->getCookie(MessagePlugin::MESSAGES_COOKIES_NAME, json_encode([]))
-        );
-        if (!is_array($messages)) {
+
+        /** @var $jsonSerializer \Magento\Framework\Serialize\Serializer\Json */
+        $jsonSerializer = $this->_objectManager->get(\Magento\Framework\Serialize\Serializer\Json::class);
+        try {
+            $messages = $jsonSerializer->unserialize(
+                $cookieManager->getCookie(
+                    MessagePlugin::MESSAGES_COOKIES_NAME,
+                    $jsonSerializer->serialize([])
+                )
+            );
+
+            if (!is_array($messages)) {
+                $messages = [];
+            }
+        } catch (\InvalidArgumentException $e) {
             $messages = [];
         }
 

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -15,7 +15,6 @@ use Magento\Theme\Controller\Result\MessagePlugin;
 
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 abstract class AbstractController extends \PHPUnit_Framework_TestCase
 {
@@ -26,12 +25,12 @@ abstract class AbstractController extends \PHPUnit_Framework_TestCase
     protected $_runOptions = [];
 
     /**
-     * @var \Magento\TestFramework\Request
+     * @var \Magento\Framework\App\RequestInterface
      */
     protected $_request;
 
     /**
-     * @var \Magento\TestFramework\Response
+     * @var \Magento\Framework\App\ResponseInterface
      */
     protected $_response;
 
@@ -103,7 +102,7 @@ abstract class AbstractController extends \PHPUnit_Framework_TestCase
     /**
      * Request getter
      *
-     * @return \Magento\TestFramework\Request
+     * @return \Magento\Framework\App\RequestInterface
      */
     public function getRequest()
     {
@@ -116,7 +115,7 @@ abstract class AbstractController extends \PHPUnit_Framework_TestCase
     /**
      * Response getter
      *
-     * @return \Magento\TestFramework\Response
+     * @return \Magento\Framework\App\ResponseInterface
      */
     public function getResponse()
     {

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
@@ -25,12 +25,25 @@ class ControllerAbstractTest extends \Magento\TestFramework\TestCase\AbstractCon
     /** @var \PHPUnit_Framework_MockObject_MockObject | CookieManagerInterface */
     private $cookieManagerMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializerMock;
+
     protected function setUp()
     {
         $testObjectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $this->messageManager = $this->getMock(\Magento\Framework\Message\Manager::class, [], [], '', false);
         $this->cookieManagerMock = $this->getMock(CookieManagerInterface::class, [], [], '', false);
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->serializerMock->expects($this->any())->method('unserialize')->willReturnCallback(
+            function ($serializedData) {
+                return json_decode($serializedData, true);
+            }
+        );
         $this->interpretationStrategyMock = $this->getMock(InterpretationStrategyInterface::class, [], [], '', false);
         $this->interpretationStrategyMock->expects($this->any())
             ->method('interpret')
@@ -58,6 +71,7 @@ class ControllerAbstractTest extends \Magento\TestFramework\TestCase\AbstractCon
                         [\Magento\Framework\App\ResponseInterface::class, $response],
                         [\Magento\Framework\Message\Manager::class, $this->messageManager],
                         [CookieManagerInterface::class, $this->cookieManagerMock],
+                        [\Magento\Framework\Serialize\Serializer\Json::class, $this->serializerMock],
                         [InterpretationStrategyInterface::class, $this->interpretationStrategyMock],
                     ]
                 )

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
@@ -244,6 +244,6 @@ class ControllerAbstractTest extends \Magento\TestFramework\TestCase\AbstractCon
 
         $this->cookieManagerMock->expects($this->any())
             ->method('getCookie')
-            ->willReturn(\Zend_Json::encode($cookieMessages));
+            ->willReturn(json_encode($cookieMessages));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
@@ -108,7 +108,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($this->model->getTemplateText());
         $this->assertNotEmpty($this->model->getTemplateSubject());
         $this->assertNotEmpty($this->model->getOrigTemplateVariables());
-        $this->assertInternalType('array', \Zend_Json::decode($this->model->getOrigTemplateVariables()));
+        $this->assertInternalType('array', json_decode($this->model->getOrigTemplateVariables()));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
@@ -108,7 +108,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($this->model->getTemplateText());
         $this->assertNotEmpty($this->model->getTemplateSubject());
         $this->assertNotEmpty($this->model->getOrigTemplateVariables());
-        $this->assertInternalType('array', json_decode($this->model->getOrigTemplateVariables()));
+        $this->assertInternalType('array', json_decode($this->model->getOrigTemplateVariables(), true));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Import/Edit/BeforeTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Import/Edit/BeforeTest.php
@@ -93,7 +93,7 @@ class BeforeTest extends \PHPUnit_Framework_TestCase
     public function testGetEntityBehaviors()
     {
         $actualEntities = $this->_model->getEntityBehaviors();
-        $expectedEntities = \Zend_Json::encode($this->_expectedEntities);
+        $expectedEntities = json_encode($this->_expectedEntities);
         $this->assertEquals($expectedEntities, $actualEntities);
     }
 
@@ -105,7 +105,7 @@ class BeforeTest extends \PHPUnit_Framework_TestCase
     public function testGetUniqueBehaviors()
     {
         $actualBehaviors = $this->_model->getUniqueBehaviors();
-        $expectedBehaviors = \Zend_Json::encode($this->_expectedBehaviors);
+        $expectedBehaviors = json_encode($this->_expectedBehaviors);
         $this->assertEquals($expectedBehaviors, $actualBehaviors);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Since Zend_Json is at EOL we should replace the usage of `\Magento\Framework\Serialize\Serializer\Json` when required. In this PR I have removed the usage of `Zend_Json` from the test suite.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Running the test suite causes no failures

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
