### PR TITLE
Improves cms page options in the adminhtml configuration by sorting them alphabetically and adding the store code to the label.

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -26,6 +26,12 @@ class Collection extends AbstractCollection
     protected $_previewFlag;
 
     /**
+     *
+     * @var array|null
+     */
+    private $storeLabelsCache;
+
+    /**
      * Define resource model
      *
      * @return void
@@ -52,7 +58,7 @@ class Collection extends AbstractCollection
 
             $data['value'] = $identifier;
             $data['label'] = $item->getData('title');
-            $data['store'] = $item->getData('store_code');
+            $data['store_ids'] = $item->getData('store_id');
 
             if (in_array($identifier, $existingIdentifiers)) {
                 $data['value'] .= '|' . $item->getData('page_id');
@@ -68,36 +74,85 @@ class Collection extends AbstractCollection
             return strcmp($optionA['label'], $optionB['label']);
         });
 
-        $res = $this->groupOptionsByStore($res);
-
-        // TODO: transform the storecode to the website/store/storeview name here
-        // we have to do this here, because website/store/storeview combination isn't strictly unique,
-        // whereas the storecode is
-        // if we do the transformation earlier, the 'groupOptionsByStore' method would behave incorrectly
-        // TODO: also sort the array by the website/store/storeview name
+        $res = $this->groupOptionsByStoreLabels($res);
 
         return $res;
     }
 
     /**
-     * Changes the options, so they are grouped by store
+     * Changes the options, so they are grouped by store labels
      *
      * @param array $options
      * @return array
      */
-    private function groupOptionsByStore(array $options)
+    private function groupOptionsByStoreLabels(array $options)
     {
         $grouped = [];
 
         foreach ($options as $option) {
-            $store = $option['store'];
-            if (!array_key_exists($store, $grouped)) {
-                $grouped[$store] = ['label' => $store, 'value' => []];
+            $storeIds = $option['store_ids'];
+            foreach ($storeIds as $storeId) {
+                if (!array_key_exists($storeId, $grouped)) {
+                    $grouped[$storeId] = ['label' => $this->replaceStoreIdWithLabel($storeId), 'value' => []];
+                }
+                $grouped[$storeId]['value'][] = ['label' => $option['label'], 'value' => $option['value']];
             }
-            $grouped[$store]['value'][] = ['label' => $option['label'], 'value' => $option['value']];
         }
 
+        // sort by store labels
+        usort($grouped, function ($storeA, $storeB) {
+            return strcmp($storeA['label'], $storeB['label']);
+        });
+
         return ['values' => ['label' => '', 'value' => $grouped]];
+    }
+
+    /**
+     * Replace the store id we receive with the store label
+     * If label isn't found, we return the store id back (this "should" never happen)
+     *
+     * @param string $storeId
+     * @return string
+     */
+    private function replaceStoreIdWithLabel(string $storeId)
+    {
+        $storeLabels = $this->getStoreLabels();
+
+        if (array_key_exists($storeId, $storeLabels)) {
+            return $storeLabels[$storeId];
+        }
+
+        return $storeId;
+    }
+
+    /**
+     * Get array with all store labels, in the form of 'WebsiteName > StoreName > StoreviewName'
+     * The key of the array is the store id
+     *
+     * @return array
+     */
+    private function getStoreLabels()
+    {
+        if ($this->storeLabelsCache === null) {
+            $this->storeLabelsCache = [];
+
+            $websites = $this->storeManager->getWebsites();
+            foreach ($websites as $website) {
+                $groups = $website->getGroups();
+                foreach ($groups as $group) {
+                    $stores = $group->getStores();
+                    foreach ($stores as $store) {
+                        $this->storeLabelsCache[$store->getStoreId()] =
+                            "{$website->getName()} > {$group->getName()} > {$store->getName()}";
+                    }
+                }
+            }
+
+            // also add a label for the default/admin store id
+            $this->storeLabelsCache[\Magento\Store\Model\Store::DEFAULT_STORE_ID] = __('All Store Views');
+        }
+
+        return $this->storeLabelsCache;
     }
 
     /**

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -51,7 +51,7 @@ class Collection extends AbstractCollection
             $identifier = $item->getData('identifier');
 
             $data['value'] = $identifier;
-            $data['label'] = $item->getData('title');
+            $data['label'] = $item->getData('title') . ' (' . $item->getData('store_code') . ')';
 
             if (in_array($identifier, $existingIdentifiers)) {
                 $data['value'] .= '|' . $item->getData('page_id');
@@ -61,6 +61,10 @@ class Collection extends AbstractCollection
 
             $res[] = $data;
         }
+
+        usort($res, function ($optionA, $optionB) {
+            return strcmp($optionA['label'], $optionB['label']);
+        });
 
         return $res;
     }


### PR DESCRIPTION
### Description

This is a first quick proposition for improving the options in the dropdown for selecting a cms page in the configuration in the adminhtml.

Changed:
- Alphabetised the cms pages
- Added the store code at the end between round brackets

Before:
<img width="1345" alt="screen shot 2017-08-03 at 22 00 35" src="https://user-images.githubusercontent.com/85479/28941676-0039914e-7899-11e7-9d3f-239ed6359c19.png">

After:
<img width="1338" alt="screen shot 2017-08-03 at 22 00 57" src="https://user-images.githubusercontent.com/85479/28941688-07ecee4a-7899-11e7-9242-973fb04d12bc.png">

Possible further improvements I had in mind:
- Only add the store code when there is more then one store view
- Instead of the store code, use the name of the store view
- Maybe also include the name of the website and/or store, since a store view's name isn't unique

This is only a first attempt, feel free to give me feedback if something could be improved.
If this shouldn't be accepted to be added to Magento's core code, please let me know, it's not a big deal.

### Fixed Issues (if relevant)
None

### Manual testing scenarios
1. Add a couple of storeviews
2. Create a cms page for each storeview and use the exact same name
3. Go to Stores => Configuration => General => Web => Default Pages
4. Expect to easily find the cms page you want instead of seeing the exact same page names

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
