### PR TITLE
Remove decoder interface usage

### DIFF
--- a/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Save.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Save.php
@@ -70,6 +70,8 @@ class Save extends AbstractAction
      * @param BookmarkInterfaceFactory $bookmarkFactory
      * @param UserContextInterface $userContext
      * @param DecoderInterface $jsonDecoder
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         Context $context,

--- a/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Save.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Save.php
@@ -53,8 +53,14 @@ class Save extends AbstractAction
 
     /**
      * @var DecoderInterface
+     * @deprecated
      */
     protected $jsonDecoder;
+
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
 
     /**
      * @param Context $context
@@ -72,7 +78,8 @@ class Save extends AbstractAction
         BookmarkManagementInterface $bookmarkManagement,
         BookmarkInterfaceFactory $bookmarkFactory,
         UserContextInterface $userContext,
-        DecoderInterface $jsonDecoder
+        DecoderInterface $jsonDecoder,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         parent::__construct($context, $factory);
         $this->bookmarkRepository = $bookmarkRepository;
@@ -80,12 +87,16 @@ class Save extends AbstractAction
         $this->bookmarkFactory = $bookmarkFactory;
         $this->userContext = $userContext;
         $this->jsonDecoder = $jsonDecoder;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
      * Action for AJAX request
      *
      * @return void
+     * @throws \InvalidArgumentException
+     * @throws \LogicException
      */
     public function execute()
     {
@@ -94,7 +105,7 @@ class Save extends AbstractAction
         if (!$jsonData) {
             throw new \InvalidArgumentException('Invalid parameter "data"');
         }
-        $data = $this->jsonDecoder->decode($jsonData);
+        $data = $this->serializer->unserialize($jsonData);
         $action = key($data);
         switch ($action) {
             case self::ACTIVE_IDENTIFIER:

--- a/app/code/Magento/Ui/Model/Bookmark.php
+++ b/app/code/Magento/Ui/Model/Bookmark.php
@@ -23,8 +23,14 @@ class Bookmark extends AbstractExtensibleModel implements BookmarkInterface
 {
     /**
      * @var DecoderInterface
+     * @deprecated
      */
     protected $jsonDecoder;
+
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
 
     /**
      * @param Context $context
@@ -35,6 +41,8 @@ class Bookmark extends AbstractExtensibleModel implements BookmarkInterface
      * @param Collection $resourceCollection
      * @param DecoderInterface $jsonDecoder
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         Context $context,
@@ -44,9 +52,12 @@ class Bookmark extends AbstractExtensibleModel implements BookmarkInterface
         ResourceBookmark $resource,
         Collection $resourceCollection,
         DecoderInterface $jsonDecoder,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->jsonDecoder = $jsonDecoder;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct(
             $context,
             $registry,
@@ -127,7 +138,7 @@ class Bookmark extends AbstractExtensibleModel implements BookmarkInterface
     {
         $config = $this->getData(self::CONFIG);
         if ($config) {
-            return $this->jsonDecoder->decode($config);
+            return $this->serializer->unserialize($config);
         }
         return [];
     }


### PR DESCRIPTION
### Description
Since the DecoderInterface in deprecated we can start to remove the usage with \Magento\Framework\Serialize\Serializer\Json instead.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
