### PR TITLE
Removed instantiating new driverpool class when it's already available.

### DIFF
--- a/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
+++ b/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
@@ -260,7 +260,7 @@ class ObjectManagerFactory
                     new \Magento\Framework\Filesystem\Directory\WriteFactory($driverPool)
                 ),
                 new \Magento\Framework\Config\FileIteratorFactory(
-                    new \Magento\Framework\Filesystem\File\ReadFactory(new \Magento\Framework\Filesystem\DriverPool())
+                    new \Magento\Framework\Filesystem\File\ReadFactory($driverPool)
                 )
             );
             $schemaLocator = new \Magento\Framework\ObjectManager\Config\SchemaLocator();


### PR DESCRIPTION
Removed instantiating new driverpool class when it's already available. This change will make Magento a little bit faster since it will not instantiate a new class, but use the class already available. Will also make Magento use slightly less memory. 