### PR TITLE
Fix product gallery image failed to delete when collide among stores

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
@@ -27,10 +27,15 @@ class UpdateHandler extends \Magento\Catalog\Model\Product\Gallery\CreateHandler
 
         foreach ($images as &$image) {
             if (!empty($image['removed'])) {
-                if (!empty($image['value_id']) && !isset($picturesInOtherStores[$image['file']])) {
+                if (!empty($image['value_id'])) {
+                    /**
+                     * Records work on store level and should be deleted no matter the same file
+                     * used across stores or not
+                     */
                     $recordsToDelete[] = $image['value_id'];
+
                     // only delete physical files if they are not used by any other products
-                    if (!($this->resourceModel->countImageUses($image['file']) > 1)) {
+                    if (!($this->resourceModel->countImageUses($image['file']) > 1) && !isset($picturesInOtherStores[$image['file']])) {
                         $filesToDelete[] = ltrim($image['file'], '/');
                     }
                 }

--- a/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
@@ -21,8 +21,14 @@ class UpdateHandler extends \Magento\Catalog\Model\Product\Gallery\CreateHandler
         $recordsToDelete = [];
         $picturesInOtherStores = [];
 
-        foreach ($this->resourceModel->getProductImages($product, $this->extractStoreIds($product)) as $image) {
-            $picturesInOtherStores[$image['filepath']] = true;
+        $galleryImages = $this->resourceModel->getProductGallery(
+            $product,
+            $this->getAttribute()->getAttributeId(),
+            $this->extractStoreIds($product)
+        );
+        foreach ($galleryImages as $image) {
+            // Same file can share among gallery on store level
+            $picturesInOtherStores[$image['file']] = true;
         }
 
         foreach ($images as &$image) {
@@ -35,7 +41,7 @@ class UpdateHandler extends \Magento\Catalog\Model\Product\Gallery\CreateHandler
                     $recordsToDelete[] = $image['value_id'];
 
                     // only delete physical files if they are not used by any other products
-                    if (!($this->resourceModel->countImageUses($image['file']) > 1) && !isset($picturesInOtherStores[$image['file']])) {
+                    if (!isset($picturesInOtherStores[$image['file']])) {
                         $filesToDelete[] = ltrim($image['file'], '/');
                     }
                 }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -474,4 +474,33 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
         return $this->getConnection()->fetchOne($select);
     }
+
+    /**
+     * Returns product gallery of given attribute in specific stores.
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     * @param int $attributeId
+     * @param int|array $storeIds
+     *
+     * @return array
+     */
+    public function getProductGallery($product, $attributeId, $storeIds)
+    {
+        if (!is_array($storeIds)) {
+            $storeIds = [$storeIds];
+        }
+
+        $select = $this->createBatchBaseSelect($storeIds, $attributeId);
+
+        $select = $select->where(
+            'entity.' . $this->metadata->getLinkField() .' = ?',
+            $product->getData($this->metadata->getLinkField())
+        );
+
+        $result = $this->getConnection()->fetchAll($select);
+
+        $this->removeDuplicates($result);
+
+        return $result;
+    }
 }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -142,7 +142,7 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     }
 
     /**
-     * @param int $storeId
+     * @param int|int[] $storeId
      * @param int $attributeId
      * @return \Magento\Framework\DB\Select
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -158,6 +158,12 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         );
 
         $mainTableAlias = $this->getMainTableAlias();
+
+        if (is_array($storeId)) {
+            $storeCondition = $this->getConnection()->quoteInto('value.store_id IN (?)', $storeId);
+        } else {
+            $storeCondition = $this->getConnection()->quoteInto('value.store_id = ?', (int)$storeId);
+        }
 
         $select = $this->getConnection()->select()->from(
             [$mainTableAlias => $this->getMainTable()],
@@ -176,7 +182,7 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 ' AND ',
                 [
                     $mainTableAlias . '.value_id = value.value_id',
-                    $this->getConnection()->quoteInto('value.store_id = ?', (int)$storeId),
+                    $storeCondition,
                 ]
             ),
             ['label', 'position', 'disabled']

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -195,6 +195,8 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $attributeId
         )->where(
             $mainTableAlias . '.disabled = 0'
+        )->where(
+            'value.value_id IS NOT NULL OR default_value.value_id IS NOT NULL'
         )->order(
             $positionCheckSql . ' ' . \Magento\Framework\DB\Select::SQL_ASC
         );
@@ -216,7 +218,6 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             if (!isset($fileToId[$result[$index]['file']])) {
                 $fileToId[$result[$index]['file']] = $result[$index]['value_id'];
             } elseif ($fileToId[$result[$index]['file']] != $result[$index]['value_id']) {
-                $this->deleteGallery($result[$index]['value_id']);
                 unset($result[$index]);
             }
         }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
@@ -381,7 +381,10 @@ class GalleryTest extends \PHPUnit_Framework_TestCase
             $attributeId
         )->willReturnSelf();
         $this->select->expects($this->at(5))->method('where')->with('main.disabled = 0')->willReturnSelf();
-        $this->select->expects($this->at(7))->method('where')
+        $this->select->expects($this->at(6))->method('where')->with(
+            'value.value_id IS NOT NULL OR default_value.value_id IS NOT NULL'
+        )->willReturnSelf();
+        $this->select->expects($this->at(8))->method('where')
                      ->with('entity.entity_id = ?', $productId)
                      ->willReturnSelf();
         $this->select->expects($this->once())->method('order')


### PR DESCRIPTION
Same image used by the same product across stores as gallery image attributes (i.e., `image`, `small_image`, `thumbnail`) fails to delete.

### Description

The issue is caused by a bug that gallery images **update** on **STORE** level however **retrieve** on **GLOBAL** level.

Because the update and retrieval are performed on different level, during image deletions, there is a chance that a image entry may be shared by other store and thus consider unable to remove - that is when a collision occurs.

This PR update the retrieval query to work on **STORE** level so that update and retrieval will be consistent. During deletion, the program will no longer need to consider image entry collision (https://github.com/magento/magento2/issues/7647) and can delete the entry right away, because each entry is delegated to specific store - no collision will happen.

### Discussion

This issue involves state changes in at least two tables:

1. `catalog_product_entity_varchar` (storing `image`, `small_image`, `thumbnail`)

    The three attributes by default are on **STORE** level

    Example sql query:

    ```sql
    SELECT `images`.`value` AS `filepath`, `images`.`store_id`, `attr`.`attribute_code`
    FROM `catalog_product_entity_varchar` AS `images`
    LEFT JOIN `eav_attribute` AS `attr`
        ON images.attribute_id = attr.attribute_id
    WHERE
        (attribute_code IN ('small_image', 'thumbnail', 'image'))
        AND  (row_id = '12345');
    +------------------+----------+----------------+
    | filepath         | store_id | attribute_code |
    +------------------+----------+----------------+
    | /e/x/example.jpg |        1 | image          |
    | /e/x/example.jpg |        2 | image          |
    | /e/x/example.jpg |        1 | small_image    |
    | /e/x/example.jpg |        2 | small_image    |
    | /e/x/example.jpg |        1 | thumbnail      |
    | /e/x/example.jpg |        2 | thumbnail      |
    +------------------+----------+----------------+
    6 rows in set (0.01 sec)
    ```

    The three image attributes store file path (i.e., value) of specific entry in `catalog_product_entity_media_gallery`

2. `catalog_product_entity_media_gallery` (joint by `value_id` against `catalog_product_entity_media_gallery_value` and `catalog_product_entity_media_gallery_value_to_entity`)

    The three tables I believe they are all intended to be on **STORE** level. This is because:

     - The three tables have DELETE CASCADE on them all linked to `value_id`, which in the `catalog_product_entity_media_gallery_value` sets on store level

     - The update method (in \Magento\Catalog\Model\Product\Gallery\CreateHandler::processNewAndExistingImages) will always create a set of new entries in the three table for each store.

     - The three varchar attributes image, small_image, and thumbnail all support on store level. Unless we limit them to global level, if gallery not work on store level will create discrepancy.

    If we consider they ALL should live on **STORE** level, the changes in this PR will be safe.

    Example join query:

    ```sql
    select v.value_id, v.store_id, g.value
    from catalog_product_entity_media_gallery_value as v
    left join catalog_product_entity_media_gallery as g on v.value_id = g.value_id
    left join catalog_product_entity_media_gallery_value_to_entity as l
        on v.value_id = l.value_id
    where l.row_id = 12345;
    +----------+----------+------------------+
    | value_id | store_id | value            |
    +----------+----------+------------------+
    |  1000000 |        2 | /e/x/example.jpg |
    +----------+----------+------------------+
    1 row in set (0.00 sec)
   ```

#### Gallery Image Create / Update

Update takes place in `\Magento\Catalog\Model\Product\Gallery\CreateHandler::processNewAndExistingImages`

Image create / update on **STORE** level.

This perfectly matches the table structures that the three tables joint together to represent SINGLE image entry - value_id:

#### Gallery Image Retrieval

Retrieval takes place in `\Magento\Catalog\Model\ResourceModel\Product\Gallery::loadProductGalleryByAttributeId`

Image retrieved on **GLOBAL** level - that is, regardless store_id entry in `catalog_product_entity_media_gallery_value`, ever entries in `catalog_product_entity_media_gallery_value_to_entity` that links the image entry to the product entity, will be retrieved. This means, no matter what store a image entry is assigned to, as long as it is linked to the same product, it will be retrieved together.

This causes a worse data issue.

Only LAST updated store will get the images assigned. Because we have been retrieving images globally, this issue is not revealed.

1. Update product images on **store A**
    - Retrieve product images globally
    - Delete retrieved product images
    - Create product images against **store A**
2. Update product images on **store B**
    - Retrieve product images globally
    - Delete retrieved product images
    - Create product images against **store B**

**Store A** lost the image links because of the global retrieval query.

See: \Magento\Catalog\Model\ResourceModel\Product\Gallery::createBatchBaseSelect

https://github.com/magento/magento2/pull/10548/files#diff-ced6f014f1c31e09ceb386cb6e71219dR173

### Impacts

Even though this PR can fix the issue, there are some downsides:

1. Data was set globally. This will probably cause migration issue.

    Updating image retrieval from **GLOBAL** to **STORE** level will result in an illusion of losing product image. Because image deletions were affected by global image retrieval (see above update scenario), only the LAST store that update the product images will get the images assigned.

    This implies that for Magento project which has more than one store will need to have data level migration to make sure each project images are populated against all stores.

2. Fallback feature needs reviewing

    This PR has kept the fallback feature. All gallery images matching store=0 or store=CURRENT_STORE will return on retrieval.

    Fallback is ambiguous during update as image entries from store=0 should not be updated by update requests on specific store. A new flag may be needed to indicate if that product on specific store should include default gallery or not.

    On retrieval, the flag should be used to decide if gallery of store=0 should be included or not.

    https://github.com/magento/magento2/pull/10548/files#diff-ced6f014f1c31e09ceb386cb6e71219dR205

    On update, only entires belonging to the updating store should be updated / deleted. This requires some changes on the codebase.

### Alternative

On update, always delete entries in `catalog_product_entity_media_gallery_value` and keep `catalog_product_entity_media_gallery_value_to_entity` and `catalog_product_entity_media_gallery` on global level.

This approach will still require gallery images retrieval change from GLOBAL to STORE level and will result in the same migration issue.

On the other hand, we can give up the store level assignment. This means ignoring the store_id value in `catalog_product_entity_media_gallery_value` table and keep gallery global. In this case, `image`, `thumbnail` and `small_image` attributes must also be global. Otherwise, we cannot guarantee the file referenced by the three attributes on store level still exists after removing `catalog_product_entity_media_gallery` entries globally. This implies breaking backward compatibility.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#7647: The image cannot be removed as it has been assigned to the other image role

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. In Store A, set Image A against a product and set it as thumbnail, image, and small_image
1. Save.
1. In Store B, remove Image A from the product.
1. Save.

**Expected result:**

Save successfully

**Actual result:**

The image cannot be removed as it has been assigned to the other image role

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
