### PR TITLE
Test cron expressions against localized time

### DIFF
--- a/app/code/Magento/Cron/Model/Schedule.php
+++ b/app/code/Magento/Cron/Model/Schedule.php
@@ -66,8 +66,7 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\Stdlib\DateTime\DateTime $dateTime = null
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
-        $this->dateTime = $dateTime ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Stdlib\DateTime\DateTime::class);
+        $this->dateTime = $dateTime;
     }
 
     /**
@@ -103,6 +102,8 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
      */
     public function trySchedule()
     {
+        $this->dateTime = $this->dateTime ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Stdlib\DateTime\DateTime::class);
         $time = $this->getScheduledAt();
         $e = $this->getCronExprArr();
 

--- a/app/code/Magento/Cron/Model/Schedule.php
+++ b/app/code/Magento/Cron/Model/Schedule.php
@@ -45,20 +45,29 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
     const STATUS_ERROR = 'error';
 
     /**
+     * @var \Magento\Framework\Stdlib\DateTime\DateTime
+     */
+    private $dateTime;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
+     * @param \Magento\Framework\Stdlib\DateTime\DateTime|null $dateTime
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Stdlib\DateTime\DateTime $dateTime = null
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
+        $this->dateTime = $dateTime ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Stdlib\DateTime\DateTime::class);
     }
 
     /**
@@ -101,7 +110,7 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
             return false;
         }
         if (!is_numeric($time)) {
-            $time = strtotime($time);
+            $time = strtotime($time) + $this->dateTime->getGmtOffset();
         }
         $match = $this->matchCronExpression($e[0], strftime('%M', $time))
             && $this->matchCronExpression($e[1], strftime('%H', $time))

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -12,7 +12,7 @@ namespace Magento\Cron\Observer;
 use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Event\ObserverInterface;
-use \Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\Schedule;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
As mentioned in #4237: 
@AlexanderRakov I do expect it now you mention it, having the current code change in place. But I would not expect it if I were a shop owner. So now that the times are correct in the cron_schedule table, I need to add a change that converts the crontab expression to the correct unix time stamp (UTC) for the matching time in the admin store view time zone.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4237: Cron times in the database have a double timezone correction

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set the global time zone to something other than GMT.
2. Schedule the sitemap_generate cron job at 00:00:00.
3. Configure cron to schedule ahead for 1440
4. Flush caches
5. run `bin/magento cron:run`
6. Run `SELECT `scheduled_at` FROM `cron_schedule` WHERE `job_code` = "sitemap_generate";`
7. This should be yyyy-mm-dd 00:00:00 (it was yyyy-mm-dd 00:06:00 in timezone GMT+6 before this PR)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
