### PR TITLE
PayPal checkout causes quote validation after order placement

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -508,7 +508,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                     'quote' => $quote
                 ]
             );
-            $this->quoteRepository->save($quote);
+            $quote->getResource()->save($quote);
         } catch (\Exception $e) {
             if (!empty($this->addressesToSync)) {
                 foreach ($this->addressesToSync as $addressId) {


### PR DESCRIPTION
### Description
A continuation of #10511 but generally a different change so raising separately. They are closely related, however.

### Fixed Issues (if relevant)
Part of #9116
Possibly #10142

### Manual testing scenarios
See #10511

### Rationale
Even after #10511 is committed there is still the issue you can't order the last item in stock. So if quantity is 1 and you order that last item you have the same issue. This is a slightly different cause and fix even though the issue is generally the same.
This commit just stops the quote being validated and stock checked AFTER the order was placed, which is the issue. If order is placed for last item in stock, the stock is now 0. Thus validating the quote stock again (which saving via repository does) will throw an exception that stock is not available.
However, save is REQUIRED since we have to persist the inactive state of the quote.
Fix here is to save by resource so it does no validation, since the order is placed and the quote is already validated earlier on via a prior save.

### Contribution checklist
[x] Pull request has a meaningful description of its purpose
[x] All commits are accompanied by meaningful commit messages
[ ] All new or changed code is covered with unit/integration tests (if applicable)
[ ] All automated tests passed successfully (all builds on Travis CI are green)