### PR TITLE
Bugfix: Roles resource tree not shown in admin

### DIFF
--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -200,7 +200,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form implements \Magento\Backen
     {
         $resources = $this->_aclResourceProvider->getAclResources();
         $rootArray = $this->_integrationData->mapResources(
-            isset($resources[1]['children']) ? $resources[1]['children'] : []
+            isset($resources[2]['children']) ? $resources[2]['children'] : []
         );
         return $rootArray;
     }


### PR DESCRIPTION
In the admin, the resource tree is not shown on the user role edit/create pages when setting the access mode to custom permissions.

This PR fixes this bug

### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Tested on Magento 2.1.7
2. Installation uses PHP 7.0.17 on nginx and MySQL 5.7.18

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. In de admin, go to System > User Roles > Add new role / edit existing role
2. Go to tab Role Resources
3. Choose for Custom

### Expected result
<!--- Tell us what should happen -->
1. The resource tree should be shown


### Actual result
<!--- Tell us what happens instead -->
1. The resource tree is not shown
![image](https://user-images.githubusercontent.com/6915990/28617828-32ef08dc-7202-11e7-9cc1-f960f70c121d.png)
