### PR TITLE
Remove zend json from json controller

### DIFF
--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxLoad.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxLoad.php
@@ -14,7 +14,8 @@ class AjaxLoad extends \Magento\Tax\Controller\Adminhtml\Rate
     /**
      * Json needed for the Ajax Edit Form
      *
-     * @return void
+     * @return \Magento\Framework\Controller\Result\Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxSave.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxSave.php
@@ -14,6 +14,7 @@ class AjaxSave extends \Magento\Tax\Controller\Adminhtml\Rate
      * Save Tax Rate via AJAX
      *
      * @return \Magento\Framework\Controller\Result\Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -59,7 +59,11 @@ class Json extends AbstractResult
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {
-        $this->json = $this->serializer->serialize($data);
+        if (is_object($data) && method_exists($data, 'toJson')) {
+            $this->json = $data->toJson();
+        } else {
+            $this->json = $this->serializer->serialize($data);
+        }
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -29,11 +29,22 @@ class Json extends AbstractResult
     protected $json;
 
     /**
-     * @param \Magento\Framework\Translate\InlineInterface $translateInline
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
-    public function __construct(InlineInterface $translateInline)
-    {
+    private $serializer;
+
+    /**
+     * @param InlineInterface $translateInline
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
+     */
+    public function __construct(
+        InlineInterface $translateInline,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+    ) {
         $this->translateInline = $translateInline;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -43,10 +54,11 @@ class Json extends AbstractResult
      * @param boolean $cycleCheck Optional; whether or not to check for object recursion; off by default
      * @param array $options Additional options used during encoding
      * @return $this
+     * @throws \InvalidArgumentException
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {
-        $this->json = \Zend_Json::encode($data, $cycleCheck, $options);
+        $this->json = $this->serializer->serialize($data);
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -55,6 +55,7 @@ class Json extends AbstractResult
      * @param array $options Additional options used during encoding
      * @return $this
      * @throws \InvalidArgumentException
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -50,20 +50,45 @@ class Json extends AbstractResult
     /**
      * Set json data
      *
-     * @param mixed $data
-     * @param boolean $cycleCheck Optional; whether or not to check for object recursion; off by default
-     * @param array $options Additional options used during encoding
-     * @return $this
+     * @param array|string|\Magento\Framework\DataObject $data
+     * @param bool $cycleCheck
+     * @param array $options
+     * @return Json
      * @throws \InvalidArgumentException
+     * @throws \Magento\Framework\Exception\LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @deprecated
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {
-        if (is_object($data) && method_exists($data, 'toJson')) {
-            $this->json = $data->toJson();
-        } else {
-            $this->json = $this->serializer->serialize($data);
+        if ($data instanceof \Magento\Framework\DataObject) {
+            return $this->setArrayData($data->toArray());
         }
+
+        if (is_array($data)) {
+            return $this->setArrayData($data);
+        }
+
+        //Should we validate the json here?
+        if (is_string($data)) {
+            return $this->setJsonData($data);
+        }
+
+        throw new \Magento\Framework\Exception\LocalizedException(
+            new \Magento\Framework\Phrase('Invalid argument type')
+        );
+    }
+
+    /**
+     * Should cover this with a test or 2
+     *
+     * @param array $data
+     * @return $this
+     * @throws \InvalidArgumentException
+     */
+    public function setArrayData(array $data)
+    {
+        $this->setJsonData($this->serializer->serialize($data));
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -69,7 +69,6 @@ class Json extends AbstractResult
             return $this->setArrayData($data);
         }
 
-        //Should we validate the json here?
         if (is_string($data)) {
             return $this->setJsonData($data);
         }
@@ -80,8 +79,6 @@ class Json extends AbstractResult
     }
 
     /**
-     * Should cover this with a test or 2
-     *
      * @param array $data
      * @return $this
      * @throws \InvalidArgumentException


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Removing the usage of `Zend_Json` in the Json Controller. Deprecating the method `setData` to encourage the use of the more type specific methods in this class after talking through options with @okorshenko 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
