### PR TITLE
Change Customers tab label to Best Customers, on dashboard

### DIFF
--- a/app/code/Magento/Backend/Block/Dashboard/Grids.php
+++ b/app/code/Magento/Backend/Block/Dashboard/Grids.php
@@ -77,7 +77,7 @@ class Grids extends \Magento\Backend\Block\Widget\Tabs
         $this->addTab(
             'customers',
             [
-                'label' => __('Customers'),
+                'label' => __('Best Customers'),
                 'url' => $this->getUrl('adminhtml/*/customersMost', ['_current' => true]),
                 'class' => 'ajax'
             ]


### PR DESCRIPTION
On the admin Dashboard below the sales chart, I think that the 4th tab according to its content "Best Customers" is more relevance label as "Customers".

Renaming this label also give us the ability for better and more relevance translation, as the "Customers" string used a lot in Magento code.