### PR TITLE
Fix JS translation search

### DIFF
--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -134,7 +134,8 @@ class DataProvider implements DataProviderInterface
     {
         $phrases = [];
         foreach ($this->config->getPatterns() as $pattern) {
-            $result = preg_match_all($pattern, $content, $matches);
+            $concatenatedContent = preg_replace('~(["\'])\s*?\+\s*?\1~', '', $content);
+            $result = preg_match_all($pattern, $concatenatedContent, $matches);
 
             if ($result) {
                 if (isset($matches[2])) {

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -139,7 +139,7 @@ class DataProvider implements DataProviderInterface
             if ($result) {
                 if (isset($matches[2])) {
                     foreach ($matches[2] as $match) {
-                        $phrases[] = str_replace('\\\'', '\'', $match);
+                        $phrases[] = str_replace(["\'", '\"'], ["'", '"'], $match);
                     }
                 }
             }

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -65,8 +65,8 @@
             <argument name="patterns" xsi:type="array">
                 <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
-                <item name="mage_translation_widget" xsi:type="string">~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)\1(?s).*?\)~</item>
-                <item name="mage_translation_static" xsi:type="string">~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~</item>
+                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)\1(?s).*?\)~]]></item>
+                <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -65,7 +65,7 @@
             <argument name="patterns" xsi:type="array">
                 <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
-                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
+                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~(?:\$|jQuery)\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
                 <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
             </argument>
         </arguments>

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -65,7 +65,7 @@
             <argument name="patterns" xsi:type="array">
                 <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
-                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)\1(?s).*?\)~]]></item>
+                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
                 <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
             </argument>
         </arguments>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
- Add support for `jQuery.mage.__('translate me')` as well as `$.mage.__('translate me')`
- Add support for `$.mage.__('Don\'t break on escape characters before \' or "')`
- Add support for `$.mage.__('Concatenating strings' + 'within a tranlation' + 'function')`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/7403: JS Translation Regex leads to unexpected results and untranslatable strings
2. https://github.com/magento/magento2/issues/5509: Translate messages on password strength
3. https://github.com/magento/magento2/issues/5820: js validation messages translation not working in customer account
4. https://github.com/magento/magento2/issues/9967: Some messages in Customer Account Create not translated

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. See mentioned tickets for instances that could not be translated so far and translate them 
2. Flush caches, clear browser storage, hard refresh and see translated strings

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
