### PR TITLE
Feature/variable helper

### DIFF
--- a/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
+++ b/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
@@ -32,6 +32,15 @@ interface BlockRepositoryInterface
     public function getById($blockId);
 
     /**
+     * Load Block data by given Block identifier
+     *
+     * @param string $blockIdentifier
+     * @return Block
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getByIdentifier($blockIdentifier);
+
+    /**
      * Retrieve blocks matching the specified criteria.
      *
      * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria

--- a/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
+++ b/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
@@ -35,10 +35,11 @@ interface BlockRepositoryInterface
      * Load Block data by given Block identifier
      *
      * @param string $blockIdentifier
-     * @return Block
+     * @param int $storeId
+     * @return \Magento\Cms\Api\Data\BlockInterface
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getByIdentifier($blockIdentifier);
+    public function getByIdentifier($blockIdentifier, $storeId);
 
     /**
      * Retrieve blocks matching the specified criteria.

--- a/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
+++ b/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
@@ -32,16 +32,6 @@ interface BlockRepositoryInterface
     public function getById($blockId);
 
     /**
-     * Load Block data by given Block identifier
-     *
-     * @param string $blockIdentifier
-     * @param int $storeId
-     * @return \Magento\Cms\Api\Data\BlockInterface
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     */
-    public function getByIdentifier($blockIdentifier, $storeId);
-
-    /**
      * Retrieve blocks matching the specified criteria.
      *
      * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -16,6 +16,7 @@ use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Cms\Model\ResourceModel\Block as ResourceBlock;
 use Magento\Cms\Model\ResourceModel\Block\CollectionFactory as BlockCollectionFactory;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Cms\Api\Data\BlockInterface;
 
 /**
  * Class BlockRepository
@@ -134,6 +135,24 @@ class BlockRepository implements BlockRepositoryInterface
         if (!$block->getId()) {
             throw new NoSuchEntityException(__('CMS Block with id "%1" does not exist.', $blockId));
         }
+        return $block;
+    }
+
+    /**
+     * Load Block data by given Block identifier
+     *
+     * @param string $blockIdentifier
+     * @return Block
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getByIdentifier($blockIdentifier)
+    {
+        $block = $this->blockFactory->create();
+        $this->resource->load($block, $blockIdentifier, BlockInterface::IDENTIFIER);
+        if (!$block->getId()) {
+            throw new NoSuchEntityException(__('CMS Block with identifier "%1" does not exist.', $blockIdentifier));
+        }
+
         return $block;
     }
 

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -17,6 +17,7 @@ use Magento\Cms\Model\ResourceModel\Block as ResourceBlock;
 use Magento\Cms\Model\ResourceModel\Block\CollectionFactory as BlockCollectionFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Cms\Api\Data\BlockInterface;
+use Magento\Store\Model\Store;
 
 /**
  * Class BlockRepository
@@ -142,18 +143,22 @@ class BlockRepository implements BlockRepositoryInterface
      * Load Block data by given Block identifier
      *
      * @param string $blockIdentifier
+     * @param int $storeId
      * @return Block
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getByIdentifier($blockIdentifier)
+    public function getByIdentifier($blockIdentifier, $storeId = null)
     {
-        $block = $this->blockFactory->create();
-        $this->resource->load($block, $blockIdentifier, BlockInterface::IDENTIFIER);
-        if (!$block->getId()) {
-            throw new NoSuchEntityException(__('CMS Block with identifier "%1" does not exist.', $blockIdentifier));
+        $storeIdentifier = $storeId === null ? Store::DEFAULT_STORE_ID : $storeId;
+        $result = $this->resource->getByIdentifier($blockIdentifier, $storeIdentifier);
+
+        if(empty($result)) {
+            throw new NoSuchEntityException(
+                __('CMS Block with identifier "%1" and store id "%2" does not exist.', $blockIdentifier, $storeId)
+            );
         }
 
-        return $block;
+        return $this->blockFactory->create()->setData($result);
     }
 
     /**

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -152,7 +152,7 @@ class BlockRepository implements BlockRepositoryInterface
         $storeIdentifier = $storeId === null ? Store::DEFAULT_STORE_ID : $storeId;
         $result = $this->resource->getByIdentifier($blockIdentifier, $storeIdentifier);
 
-        if(empty($result)) {
+        if (empty($result)) {
             throw new NoSuchEntityException(
                 __('CMS Block with identifier "%1" and store id "%2" does not exist.', $blockIdentifier, $storeId)
             );

--- a/app/code/Magento/Cms/Model/ResourceModel/Block.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block.php
@@ -254,4 +254,26 @@ class Block extends AbstractDb
         $this->entityManager->delete($object);
         return $this;
     }
+
+    /**
+     * Return the block data linked the given id and store id
+     *
+     * @param string $identifier is the block identifier
+     * @param int $storeId is the store id
+     * @return array
+     */
+    public function getByIdentifier($identifier, $storeId)
+    {
+        $select = parent::_getLoadSelect(BlockInterface::IDENTIFIER, $identifier, BlockInterface::class);
+
+        $select->join(
+            ['cbs' => $this->getTable('cms_block_store')],
+            $this->getMainTable() . '.' . BlockInterface::BLOCK_ID . ' = cbs.' . BlockInterface::BLOCK_ID,
+            ['store_id']
+        )
+            ->where('cbs.store_id = (?)', $storeId)
+            ->limit(1);
+
+        return $this->getConnection()->fetchRow($select);
+    }
 }

