### PR TITLE
Handle lifetime value 0 for form_key cookie

### DIFF
--- a/app/code/Magento/PageCache/Observer/RegisterFormKeyFromCookie.php
+++ b/app/code/Magento/PageCache/Observer/RegisterFormKeyFromCookie.php
@@ -88,7 +88,10 @@ class RegisterFormKeyFromCookie implements ObserverInterface
             ->createPublicCookieMetadata();
         $cookieMetadata->setDomain($this->sessionConfig->getCookieDomain());
         $cookieMetadata->setPath($this->sessionConfig->getCookiePath());
-        $cookieMetadata->setDuration($this->sessionConfig->getCookieLifetime());
+        $lifetime = $this->sessionConfig->getCookieLifetime();
+        if ($lifetime !== 0) {
+            $cookieMetadata->setDuration($lifetime);
+        }
 
         $this->cookieFormKey->set(
             $formKey,


### PR DESCRIPTION
0 should not be interpreted as a duration but so that the cookie lasts until session closes.

### Description
Leave out the duration if lifetime is set to 0. This results in the cookie to last until the session closes.

### Fixed Issues
1. magento/magento2#10527: form_key cookie expires immediately if cookie lifetime is set to 0

### Manual testing scenarios
See steps to reproduce in #10527 