### PR TITLE
Bug fix, prevent displaying `0000-00-00 00:00:00` as anything else in admin grids

### DIFF
--- a/app/code/Magento/Ui/Component/Listing/Columns/Date.php
+++ b/app/code/Magento/Ui/Component/Listing/Columns/Date.php
@@ -53,7 +53,9 @@ class Date extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
-                if (isset($item[$this->getData('name')])) {
+                if (isset($item[$this->getData('name')])
+                   && $item[$this->getData('name')] !== "0000-00-00 00:00:00"
+                ) {
                     $date = $this->timezone->date(new \DateTime($item[$this->getData('name')]));
                     $timezone = isset($this->getConfiguration()['timezone'])
                         ? $this->booleanUtils->convert($this->getConfiguration()['timezone'])

--- a/app/code/Magento/Ui/Test/Unit/Component/Listing/Columns/DateTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Listing/Columns/DateTest.php
@@ -89,4 +89,14 @@ class DateTest extends \PHPUnit\Framework\TestCase
         $result = $this->model->prepareDataSource(['data' => ['items' => [$item]]]);
         $this->assertEquals(self::TEST_TIME, $result['data']['items'][0]['field_name']);
     }
+
+    public function testPrepareDataSourceWithZeroDate()
+    {
+        $zeroDate = '0000-00-00 00:00:00';
+        $item = ['test_data' => 'some_data', 'field_name' => $zeroDate];
+        $this->timezoneMock->expects($this->never())->method('date');
+
+        $result = $this->model->prepareDataSource(['data' => ['items' => [$item]]]);
+        $this->assertEquals($zeroDate, $result['data']['items'][0]['field_name']);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The datetime 0000-00-00 00:00:00 is converted to a different time zone, leading to unexpected outcome. This string should be treated equal as NULL.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. none

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add a '0000-00-00 00:00:00' date in the database in one of the sales grids 
2. Set the time zone to something exotic
3. See that the 0000 time is turned into something meaningless, a random-ish date and time

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
