### PR TITLE
Update Cookie Manager library to make max cookie number configurable

### DIFF
--- a/app/code/Magento/Cookie/etc/adminhtml/system.xml
+++ b/app/code/Magento/Cookie/etc/adminhtml/system.xml
@@ -22,14 +22,18 @@
                     <label>Cookie Domain</label>
                     <backend_model>Magento\Cookie\Model\Config\Backend\Domain</backend_model>
                 </field>
-                <field id="cookie_httponly" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="cookie_max" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Cookie Max Number</label>
+                    <validate>validate-digits</validate>
+                </field>
+                <field id="cookie_httponly" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use HTTP Only</label>
                     <comment>
                         <![CDATA[<strong style="color:red">Warning</strong>:  Do not set to "No". User security could be compromised.]]>
                     </comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="cookie_restriction" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="cookie_restriction" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Cookie Restriction Mode</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\Cookie\Model\Config\Backend\Cookie</backend_model>

--- a/app/code/Magento/Cookie/etc/config.xml
+++ b/app/code/Magento/Cookie/etc/config.xml
@@ -13,6 +13,7 @@
                 <cookie_httponly>1</cookie_httponly>
                 <cookie_restriction>0</cookie_restriction>
                 <cookie_restriction_lifetime>31536000</cookie_restriction_lifetime>
+                <cookie_max>50</cookie_max>
             </cookie>
         </web>
      </default>

--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -7,9 +7,11 @@
 namespace Magento\Framework\Stdlib\Cookie;
 
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Framework\Phrase;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\HTTP\Header as HttpHeader;
 use Psr\Log\LoggerInterface;
 
@@ -20,26 +22,32 @@ use Psr\Log\LoggerInterface;
  * sensitive data so that extra protection can be added to the contents of the cookie as well as how the browser
  * stores the cookie.
  *
+ * RFC 2109 - Page 15
+ * http://www.ietf.org/rfc/rfc6265.txt
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class PhpCookieManager implements CookieManagerInterface
 {
-    /**#@+
-     * Constants for Cookie manager.
-     * RFC 2109 - Page 15
-     * http://www.ietf.org/rfc/rfc6265.txt
+    /**
+     * Max cookie size
      */
-    const MAX_NUM_COOKIES = 50;
     const MAX_COOKIE_SIZE = 4096;
-    const EXPIRE_NOW_TIME = 1;
-    const EXPIRE_AT_END_OF_SESSION_TIME = 0;
-    /**#@-*/
 
-    /**#@+
+    /**
+     * Expire now time
+     */
+    const EXPIRE_NOW_TIME = 1;
+
+    /**
+     * Expire at the end of session
+     */
+    const EXPIRE_AT_END_OF_SESSION_TIME = 0;
+
+    /**
      * Constant for metadata array key
      */
     const KEY_EXPIRE_TIME = 'expiry';
-    /**#@-*/
 
     /**
      * @var CookieScopeInterface
@@ -50,6 +58,10 @@ class PhpCookieManager implements CookieManagerInterface
      * @var CookieReaderInterface
      */
     private $reader;
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
 
     /**
      * Logger for warning details.
@@ -70,17 +82,20 @@ class PhpCookieManager implements CookieManagerInterface
      * @param CookieReaderInterface $reader
      * @param LoggerInterface $logger
      * @param HttpHeader $httpHeader
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
         CookieScopeInterface $scope,
         CookieReaderInterface $reader,
         LoggerInterface $logger = null,
-        HttpHeader $httpHeader = null
+        HttpHeader $httpHeader = null,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->scope = $scope;
         $this->reader = $reader;
         $this->logger = $logger ?: ObjectManager::getInstance()->get(LoggerInterface::class);
         $this->httpHeader = $httpHeader ?: ObjectManager::getInstance()->get(HttpHeader::class);
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -179,6 +194,19 @@ class PhpCookieManager implements CookieManagerInterface
     }
 
     /**
+     * Retrieve the max cookie number from website config
+     *
+     * @return int
+     */
+    private function getMaxCookieNumber()
+    {
+        return (int) $this->scopeConfig->getValue(
+            'web/cookie/cookie_max',
+            ScopeInterface::SCOPE_WEBSITE
+        );
+    }
+
+    /**
      * Determines whether or not it is possible to send the cookie, based on the number of cookies that already
      * exist and the size of the cookie.
      *
@@ -206,7 +234,7 @@ class PhpCookieManager implements CookieManagerInterface
 
         $sizeOfCookie = $this->sizeOfCookie($name, $value);
 
-        if ($numCookies > PhpCookieManager::MAX_NUM_COOKIES) {
+        if ($numCookies > $this->getMaxCookieNumber()) {
             $this->logger->warning(
                 new Phrase('Unable to send the cookie. Maximum number of cookies would be exceeded.'),
                 array_merge($_COOKIE, ['user-agent' => $this->httpHeader->getHttpUserAgent()])


### PR DESCRIPTION
# Configurable max cookie number


### Description
Replace max_cookie_number constant with a value configurable from admin panel.
Default value is set to 50.

### Manual testing scenarios
1. To change maximum cookies number in admin panel go to: Stores -> Configuration -> Web -> Default Cookies Settings -> Cookie Max Number and set required value

2. Use following script in console to bulk create cookies:
for (let i = 0; i < 50; i++) {
 	let t = Math.random().toString(36).substring(7); 
        document.cookie = t+"="+t;   
}

3. Test if exception has been thrown.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
