### PR TITLE
FIX quote is_active flag handling

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote.php
@@ -91,9 +91,6 @@ class Quote extends AbstractDb
             'customer_id',
             $customerId,
             $quote
-        )->where(
-            'is_active = ?',
-            1
         )->order(
             'updated_at ' . \Magento\Framework\DB\Select::SQL_DESC
         )->limit(
@@ -101,8 +98,7 @@ class Quote extends AbstractDb
         );
 
         $data = $connection->fetchRow($select);
-
-        if ($data) {
+        if ($data && $data['is_active']) {
             $quote->setData($data);
         }
 


### PR DESCRIPTION
Wrong "is_active" handling in quote table

### Description
This is not a per se bugfix, but a better `is_active` flag handling suggestion.
We should not check the last active cart, but we should check the last cart and verify if it is active or not.

If, for unexpected reasons, one user has more than one active quotes and then the user completes an order, a previous cart is restored instead of having an empty new cart.

This does not happen in standard scenarios, but it can happen with programmatically created quotes.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
