### PR TITLE
Fix issue 10032

### DIFF
--- a/app/code/Magento/Backup/Model/BackupFactory.php
+++ b/app/code/Magento/Backup/Model/BackupFactory.php
@@ -38,23 +38,20 @@ class BackupFactory
      */
     public function create($timestamp, $type)
     {
-        $backupId = $timestamp . '_' . $type;
         $fsCollection = $this->_objectManager->get(\Magento\Backup\Model\Fs\Collection::class);
         $backupInstance = $this->_objectManager->get(\Magento\Backup\Model\Backup::class);
+
         foreach ($fsCollection as $backup) {
-            if ($backup->getId() == $backupId) {
-                $backupInstance->setType(
-                    $backup->getType()
-                )->setTime(
-                    $backup->getTime()
-                )->setName(
-                    $backup->getName()
-                )->setPath(
-                    $backup->getPath()
-                );
+            if ($backup->getTime() === (int) $timestamp && $backup->getType() === $type) {
+                $backupInstance->setData(['id' => $backup->getId()])
+                    ->setType($backup->getType())
+                    ->setTime($backup->getTime())
+                    ->setName($backup->getName())
+                    ->setPath($backup->getPath());
                 break;
             }
         }
+
         return $backupInstance;
     }
 }

--- a/app/code/Magento/Backup/Test/Unit/Model/BackupFactoryTest.php
+++ b/app/code/Magento/Backup/Test/Unit/Model/BackupFactoryTest.php
@@ -77,42 +77,29 @@ class BackupFactoryTest extends \PHPUnit\Framework\TestCase
 
     public function testCreate()
     {
-        $this->_backupModel->expects(
-            $this->once()
-        )->method(
-            'setType'
-        )->with(
-            $this->_data['type']
-        )->will(
-            $this->returnSelf()
-        );
-        $this->_backupModel->expects(
-            $this->once()
-        )->method(
-            'setTime'
-        )->with(
-            $this->_data['time']
-        )->will(
-            $this->returnSelf()
-        );
-        $this->_backupModel->expects(
-            $this->once()
-        )->method(
-            'setName'
-        )->with(
-            $this->_data['name']
-        )->will(
-            $this->returnSelf()
-        );
-        $this->_backupModel->expects(
-            $this->once()
-        )->method(
-            'setPath'
-        )->with(
-            $this->_data['path']
-        )->will(
-            $this->returnSelf()
-        );
+        $this->_backupModel->expects($this->once())
+            ->method('setType')
+            ->with($this->_data['type'])
+            ->will($this->returnSelf());
+
+        $this->_backupModel->expects($this->once())
+            ->method('setTime')
+            ->with($this->_data['time'])
+            ->will($this->returnSelf());
+
+        $this->_backupModel->expects($this->once())
+            ->method('setName')
+            ->with($this->_data['name'])
+            ->will($this->returnSelf());
+
+        $this->_backupModel->expects($this->once())
+            ->method('setPath')
+            ->with($this->_data['path'])
+            ->will($this->returnSelf());
+
+        $this->_backupModel->expects($this->once())
+            ->method('setData')
+            ->will($this->returnSelf());
 
         $this->_instance->create('1385661590', 'snapshot');
     }


### PR DESCRIPTION
### Description

This fixes the issue where the link to the download of a backup in the admin gives the wrong file.
The wrong file seems to be the latest backup that was generated.

### Fixed Issues
- #10032

### Manual testing scenarios
1. Create multiple backups via the admin panel.
2. Check that the downloads provided in the backup grid have the correct links

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
