### PR TITLE
Fixes #10255: base_shipping_discount_tax_compensation_amnt was empty from order onwards

### DIFF
--- a/app/code/Magento/Sales/etc/fieldset.xml
+++ b/app/code/Magento/Sales/etc/fieldset.xml
@@ -279,7 +279,7 @@
                 <aspect name="to_order" />
             </field>
             <field name="base_shipping_discount_tax_compensation_amount">
-                <aspect name="to_order" />
+                <aspect name="to_order" targetField="base_shipping_discount_tax_compensation_amnt" />
             </field>
             <field name="prefix">
                 <aspect name="to_order_address" />


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10255: Invoice grand_total and base_grand_total differ while in the same currency

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. see #10255 for testing scenario and MySQL dump file

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
