### PR TITLE
Option to send currency in Google Adwords when using dynamic value

### DIFF
--- a/app/code/Magento/GoogleAdwords/Helper/Data.php
+++ b/app/code/Magento/GoogleAdwords/Helper/Data.php
@@ -64,6 +64,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     const XML_PATH_CONVERSION_VALUE = 'google/adwords/conversion_value';
 
+    /**
+     * Google Adwords send order conversion value currency when using dynamic value
+     */
     const XML_PATH_SEND_CURRENCY = 'google/adwords/send_currency';
 
     /**#@-*/
@@ -277,7 +280,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return boolean
      */
-    public function hasSendCurrency()
+    public function hasSendConversionValueCurrency()
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_SEND_CURRENCY,
@@ -288,11 +291,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Google AdWords conversion value currency
      *
-     * @return float
+     * @return string|false
      */
     public function getConversionValueCurrency()
     {
-        if ($this->hasSendCurrency()) {
+        if ($this->hasSendConversionValueCurrency()) {
             return (string) $this->_registry->registry(self::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME);
         }
         return false;

--- a/app/code/Magento/GoogleAdwords/Helper/Data.php
+++ b/app/code/Magento/GoogleAdwords/Helper/Data.php
@@ -36,6 +36,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CONVERSION_VALUE_REGISTRY_NAME = 'google_adwords_conversion_value';
 
     /**
+     * Google AdWords registry name for conversion value currency
+     */
+    const CONVERSION_VALUE_CURRENCY_REGISTRY_NAME = 'google_adwords_conversion_value_currency';
+
+    /**
      * Default value for conversion value
      */
     const CONVERSION_VALUE_DEFAULT = 0;
@@ -58,6 +63,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PATH_CONVERSION_VALUE_TYPE = 'google/adwords/conversion_value_type';
 
     const XML_PATH_CONVERSION_VALUE = 'google/adwords/conversion_value';
+
+    const XML_PATH_SEND_CURRENCY = 'google/adwords/send_currency';
 
     /**#@-*/
 
@@ -263,5 +270,30 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $conversionValue = $this->getConversionValueConstant();
         }
         return empty($conversionValue) ? self::CONVERSION_VALUE_DEFAULT : $conversionValue;
+    }
+
+    /**
+     * Get send order currency to Google Adwords
+     *
+     * @return boolean
+     */
+    public function getSendCurrency() {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_SEND_CURRENCY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * Get Google AdWords conversion value currency
+     *
+     * @return float
+     */
+    public function getConversionValueCurrency()
+    {
+        if ($this->getSendCurrency()) {
+            return (string) $this->_registry->registry(self::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME);
+        } 
+        return false;
     }
 }

--- a/app/code/Magento/GoogleAdwords/Helper/Data.php
+++ b/app/code/Magento/GoogleAdwords/Helper/Data.php
@@ -277,7 +277,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return boolean
      */
-    public function getSendCurrency() {
+    public function hasSendCurrency()
+    {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_SEND_CURRENCY,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
@@ -291,9 +292,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getConversionValueCurrency()
     {
-        if ($this->getSendCurrency()) {
+        if ($this->hasSendCurrency()) {
             return (string) $this->_registry->registry(self::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME);
-        } 
+        }
         return false;
     }
 }

--- a/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
+++ b/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
@@ -58,12 +58,14 @@ class SetConversionValueObserver implements ObserverInterface
             return $this;
         }
         $this->_collection->addFieldToFilter('entity_id', ['in' => $orderIds]);
-        $conversionValue = 0;
-        /** @var $order \Magento\Sales\Model\Order */
 
