### PR TITLE
Add missing translations in Customer module

### DIFF
--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -536,3 +536,7 @@ Addresses,Addresses
 "Password forgotten","Password forgotten"
 "My Dashboard","My Dashboard"
 "You are signed out","You are signed out"
+"Associate to Website","Associate to Website"
+"Prefix","Prefix"
+"Middle Name/Initial","Middle Name/Initial"
+"Suffix","Suffix"


### PR DESCRIPTION
### Description
Add missing translations in Customer module (taken from https://github.com/magento/magento2/blob/develop/app/code/Magento/Customer/Setup/CustomerSetup.php).

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Set locale of backend user to something different then english.
2. Add new customer and see that labels in `Account Information` are still english.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
