### PR TITLE
Translate order getCreatedAtFormatted() to store locale

### DIFF
--- a/app/code/Magento/Braintree/Model/LocaleResolver.php
+++ b/app/code/Magento/Braintree/Model/LocaleResolver.php
@@ -49,9 +49,9 @@ class LocaleResolver implements ResolverInterface
     /**
      * @inheritdoc
      */
-    public function getDefaultLocale()
+    public function getDefaultLocale($store = null)
     {
-        return $this->resolver->getDefaultLocale();
+        return $this->resolver->getDefaultLocale($store);
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -7,6 +7,8 @@ namespace Magento\Sales\Model;
 
 use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\AttributeValueFactory;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderStatusHistoryInterface;
@@ -269,6 +271,11 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     protected $timezone;
 
     /**
+     * @var ResolverInterface
+     */
+    protected $localeResolver;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -296,6 +303,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
+     * @param ResolverInterface $localeResolver
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -325,7 +333,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productListFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        ResolverInterface $localeResolver = null
     ) {
         $this->_storeManager = $storeManager;
         $this->_orderConfig = $orderConfig;
@@ -347,6 +356,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         $this->_trackCollectionFactory = $trackCollectionFactory;
         $this->salesOrderCollectionFactory = $salesOrderCollectionFactory;
         $this->priceCurrency = $priceCurrency;
+        $this->localeResolver = $localeResolver ?: ObjectManager::getInstance()->get(ResolverInterface::class);
+
         parent::__construct(
             $context,
             $registry,
@@ -1831,7 +1842,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             new \DateTime($this->getCreatedAt()),
             $format,
             $format,
-            null,
+            $this->localeResolver->getDefaultLocale($this->getStore()),
             $this->timezone->getConfigTimezone('store', $this->getStore())
         );
     }

--- a/lib/internal/Magento/Framework/Locale/Resolver.php
+++ b/lib/internal/Magento/Framework/Locale/Resolver.php
@@ -85,10 +85,10 @@ class Resolver implements ResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getDefaultLocale()
+    public function getDefaultLocale($store = null)
     {
         if (!$this->defaultLocale) {
-            $locale = $this->scopeConfig->getValue($this->getDefaultLocalePath(), $this->scopeType);
+            $locale = $this->scopeConfig->getValue($this->getDefaultLocalePath(), $this->scopeType, $store);
             if (!$locale) {
                 $locale = self::DEFAULT_LOCALE;
             }

--- a/lib/internal/Magento/Framework/Locale/ResolverInterface.php
+++ b/lib/internal/Magento/Framework/Locale/ResolverInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\Locale;
 
+use Magento\Store\Api\Data\StoreInterface;
+
 /**
  * Manages locale config information
  *
@@ -30,9 +32,11 @@ interface ResolverInterface
     /**
      * Retrieve default locale code
      *
+     * @param bool|int|null|string|StoreInterface $store
+     *
      * @return string
      */
-    public function getDefaultLocale();
+    public function getDefaultLocale($store = null);
 
     /**
      * Set locale


### PR DESCRIPTION
### Description
Extend `getDefaultLocale()` to allow fetching scoped values. Use this in `getCreatedAtFormatted()` so `created_at` date of order will be translated in emails to locale being used in that store view.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Set default locale of your store to any language but English.
2. Create order and send confirmation email.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
