### PR TITLE
#10402 fix theme templates overrides in environment emulation cross-area

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -148,7 +148,7 @@ class Repository
 
         if ($themeId) {
             $params['themeModel'] = $this->getThemeProvider()->getThemeById($themeId);
-            if (!$params['themeModel']) {
+            if (!$params['themeModel'] || $params['themeModel']->getArea() != $area) {
                 throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
             }
         } elseif ($themePath) {

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -142,7 +142,7 @@ class Repository
             $params['themeModel'] = $this->getThemeByPath($params['theme'], $area);
         } elseif (empty($params['themeModel']) && $area !== $this->getDefaultParameter('area')) {
             $themeId = $this->design->getConfigurationDesignTheme($area);
-            $params['themeModel'] = $this->getThemeById($themeId, $area);
+            $params['themeModel'] = $this->getTheme($themeId, $area);
         }
 
         if (empty($params['themeModel'])) {
@@ -159,6 +159,22 @@ class Repository
             $params['locale'] = $this->getDefaultParameter('locale');
         }
         return $this;
+    }
+
+    /**
+     * Get theme either by id or path based on whether the passed $theme is a numeric value or not
+     *
+     * @param string|int $theme
+     * @param $area
+     * @return \Magento\Framework\View\Design\ThemeInterface
+     */
+    private function getTheme($theme, $area)
+    {
+        if (is_numeric($theme)) {
+            return $this->getThemeById($theme, $area);
+        }
+
+        return $this->getThemeByPath($theme, $area);
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -135,28 +135,28 @@ class Repository
         }
 
         // Set themeModel
-        $themeId = null;
-        $themePath = null;
         $area = $params['area'];
         if (!empty($params['themeId'])) {
             $themeId = $params['themeId'];
-        } elseif (isset($params['theme'])) {
-            $themePath = $params['theme'];
-        } elseif (empty($params['themeModel']) && $area !== $this->getDefaultParameter('area')) {
-            $themeId = $this->design->getConfigurationDesignTheme($area);
-        }
-
-        if ($themeId) {
             $params['themeModel'] = $this->getThemeProvider()->getThemeById($themeId);
             if (!$params['themeModel'] || $params['themeModel']->getArea() != $area) {
                 throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
             }
-        } elseif ($themePath) {
+        } elseif (isset($params['theme'])) {
+            $themePath = $params['theme'];
             $params['themeModel'] = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $themePath);
             if (!$params['themeModel']) {
                 throw new \UnexpectedValueException("Could not find theme '$themePath' for area '$area'");
             }
-        } elseif (empty($params['themeModel'])) {
+        } elseif (empty($params['themeModel']) && $area !== $this->getDefaultParameter('area')) {
+            $themeId = $this->design->getConfigurationDesignTheme($area);
+            $params['themeModel'] = $this->getThemeProvider()->getThemeById($themeId);
+            if (!$params['themeModel'] || $params['themeModel']->getArea() != $area) {
+                throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
+            }
+        }
+
+        if (empty($params['themeModel'])) {
             $params['themeModel'] = $this->getDefaultParameter('themeModel');
         }
 

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -146,7 +146,7 @@ class Repository
         }
 
         if ($theme) {
-            $params['themeModel'] = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $theme);
+            $params['themeModel'] = $this->getThemeProvider()->getThemeById($theme);
             if (!$params['themeModel']) {
                 throw new \UnexpectedValueException("Could not find theme '$theme' for area '$area'");
             }

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -135,20 +135,26 @@ class Repository
         }
 
         // Set themeModel
-        $theme = null;
+        $themeId = null;
+        $themePath = null;
         $area = $params['area'];
         if (!empty($params['themeId'])) {
-            $theme = $params['themeId'];
+            $themeId = $params['themeId'];
         } elseif (isset($params['theme'])) {
-            $theme = $params['theme'];
+            $themePath = $params['theme'];
         } elseif (empty($params['themeModel']) && $area !== $this->getDefaultParameter('area')) {
-            $theme = $this->design->getConfigurationDesignTheme($area);
+            $themeId = $this->design->getConfigurationDesignTheme($area);
         }
 
