### PR TITLE
Align Magento\Framework\Mail\Message with MessageInterface

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Message.php
+++ b/lib/internal/Magento/Framework/Mail/Message.php
@@ -34,6 +34,23 @@ class Message extends \Zend_Mail implements MessageInterface
     {
         return $this->messageType == self::TYPE_TEXT ? $this->setBodyText($body) : $this->setBodyHtml($body);
     }
+    
+    /**
+     * Set from address
+     *
+     * @param string|array $email
+     * @return $this
+     */
+    public function setFrom($email)
+    {
+        $name = null;
+        if (is_array($email)) {
+            $name = array_keys($email)[0];
+            $name = !is_int($name) ? $name : null;
+            $email = array_values($email)[0];
+        }
+        return parent::setFrom($email, $name);
+    }
 
     /**
      * Set message body


### PR DESCRIPTION
### Description

MessageInterface allows for an array, but implementation does not.  These changes align the implementation with the interface in such a way that aligns with other methods (such as the addTo method).

This allows for all the following to be possible without a bc break:

* `->setFrom('support@magento.com')`
* `->setFrom(['support@magento.com'])`
* `->setFrom(['Magento Support' => 'support@magento.com'])`

### Fixed Issues (if relevant)
There is no public issue for the bug of the interface not matching the implementation.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
