### PR TITLE
Get scope config values from stores scope by default

### DIFF
--- a/app/code/Magento/Backup/Cron/SystemBackup.php
+++ b/app/code/Magento/Backup/Cron/SystemBackup.php
@@ -101,11 +101,11 @@ class SystemBackup
      */
     public function execute()
     {
-        if (!$this->_scopeConfig->isSetFlag(self::XML_PATH_BACKUP_ENABLED, ScopeInterface::SCOPE_STORE)) {
+        if (!$this->_scopeConfig->isSetFlag(self::XML_PATH_BACKUP_ENABLED)) {
             return $this;
         }
 
-        if ($this->_scopeConfig->isSetFlag(self::XML_PATH_BACKUP_MAINTENANCE_MODE, ScopeInterface::SCOPE_STORE)) {
+        if ($this->_scopeConfig->isSetFlag(self::XML_PATH_BACKUP_MAINTENANCE_MODE)) {
             $this->maintenanceMode->set(true);
         }
 
@@ -142,7 +142,7 @@ class SystemBackup
             throw $e;
         }
 
-        if ($this->_scopeConfig->isSetFlag(self::XML_PATH_BACKUP_MAINTENANCE_MODE, ScopeInterface::SCOPE_STORE)) {
+        if ($this->_scopeConfig->isSetFlag(self::XML_PATH_BACKUP_MAINTENANCE_MODE)) {
             $this->maintenanceMode->set(false);
         }
 

--- a/app/code/Magento/Catalog/Block/Rss/Category.php
+++ b/app/code/Magento/Catalog/Block/Rss/Category.php
@@ -212,8 +212,7 @@ class Category extends \Magento\Framework\View\Element\AbstractBlock implements 
     public function isAllowed()
     {
         return $this->_scopeConfig->isSetFlag(
-            'rss/catalog/category',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'rss/catalog/category'
         );
     }
 

--- a/app/code/Magento/Catalog/Block/Rss/Product/Special.php
+++ b/app/code/Magento/Catalog/Block/Rss/Product/Special.php
@@ -239,8 +239,7 @@ class Special extends \Magento\Framework\View\Element\AbstractBlock implements D
     public function isAllowed()
     {
         return $this->_scopeConfig->isSetFlag(
-            'rss/catalog/special',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'rss/catalog/special'
         );
     }
 

--- a/app/code/Magento/Catalog/Model/Indexer/AbstractFlatState.php
+++ b/app/code/Magento/Catalog/Model/Indexer/AbstractFlatState.php
@@ -57,7 +57,7 @@ abstract class AbstractFlatState
      */
     public function isFlatEnabled()
     {
-        return $this->scopeConfig->isSetFlag(static::INDEXER_ENABLED_XML_PATH, ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->isSetFlag(static::INDEXER_ENABLED_XML_PATH);
     }
 
     /**

--- a/app/code/Magento/CatalogInventory/Model/Plugin/Layer.php
+++ b/app/code/Magento/CatalogInventory/Model/Plugin/Layer.php
@@ -60,8 +60,7 @@ class Layer
     protected function _isEnabledShowOutOfStock()
     {
         return $this->scopeConfig->isSetFlag(
-            'cataloginventory/options/show_out_of_stock',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'cataloginventory/options/show_out_of_stock'
         );
     }
 }

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
@@ -223,8 +223,7 @@ class DefaultStock extends AbstractIndexer implements StockInterface
     protected function _isManageStock()
     {
         return $this->_scopeConfig->isSetFlag(
-            \Magento\CatalogInventory\Model\Configuration::XML_PATH_MANAGE_STOCK,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\CatalogInventory\Model\Configuration::XML_PATH_MANAGE_STOCK
         );
     }
 

--- a/app/code/Magento/CatalogSearch/Model/Adapter/Mysql/Filter/Preprocessor.php
+++ b/app/code/Magento/CatalogSearch/Model/Adapter/Mysql/Filter/Preprocessor.php
@@ -296,8 +296,7 @@ class Preprocessor implements PreprocessorInterface
     private function isAddStockFilter()
     {
         $isShowOutOfStock = $this->scopeConfig->isSetFlag(
-            'cataloginventory/options/show_out_of_stock',
-            ScopeInterface::SCOPE_STORE
+            'cataloginventory/options/show_out_of_stock'
         );
         return false === $isShowOutOfStock;
     }

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/TermDropdownStrategy.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/TermDropdownStrategy.php
@@ -138,8 +138,7 @@ class TermDropdownStrategy implements FilterStrategyInterface
     private function isAddStockFilter()
     {
         $isShowOutOfStock = $this->scopeConfig->isSetFlag(
-            'cataloginventory/options/show_out_of_stock',
-            ScopeInterface::SCOPE_STORE
+            'cataloginventory/options/show_out_of_stock'
         );
 
         return false === $isShowOutOfStock;

--- a/app/code/Magento/Checkout/Helper/Data.php
+++ b/app/code/Magento/Checkout/Helper/Data.php
@@ -397,8 +397,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function isCustomerMustBeLogged()
     {
         return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_CUSTOMER_MUST_BE_LOGGED,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            self::XML_PATH_CUSTOMER_MUST_BE_LOGGED
         );
     }
 

--- a/app/code/Magento/Checkout/Model/DefaultConfigProvider.php
+++ b/app/code/Magento/Checkout/Model/DefaultConfigProvider.php
@@ -279,8 +279,7 @@ class DefaultConfigProvider implements ConfigProviderInterface
         $output['totalsData'] = $this->getTotalsData();
         $output['shippingPolicy'] = [
             'isEnabled' => $this->scopeConfig->isSetFlag(
-                'shipping/shipping_policy/enable_shipping_policy',
-                ScopeInterface::SCOPE_STORE
+                'shipping/shipping_policy/enable_shipping_policy'
             ),
             'shippingPolicyContent' => nl2br(
                 $this->scopeConfig->getValue(

--- a/app/code/Magento/CheckoutAgreements/Block/Agreements.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Agreements.php
@@ -40,7 +40,7 @@ class Agreements extends \Magento\Framework\View\Element\Template
     {
         if (!$this->hasAgreements()) {
             $agreements = [];
-            if ($this->_scopeConfig->isSetFlag('checkout/options/enable_agreements', ScopeInterface::SCOPE_STORE)) {
+            if ($this->_scopeConfig->isSetFlag('checkout/options/enable_agreements')) {
                 /** @var \Magento\CheckoutAgreements\Model\ResourceModel\Agreement\Collection $agreements */
                 $agreements = $this->_agreementCollectionFactory->create();
                 $agreements->addStoreFilter($this->_storeManager->getStore()->getId());

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -63,8 +63,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
     {
         $agreementConfiguration = [];
         $isAgreementsEnabled = $this->scopeConfiguration->isSetFlag(
-            AgreementsProvider::PATH_ENABLED,
-            ScopeInterface::SCOPE_STORE
+            AgreementsProvider::PATH_ENABLED
         );
 
         $agreementsList = $this->checkoutAgreementsRepository->getList();

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsProvider.php
@@ -57,7 +57,7 @@ class AgreementsProvider implements AgreementsProviderInterface
     public function getRequiredAgreementIds()
     {
         $agreementIds = [];
-        if ($this->scopeConfig->isSetFlag(self::PATH_ENABLED, ScopeInterface::SCOPE_STORE)) {
+        if ($this->scopeConfig->isSetFlag(self::PATH_ENABLED)) {
             $agreementCollection = $this->agreementCollectionFactory->create();
             $agreementCollection->addStoreFilter($this->storeManager->getStore()->getId());
             $agreementCollection->addFieldToFilter('is_active', 1);

--- a/app/code/Magento/CheckoutAgreements/Model/Checkout/Plugin/Validation.php
+++ b/app/code/Magento/CheckoutAgreements/Model/Checkout/Plugin/Validation.php
@@ -106,8 +106,7 @@ class Validation
     protected function isAgreementEnabled()
     {
         $isAgreementsEnabled = $this->scopeConfiguration->isSetFlag(
-            AgreementsProvider::PATH_ENABLED,
-            ScopeInterface::SCOPE_STORE
+            AgreementsProvider::PATH_ENABLED
         );
         $agreementsList = $isAgreementsEnabled ? $this->checkoutAgreementsRepository->getList() : [];
         return (bool)($isAgreementsEnabled && count($agreementsList) > 0);

--- a/app/code/Magento/CheckoutAgreements/Model/CheckoutAgreementsRepository.php
+++ b/app/code/Magento/CheckoutAgreements/Model/CheckoutAgreementsRepository.php
@@ -94,7 +94,7 @@ class CheckoutAgreementsRepository implements CheckoutAgreementsRepositoryInterf
      */
     public function getList()
     {
-        if (!$this->scopeConfig->isSetFlag('checkout/options/enable_agreements', ScopeInterface::SCOPE_STORE)) {
+        if (!$this->scopeConfig->isSetFlag('checkout/options/enable_agreements')) {
             return [];
         }
         $storeId = $this->storeManager->getStore()->getId();

--- a/app/code/Magento/Cms/Controller/Index/Index.php
+++ b/app/code/Magento/Cms/Controller/Index/Index.php
@@ -37,8 +37,7 @@ class Index extends \Magento\Framework\App\Action\Action
         $pageId = $this->_objectManager->get(
             \Magento\Framework\App\Config\ScopeConfigInterface::class
         )->getValue(
-            \Magento\Cms\Helper\Page::XML_PATH_HOME_PAGE,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Cms\Helper\Page::XML_PATH_HOME_PAGE
         );
         $resultPage = $this->_objectManager->get(\Magento\Cms\Helper\Page::class)->prepareResultPage($this, $pageId);
         if (!$resultPage) {

--- a/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
+++ b/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
@@ -55,8 +55,7 @@ class ConfigurableItem extends DefaultItem
          * or if child thumbnail is not available
          */
         $config = $this->_scopeConfig->getValue(
-            \Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable::CONFIG_THUMBNAIL_SOURCE,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable::CONFIG_THUMBNAIL_SOURCE
         );
 
         $product = $config == ThumbnailSource::OPTION_USE_PARENT_IMAGE

--- a/app/code/Magento/Contact/Model/Config.php
+++ b/app/code/Magento/Contact/Model/Config.php
@@ -32,8 +32,7 @@ class Config implements ConfigInterface
     public function isEnabled()
     {
         return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_ENABLED,
-            ScopeInterface::SCOPE_STORE
+            self::XML_PATH_ENABLED
         );
     }
 

--- a/app/code/Magento/Customer/Controller/Account/Confirm.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirm.php
@@ -202,8 +202,7 @@ class Confirm extends \Magento\Customer\Controller\AbstractAccount
     {
         $backUrl = $this->getRequest()->getParam('back_url', false);
         $redirectToDashboard = $this->scopeConfig->isSetFlag(
-            Url::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD,
-            ScopeInterface::SCOPE_STORE
+            Url::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD
         );
         if (!$redirectToDashboard && $this->session->getBeforeAuthUrl()) {
             $successUrl = $this->session->getBeforeAuthUrl(true);

--- a/app/code/Magento/Customer/Model/Account/Redirect.php
+++ b/app/code/Magento/Customer/Model/Account/Redirect.php
@@ -199,8 +199,7 @@ class Redirect
         $this->applyRedirect($this->customerUrl->getAccountUrl());
 
         if (!$this->scopeConfig->isSetFlag(
-            CustomerUrl::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD,
-            ScopeInterface::SCOPE_STORE
+            CustomerUrl::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD
         )
         ) {
             $referer = $this->request->getParam(CustomerUrl::REFERER_QUERY_PARAM_NAME);

--- a/app/code/Magento/Customer/Model/Url.php
+++ b/app/code/Magento/Customer/Model/Url.php
@@ -116,8 +116,7 @@ class Url
         $referer = $this->getRequestReferrer();
         if (!$referer
             && !$this->scopeConfig->isSetFlag(
-                self::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD,
-                ScopeInterface::SCOPE_STORE
+                self::XML_PATH_CUSTOMER_STARTUP_REDIRECT_TO_DASHBOARD
             )
             && !$this->customerSession->getNoReferer()
         ) {

--- a/app/code/Magento/Developer/Model/Logger/Handler/Debug.php
+++ b/app/code/Magento/Developer/Model/Logger/Handler/Debug.php
@@ -61,7 +61,7 @@ class Debug extends \Magento\Framework\Logger\Handler\Debug
             return
                 parent::isHandling($record)
                 && $this->state->getMode() !== State::MODE_PRODUCTION
-                && $this->scopeConfig->getValue('dev/debug/debug_logging', ScopeInterface::SCOPE_STORE);
+                && $this->scopeConfig->getValue('dev/debug/debug_logging');
         }
 
         return parent::isHandling($record);

--- a/app/code/Magento/Developer/Model/View/Page/Config/RendererFactory.php
+++ b/app/code/Magento/Developer/Model/View/Page/Config/RendererFactory.php
@@ -63,7 +63,7 @@ class RendererFactory extends \Magento\Framework\View\Page\Config\RendererFactor
     {
         $renderer = $this->objectManager->get(State::class)->getMode() === State::MODE_PRODUCTION ?
             WorkflowType::SERVER_SIDE_COMPILATION :
-            $this->scopeConfig->getValue(WorkflowType::CONFIG_NAME_PATH, ScopeInterface::SCOPE_STORE);
+            $this->scopeConfig->getValue(WorkflowType::CONFIG_NAME_PATH);
 
         return $this->objectManager->create(
             $this->rendererTypes[$renderer],

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Links.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Links.php
@@ -133,8 +133,7 @@ class Links extends \Magento\Catalog\Block\Product\AbstractProduct
             return $this->getProduct()->getLinksTitle();
         }
         return $this->_scopeConfig->getValue(
-            \Magento\Downloadable\Model\Link::XML_PATH_LINKS_TITLE,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Downloadable\Model\Link::XML_PATH_LINKS_TITLE
         );
     }
 
@@ -147,8 +146,7 @@ class Links extends \Magento\Catalog\Block\Product\AbstractProduct
     public function getIsOpenInNewWindow()
     {
         return $this->_scopeConfig->isSetFlag(
-            \Magento\Downloadable\Model\Link::XML_PATH_TARGET_NEW_WINDOW,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Downloadable\Model\Link::XML_PATH_TARGET_NEW_WINDOW
         );
     }
 

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
@@ -56,7 +56,7 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
         if ($this->getProduct()->getSamplesTitle()) {
             return $this->getProduct()->getSamplesTitle();
         }
-        return $this->_scopeConfig->getValue(\Magento\Downloadable\Model\Sample::XML_PATH_SAMPLES_TITLE, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->getValue(\Magento\Downloadable\Model\Sample::XML_PATH_SAMPLES_TITLE);
     }
 
     /**
@@ -67,6 +67,6 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
      */
     public function getIsOpenInNewWindow()
     {
-        return $this->_scopeConfig->isSetFlag(\Magento\Downloadable\Model\Link::XML_PATH_TARGET_NEW_WINDOW, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->isSetFlag(\Magento\Downloadable\Model\Link::XML_PATH_TARGET_NEW_WINDOW);
     }
 }

--- a/app/code/Magento/Downloadable/Block/Customer/Products/ListProducts.php
+++ b/app/code/Magento/Downloadable/Block/Customer/Products/ListProducts.php
@@ -165,6 +165,6 @@ class ListProducts extends \Magento\Framework\View\Element\Template
      */
     public function getIsOpenInNewWindow()
     {
-        return $this->_scopeConfig->isSetFlag(\Magento\Downloadable\Model\Link::XML_PATH_TARGET_NEW_WINDOW, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->isSetFlag(\Magento\Downloadable\Model\Link::XML_PATH_TARGET_NEW_WINDOW);
     }
 }

--- a/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
@@ -86,8 +86,7 @@ class Downloadable extends \Magento\Sales\Block\Order\Email\Items\DefaultItems
     public function getLinksTitle()
     {
         return $this->getLinks()->getLinkSectionTitle() ?: $this->_scopeConfig->getValue(
-            Link::XML_PATH_LINKS_TITLE,
-            ScopeInterface::SCOPE_STORE
+            Link::XML_PATH_LINKS_TITLE
         );
     }
 

--- a/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
@@ -80,8 +80,7 @@ class Downloadable extends \Magento\Sales\Block\Order\Email\Items\Order\DefaultO
     public function getLinksTitle()
     {
         return $this->getLinks()->getLinkSectionTitle() ?: $this->_scopeConfig->getValue(
-            Link::XML_PATH_LINKS_TITLE,
-            ScopeInterface::SCOPE_STORE
+            Link::XML_PATH_LINKS_TITLE
         );
     }
 

--- a/app/code/Magento/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
@@ -79,8 +79,7 @@ class Downloadable extends \Magento\Sales\Block\Order\Item\Renderer\DefaultRende
     public function getLinksTitle()
     {
         return $this->getLinks()->getLinkSectionTitle() ?: $this->_scopeConfig->getValue(
-            Link::XML_PATH_LINKS_TITLE,
-            ScopeInterface::SCOPE_STORE
+            Link::XML_PATH_LINKS_TITLE
         );
     }
 }

--- a/app/code/Magento/Downloadable/Helper/Data.php
+++ b/app/code/Magento/Downloadable/Helper/Data.php
@@ -31,8 +31,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 break;
             case \Magento\Downloadable\Model\Link::LINK_SHAREABLE_CONFIG:
                 $shareable = (bool)$this->scopeConfig->isSetFlag(
-                    \Magento\Downloadable\Model\Link::XML_PATH_CONFIG_IS_SHAREABLE,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    \Magento\Downloadable\Model\Link::XML_PATH_CONFIG_IS_SHAREABLE
                 );
         }
         return $shareable;

--- a/app/code/Magento/Email/Model/Mail/TransportInterfacePlugin.php
+++ b/app/code/Magento/Email/Model/Mail/TransportInterfacePlugin.php
@@ -44,7 +44,7 @@ class TransportInterfacePlugin
         TransportInterface $subject,
         \Closure $proceed
     ) {
-        if (!$this->scopeConfig->isSetFlag(self::XML_PATH_SYSTEM_SMTP_DISABLE, ScopeInterface::SCOPE_STORE)) {
+        if (!$this->scopeConfig->isSetFlag(self::XML_PATH_SYSTEM_SMTP_DISABLE)) {
             $proceed();
         }
     }

--- a/app/code/Magento/GoogleAdwords/Helper/Data.php
+++ b/app/code/Magento/GoogleAdwords/Helper/Data.php
@@ -95,8 +95,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function isGoogleAdwordsActive()
     {
         return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_ACTIVE,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            self::XML_PATH_ACTIVE
         ) &&
             $this->getConversionId() &&
             $this->getConversionLanguage() &&

--- a/app/code/Magento/Multishipping/Helper/Data.php
+++ b/app/code/Magento/Multishipping/Helper/Data.php
@@ -72,7 +72,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function isMultishippingCheckoutAvailable()
     {
         $quote = $this->getQuote();
-        $isMultiShipping = $this->scopeConfig->isSetFlag(self::XML_PATH_CHECKOUT_MULTIPLE_AVAILABLE, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        $isMultiShipping = $this->scopeConfig->isSetFlag(self::XML_PATH_CHECKOUT_MULTIPLE_AVAILABLE);
         if (!$quote || !$quote->hasItems()) {
             return $isMultiShipping;
         }

--- a/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
+++ b/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
@@ -814,11 +814,9 @@ class Multishipping extends \Magento\Framework\DataObject
     public function validateMinimumAmount()
     {
         return !($this->_scopeConfig->isSetFlag(
-            'sales/minimum_order/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'sales/minimum_order/active'
         ) && $this->_scopeConfig->isSetFlag(
-            'sales/minimum_order/multi_address',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'sales/minimum_order/multi_address'
         ) && !$this->getQuote()->validateMinimumAmount());
     }
 

--- a/app/code/Magento/Paypal/Model/Express.php
+++ b/app/code/Magento/Paypal/Model/Express.php
@@ -297,11 +297,9 @@ class Express extends \Magento\Payment\Model\Method\AbstractMethod
     public function canUseCheckout()
     {
         if ($this->_scopeConfig->isSetFlag(
-            'payment/hosted_pro/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'payment/hosted_pro/active'
         ) && !$this->_scopeConfig->isSetFlag(
-            'payment/hosted_pro/display_ec',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'payment/hosted_pro/display_ec'
         )
         ) {
             return false;

--- a/app/code/Magento/Persistent/Helper/Data.php
+++ b/app/code/Magento/Persistent/Helper/Data.php
@@ -155,8 +155,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getClearOnLogout()
     {
         return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_LOGOUT_CLEAR,
-            ScopeInterface::SCOPE_STORE
+            self::XML_PATH_LOGOUT_CLEAR
         );
     }
 

--- a/app/code/Magento/ProductAlert/Helper/Data.php
+++ b/app/code/Magento/ProductAlert/Helper/Data.php
@@ -132,8 +132,7 @@ class Data extends \Magento\Framework\Url\Helper\Data
     public function isStockAlertAllowed()
     {
         return $this->scopeConfig->isSetFlag(
-            \Magento\ProductAlert\Model\Observer::XML_PATH_STOCK_ALLOW,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\ProductAlert\Model\Observer::XML_PATH_STOCK_ALLOW
         );
     }
 
@@ -145,8 +144,7 @@ class Data extends \Magento\Framework\Url\Helper\Data
     public function isPriceAlertAllowed()
     {
         return $this->scopeConfig->isSetFlag(
-            \Magento\ProductAlert\Model\Observer::XML_PATH_PRICE_ALLOW,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\ProductAlert\Model\Observer::XML_PATH_PRICE_ALLOW
         );
     }
 }

--- a/app/code/Magento/Review/Helper/Data.php
+++ b/app/code/Magento/Review/Helper/Data.php
@@ -76,7 +76,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getIsGuestAllowToWrite()
     {
-        return $this->scopeConfig->isSetFlag(self::XML_REVIEW_GUETS_ALLOW, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->isSetFlag(self::XML_REVIEW_GUETS_ALLOW);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Order/Info/Buttons/Rss.php
+++ b/app/code/Magento/Sales/Block/Order/Info/Buttons/Rss.php
@@ -68,8 +68,7 @@ class Rss extends \Magento\Framework\View\Element\Template
     public function isRssAllowed()
     {
         return $this->_scopeConfig->isSetFlag(
-            'rss/order/status',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'rss/order/status'
         );
     }
 

--- a/app/code/Magento/SalesRule/Block/Rss/Discounts.php
+++ b/app/code/Magento/SalesRule/Block/Rss/Discounts.php
@@ -149,8 +149,7 @@ class Discounts extends \Magento\Framework\View\Element\AbstractBlock implements
     public function isAllowed()
     {
         return $this->_scopeConfig->isSetFlag(
-            'rss/catalog/discounts',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'rss/catalog/discounts'
         );
     }
 

--- a/app/code/Magento/Security/Model/Config.php
+++ b/app/code/Magento/Security/Model/Config.php
@@ -109,8 +109,7 @@ class Config implements ConfigInterface
     public function isAdminAccountSharingEnabled()
     {
         return $this->scopeConfig->isSetFlag(
-            self::XML_PATH_ADMIN_ACCOUNT_SHARING,
-            StoreScopeInterface::SCOPE_STORE
+            self::XML_PATH_ADMIN_ACCOUNT_SHARING
         );
     }
 

--- a/app/code/Magento/Shipping/Model/CarrierFactory.php
+++ b/app/code/Magento/Shipping/Model/CarrierFactory.php
@@ -88,8 +88,7 @@ class CarrierFactory implements CarrierFactoryInterface
     public function getIfActive($carrierCode)
     {
         return $this->_scopeConfig->isSetFlag(
-            'carriers/' . $carrierCode . '/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'carriers/' . $carrierCode . '/active'
         ) ? $this->get(
             $carrierCode
         ) : false;

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -98,8 +98,7 @@ class Observer
 
         // check if scheduled generation enabled
         if (!$this->_scopeConfig->isSetFlag(
-            self::XML_PATH_GENERATION_ENABLED,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            self::XML_PATH_GENERATION_ENABLED
         )
         ) {
             return;

--- a/app/code/Magento/Store/Block/Store/Switcher.php
+++ b/app/code/Magento/Store/Block/Store/Switcher.php
@@ -110,8 +110,7 @@ class Switcher extends \Magento\Framework\View\Element\Template
     {
         $stores = [];
         $localeCode = $this->_scopeConfig->getValue(
-            Data::XML_PATH_DEFAULT_LOCALE,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            Data::XML_PATH_DEFAULT_LOCALE
         );
         foreach ($this->_groups as $group) {
             if (!isset($this->_stores[$group->getId()])) {

--- a/app/code/Magento/Store/Model/PathConfig.php
+++ b/app/code/Magento/Store/Model/PathConfig.php
@@ -53,18 +53,15 @@ class PathConfig implements \Magento\Framework\App\Router\PathConfigInterface
     {
         return parse_url(
             $this->scopeConfig->getValue(
-                Store::XML_PATH_UNSECURE_BASE_URL,
-                ScopeInterface::SCOPE_STORE
+                Store::XML_PATH_UNSECURE_BASE_URL
             ),
             PHP_URL_SCHEME
         ) === 'https'
         || $this->scopeConfig->isSetFlag(
-            Store::XML_PATH_SECURE_IN_FRONTEND,
-            ScopeInterface::SCOPE_STORE
+            Store::XML_PATH_SECURE_IN_FRONTEND
         ) && parse_url(
             $this->scopeConfig->getValue(
-                Store::XML_PATH_SECURE_BASE_URL,
-                ScopeInterface::SCOPE_STORE
+                Store::XML_PATH_SECURE_BASE_URL
             ),
             PHP_URL_SCHEME
         ) == 'https' && $this->urlSecurityInfo->isSecure($path);
@@ -77,6 +74,6 @@ class PathConfig implements \Magento\Framework\App\Router\PathConfigInterface
      */
     public function getDefaultPath()
     {
-        return $this->scopeConfig->getValue('web/default/front', ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->getValue('web/default/front');
     }
 }

--- a/app/code/Magento/Store/Model/StoreManager.php
+++ b/app/code/Magento/Store/Model/StoreManager.php
@@ -292,8 +292,7 @@ class StoreManager implements
     protected function isSingleStoreModeEnabled()
     {
         return (bool)$this->scopeConfig->getValue(
-            self::XML_PATH_SINGLE_STORE_MODE_ENABLED,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            self::XML_PATH_SINGLE_STORE_MODE_ENABLED
         );
     }
 

--- a/app/code/Magento/Wishlist/Block/Rss/Link.php
+++ b/app/code/Magento/Wishlist/Block/Rss/Link.php
@@ -65,8 +65,7 @@ class Link extends \Magento\Framework\View\Element\Template
     public function isRssAllowed()
     {
         return $this->_scopeConfig->isSetFlag(
-            'rss/wishlist/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            'rss/wishlist/active'
         );
     }
 

--- a/app/code/Magento/Wishlist/Helper/Rss.php
+++ b/app/code/Magento/Wishlist/Helper/Rss.php
@@ -123,8 +123,7 @@ class Rss extends \Magento\Wishlist\Helper\Data
     {
         return $this->_moduleManager->isEnabled('Magento_Rss')
             && $this->scopeConfig->isSetFlag(
-                'rss/wishlist/active',
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                'rss/wishlist/active'
             );
     }
 }

--- a/lib/internal/Magento/Framework/App/Config.php
+++ b/lib/internal/Magento/Framework/App/Config.php
@@ -55,7 +55,7 @@ class Config implements ScopeConfigInterface
      */
     public function getValue(
         $path = null,
-        $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+        $scope = ScopeConfigInterface::SCOPE_TYPE_STORES,
         $scopeCode = null
     ) {
         if ($scope === 'store') {
@@ -88,7 +88,7 @@ class Config implements ScopeConfigInterface
      * @param null|string $scopeCode
      * @return bool
      */
-    public function isSetFlag($path, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null)
+    public function isSetFlag($path, $scope = ScopeConfigInterface::SCOPE_TYPE_STORES, $scopeCode = null)
     {
         return !!$this->getValue($path, $scope, $scopeCode);
     }

--- a/lib/internal/Magento/Framework/App/Config/ScopeConfigInterface.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeConfigInterface.php
@@ -16,25 +16,27 @@ interface ScopeConfigInterface
     /**
      * Default scope type
      */
-    const SCOPE_TYPE_DEFAULT = 'default';
+    const SCOPE_TYPE_DEFAULT    = 'default';
+    const SCOPE_TYPE_WEBSITES   = 'websites';
+    const SCOPE_TYPE_STORES     = 'stores';
 
     /**
      * Retrieve config value by path and scope.
      *
      * @param string $path The path through the tree of configuration values, e.g., 'general/store_information/name'
-     * @param string $scopeType The scope to use to determine config value, e.g., 'store' or 'default'
+     * @param string $scopeType The scope to use to determine config value, e.g., 'stores', 'websites' or 'default'
      * @param null|string $scopeCode
      * @return mixed
      */
-    public function getValue($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null);
+    public function getValue($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_STORES, $scopeCode = null);
 
     /**
      * Retrieve config flag by path and scope
      *
      * @param string $path The path through the tree of configuration values, e.g., 'general/store_information/name'
-     * @param string $scopeType The scope to use to determine config value, e.g., 'store' or 'default'
+     * @param string $scopeType The scope to use to determine config value, e.g., 'stores', 'websites' or 'default'
      * @param null|string $scopeCode
      * @return bool
      */
-    public function isSetFlag($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null);
+    public function isSetFlag($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_STORES, $scopeCode = null);
 }


### PR DESCRIPTION
Hello,

The `getValue()` and `isSetFlag()` methods from the `ScopeConfigInterface` should search in the `stores` scope by default, except in some very specific cases.
It's very confusing to have to use `$this->scopeConfig->getValue('path/to/config', 'stores')` everytime we want to access a config value.

It should be like in M1 where we just had to do `Mage::getStoreConfig('path/to/config')` and if we want to look for a specific scope we can with the additional parameters.

I'm open to discussion though.