### PR TITLE
Remove zend json from framework json classes

### DIFF
--- a/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/CustomerComposite/DataTest.php
+++ b/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/CustomerComposite/DataTest.php
@@ -100,16 +100,19 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
         $resource = $dependencies['resource'];
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $jsonDecoderMock = $this->getMockBuilder(\Magento\Framework\Json\DecoderInterface::class)
-            ->disableOriginalConstructor()
+        $serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
             ->getMock();
-        $jsonDecoderMock->expects($this->once())
-            ->method('decode')
-            ->willReturn(json_decode($bunchData, true));
+        $serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->willReturnCallback(
+                function ($serializedData) {
+                    return json_decode($serializedData, true);
+                }
+            );
         $jsonHelper = $helper->getObject(
             \Magento\Framework\Json\Helper\Data::class,
             [
-                'jsonDecoder' => $jsonDecoderMock,
+                'serializer' => $serializerMock,
             ]
         );
         unset($dependencies['resource'], $dependencies['json_helper']);

--- a/lib/internal/Magento/Framework/Json/Decoder.php
+++ b/lib/internal/Magento/Framework/Json/Decoder.php
@@ -11,13 +11,29 @@ namespace Magento\Framework\Json;
 class Decoder implements DecoderInterface
 {
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
+     */
+    public function __construct(\Magento\Framework\Serialize\Serializer\Json $serializer = null)
+    {
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+    }
+
+    /**
      * Decodes the given $data string which is encoded in the JSON format.
      *
      * @param string $data
-     * @return mixed
+     * @return array|bool|float|int|mixed|null|string
+     * @throws \InvalidArgumentException
      */
     public function decode($data)
     {
-        return \Zend_Json::decode($data);
+        return $this->serializer->unserialize($data);
     }
 }

--- a/lib/internal/Magento/Framework/Json/Encoder.php
+++ b/lib/internal/Magento/Framework/Json/Encoder.php
@@ -18,22 +18,34 @@ class Encoder implements EncoderInterface
     protected $translateInline;
 
     /**
-     * @param \Magento\Framework\Translate\InlineInterface $translateInline
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
-    public function __construct(\Magento\Framework\Translate\InlineInterface $translateInline)
-    {
+    private $serializer;
+
+    /**
+     * @param \Magento\Framework\Translate\InlineInterface $translateInline
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
+     */
+    public function __construct(
+        \Magento\Framework\Translate\InlineInterface $translateInline,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+    ) {
         $this->translateInline = $translateInline;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
      * Encode the mixed $data into the JSON format.
      *
      * @param mixed $data
-     * @return string
+     * @return bool|string
+     * @throws \InvalidArgumentException
      */
     public function encode($data)
     {
         $this->translateInline->processResponseBody($data);
-        return \Zend_Json::encode($data);
+        return $this->serializer->serialize($data);
     }
 }

--- a/lib/internal/Magento/Framework/Json/Helper/Data.php
+++ b/lib/internal/Magento/Framework/Json/Helper/Data.php
@@ -23,29 +23,40 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $jsonEncoder;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\App\Helper\Context $context
      * @param \Magento\Framework\Json\DecoderInterface $jsonDecoder
      * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
         \Magento\Framework\Json\DecoderInterface $jsonDecoder,
-        \Magento\Framework\Json\EncoderInterface $jsonEncoder
+        \Magento\Framework\Json\EncoderInterface $jsonEncoder,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         parent::__construct($context);
         $this->jsonDecoder = $jsonDecoder;
         $this->jsonEncoder = $jsonEncoder;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
      * Encode the mixed $valueToEncode into the JSON format
      *
      * @param mixed $valueToEncode
-     * @return string
+     * @return bool|string
+     * @throws \InvalidArgumentException
      */
     public function jsonEncode($valueToEncode)
     {
-        return $this->jsonEncoder->encode($valueToEncode);
+        return $this->serializer->serialize($valueToEncode);
     }
 
     /**
@@ -53,10 +64,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * encoded in the JSON format
      *
      * @param string $encodedValue
-     * @return mixed
+     * @return array|bool|float|int|mixed|null|string
+     * @throws \InvalidArgumentException
      */
     public function jsonDecode($encodedValue)
     {
-        return $this->jsonDecoder->decode($encodedValue);
+        return $this->serializer->unserialize($encodedValue);
     }
 }

--- a/lib/internal/Magento/Framework/Json/Helper/Data.php
+++ b/lib/internal/Magento/Framework/Json/Helper/Data.php
@@ -14,11 +14,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
     /**
      * @var \Magento\Framework\Json\DecoderInterface
+     * @deprecated
      */
     protected $jsonDecoder;
 
     /**
      * @var \Magento\Framework\Json\EncoderInterface
+     * @deprecated
      */
     protected $jsonEncoder;
 

