### PR TITLE
Improvements to the phpserver router

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Phpserver/PhpserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Phpserver/PhpserverTest.php
@@ -15,7 +15,7 @@ namespace Magento\Phpserver;
  *
  * @magentoAppArea frontend
  */
-class PhpserverTest extends \PHPUnit_Framework_TestCase
+class PhpserverTest extends \PHPUnit\Framework\TestCase
 {
 
     const BASE_URL = '127.0.0.1:8082';

--- a/dev/tests/integration/testsuite/Magento/Phpserver/PhpserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Phpserver/PhpserverTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Phpserver;
+
+/**
+ * @magentoAppIsolation enabled
+ *
+ * @magentoConfigFixture current_store web/secure/base_url http://127.0.0.1:8082/
+ * @magentoConfigFixture current_store web/unsecure/base_link_url http://127.0.0.1:8082/
+ * @magentoConfigFixture current_store web/secure/base_link_url http://127.0.0.1:8082/
+ * @magentoConfigFixture current_store web/secure/use_in_frontend 0
+ *
+ * @magentoAppArea frontend
+ */
+class PhpserverTest extends \PHPUnit_Framework_TestCase
+{
+
+    const BASE_URL = '127.0.0.1:8082';
+
+    private static $serverPid;
+
+    private $httpClient;
+
+    /**
+     * Instantiate phpserver in the pub folder
+     */
+    public static function setUpBeforeClass()
+    {
+        $return = [];
+
+        $baseDir = __DIR__.'/../../../../../../';
+        $command = sprintf(
+            'cd %s && php -S %s -t ./pub/ ./phpserver/router.php >/dev/null 2>&1 & echo $!',
+            $baseDir,
+            static::BASE_URL
+        );
+        exec($command, $return);
+        static::$serverPid = (int) $return[0];
+    }
+
+    private function getUrl($url)
+    {
+        return sprintf('http://%s/%s', self::BASE_URL, ltrim($url, '/'));
+    }
+
+    public function setUp()
+    {
+        $this->httpClient = new \Zend\Http\Client(null, ['timeout' => 10]);
+    }
+
+    public function testServerHasPid()
+    {
+        $this->assertTrue(static::$serverPid > 0);
+    }
+
+    public function testServerResponds()
+    {
+        $this->httpClient->setUri($this->getUrl('/'));
+        $response = $this->httpClient->send();
+        $this->assertFalse($response->isClientError());
+    }
+
+    public function testStaticCssFile()
+    {
+        $this->httpClient->setUri($this->getUrl('/errors/default/css/styles.css'));
+        $response = $this->httpClient->send();
+
+        $this->assertFalse($response->isClientError());
+        $this->assertStringStartsWith('text/css', $response->getHeaders()->get('Content-Type')->getMediaType());
+    }
+
+    public function testStaticImageFile()
+    {
+        $this->httpClient->setUri($this->getUrl('/errors/default/images/logo.gif'));
+        $response = $this->httpClient->send();
+
+        $this->assertFalse($response->isClientError());
+        $this->assertStringStartsWith('image/gif', $response->getHeaders()->get('Content-Type')->getMediaType());
+    }
+
+    public static function tearDownAfterClass()
+    {
+        posix_kill(static::$serverPid, SIGKILL);
+    }
+}

--- a/phpserver/README.md
+++ b/phpserver/README.md
@@ -21,13 +21,10 @@ php bin/magento setup:install --base-url=http://127.0.0.1:8082
 --db-host=localhost --db-name=magento --db-user=magento --db-password=magento
 --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com
 --admin-user=admin --admin-password=admin123 --language=en_US
---currency=USD --timezone=America/Chicago --use-rewrites=0
+--currency=USD --timezone=America/Chicago --use-rewrites=1
 ```
 
-It's important to note that the router is not able to work with rewrite urls, that's why the flag `use-rewrites` is set to `0`.
-
 Notes:
-- You must use `--use-rewrites=0` because the web server cannot rewrite URLs
 - By default, Magento creates a random Admin URI for you. Make sure to write this value down because it's how you access the Magento Admin later. For example : ```http://127.0.0.1:8082/index.php/admin_1vpn01```.
 
 For more informations about the installation process using the CLI, you can consult the dedicated documentation that can found in [the developer documentation](https://github.com/magento/devdocs/blob/develop/guides/v2.0/install-gde/install/cli/install-cli-install.md).

--- a/phpserver/router.php
+++ b/phpserver/router.php
@@ -76,10 +76,12 @@ if (php_sapi_name() === 'cli-server') {
 
         $debug("file: $file");
 
-        if (file_exists($origFile)) {
+        if (file_exists($origFile) || file_exists($file)) {
+            if (file_exists($origFile)) {
+                $file = $origFile;
+            }
+
             $debug('file exists');
-            return false;
-        } else if (file_exists($file)) {
             $mimeTypes = [
                 'css' => 'text/css',
                 'js'  => 'application/javascript',
@@ -93,9 +95,8 @@ if (php_sapi_name() === 'cli-server') {
                 'html' => 'text/html',
             ];
 
-            $type = isset($mimeTypes[$ext]) && $mimeTypes[$ext];
-            if ($type) {
-                header("Content-Type: $type");
+            if (isset($mimeTypes[$ext])) {
+                header("Content-Type: $mimeTypes[$ext]");
             }
             readfile($file);
             return;


### PR DESCRIPTION
- handles versioned static assets
- our own mime handling for those, since php's built in web server's mime table isn't accessible from userland
- works with a magento instance set up with use-rewrites=1

Is this a useful amendment? I'm happy to fix this up with suggestions, too, as I intend to use it for my daily development.