### PR TITLE
Replace the usage of Zend_Json::encode in the setup marketplace tests

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Controller/MarketplaceTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Controller/MarketplaceTest.php
@@ -39,7 +39,7 @@ class MarketplaceTest extends \PHPUnit_Framework_TestCase
         $this->packagesAuth
             ->expects($this->once())
             ->method('checkCredentials')
-            ->will($this->returnValue(\Zend_Json::encode(['success' => true])));
+            ->will($this->returnValue(json_encode(['success' => true])));
         $this->packagesAuth
             ->expects($this->once())
             ->method('saveAuthJson')
@@ -75,7 +75,7 @@ class MarketplaceTest extends \PHPUnit_Framework_TestCase
         $this->packagesAuth
             ->expects($this->once())
             ->method('checkCredentials')
-            ->will($this->returnValue(\Zend_Json::encode(['success' => true])));
+            ->will($this->returnValue(json_encode(['success' => true])));
         $jsonModel = $this->controller->checkAuthAction();
         $this->assertInstanceOf(\Zend\View\Model\ViewModel::class, $jsonModel);
         $variables = $jsonModel->getVariables();


### PR DESCRIPTION
### Description
Replace the usage of Zend_Json::encode in the setup marketplace controller tests. Since Zend_Json is now in EOL

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Running the test case `setup/src/Magento/Setup/Test/Unit/Controller/MarketplaceTest.php` should still be green,

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