-        if ($theme) {
-            $params['themeModel'] = $this->getThemeProvider()->getThemeById($theme);
+        if ($themeId) {
+            $params['themeModel'] = $this->getThemeProvider()->getThemeById($themeId);
             if (!$params['themeModel']) {
-                throw new \UnexpectedValueException("Could not find theme '$theme' for area '$area'");
+                throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
+            }
+        } elseif ($themePath) {
+            $params['themeModel'] = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $themePath);
+            if (!$params['themeModel']) {
+                throw new \UnexpectedValueException("Could not find theme '$themePath' for area '$area'");
             }
         } elseif (empty($params['themeModel'])) {
             $params['themeModel'] = $this->getDefaultParameter('themeModel');

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -137,23 +137,12 @@ class Repository
         // Set themeModel
         $area = $params['area'];
         if (!empty($params['themeId'])) {
-            $themeId = $params['themeId'];
-            $params['themeModel'] = $this->getThemeProvider()->getThemeById($themeId);
-            if (!$params['themeModel'] || $params['themeModel']->getArea() != $area) {
-                throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
-            }
+            $params['themeModel'] = $this->getThemeById($params['themeId'], $area);
         } elseif (isset($params['theme'])) {
-            $themePath = $params['theme'];
-            $params['themeModel'] = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $themePath);
-            if (!$params['themeModel']) {
-                throw new \UnexpectedValueException("Could not find theme '$themePath' for area '$area'");
-            }
+            $params['themeModel'] = $this->getThemeByPath($params['theme'], $area);
         } elseif (empty($params['themeModel']) && $area !== $this->getDefaultParameter('area')) {
             $themeId = $this->design->getConfigurationDesignTheme($area);
-            $params['themeModel'] = $this->getThemeProvider()->getThemeById($themeId);
-            if (!$params['themeModel'] || $params['themeModel']->getArea() != $area) {
-                throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
-            }
+            $params['themeModel'] = $this->getThemeById($themeId, $area);
         }
 
         if (empty($params['themeModel'])) {
@@ -170,6 +159,36 @@ class Repository
             $params['locale'] = $this->getDefaultParameter('locale');
         }
         return $this;
