### PR TITLE
Remove zend json from package info

### DIFF
--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -64,10 +64,10 @@ class PackageInfo
     private $serializer;
 
     /**
-     * Constructor
-     *
      * @param Dir\Reader $reader
      * @param ComponentRegistrar $componentRegistrar
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         Dir\Reader $reader,

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -59,22 +59,32 @@ class PackageInfo
     protected $nonExistingDependencies = [];
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * Constructor
      *
      * @param Dir\Reader $reader
      * @param ComponentRegistrar $componentRegistrar
      */
-    public function __construct(Dir\Reader $reader, ComponentRegistrar $componentRegistrar)
-    {
+    public function __construct(
+        Dir\Reader $reader,
+        ComponentRegistrar $componentRegistrar,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+    ) {
         $this->reader = $reader;
         $this->componentRegistrar = $componentRegistrar;
+        $this->serializer = $serializer?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
      * Load the packages information
      *
      * @return void
-     * @throws \Zend_Json_Exception
+     * @throws \InvalidArgumentException
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     private function load()
@@ -85,9 +95,9 @@ class PackageInfo
                 $key = $moduleDir . '/composer.json';
                 if (isset($jsonData[$key]) && $jsonData[$key]) {
                     try {
-                        $packageData = \Zend_Json::decode($jsonData[$key]);
-                    } catch (\Zend_Json_Exception $e) {
-                        throw new \Zend_Json_Exception(
+                        $packageData = $this->serializer->unserialize($jsonData[$key]);
+                    } catch (\InvalidArgumentException $e) {
+                        throw new \InvalidArgumentException(
                             sprintf(
                                 "%s composer.json error: %s",
                                 $moduleName,

--- a/lib/internal/Magento/Framework/Module/Test/Unit/PackageInfoTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/PackageInfoTest.php
@@ -54,7 +54,21 @@ class PackageInfoTest extends \PHPUnit_Framework_TestCase
             ->method('getComposerJsonFiles')
             ->will($this->returnValue($fileIteratorMock));
 
-        $this->packageInfo = new PackageInfo($this->reader, $this->componentRegistrar);
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
+            ->getMock();
+
+        $this->serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->willReturnCallback(
+                function ($serializedData) {
+                    return json_decode($serializedData, true);
+                }
+            );
+        $this->packageInfo = new PackageInfo(
+            $this->reader,
+            $this->componentRegistrar,
+            $this->serializerMock
+        );
     }
 
     public function testGetModuleName()


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Replace Zend_Json usage in Framework/Module/PackageInfo.php  …
 - inject the new \Magento\Framework\Serialize\Serializer\Json class,
 - update the load method to use the Serializer,
 - update the load method to catch the InvalidArgumentException exception

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
