### PR TITLE
fixed notice when remove column from grid

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Extended.php
@@ -314,7 +314,8 @@ class Extended extends \Magento\Backend\Block\Widget\Grid implements \Magento\Ba
         if ($this->getColumnSet()->getChildBlock($columnId)) {
             $this->getColumnSet()->unsetChild($columnId);
             if ($this->_lastColumnId == $columnId) {
-                $this->_lastColumnId = array_pop($this->getColumnSet()->getChildNames());
+                $names = $this->getColumnSet()->getChildNames();
+                $this->_lastColumnId = array_pop($names);
             }
         }
         return $this;


### PR DESCRIPTION
Magento 2.1.8
PHP 7.0.22

### Description

Magento 2.1.8
PHP 7.0.22

$adminGrid->removeColumn('column_name');

Notice: Only variables should be passed by reference in Magento/Backend/Block/Widget/Grid/Extended.php on line 314
