### PR TITLE
Deprecate not used `getItemsData` functionality in Checkout

### DIFF
--- a/app/code/Magento/Checkout/Model/DefaultConfigProvider.php
+++ b/app/code/Magento/Checkout/Model/DefaultConfigProvider.php
@@ -254,7 +254,7 @@ class DefaultConfigProvider implements ConfigProviderInterface
         $output['formKey'] = $this->formKey->getFormKey();
         $output['customerData'] = $this->getCustomerData();
         $output['quoteData'] = $this->getQuoteData();
-        $output['quoteItemData'] = $this->getQuoteItemData();
+        $output['quoteItemData'] = $this->getQuoteItemData(); //@deprecated see $this->getQuoteItemData()
         $output['isCustomerLoggedIn'] = $this->isCustomerLoggedIn();
         $output['selectedShippingMethod'] = $this->getSelectedShippingMethod();
         $output['storeCode'] = $this->getStoreCode();
@@ -373,6 +373,7 @@ class DefaultConfigProvider implements ConfigProviderInterface
      * Retrieve quote item data
      *
      * @return array
+     * @deprecated Items data should be accessed using "getTotalsData()['items']"
      */
     private function getQuoteItemData()
     {

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
@@ -77,7 +77,7 @@ define([
          * @return {*}
          */
         getItems: function () {
-            return window.checkoutConfig.quoteItemData;
+            return totals.getItems();
         },
 
         /**


### PR DESCRIPTION
These `Quote Items` are never used, so there is no need to load them. Removing this code will same some resources avoiding loading quote items and its attributes that will never be used. 

`Quote Items` used in checkout are all coming from `totalsData` as shown here:

* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/Model/DefaultConfigProvider.php#L279
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/Model/DefaultConfigProvider.php#L571
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/view/frontend/web/js/view/summary/cart-items.js#L27
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js#L15
* https://github.com/magento/magento2/blob/develop/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js#L36