### PR TITLE
Fix missing extension_attributes on checkout item

### DIFF
--- a/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
+++ b/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
@@ -79,7 +79,6 @@ class ItemConverter
         $this->eventManager->dispatch('items_additional_data', ['item' => $item]);
         $items = $item->toArray();
         $items['options'] = $this->getFormattedOptionValue($item);
-        unset($items[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]);
 
         $itemsData = $this->totalsItemFactory->create();
         $this->dataObjectHelper->populateWithArray(


### PR DESCRIPTION
Do not remove extension attributes when converting the quote Item to dataObject. Otherwise it is not possible to display custom attributes on checkout.