### PR TITLE
Show shipping methods in shipping estimator as loading during estimation

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/cart/shipping-estimation.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/cart/shipping-estimation.js
@@ -14,6 +14,7 @@ define(
         'uiRegistry',
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/model/checkout-data-resolver',
+        'Magento_Checkout/js/model/shipping-service',
         'mage/validation'
     ],
     function (
@@ -26,7 +27,8 @@ define(
         shippingRatesValidator,
         registry,
         quote,
-        checkoutDataResolver
+        checkoutDataResolver,
+        shippingService
     ) {
         'use strict';
 
@@ -41,8 +43,14 @@ define(
              */
             initialize: function () {
                 this._super();
+
+                // Prevent shipping methods showing none available whilst we resolve
+                shippingService.isLoading(true);
+
                 registry.async('checkoutProvider')(function (checkoutProvider) {
                     var address, estimatedAddress;
+
+                    shippingService.isLoading(false);
 
                     checkoutDataResolver.resolveEstimationAddress();
                     address = quote.isVirtual() ? quote.billingAddress() : quote.shippingAddress();

--- a/app/code/Magento/Checkout/view/frontend/web/template/cart/shipping-rates.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/cart/shipping-rates.html
@@ -5,7 +5,7 @@
  */
 -->
 <form id="co-shipping-method-form" data-bind="blockLoader: isLoading, visible: isVisible()">
-    <p class="field note" data-bind="visible: (shippingRates().length <= 0)">
+    <p class="field note" data-bind="visible: (!isLoading() && shippingRates().length <= 0)">
         <!-- ko text: $t('Sorry, no quotes are available for this order at this time')--><!-- /ko -->
     </p>
     <fieldset class="fieldset rate" data-bind="visible: (shippingRates().length > 0)">

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -63,10 +63,6 @@
 
             .field {
                 margin: 0 0 16px;
-
-                &.note {
-                    display: none;
-                }
             }
 
             .actions-toolbar {


### PR DESCRIPTION
### Description
Prevents the momentary display of "Sorry, no quotes are available" whilst the shipping estimator is loading available methods when you're using your own theme and aren't hiding the field notes.

I've also put in a small chance to unhide the field notes on the Luma theme so this "Sorry, no quotes are available" message is restored properly. Seems the CSS just hides it, along with the "Enter your destination to get a shipping estimate" note in the shipping estimator. Once these are restored you can see the issue with the momentary sorry message. With this PR it will not show it when it is calculating.

### Fixed Issues (if relevant)
N/A - just raised pull request

### Manual testing scenarios
1. Use Luma theme and unhide the field notes (see changes) to make the notes properly appear as they would in most custom themes. With sample data just disable Flat Rates so you only use Table Rates.
2. Add items to cart, anything
3. Proceed to cart page and on initial page load, or on slow connections, you will momentarily see "Sorry, no quotes are available" where the shipping method list should be, before it reloads

### Rationale
When the cart page loads the shipping method list is initially empty when it finishes loading and the estimator doesn't mark itself loading until a little later if there are table rates etc, and thus it shows this message until the shipping estimate starts loading.
This change makes the shipping estimator inform the shipping panel that it is loading until it gets to initialising the table rates etc so that there is a continuous flag of loading until everything is ready, rather than a small period of "not loading" before moving to "loading", causing this momentary message of no quotes available

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)