### PR TITLE
Translate order getCreatedAtFormatted() to store locale

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -7,6 +7,8 @@ namespace Magento\Sales\Model;
 
 use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\AttributeValueFactory;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderStatusHistoryInterface;
@@ -212,6 +214,11 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     protected $_currencyFactory;
 
     /**
+     * @var \Magento\Eav\Model\Config
+     */
+    private $_eavConfig;
+
+    /**
      * @var \Magento\Sales\Model\Order\Status\HistoryFactory
      */
     protected $_orderHistoryFactory;
@@ -267,6 +274,11 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     protected $timezone;
 
     /**
+     * @var ResolverInterface
+     */
+    private $localeResolver;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -294,6 +306,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
+     * @param ResolverInterface $localeResolver
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -323,7 +336,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productListFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        ResolverInterface $localeResolver = null
     ) {
         $this->_storeManager = $storeManager;
         $this->_orderConfig = $orderConfig;
@@ -345,6 +359,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         $this->_trackCollectionFactory = $trackCollectionFactory;
         $this->salesOrderCollectionFactory = $salesOrderCollectionFactory;
         $this->priceCurrency = $priceCurrency;
+        $this->localeResolver = $localeResolver ?: ObjectManager::getInstance()->get(ResolverInterface::class);
+
         parent::__construct(
             $context,
             $registry,
@@ -1829,7 +1845,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             new \DateTime($this->getCreatedAt()),
             $format,
             $format,
-            null,
+            $this->localeResolver->getDefaultLocale(),
             $this->timezone->getConfigTimezone('store', $this->getStore())
         );
     }

--- a/app/code/Magento/Sales/Test/Unit/Model/OrderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/OrderTest.php
@@ -7,6 +7,8 @@ namespace Magento\Sales\Test\Unit\Model;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
+use Magento\Framework\Locale\ResolverInterface;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\ResourceModel\Order\Status\History\CollectionFactory as HistoryCollectionFactory;
@@ -73,6 +75,16 @@ class OrderTest extends \PHPUnit\Framework\TestCase
      */
     protected $productCollectionFactoryMock;
 
+    /**
+     * @var ResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $localeResolver;
+
+    /**
+     * @var TimezoneInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $timezone;
+
     protected function setUp()
     {
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -124,6 +136,8 @@ class OrderTest extends \PHPUnit\Framework\TestCase
             true,
             ['round']
         );
+        $this->localeResolver = $this->createMock(ResolverInterface::class);
+        $this->timezone = $this->createMock(TimezoneInterface::class);
         $this->incrementId = '#00000001';
         $this->eventManager = $this->createMock(\Magento\Framework\Event\Manager::class);
         $context = $this->createPartialMock(\Magento\Framework\Model\Context::class, ['getEventDispatcher']);
@@ -138,7 +152,9 @@ class OrderTest extends \PHPUnit\Framework\TestCase
                 'historyCollectionFactory' => $this->historyCollectionFactoryMock,
                 'salesOrderCollectionFactory' => $this->salesOrderCollectionFactoryMock,
                 'priceCurrency' => $this->priceCurrency,
-                'productListFactory' => $this->productCollectionFactoryMock
+                'productListFactory' => $this->productCollectionFactoryMock,
+                'localeResolver' => $this->localeResolver,
+                'timezone' => $this->timezone,
             ]
         );
     }
@@ -1042,6 +1058,22 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(
             $this->order->hasDataChanges()
         );
+    }
+
+    public function testGetCreatedAtFormattedUsesCorrectLocale()
+    {
+        $localeCode = 'nl_NL';
+
+        $this->localeResolver->expects($this->once())->method('getDefaultLocale')->willReturn($localeCode);
+        $this->timezone->expects($this->once())->method('formatDateTime')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $localeCode
+            );
+
+        $this->order->getCreatedAtFormatted(\IntlDateFormatter::SHORT);
     }
 
     public function notInvoicingStatesProvider()


### PR DESCRIPTION
### Description
Updated version of #10390, added new interface method en deprecated the current one.

Add `getDefaultStoreLocale()` to allow fetching scoped values. Use this in `getCreatedAtFormatted()` so `created_at` date of order will be translated in emails to locale being used in that store view.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Set default locale of your store to any language but English.
2. Create order and send confirmation email.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)