--- a/app/code/Magento/Cms/Test/Unit/Model/BlockRepositoryTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/BlockRepositoryTest.php
@@ -219,6 +219,24 @@ class BlockRepositoryTest extends \PHPUnit_Framework_TestCase
      *
      * @expectedException \Magento\Framework\Exception\NoSuchEntityException
      */
+    public function testGetByIdentifierException()
+    {
+        $blockIdentifier = "test";
+        $storeId = 0;
+
+        $this->blockResource->expects($this->once())
+            ->method('getByIdentifier')
+            ->with($blockIdentifier, $storeId)
+            ->willReturn(null);
+
+        $this->repository->getByIdentifier($blockIdentifier, $storeId);
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
+     */
     public function testGetByIdException()
     {
         $blockId = '123';

--- a/app/code/Magento/Variable/Helper/Variable.php
+++ b/app/code/Magento/Variable/Helper/Variable.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Variable\Helper;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Variable\Model\Variable as VariableModel;
+
+class Variable
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @var \Magento\Variable\Model\Variable
+     */
+    protected $variableModel;
+
+    /**
+     * VariableHelper constructor.
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Variable\Model\Variable $variableModel
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        VariableModel $variableModel
+    ) {
+        $this->storeManager = $storeManager;
+        $this->variableModel = $variableModel;
+    }
+
+    /**
+     * Check if the given store (or the current one) has the given
+     * variable set with the given text value
+     *
+     * @param string $variableCode
+     * @param string $expectedValue
+     * @param string $type
+     * @param int $storeId
+     *
+     * @return boolean
+     */
+    public function customVariableHasValue(
+        $variableCode,
+        $expectedValue,
+        $type = VariableModel::TYPE_TEXT,
+        $storeId = null
+    ) {
+        $status = false;
+
+        if ($storeId === null) {
+            $storeId = $this->storeManager->getStore()->getId();
+        }
+
+        $this->variableModel
+            ->setStoreId($storeId)
+            ->loadByCode($variableCode);
+
+        $value = $this->variableModel->getValue($type);
+
+        if ($value && $value === (string) $expectedValue) {
+            $status = true;
+        }
+
+        return $status;
+    }
+}


### PR DESCRIPTION
Add a Variable Helper

### Description
In the module Magento/Variable, add a Helper to store various methods which could be needed by
developers. One method is currently given : _customVariableHasValue()_.

This method return a boolean. It checks if a given variable exists and contain the expected value.
It is possible to be more accurate: the type of content (HTML or full text) and to give a store.

### Manual testing scenarios
Quick test example.
In the back-office, go to System->Custom Variables. Create a new variable named 'foo' and set the full
text value to '2'.

Test your variable in a controller:

>         $variableModel = $this->_objectManager->get('Magento\Variable\Helper\Variable');
>         if ($variableModel->customVariableHasValue('foo', '2')) {
>             echo 'OK';
>         } else {
>             echo 'fail';
>         }

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