+        $conversionValue = 0;
+        $conversionCurrency = false;
+        $orderHasSendCurrency = $this->_helper->hasSendCurrency();
         foreach ($this->_collection as $order) {
-            $conversionValue += ($this->_helper->hasSendCurrency()) ? $order->getGrandTotal() :  $order->getBaseGrandTotal();
-            $conversionCurrency = ($this->_helper->hasSendCurrency()) ? $order->getOrderCurrencyCode() : false;
+            /** @var $order \Magento\Sales\Model\Order */
+            $conversionValue += $orderHasSendCurrency ? $order->getGrandTotal() : $order->getBaseGrandTotal();
+            $conversionCurrency = $orderHasSendCurrency ? $order->getOrderCurrencyCode() : false;
         }
         $this->_registry->register(
             \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,

--- a/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
+++ b/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
@@ -61,7 +61,7 @@ class SetConversionValueObserver implements ObserverInterface
 
         $conversionValue = 0;
         $conversionCurrency = false;
-        $sendOrderCurrency = $this->_helper->hasSendCurrency();
+        $sendOrderCurrency = $this->_helper->hasSendConversionValueCurrency();
         foreach ($this->_collection as $order) {
             /** @var $order \Magento\Sales\Api\Data\OrderInterface */
             $conversionValue += $sendOrderCurrency ? $order->getGrandTotal() : $order->getBaseGrandTotal();

--- a/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
+++ b/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
@@ -61,20 +61,14 @@ class SetConversionValueObserver implements ObserverInterface
         $conversionValue = 0;
         /** @var $order \Magento\Sales\Model\Order */
 
-        if($this->_helper->getSendCurrency()) {
-            foreach ($this->_collection as $order) {
-                $conversionValue += $order->getGrandTotal();
-                $conversionCurrency = $order->getOrderCurrencyCode();
-            }
-            $this->_registry->register(
-                \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
-                $conversionCurrency
-            );
-        } else {
-            foreach ($this->_collection as $order) {
-                $conversionValue += $order->getBaseGrandTotal();
-            }
+        foreach ($this->_collection as $order) {
+            $conversionValue += ($this->_helper->hasSendCurrency()) ? $order->getGrandTotal() :  $order->getBaseGrandTotal();
+            $conversionCurrency = ($this->_helper->hasSendCurrency()) ? $order->getOrderCurrencyCode() : false;
         }
+        $this->_registry->register(
+            \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
+            $conversionCurrency
+        );
         $this->_registry->register(
             \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_REGISTRY_NAME,
             $conversionValue

--- a/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
+++ b/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
@@ -61,11 +61,11 @@ class SetConversionValueObserver implements ObserverInterface
 
         $conversionValue = 0;
         $conversionCurrency = false;
-        $orderHasSendCurrency = $this->_helper->hasSendCurrency();
+        $sendOrderCurrency = $this->_helper->hasSendCurrency();
         foreach ($this->_collection as $order) {
-            /** @var $order \Magento\Sales\Model\Order */
-            $conversionValue += $orderHasSendCurrency ? $order->getGrandTotal() : $order->getBaseGrandTotal();
-            $conversionCurrency = $orderHasSendCurrency ? $order->getOrderCurrencyCode() : false;
+            /** @var $order \Magento\Sales\Api\Data\OrderInterface */
+            $conversionValue += $sendOrderCurrency ? $order->getGrandTotal() : $order->getBaseGrandTotal();
+            $conversionCurrency = $sendOrderCurrency ? $order->getOrderCurrencyCode() : false;
         }
         $this->_registry->register(
             \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,

--- a/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
+++ b/app/code/Magento/GoogleAdwords/Observer/SetConversionValueObserver.php
@@ -60,8 +60,20 @@ class SetConversionValueObserver implements ObserverInterface
         $this->_collection->addFieldToFilter('entity_id', ['in' => $orderIds]);
         $conversionValue = 0;
         /** @var $order \Magento\Sales\Model\Order */
-        foreach ($this->_collection as $order) {
-            $conversionValue += $order->getBaseGrandTotal();
+
+        if($this->_helper->getSendCurrency()) {
+            foreach ($this->_collection as $order) {
+                $conversionValue += $order->getGrandTotal();
+                $conversionCurrency = $order->getOrderCurrencyCode();
+            }
+            $this->_registry->register(
+                \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
+                $conversionCurrency
+            );
+        } else {
+            foreach ($this->_collection as $order) {
+                $conversionValue += $order->getBaseGrandTotal();
+            }
         }
         $this->_registry->register(
             \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_REGISTRY_NAME,

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -227,7 +227,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
 
 
         $this->assertEquals($returnValue, $this->_helper->getConversionValue());
-
     }
 
     public function testGetConversionValueCurrency()

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -171,7 +171,8 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ['getConversionColor', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_COLOR, 'ffffff'],
             ['getConversionLabel', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_LABEL, 'Label'],
             ['getConversionValueType', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_VALUE_TYPE, '1'],
-            ['getConversionValueConstant', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_VALUE, '0']
+            ['getConversionValueConstant', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_VALUE, '0'],
+            ['hasSendCurrency', \Magento\GoogleAdwords\Helper\Data::XML_PATH_SEND_CURRENCY, '1']
         ];
     }
 

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -172,7 +172,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ['getConversionLabel', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_LABEL, 'Label'],
             ['getConversionValueType', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_VALUE_TYPE, '1'],
             ['getConversionValueConstant', \Magento\GoogleAdwords\Helper\Data::XML_PATH_CONVERSION_VALUE, '0'],
-            ['hasSendCurrency', \Magento\GoogleAdwords\Helper\Data::XML_PATH_SEND_CURRENCY, '1']
         ];
     }
 
@@ -197,10 +196,16 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($returnValue, $this->_helper->{$method}());
     }
 
+    public function testHasSendCurrency()
+    {
+        $this->_scopeConfigMock->expects($this->once())->method('isSetFlag')->willReturn(true);
+
+        $this->assertTrue($this->_helper->hasSendCurrency());
+    }
+
     public function testGetConversionValueDynamic()
     {
         $returnValue = 4.1;
-        $returnValueCurrency = 'USD';
         $this->_scopeConfigMock->expects(
             $this->any()
         )->method(
@@ -219,6 +224,16 @@ class DataTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($returnValue)
         );
+
+
+        $this->assertEquals($returnValue, $this->_helper->getConversionValue());
+
+    }
+
+    public function testGetConversionValueCurrency()
+    {
+        $returnValueCurrency = 'USD';
+        $this->_scopeConfigMock->expects($this->once())->method('isSetFlag')->willReturn(true);
         $this->_registryMock->expects(
             $this->once()
         )->method(
@@ -229,7 +244,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($returnValueCurrency)
         );
 
-        $this->assertEquals($returnValue, $this->_helper->getConversionValue());
         $this->assertEquals($returnValueCurrency, $this->_helper->getConversionValueCurrency());
     }
 

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -199,6 +199,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
     public function testGetConversionValueDynamic()
     {
         $returnValue = 4.1;
+        $returnValueCurrency = 'USD';
         $this->_scopeConfigMock->expects(
             $this->any()
         )->method(
@@ -217,8 +218,18 @@ class DataTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($returnValue)
         );
+        $this->_registryMock->expects(
+            $this->once()
+        )->method(
+            'registry'
+        )->with(
+            \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME
+        )->will(
+            $this->returnValue($returnValueCurrency)
+        );
 
         $this->assertEquals($returnValue, $this->_helper->getConversionValue());
+        $this->assertEquals($returnValueCurrency, $this->_helper->getConversionValueCurrency());
     }
 
     /**

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -196,11 +196,11 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($returnValue, $this->_helper->{$method}());
     }
 
-    public function testHasSendCurrency()
+    public function testHasSendConversionValueCurrency()
     {
         $this->_scopeConfigMock->expects($this->once())->method('isSetFlag')->willReturn(true);
 
-        $this->assertTrue($this->_helper->hasSendCurrency());
+        $this->assertTrue($this->_helper->hasSendConversionValueCurrency());
     }
 
     public function testGetConversionValueDynamic()

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -225,7 +225,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($returnValue)
         );
 
-
         $this->assertEquals($returnValue, $this->_helper->getConversionValue());
     }
 

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
@@ -122,6 +122,7 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
     {
         $ordersIds = [1, 2, 3];
         $conversionValue = 0;
+        $conversionValueCurrency = 'USD';
         $this->_helperMock->expects($this->once())->method('isGoogleAdwordsActive')->will($this->returnValue(true));
         $this->_helperMock->expects($this->once())->method('isDynamicConversionValue')->will($this->returnValue(true));
         $this->_eventMock->expects($this->once())->method('getOrderIds')->will($this->returnValue($ordersIds));
@@ -150,6 +151,14 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
         )->with(
             \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_REGISTRY_NAME,
             $conversionValue
+        );
+        $this->_registryMock->expects(
+            $this->once()
+        )->method(
+            'register'
+        )->with(
+            \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
+            $conversionValueCurrency
         );
 
         $this->assertSame($this->_model, $this->_model->execute($this->_eventObserverMock));

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
@@ -127,7 +127,8 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
         $conversionCurrency = 'USD';
         $this->_helperMock->expects($this->once())->method('isGoogleAdwordsActive')->will($this->returnValue(true));
         $this->_helperMock->expects($this->once())->method('isDynamicConversionValue')->will($this->returnValue(true));
-        $this->_helperMock->expects($this->once())->method('hasSendConversionValueCurrency')->will($this->returnValue(true));
+        $this->_helperMock->expects($this->once())->method('hasSendConversionValueCurrency')
+            ->will($this->returnValue(true));
         $this->_eventMock->expects($this->once())->method('getOrderIds')->will($this->returnValue($ordersIds));
         $this->_eventObserverMock->expects(
             $this->once()

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GoogleAdwords\Test\Unit\Observer;
 
+use Magento\GoogleAdwords\Helper\Data;
+
 class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -135,7 +137,10 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($this->_eventMock)
         );
 
-        $iteratorMock = $this->createMock(\Iterator::class);
+        $orderMock = $this->createMock(\Magento\Sales\Api\Data\OrderInterface::class);
+        $orderMock->expects($this->once())->method('getOrderCurrencyCode')->willReturn($conversionCurrency);
+
+        $iteratorMock = new \ArrayIterator([$orderMock]);
         $this->_collectionMock->expects($this->any())->method('getIterator')->will($this->returnValue($iteratorMock));
         $this->_collectionMock->expects(
             $this->once()
@@ -146,20 +151,18 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
             ['in' => $ordersIds]
         );
         $this->_registryMock->expects(
-            $this->once()
+            $this->atLeastOnce()
         )->method(
             'register'
-        )->with(
-            \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_REGISTRY_NAME,
-            $conversionValue
-        );
-        $this->_registryMock->expects(
-            $this->once()
-        )->method(
-            'register'
-        )->with(
-            \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
-            $conversionCurrency
+        )->withConsecutive(
+            [
+                Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
+                $conversionCurrency
+            ],
+            [
+                Data::CONVERSION_VALUE_REGISTRY_NAME,
+                $conversionValue,
+            ]
         );
 
         $this->assertSame($this->_model, $this->_model->execute($this->_eventObserverMock));

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
@@ -122,9 +122,10 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
     {
         $ordersIds = [1, 2, 3];
         $conversionValue = 0;
-        $conversionValueCurrency = 'USD';
+        $conversionCurrency = 'USD';
         $this->_helperMock->expects($this->once())->method('isGoogleAdwordsActive')->will($this->returnValue(true));
         $this->_helperMock->expects($this->once())->method('isDynamicConversionValue')->will($this->returnValue(true));
+        $this->_helperMock->expects($this->once())->method('hasSendCurrency')->will($this->returnValue(true));
         $this->_eventMock->expects($this->once())->method('getOrderIds')->will($this->returnValue($ordersIds));
         $this->_eventObserverMock->expects(
             $this->once()
@@ -158,7 +159,7 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
             'register'
         )->with(
             \Magento\GoogleAdwords\Helper\Data::CONVERSION_VALUE_CURRENCY_REGISTRY_NAME,
-            $conversionValueCurrency
+            $conversionCurrency
         );
 
         $this->assertSame($this->_model, $this->_model->execute($this->_eventObserverMock));

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Observer/SetConversionValueObserverTest.php
@@ -127,7 +127,7 @@ class SetConversionValueObserverTest extends \PHPUnit\Framework\TestCase
         $conversionCurrency = 'USD';
         $this->_helperMock->expects($this->once())->method('isGoogleAdwordsActive')->will($this->returnValue(true));
         $this->_helperMock->expects($this->once())->method('isDynamicConversionValue')->will($this->returnValue(true));
-        $this->_helperMock->expects($this->once())->method('hasSendCurrency')->will($this->returnValue(true));
+        $this->_helperMock->expects($this->once())->method('hasSendConversionValueCurrency')->will($this->returnValue(true));
         $this->_eventMock->expects($this->once())->method('getOrderIds')->will($this->returnValue($ordersIds));
         $this->_eventObserverMock->expects(
             $this->once()

--- a/app/code/Magento/GoogleAdwords/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleAdwords/etc/adminhtml/system.xml
@@ -61,6 +61,14 @@
                         <field id="*/*/conversion_value_type">0</field>
                     </depends>
                 </field>
+                <field id="send_currency" translate="label" type="select" sortOrder="18" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Send Order Currency</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="*/*/active">1</field>
+                        <field id="*/*/conversion_value_type">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/GoogleAdwords/etc/config.xml
+++ b/app/code/Magento/GoogleAdwords/etc/config.xml
@@ -15,6 +15,7 @@
                 <conversion_color>FFFFFF</conversion_color>
                 <conversion_value_type>1</conversion_value_type>
                 <conversion_value>0</conversion_value>
+                <send_currency>0</send_currency>
                 <languages>
                     <ar>ar</ar>
                     <bg>bg</bg>

--- a/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
@@ -18,6 +18,9 @@
     var google_conversion_color = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionColor() ?>";
     var google_conversion_label = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionLabel() ?>";
     var google_conversion_value = <?= /* @escapeNotVerified */ $block->getHelper()->getConversionValue() ?>;
+    <?php if($block->getHelper()->getSendCurrency() && $block->getHelper()->getConversionValueCurrency()): ?>
+    var google_conversion_currency = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionValueCurrency() ?>";
+    <?php endif; ?>
     /* ]]> */
 </script>
 <script src="<?= /* @escapeNotVerified */ $block->getHelper()->getConversionJsSrc() ?>"></script>

--- a/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
@@ -18,7 +18,7 @@
     var google_conversion_color = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionColor() ?>";
     var google_conversion_label = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionLabel() ?>";
     var google_conversion_value = <?= /* @escapeNotVerified */ $block->getHelper()->getConversionValue() ?>;
-    <?php if($block->getHelper()->hasSendCurrency() && $block->getHelper()->getConversionValueCurrency()): ?>
+    <?php if($block->getHelper()->hasSendConversionValueCurrency() && $block->getHelper()->getConversionValueCurrency()): ?>
     var google_conversion_currency = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionValueCurrency() ?>";
     <?php endif; ?>
     /* ]]> */

--- a/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
@@ -18,7 +18,7 @@
     var google_conversion_color = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionColor() ?>";
     var google_conversion_label = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionLabel() ?>";
     var google_conversion_value = <?= /* @escapeNotVerified */ $block->getHelper()->getConversionValue() ?>;
-    <?php if($block->getHelper()->getSendCurrency() && $block->getHelper()->getConversionValueCurrency()): ?>
+    <?php if($block->getHelper()->hasSendCurrency() && $block->getHelper()->getConversionValueCurrency()): ?>
     var google_conversion_currency = "<?= /* @escapeNotVerified */ $block->getHelper()->getConversionValueCurrency() ?>";
     <?php endif; ?>
     /* ]]> */


### PR DESCRIPTION
Introduces option to send currency in adwords when using dynamic value to cope with multisite scenario where base currency differs between websites

### Description
Introduce option to send currency in adwords when using dynamic value.   Configurable via backend. Defaults to off.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6708

### Manual testing scenarios
1. Enable via API config screen
2. Switch currency
3. Add to basket
4. Complete checkout
5. Observe results within Adwords

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
