### PR TITLE
Resolve fatal error in repository generator

### DIFF
--- a/app/code/Magento/Bundle/Model/OptionRepository.php
+++ b/app/code/Magento/Bundle/Model/OptionRepository.php
@@ -208,7 +208,7 @@ class OptionRepository implements \Magento\Bundle\Api\ProductOptionRepositoryInt
             }
         } else {
             if (!$existingOption->getOptionId()) {
-                throw new NoSuchEntityException('Requested option doesn\'t exist');
+                throw new NoSuchEntityException(__('Requested option doesn\'t exist'));
             }
 
             $option->setData(array_merge($existingOption->getData(), $option->getData()));

--- a/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Repository.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Repository.php
@@ -223,13 +223,13 @@ class Repository extends \Magento\Framework\Code\Generator\EntityAbstract
         /** @var ParameterReflection $parameterReflection */
         $parameterReflection = $methodReflection->getParameters()[0];
         $body = "if (!\$id) {\n"
-            . "    throw new \\" . InputException::class . "('ID required');\n"
+            . "    throw new \\" . InputException::class . "(__('ID required'));\n"
             . "}\n"
             . "if (!isset(\$this->registry[\$id])) {\n"
             . "    \$entity = \$this->" . $this->_getSourcePersistorPropertyName()
             . "->loadEntity(\$id);\n"
             . "    if (!\$entity->getId()) {\n"
-            . "        throw new \\" . NoSuchEntityException::class . "('Requested entity doesn\\'t exist');\n"
+            . "        throw new \\" . NoSuchEntityException::class . "(__('Requested entity doesn\\'t exist'));\n"
             . "    }\n"
             . "    \$this->registry[\$id] = \$entity;\n"
             . "}\n"

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/SampleRepository.txt
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/SampleRepository.txt
@@ -67,12 +67,12 @@ class SampleRepository implements SampleRepositoryInterface
     public function get($id)
     {
         if (!$id) {
-            throw new \Magento\Framework\Exception\InputException('ID required');
+            throw new \Magento\Framework\Exception\InputException(__('ID required'));
         }
         if (!isset($this->registry[$id])) {
             $entity = $this->sampleInterfacePersistor->loadEntity($id);
             if (!$entity->getId()) {
-                throw new \Magento\Framework\Exception\NoSuchEntityException('Requested entity doesn\'t exist');
+                throw new \Magento\Framework\Exception\NoSuchEntityException(__('Requested entity doesn\'t exist'));
             }
             $this->registry[$id] = $entity;
         }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/TSampleRepository.txt
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/TSampleRepository.txt
@@ -67,12 +67,12 @@ class TSampleRepository implements TSampleRepositoryInterface
     public function get(int $id) : \Magento\Framework\ObjectManager\Code\Generator\TSampleInterface
     {
         if (!$id) {
-            throw new \Magento\Framework\Exception\InputException('ID required');
+            throw new \Magento\Framework\Exception\InputException(__('ID required'));
         }
         if (!isset($this->registry[$id])) {
             $entity = $this->tSampleInterfacePersistor->loadEntity($id);
             if (!$entity->getId()) {
-                throw new \Magento\Framework\Exception\NoSuchEntityException('Requested entity doesn\'t exist');
+                throw new \Magento\Framework\Exception\NoSuchEntityException(__('Requested entity doesn\'t exist'));
             }
             $this->registry[$id] = $entity;
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Both InputException and NoSuchEntityException require a Phrase object as first constructor argument
`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\\Framework\\Exception\\InputException::__construct() must be an instance of Magento\\Framework\\Phrase, string given`
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/6151
### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. auto-generate a repository
2. call the get method without a parameter

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
