### PR TITLE
Prevent remove click listener when switch from mobile to desktop mode.

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -371,7 +371,8 @@ define([
          */
         _toggleDesktopMode: function () {
             var categoryParent, html;
-
+            
+            $(this.element).off('click mouseenter mouseleave');
             this._on({
                 /**
                  * Prevent focus from sticking to links inside menu after clicking

--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -323,6 +323,7 @@ define([
 
             $(this.element).off('mouseenter mouseleave');
             this._on({
+
                 /**
                  * @param {jQuery.Event} event
                  */
@@ -371,9 +372,10 @@ define([
          */
         _toggleDesktopMode: function () {
             var categoryParent, html;
-            
+
             $(this.element).off('click mousedown mouseenter mouseleave');
             this._on({
+
                 /**
                  * Prevent focus from sticking to links inside menu after clicking
                  * them (focus should always stay on UL during navigation).

--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -372,7 +372,7 @@ define([
         _toggleDesktopMode: function () {
             var categoryParent, html;
             
-            $(this.element).off('click mouseenter mouseleave');
+            $(this.element).off('click mousedown mouseenter mouseleave');
             this._on({
                 /**
                  * Prevent focus from sticking to links inside menu after clicking


### PR DESCRIPTION
### Description
When clicking on  level0 menu item after switching from mobile to desktop mode the click event is not active. This only occurs for menu items with children.

### Manual testing scenarios
1. Open website http://magento2-demo.nexcess.net/ in desktop mode
2. Click "woman" menu item (goes to category page)
3. Switch to mobile mode by resizing screen
4. Switch back to desktop mode by resizing screen
5. "Woman" menu item click doesn't work.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
