### PR TITLE
Send different base currency in Google analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.metadata
 /.project
 /.settings
+/.vscode
 atlassian*
 /nbproject
 /robots.txt

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -120,7 +120,7 @@ class Ga extends \Magento\Framework\View\Element\Template
         $result[] = "ga('require', 'ec', 'ec.js');";
 
         foreach ($collection as $order) {
-            $result[] = "ga('set', 'currencyCode', '" . $order->getBaseCurrencyCode() . "');";
+            $result[] = "ga('set', 'currencyCode', '" . $order->getOrderCurrencyCode() . "');";
             foreach ($order->getAllVisibleItems() as $item) {
                 $result[] = sprintf(
                     "ga('ec:addProduct', {
@@ -131,7 +131,7 @@ class Ga extends \Magento\Framework\View\Element\Template
                     });",
                     $this->escapeJs($item->getSku()),
                     $this->escapeJs($item->getName()),
-                    $item->getBasePrice(),
+                    $item->getPrice(),
                     $item->getQtyOrdered()
                 );
             }
@@ -146,9 +146,9 @@ class Ga extends \Magento\Framework\View\Element\Template
                 });",
                 $order->getIncrementId(),
                 $this->escapeJs($this->_storeManager->getStore()->getFrontendName()),
-                $order->getBaseGrandTotal(),
-                $order->getBaseTaxAmount(),
-                $order->getBaseShippingAmount()
+                $order->getGrandTotal(),
+                $order->getTaxAmount(),
+                $order->getShippingAmount()
             );
 
             $result[] = "ga('send', 'pageview');";
@@ -233,18 +233,18 @@ class Ga extends \Magento\Framework\View\Element\Template
                 $result['products'][] = [
                     'id' => $this->escapeJs($item->getSku()),
                     'name' =>  $this->escapeJs($item->getName()),
-                    'price' => $item->getBasePrice(),
+                    'price' => $item->getPrice(),
                     'quantity' => $item->getQtyOrdered(),
                 ];
             }
             $result['orders'][] = [
                 'id' =>  $order->getIncrementId(),
                 'affiliation' => $this->escapeJs($this->_storeManager->getStore()->getFrontendName()),
-                'revenue' => $order->getBaseGrandTotal(),
-                'tax' => $order->getBaseTaxAmount(),
-                'shipping' => $order->getBaseShippingAmount(),
+                'revenue' => $order->getGrandTotal(),
+                'tax' => $order->getTaxAmount(),
+                'shipping' => $order->getShippingAmount(),
             ];
-            $result['currency'] = $order->getBaseCurrencyCode();
+            $result['currency'] = $order->getOrderCurrencyCode();
         }
         return $result;
     }

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -120,6 +120,7 @@ class Ga extends \Magento\Framework\View\Element\Template
         $result[] = "ga('require', 'ec', 'ec.js');";
 
         foreach ($collection as $order) {
+            $result[] = "ga('set', 'currencyCode', '" . $order->getBaseCurrencyCode() . "');";
             foreach ($order->getAllVisibleItems() as $item) {
                 $result[] = sprintf(
                     "ga('ec:addProduct', {
@@ -243,6 +244,7 @@ class Ga extends \Magento\Framework\View\Element\Template
                 'tax' => $order->getBaseTaxAmount(),
                 'shipping' => $order->getBaseShippingAmount(),
             ];
+            $result['currency'] = $order->getBaseCurrencyCode();
         }
         return $result;
     }

--- a/app/code/Magento/GoogleAnalytics/Test/Unit/Block/GaTest.php
+++ b/app/code/Magento/GoogleAnalytics/Test/Unit/Block/GaTest.php
@@ -103,6 +103,7 @@ class GaTest extends PHPUnit_Framework_TestCase
         $this->storeManagerMock->expects($this->once())->method('getStore')->willReturn($this->storeMock);
 
         $expectedCode = "ga('require', 'ec', 'ec.js');
