### PR TITLE
Added a custom variable helper

### DIFF
--- a/app/code/Magento/Variable/Helper/Variable.php
+++ b/app/code/Magento/Variable/Helper/Variable.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Variable\Helper;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Variable\Model\Variable as VariableModel;
+
+class Variable
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @var \Magento\Variable\Model\Variable
+     */
+    protected $variableModel;
+
+    /**
+     * VariableHelper constructor.
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Variable\Model\Variable $variableModel
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        VariableModel $variableModel
+    ) {
+        $this->storeManager = $storeManager;
+        $this->variableModel = $variableModel;
+    }
+
+    /**
+     * Check if the given store (or the current one) has the given
+     * variable set with the given text value
+     *
+     * @param string $variableCode
+     * @param string $expectedValue
+     * @param string $type
+     * @param int $storeId
+     *
+     * @return boolean
+     */
+    public function customVariableHasValue(
+        $variableCode,
+        $expectedValue,
+        $type = VariableModel::TYPE_TEXT,
+        $storeId = null
+    ) {
+        $status = false;
+
+        if ($storeId === null) {
+            $storeId = $this->storeManager->getStore()->getId();
+        }
+
+        $this->variableModel
+            ->setStoreId($storeId)
+            ->loadByCode($variableCode);
+
+        $value = $this->variableModel->getValue($type);
+
+        if ($value && $value === (string) $expectedValue) {
+            $status = true;
+        }
+
+        return $status;
+    }
+}


### PR DESCRIPTION
Add a Variable Helper

### Description
In the module Magento/Variable, add a Helper to store various methods which could be needed by
developers. One method is currently given : _customVariableHasValue()_.

This method return a boolean. It checks if a given variable exists and contain the expected value.
It is possible to be more accurate: the type of content (HTML or full text) and to give a store.

### Manual testing scenarios
Quick test example.
In the back-office, go to System->Custom Variables. Create a new variable named 'foo' and set the full
text value to '2'.

Test your variable in a controller:

>         $variableModel = $this->_objectManager->get('Magento\Variable\Helper\Variable');
>         if ($variableModel->customVariableHasValue('foo', '2')) {
>             echo 'OK';
>         } else {
>             echo 'fail';
>         }

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
