### PR TITLE
Add missing block name to allow block customisation

### DIFF
--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_onepage_review_item_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_onepage_review_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.onepage.review.item.renderers">
-            <block class="Magento\Bundle\Block\Checkout\Cart\Item\Renderer" as="bundle" template="Magento_Checkout::onepage/review/item.phtml"/>
+            <block class="Magento\Bundle\Block\Checkout\Cart\Item\Renderer" name="checkout.onepage.review.item.renderers.bundle" as="bundle" template="Magento_Checkout::onepage/review/item.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/creditmemo/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.email.order.creditmemo.renderers.bundle" as="bundle" template="Magento_Bundle::email/order/items/creditmemo/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/invoice/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.email.order.invoice.renderers.bundle" as="bundle" template="Magento_Bundle::email/order/items/invoice/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/order/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.email.order.renderers.bundle" as="bundle" template="Magento_Bundle::email/order/items/order/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_shipment_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.shipment.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/shipment/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.email.order.shipment.renderers.bundle" as="bundle" template="Magento_Bundle::email/order/items/shipment/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/creditmemo/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.creditmemo.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/creditmemo/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/invoice/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.invoice.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/invoice/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.items.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/creditmemo/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.print.creditmemo.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/creditmemo/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.invoice.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/invoice/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.print.invoice.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/invoice/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.print.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_shipment_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.shipment.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/shipment/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.print.shipment.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/shipment/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_shipment_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.shipment.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/shipment/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" name="sales.order.shipment.renderers.bundle" as="bundle" template="Magento_Bundle::sales/order/shipment/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_review_item_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_review_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.onepage.review.item.renderers">
-            <block class="Magento\Downloadable\Block\Checkout\Cart\Item\Renderer" as="downloadable" template="Magento_Checkout::onepage/review/item.phtml"/>
+            <block class="Magento\Downloadable\Block\Checkout\Cart\Item\Renderer" name="checkout.onepage.review.item.renderers.downloadable" as="downloadable" template="Magento_Checkout::onepage/review/item.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/creditmemo/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" name="sales.email.order.creditmemo.renderers.downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/creditmemo/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/invoice/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" name="sales.email.order.invoice.renderers.downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/invoice/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/order/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable" name="sales.email.order.renderers.downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/order/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/creditmemo/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" name="sales.order.creditmemo.renderers.downloadable" as="downloadable" template="Magento_Downloadable::sales/order/creditmemo/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/invoice/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" name="sales.order.invoice.renderers.downloadable" as="downloadable" template="Magento_Downloadable::sales/order/invoice/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" name="sales.order.items.renderer.downloadable" as="downloadable" template="Magento_Downloadable::sales/order/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/creditmemo/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" name="sales.order.print.creditmemo.renderers.downloadable" as="downloadable" template="Magento_Downloadable::sales/order/creditmemo/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.invoice.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/invoice/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" name="sales.order.print.invoice.renderers.downloadable" as="downloadable" template="Magento_Downloadable::sales/order/invoice/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" name="sales.order.print.renderers.downloadable" as="downloadable" template="Magento_Downloadable::sales/order/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\GroupedProduct\Block\Cart\Item\Renderer\Grouped" as="grouped" template="Magento_Checkout::cart/item/default.phtml">
+            <block class="Magento\GroupedProduct\Block\Cart\Item\Renderer\Grouped" name="checkout.cart.item.renderers.grouped" as="grouped" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.grouped.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.grouped.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.grouped.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/checkout_onepage_review_item_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/checkout_onepage_review_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.onepage.review.item.renderers">
-            <block class="Magento\GroupedProduct\Block\Cart\Item\Renderer\Grouped" as="grouped" template="Magento_Checkout::onepage/review/item.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Cart\Item\Renderer\Grouped" name="checkout.onepage.review.item.renderers.grouped" as="grouped" template="Magento_Checkout::onepage/review/item.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped" as="grouped" template="Magento_Sales::email/items/creditmemo/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped" name="sales.email.order.creditmemo.renderers.grouped" as="grouped" template="Magento_Sales::email/items/creditmemo/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Invoice Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped" as="grouped" template="Magento_Sales::email/items/invoice/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped" name="sales.email.order.invoice.renderers.grouped" as="grouped" template="Magento_Sales::email/items/invoice/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_email_order_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_email_order_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Order Items List" design_abstraction="custom">
     <body>
         <block name="sales.email.order.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped" as="grouped" template="Magento_Sales::email/items/order/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped" name="sales.email.order.renderers.grouped" as="grouped" template="Magento_Sales::email/items/order/default.phtml"/>
         </block>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="sales.order.creditmemo.renderers.grouped" as="grouped" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="sales.order.invoice.renderers.grouped" as="grouped" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="sales.order.items.renderers.grouped" as="grouped" template="Magento_Sales::order/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="sales.order.print.creditmemo.renderers.grouped" as="grouped" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.order.print.invoice.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="checkout.order.print.invoice.renderers.grouped" as="grouped" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="sales.order.print.renderers.grouped" as="grouped" template="Magento_Sales::order/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="Magento_Sales::email/items/creditmemo/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" name="sales.email.order.creditmemo.renderers.default" as="default" template="Magento_Sales::email/items/creditmemo/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="Magento_Sales::email/items/invoice/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" name="sales.email.order.invoice.renderers.default" as="default" template="Magento_Sales::email/items/invoice/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.shipment.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="Magento_Sales::email/items/shipment/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" name="sales.email.order.shipment.renderers.default" as="default" template="Magento_Sales::email/items/shipment/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.creditmemo.renderers.default" as="default" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.invoice.renderers.default" as="default" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.items.renderers.default" as="default" template="Magento_Sales::order/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.print.creditmemo.renderers.default" as="default" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.invoice.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.print.invoice.renderers.default" as="default" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.print.renderers.default" as="default" template="Magento_Sales::order/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_shipment_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.shipment.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/shipment/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.print.shipment.renderers.default" as="default" template="Magento_Sales::order/shipment/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.shipment.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/shipment/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="sales.order.shipment.renderers.default" as="default" template="Magento_Sales::order/shipment/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
### Description
Add ability to customize order renderers

### Related Issues (if relevant)
1. https://github.com/magento/magento2/pull/10352: Add missing block name to allow block customisation

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
