### PR TITLE
Update the return type in the tax rate ajax controllers to be correct

### DIFF
--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxLoad.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxLoad.php
@@ -4,6 +4,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Tax\Controller\Adminhtml\Rate;
 
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -14,7 +15,8 @@ class AjaxLoad extends \Magento\Tax\Controller\Adminhtml\Rate
     /**
      * Json needed for the Ajax Edit Form
      *
-     * @return void
+     * @return \Magento\Framework\Controller\Result\Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {
@@ -23,13 +25,13 @@ class AjaxLoad extends \Magento\Tax\Controller\Adminhtml\Rate
             /* @var \Magento\Tax\Api\Data\TaxRateInterface */
             $taxRateDataObject = $this->_taxRateRepository->get($rateId);
             /* @var array */
-            $resultArray= $this->_taxRateConverter->createArrayFromServiceObject($taxRateDataObject, true);
+            $resultArray = $this->_taxRateConverter->createArrayFromServiceObject($taxRateDataObject, true);
 
             $responseContent = [
                 'success' => true,
                 'error_message' => '',
-                'result'=>$resultArray,
-                ];
+                'result' => $resultArray,
+            ];
         } catch (NoSuchEntityException $e) {
             $responseContent = [
                 'success' => false,

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxSave.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/AjaxSave.php
@@ -14,6 +14,7 @@ class AjaxSave extends \Magento\Tax\Controller\Adminhtml\Rate
      * Save Tax Rate via AJAX
      *
      * @return \Magento\Framework\Controller\Result\Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/AjaxLoadRates.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/AjaxLoadRates.php
@@ -48,6 +48,7 @@ class AjaxLoadRates extends Action
      * Get rates page via AJAX
      *
      * @return Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {

--- a/app/code/Magento/Tax/Controller/Adminhtml/Tax/AjaxDelete.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Tax/AjaxDelete.php
@@ -14,6 +14,7 @@ class AjaxDelete extends \Magento\Tax\Controller\Adminhtml\Tax
      * Delete Tax Class via AJAX
      *
      * @return \Magento\Framework\Controller\Result\Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {
@@ -29,6 +30,7 @@ class AjaxDelete extends \Magento\Tax\Controller\Adminhtml\Tax
                 'error_message' => __('We can\'t delete this tax class right now.')
             ];
         }
+
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setData($responseContent);

--- a/app/code/Magento/Tax/Controller/Adminhtml/Tax/AjaxSave.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Tax/AjaxSave.php
@@ -14,6 +14,7 @@ class AjaxSave extends \Magento\Tax\Controller\Adminhtml\Tax
      * Save Tax Class via AJAX
      *
      * @return \Magento\Framework\Controller\Result\Json
+     * @throws \InvalidArgumentException
      */
     public function execute()
     {
@@ -47,6 +48,7 @@ class AjaxSave extends \Magento\Tax\Controller\Adminhtml\Tax
                 'class_name' => '',
             ];
         }
+
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setData($responseContent);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
While working on the Json controllers task I notices a couple of the Ajax controllers in Magento Tax had the wrong or no return type or did not show that they actually could throw an exception with the call to `$this->resultFactory->create`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
