### PR TITLE
Update the reset button of UrlRewrite block to not cause JS errors

### DIFF
--- a/app/code/Magento/UrlRewrite/Block/Edit.php
+++ b/app/code/Magento/UrlRewrite/Block/Edit.php
@@ -118,7 +118,7 @@ class Edit extends \Magento\Backend\Block\Widget\Container
             'reset',
             [
                 'label' => __('Reset'),
-                'onclick' => '$(\'edit_form\').reset()',
+                'onclick' => 'location.reload();',
                 'class' => 'scalable',
                 'level' => -1
             ]


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Currently the reset button on the url rewrite edit page causes a JavaScript error.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10459: Unable reset form in Edit URL Rewrite

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Visit the edit url rewrite form in the admin section,
2. Make a change to the form and select the reset button,
3. Page should be reloaded and form reset,

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
