### PR TITLE
fix popular search terms not displaying on frontend

### DIFF
--- a/app/code/Magento/Search/Block/Term.php
+++ b/app/code/Magento/Search/Block/Term.php
@@ -94,8 +94,8 @@ class Term extends Template
                     continue;
                 }
                 $term->setRatio(($term->getPopularity() - $this->_minPopularity) / $range);
-                $temp[$term->getName()] = $term;
-                $termKeys[] = $term->getName();
+                $temp[$term->getQueryText()] = $term;
+                $termKeys[] = $term->getQueryText();
             }
             natcasesort($termKeys);
 
@@ -127,7 +127,7 @@ class Term extends Template
          * url encoding will be done in Url.php http_build_query
          * so no need to explicitly called urlencode for the text
          */
-        $url->setQueryParam('q', $obj->getName());
+        $url->setQueryParam('q', $obj->getQueryText());
         return $url->getUrl('catalogsearch/result');
     }
 

--- a/app/code/Magento/Search/view/frontend/templates/term.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/term.phtml
@@ -13,7 +13,7 @@
             <li class="item">
                 <a href="<?= /* @escapeNotVerified */ $block->getSearchUrl($_term) ?>"
                    style="font-size:<?= /* @escapeNotVerified */ $_term->getRatio()*70+75 ?>%;">
-                    <?= $block->escapeHtml($_term->getName()) ?>
+                    <?= $block->escapeHtml($_term->getQueryText()) ?>
                 </a>
             </li>
         <?php endforeach; ?>

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/TermTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/TermTest.php
@@ -24,7 +24,7 @@ class TermTest extends \PHPUnit_Framework_TestCase
     public function testGetSearchUrl()
     {
         $query = uniqid();
-        $obj = new \Magento\Framework\DataObject(['name' => $query]);
+        $obj = new \Magento\Framework\DataObject(['query_text' => $query]);
         $this->assertStringEndsWith("/catalogsearch/result/?q={$query}", $this->_block->getSearchUrl($obj));
     }
 }


### PR DESCRIPTION
### Description
A fix for popular search terms not displaying on frontend

### Fixed Issues (if relevant)
Not aware of reported issue

### Manual testing scenarios
Search several terms using native magento search and then use link in footer /search/term/popular/ to see results

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [n/a ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ n/a] All automated tests passed successfully (all builds on Travis CI are green)
