### PR TITLE
Remove zend json from migration

### DIFF
--- a/lib/internal/Magento/Framework/Module/Setup/Migration.php
+++ b/lib/internal/Magento/Framework/Module/Setup/Migration.php
@@ -133,6 +133,11 @@ class Migration
     private $setup;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param ModuleDataSetupInterface $setup
      * @param Filesystem $filesystem
      * @param MigrationData $migrationData
@@ -144,7 +149,8 @@ class Migration
         Filesystem $filesystem,
         MigrationData $migrationData,
         $confPathToMapFile,
-        $compositeModules = []
+        $compositeModules = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->_directory = $filesystem->getDirectoryRead(DirectoryList::ROOT);
         $this->_pathToMapFile = $confPathToMapFile;
@@ -155,6 +161,8 @@ class Migration
         ];
         $this->_compositeModules = $compositeModules;
         $this->setup = $setup;
+        $this->serializer = $serializer?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -694,10 +702,12 @@ class Migration
      *
      * @param string $encodedValue
      * @param int $objectDecodeType
-     * @return mixed
+     * @return array|bool|float|int|mixed|null|string
+     * @throws \InvalidArgumentException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function _jsonDecode($encodedValue, $objectDecodeType = \Zend_Json::TYPE_ARRAY)
+    protected function _jsonDecode($encodedValue, $objectDecodeType = 1)
     {
-        return \Zend_Json::decode($encodedValue, $objectDecodeType);
+        return $this->serializer->unserialize($encodedValue);
     }
 }

--- a/lib/internal/Magento/Framework/Module/Setup/Migration.php
+++ b/lib/internal/Magento/Framework/Module/Setup/Migration.php
@@ -143,6 +143,8 @@ class Migration
      * @param MigrationData $migrationData
      * @param string $confPathToMapFile
      * @param array $compositeModules
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         ModuleDataSetupInterface $setup,

--- a/lib/internal/Magento/Framework/Module/Test/Unit/Setup/MigrationTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/Setup/MigrationTest.php
@@ -147,7 +147,9 @@ class MigrationTest extends \PHPUnit_Framework_TestCase
             $setupMock,
             $filesystemMock,
             $migrationData,
-            'app/etc/aliases_to_classes_map.json'
+            'app/etc/aliases_to_classes_map.json',
+            [],
+            $this->getSerializerMock()
         );
 
         $setupModel->appendClassAliasReplace(
@@ -203,7 +205,8 @@ class MigrationTest extends \PHPUnit_Framework_TestCase
             $filesystemMock,
             $migrationData,
             'app/etc/aliases_to_classes_map.json',
-            $this->_getModelDependencies($tableRowsCount, $tableData, $aliasesMap)
+            $this->_getModelDependencies($tableRowsCount, $tableData, $aliasesMap),
+            $this->getSerializerMock()
         );
 
         foreach ($replaceRules as $replaceRule) {
@@ -247,5 +250,24 @@ class MigrationTest extends \PHPUnit_Framework_TestCase
     {
         $mock = $this->getMockBuilder(\Magento\Framework\Filesystem::class)->disableOriginalConstructor()->getMock();
         return $mock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Serialize\Serializer\Json
+     * @throws \PHPUnit_Framework_Exception
+     */
+    private function getSerializerMock()
+    {
+        $serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
+            ->getMock();
+
+        $serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->willReturnCallback(
+                function ($serializedData) {
+                    return json_decode($serializedData, true);
+                }
+            );
+        return $serializerMock;
     }
 }


### PR DESCRIPTION
### Description
Remove the Zend_Json call from the Setup/Migration.php  …
 - inject the new \Magento\Framework\Serialize\Serializer\Json class,
 - update _jsonDecode method parameter default from Zend_Json constant,
 - update _jsonDecode to call the new Serializer method version

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