--- a/lib/internal/Magento/Framework/Json/Test/Unit/Helper/DataTest.php
+++ b/lib/internal/Magento/Framework/Json/Test/Unit/Helper/DataTest.php
@@ -18,6 +18,8 @@ class DataTest extends \PHPUnit_Framework_TestCase
     /** @var \Magento\Framework\Json\DecoderInterface | \PHPUnit_Framework_MockObject_MockObject  */
     protected $jsonDecoderMock;
 
+    private $serializerMock;
+
     protected function setUp()
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -27,32 +29,80 @@ class DataTest extends \PHPUnit_Framework_TestCase
         $this->jsonDecoderMock = $this->getMockBuilder(\Magento\Framework\Json\DecoderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
+            ->getMock();
+        $this->serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->willReturnCallback(
+                function ($serializedData) {
+                    return json_decode($serializedData, true);
+                }
+            );
+        $this->serializerMock->expects($this->any())
+            ->method('serialize')
+            ->willReturnCallback(
+                function ($serializedData) {
+                    return json_encode($serializedData);
+                }
+            );
         $this->helper = $objectManager->getObject(
             \Magento\Framework\Json\Helper\Data::class,
             [
                 'jsonEncoder' => $this->jsonEncoderMock,
                 'jsonDecoder' => $this->jsonDecoderMock,
+                'serializer' => $this->serializerMock
             ]
         );
     }
 
-    public function testJsonEncode()
+    /**
+     * @param string $value
+     * @param string|int|float|bool|array|null $expected
+     * @throws \InvalidArgumentException
+     * @dataProvider getJsonEncodeDataProvider
+     */
+    public function testJsonEncode($value, $expected)
     {
-        $expected = '"valueToEncode"';
-        $valueToEncode = 'valueToEncode';
-        $this->jsonEncoderMock->expects($this->once())
-            ->method('encode')
-            ->willReturn($expected);
-        $this->assertEquals($expected, $this->helper->jsonEncode($valueToEncode));
+        $this->assertEquals($expected, $this->helper->jsonEncode($value));
     }
 
-    public function testJsonDecode()
+    public function getJsonEncodeDataProvider()
     {
-        $expected = '"valueToDecode"';
-        $valueToDecode = 'valueToDecode';
-        $this->jsonDecoderMock->expects($this->once())
-            ->method('decode')
-            ->willReturn($expected);
-        $this->assertEquals($expected, $this->helper->jsonDecode($valueToDecode));
+        return [
+            ['', '""'],
+            ['string', '"string"'],
+            [null, 'null'],
+            [false, 'false'],
+            [['a' => 'b', 'd' => 123], '{"a":"b","d":123}'],
+            [123, '123'],
+            [10.56, '10.56'],
+            [new \stdClass(), '{}'],
+        ];
+    }
+
+    /**
+     * @param string $value
+     * @param string|int|float|bool|array|null $expected
+     * @throws \InvalidArgumentException
+     * @dataProvider getJsonDecodeDataProvider
+     */
+    public function testJsonDecode($value, $expected)
+    {
+        $this->assertEquals($expected, $this->helper->jsonDecode($value));
+    }
+
+    public function getJsonDecodeDataProvider()
+    {
+        return [
+            ['""', ''],
+            ['"string"', 'string'],
+            ['null', null],
+            ['false', false],
+            ['{"a":"b","d":123}', ['a' => 'b', 'd' => 123]],
+            ['123', 123],
+            ['10.56', 10.56],
+            ['{}', []],
+        ];
     }
 }

--- a/lib/internal/Magento/Framework/Json/Test/Unit/Helper/DataTest.php
+++ b/lib/internal/Magento/Framework/Json/Test/Unit/Helper/DataTest.php
@@ -18,6 +18,9 @@ class DataTest extends \PHPUnit_Framework_TestCase
     /** @var \Magento\Framework\Json\DecoderInterface | \PHPUnit_Framework_MockObject_MockObject  */
     protected $jsonDecoderMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Serialize\Serializer\Json
+     */
     private $serializerMock;
 
     protected function setUp()


### PR DESCRIPTION
### Description
I updated the encoder and decoder classes to use the new serializer class for the case that someone other class is using these directly.
I updated the json helper to stop using the encoder and decoder but instead going directly to the serializer class with half an eye on the removal of the encoder and decoder I thought this was a good option compared to simply updating the encoder and decoder classes.
Fix the import customer composite data test to work with the new serializer.

I was tempted to go through and replace the usage of these classes but I thought that can wait as that is a much bigger change.

I was a bit worried that this change only broke 1 other test class, but still.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