+    }
+
+    /**
+     * @param string $themePath
+     * @param string $area
+     * @return \Magento\Framework\View\Design\ThemeInterface
+     * @throws \UnexpectedValueException
+     */
+    private function getThemeByPath($themePath, $area)
+    {
+        $themeModel = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $themePath);
+        if (!$themeModel) {
+            throw new \UnexpectedValueException("Could not find theme '$themePath' for area '$area'");
+        }
+        return $themeModel;
+    }
+
+    /**
+     * @param string $themeId
+     * @param string $area
+     * @return \Magento\Framework\View\Design\ThemeInterface
+     * @throws \UnexpectedValueException
+     */
+    private function getThemeById($themeId, $area)
+    {
+        $themeModel = $this->getThemeProvider()->getThemeById($themeId);
+        if (!$themeModel || $themeModel->getArea() != $area) {
+            throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
+        }
+        return $themeModel;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -124,8 +124,6 @@ class Repository
      * @param array &$params
      * @throws \UnexpectedValueException
      * @return $this
-     *
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function updateDesignParams(array &$params)
     {
@@ -135,19 +133,18 @@ class Repository
         }
 
         // Set themeModel
+        $themeModel = null;
         $area = $params['area'];
         if (!empty($params['themeId'])) {
-            $params['themeModel'] = $this->getThemeById($params['themeId'], $area);
+            $themeModel = $this->getThemeById($params['themeId'], $area);
         } elseif (isset($params['theme'])) {
-            $params['themeModel'] = $this->getThemeByPath($params['theme'], $area);
+            $themeModel = $this->getThemeByPath($params['theme'], $area);
         } elseif (empty($params['themeModel']) && $area !== $this->getDefaultParameter('area')) {
             $themeId = $this->design->getConfigurationDesignTheme($area);
-            $params['themeModel'] = $this->getTheme($themeId, $area);
+            $themeModel = $this->getTheme($themeId, $area);
         }
 
-        if (empty($params['themeModel'])) {
-            $params['themeModel'] = $this->getDefaultParameter('themeModel');
-        }
+        $params['themeModel'] = $themeModel ?: $this->getDefaultParameter('themeModel');
 
         // Set module
         if (!array_key_exists('module', $params)) {
@@ -187,13 +184,13 @@ class Repository
     {
         $themeModel = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $themePath);
         if (!$themeModel) {
-            throw new \UnexpectedValueException("Could not find theme '$themePath' for area '$area'");
+            throw new \UnexpectedValueException("Could not find theme by full path '$themePath' for area '$area'");
         }
         return $themeModel;
     }
 
     /**
-     * @param string $themeId
+     * @param int $themeId
      * @param string $area
      * @return \Magento\Framework\View\Design\ThemeInterface
      * @throws \UnexpectedValueException
@@ -202,7 +199,7 @@ class Repository
     {
         $themeModel = $this->getThemeProvider()->getThemeById($themeId);
         if (!$themeModel || $themeModel->getArea() != $area) {
-            throw new \UnexpectedValueException("Could not find theme '$themeId' for area '$area'");
+            throw new \UnexpectedValueException("Could not find theme by id '$themeId' for area '$area'");
         }
         return $themeModel;
     }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -163,7 +163,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $params = ['themeId' => 'ThemeID'];
 
-        $themeMock = $this->getMock('Magento\Framework\View\Design\ThemeInterface');
+        $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
 
         $this->themeProvider
             ->expects($this->any())
@@ -188,7 +188,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $params = ['theme' => 'ThemePath'];
 
-        $themeMock = $this->getMock('Magento\Framework\View\Design\ThemeInterface');
+        $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
 
         $this->themeProvider
             ->expects($this->never())
@@ -229,7 +229,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
             ->method('getConfigurationDesignTheme')
             ->willReturn('ThemeID');
 
-        $themeMock = $this->getMock('Magento\Framework\View\Design\ThemeInterface');
+        $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
 
         $this->themeProvider
             ->expects($this->any())
@@ -255,7 +255,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $params = ['area' => 'frontend'];
 
-        $themeMock = $this->getMock('Magento\Framework\View\Design\ThemeInterface');
+        $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
 
         $this->designMock
             ->expects($this->any())

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -230,6 +230,9 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('ThemeID');
 
         $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
+        $themeMock->expects($this->any())
+            ->method('getArea')
+            ->willReturn('frontend');
 
         $this->themeProvider
             ->expects($this->any())
@@ -246,6 +249,47 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
             $params
         );
         $this->assertSame($themeMock, $params['themeModel']);
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Could not find theme 'ThemeID' for area 'frontend'
+     * @return void
+     */
+    public function testUpdateDesignParamsCrossAreaWithoutSuitableTheme()
+    {
+        $params = ['area' => 'frontend'];
+
+        $this->designMock
+            ->expects($this->any())
+            ->method('getDesignParams')
+            ->willReturn(
+                [
+                    'themeModel' => '',
+                    'area' => 'adminhtml',
+                    'locale' => ''
+                ]
+            );
+        $this->designMock
+            ->expects($this->any())
+            ->method('getConfigurationDesignTheme')
+            ->willReturn('ThemeID');
+
+        $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
+        $themeMock->expects($this->any())
+            ->method('getArea')
+            ->willReturn('adminhtml');
+
+        $this->themeProvider
+            ->expects($this->any())
+            ->method('getThemeById')
+            ->with('ThemeID')
+            ->willReturn($themeMock);
+        $this->themeProvider
+            ->expects($this->never())
+            ->method('getThemeByFullPath');
+
+        $this->repository->updateDesignParams($params);
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -143,7 +143,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Could not find theme 'nonexistent_theme' for area 'area'
+     * @expectedExceptionMessage Could not find theme by full path 'nonexistent_theme' for area 'area'
      * @return void
      */
     public function testUpdateDesignParamsWrongTheme()
@@ -271,7 +271,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->designMock
             ->expects($this->any())
             ->method('getConfigurationDesignTheme')
-            ->willReturn('Magento/luma');
+            ->willReturn('Vendor/themename');
 
         $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
         $themeMock->expects($this->any())
@@ -284,7 +284,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->themeProvider
             ->expects($this->any())
             ->method('getThemeByFullPath')
-            ->with('frontend/Magento/luma')
+            ->with('frontend/Vendor/themename')
             ->willReturn($themeMock);
 
         $this->repository->updateDesignParams($params);
@@ -297,7 +297,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Could not find theme '1' for area 'frontend'
+     * @expectedExceptionMessage Could not find theme by id '1' for area 'frontend'
      * @return void
      */
     public function testUpdateDesignParamsCrossAreaWithoutSuitableTheme()

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -161,7 +161,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateDesignParamsByThemeId()
     {
-        $params = ['themeId' => 'ThemeID'];
+        $params = ['themeId' => '1'];
 
         $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
 
@@ -175,7 +175,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
         $this->repository->updateDesignParams($params);
         $this->assertEquals(
-            ['area' => '', 'themeId' => 'ThemeID', 'themeModel' => $themeMock, 'module' => '', 'locale' => ''],
+            ['area' => '', 'themeId' => '1', 'themeModel' => $themeMock, 'module' => '', 'locale' => ''],
             $params
         );
         $this->assertSame($themeMock, $params['themeModel']);
@@ -210,7 +210,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
-    public function testUpdateDesignParamsCrossArea()
+    public function testUpdateDesignParamsCrossAreaThemeId()
     {
         $params = ['area' => 'frontend'];
 
@@ -227,7 +227,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->designMock
             ->expects($this->any())
             ->method('getConfigurationDesignTheme')
-            ->willReturn('ThemeID');
+            ->willReturn('1');
 
         $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
         $themeMock->expects($this->any())
@@ -237,7 +237,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->themeProvider
             ->expects($this->any())
             ->method('getThemeById')
-            ->with('ThemeID')
+            ->with('1')
             ->willReturn($themeMock);
         $this->themeProvider
             ->expects($this->never())
@@ -252,8 +252,52 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testUpdateDesignParamsCrossAreaThemePath()
+    {
+        $params = ['area' => 'frontend'];
+
+        $this->designMock
+            ->expects($this->any())
+            ->method('getDesignParams')
+            ->willReturn(
+                [
+                    'themeModel' => '',
+                    'area' => 'adminhtml',
+                    'locale' => ''
+                ]
+            );
+        $this->designMock
+            ->expects($this->any())
+            ->method('getConfigurationDesignTheme')
+            ->willReturn('Magento/luma');
+
+        $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
+        $themeMock->expects($this->any())
+            ->method('getArea')
+            ->willReturn('frontend');
+
+        $this->themeProvider
+            ->expects($this->never())
+            ->method('getThemeById');
+        $this->themeProvider
+            ->expects($this->any())
+            ->method('getThemeByFullPath')
+            ->with('frontend/Magento/luma')
+            ->willReturn($themeMock);
+
+        $this->repository->updateDesignParams($params);
+        $this->assertEquals(
+            ['area' => 'frontend', 'themeModel' => $themeMock, 'module' => '', 'locale' => ''],
+            $params
+        );
+        $this->assertSame($themeMock, $params['themeModel']);
+    }
+
+    /**
      * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Could not find theme 'ThemeID' for area 'frontend'
+     * @expectedExceptionMessage Could not find theme '1' for area 'frontend'
      * @return void
      */
     public function testUpdateDesignParamsCrossAreaWithoutSuitableTheme()
@@ -273,7 +317,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->designMock
             ->expects($this->any())
             ->method('getConfigurationDesignTheme')
-            ->willReturn('ThemeID');
+            ->willReturn('1');
 
         $themeMock = $this->getMock(\Magento\Framework\View\Design\ThemeInterface::class);
         $themeMock->expects($this->any())
@@ -283,7 +327,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->themeProvider
             ->expects($this->any())
             ->method('getThemeById')
-            ->with('ThemeID')
+            ->with('1')
             ->willReturn($themeMock);
         $this->themeProvider
             ->expects($this->never())


### PR DESCRIPTION
Row 141 and 145 are obviously returning a theme id, so we'd better load the theme by id. I'm not sure if execution will fall into row 143 what to expect.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10402: Theme templates overrides don't work in environment emulation cross-area