+            ga('set', 'currencyCode', 'USD');
             ga('ec:addProduct', {
                                     'id': 'sku0',
                                     'name': 'testName0',
@@ -165,7 +166,8 @@ class GaTest extends PHPUnit_Framework_TestCase
                     'price' => 0.00,
                     'quantity' => 1
                 ]
-            ]
+            ],
+            'currency' => 'USD'
         ];
 
         $this->gaBlock->setOrderIds([1, 2]);
@@ -213,6 +215,7 @@ class GaTest extends PHPUnit_Framework_TestCase
         $orderMock->expects($this->once())->method('getBaseGrandTotal')->willReturn(10);
         $orderMock->expects($this->once())->method('getBaseTaxAmount')->willReturn(2);
         $orderMock->expects($this->once())->method('getBaseShippingAmount')->willReturn($orderItemCount);
+        $orderMock->expects($this->once())->method('getBaseCurrencyCode')->willReturn('USD');
         return $orderMock;
     }
 

--- a/app/code/Magento/GoogleAnalytics/Test/Unit/Block/GaTest.php
+++ b/app/code/Magento/GoogleAnalytics/Test/Unit/Block/GaTest.php
@@ -204,7 +204,7 @@ class GaTest extends PHPUnit_Framework_TestCase
                 ->getMock();
             $orderItemMock->expects($this->once())->method('getSku')->willReturn('sku' . $i);
             $orderItemMock->expects($this->once())->method('getName')->willReturn('testName' . $i);
-            $orderItemMock->expects($this->once())->method('getBasePrice')->willReturn($i . '.00');
+            $orderItemMock->expects($this->once())->method('getPrice')->willReturn($i . '.00');
             $orderItemMock->expects($this->once())->method('getQtyOrdered')->willReturn($i + 1);
             $orderItems[] = $orderItemMock;
         }
@@ -212,10 +212,10 @@ class GaTest extends PHPUnit_Framework_TestCase
         $orderMock = $this->getMockBuilder(Order::class)->disableOriginalConstructor()->getMock();
         $orderMock->expects($this->once())->method('getIncrementId')->willReturn(100);
         $orderMock->expects($this->once())->method('getAllVisibleItems')->willReturn($orderItems);
-        $orderMock->expects($this->once())->method('getBaseGrandTotal')->willReturn(10);
-        $orderMock->expects($this->once())->method('getBaseTaxAmount')->willReturn(2);
-        $orderMock->expects($this->once())->method('getBaseShippingAmount')->willReturn($orderItemCount);
-        $orderMock->expects($this->once())->method('getBaseCurrencyCode')->willReturn('USD');
+        $orderMock->expects($this->once())->method('getGrandTotal')->willReturn(10);
+        $orderMock->expects($this->once())->method('getTaxAmount')->willReturn(2);
+        $orderMock->expects($this->once())->method('getShippingAmount')->willReturn($orderItemCount);
+        $orderMock->expects($this->once())->method('getOrderCurrencyCode')->willReturn('USD');
         return $orderMock;
     }
 

--- a/app/code/Magento/GoogleAnalytics/view/frontend/web/js/google-analytics.js
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/web/js/google-analytics.js
@@ -57,6 +57,8 @@ define([
             if (config.ordersTrackingData) {
                 ga('require', 'ec', 'ec.js');
 
+                ga('set', 'currencyCode', config.ordersTrackingData.currency);
+
                 // Collect product data for GA
                 if (config.ordersTrackingData.products) {
                     $.each(config.ordersTrackingData.products, function (index, value) {


### PR DESCRIPTION
We've encountered a scenario where payment providers require different base currencies configured for different websites in a multisite and as a result need to send different base currency in Google analytics

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6709
2. https://github.com/magento/magento2/issues/7471

### Manual testing scenarios
1. Add to basket
2. Complete checkout
3. Observe results within tracking

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
