### PR TITLE
Magento\Test\Js\LiveCodeTest is failing because of reference to missing file in blacklist

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Js/_files/jshint/blacklist/core.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Js/_files/jshint/blacklist/core.txt
@@ -3,7 +3,6 @@ module Magento_Captcha view/frontend/web/onepage.js
 module Magento_Catalog view/adminhtml/web/catalog/category/edit.js
 module Magento_Catalog view/adminhtml/web/catalog/product.js
 module Magento_Catalog view/adminhtml/web/catalog/product/composite/configure.js
-module Magento_Checkout view/frontend/web/js/opcheckout.js
 module Magento_Rule view/adminhtml/web/rules.js
 module Magento_Sales view/adminhtml/web/order/create/giftmessage.js
 module Magento_Sales view/adminhtml/web/order/create/scripts.js


### PR DESCRIPTION
Magento\Test\Js\LiveCodeTest is failing because of reference to missing file in blacklist

### Description

Magento\Test\Js\LiveCodeTest is failing with exception: The following patterns didn't return any result:
module Magento_Checkout view/frontend/web/js/opcheckout.js

This file is not present in develop anymore, however the reference is still in blacklist:
dev/tests/static/testsuite/Magento/Test/Js/_files/jshint/blacklist/core.txt

