### PR TITLE
Option to enable template hints on frontend with a configurable parameter

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -115,6 +115,22 @@
                     <label>Enabled Template Path Hints for Storefront</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="template_hints_storefront_show_with_parameter" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Hints for Storefront with URL Parameter</label>
+                    <depends>
+                        <field id="*/*/template_hints_storefront">1</field>
+                    </depends>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Use URL parameter to enable template path hints for Storefront</comment>
+                </field>
+                <field id="template_hints_parameter_value" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Parameter Value</label>
+                    <depends>
+                        <field id="*/*/template_hints_storefront">1</field>
+                        <field id="*/*/template_hints_storefront_show_with_parameter">1</field>
+                    </depends>
+                    <comment>Add the following paramater to the URL to show template hints ?templatehints=[parameter_value]</comment>
+                </field>
                 <field id="template_hints_admin" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enabled Template Path Hints for Admin</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/app/code/Magento/Developer/Test/Unit/Model/TemplateEngine/Plugin/DebugHintsTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Model/TemplateEngine/Plugin/DebugHintsTest.php
@@ -60,8 +60,12 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @dataProvider afterCreateActiveDataProvider
      */
-    public function testAfterCreateActive($debugHintsPath, $showBlockHints)
-    {
+    public function testAfterCreateActive(
+        $debugHintsPath,
+        $showBlockHints,
+        $debugHintsShowWithParameter,
+        $debugHintsParameter
+    ) {
         $this->devHelperMock->expects($this->once())
             ->method('isDevAllowed')
             ->willReturn(true);
@@ -88,12 +92,17 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->httpMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
+
         $debugHints = new DebugHints(
             $this->scopeConfigMock,
             $this->storeManager,
             $this->devHelperMock,
             $this->debugHintsFactory,
-            $debugHintsPath
+            $debugHintsPath,
+            $this->httpMock,
+            $debugHintsShowWithParameter,
+            $debugHintsParameter
         );
 
         $this->assertEquals($debugHintsDecorator, $debugHints->afterCreate($subjectMock, $engine));
@@ -105,10 +114,10 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
     public function afterCreateActiveDataProvider()
     {
         return [
-            ['dev/debug/template_hints_storefront', false],
-            ['dev/debug/template_hints_storefront', true],
-            ['dev/debug/template_hints_admin', false],
-            ['dev/debug/template_hints_admin', true],
+            ['dev/debug/template_hints_storefront', false, false, null],
+            ['dev/debug/template_hints_storefront', true, false, null],
+            ['dev/debug/template_hints_admin', false, false, null],
+            ['dev/debug/template_hints_admin', true, false, null],
         ];
     }
 
@@ -119,8 +128,13 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @dataProvider afterCreateInactiveDataProvider
      */
-    public function testAfterCreateInactive($debugHintsPath, $isDevAllowed, $showTemplateHints)
-    {
+    public function testAfterCreateInactive(
+        $debugHintsPath,
+        $isDevAllowed,
+        $showTemplateHints,
+        $debugHintsShowWithParameter,
+        $debugHintsParameter
+    ) {
         $this->devHelperMock->expects($this->any())
             ->method('isDevAllowed')
             ->willReturn($isDevAllowed);
@@ -133,12 +147,17 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->httpMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
+
         $debugHints = new DebugHints(
             $this->scopeConfigMock,
             $this->storeManager,
             $this->devHelperMock,
             $this->debugHintsFactory,
-            $debugHintsPath
+            $debugHintsPath,
+            $this->httpMock,
+            $debugHintsShowWithParameter,
+            $debugHintsParameter
         );
 
         $this->assertSame($engine, $debugHints->afterCreate($subjectMock, $engine));
@@ -150,12 +169,12 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
     public function afterCreateInactiveDataProvider()
     {
         return [
-            ['dev/debug/template_hints_storefront', false, false],
-            ['dev/debug/template_hints_storefront', false, true],
-            ['dev/debug/template_hints_storefront', true, false],
-            ['dev/debug/template_hints_admin', false, false],
-            ['dev/debug/template_hints_admin', false, true],
-            ['dev/debug/template_hints_admin', true, false],
+            ['dev/debug/template_hints_storefront', false, false, false, null],
+            ['dev/debug/template_hints_storefront', false, true, false, null],
+            ['dev/debug/template_hints_storefront', true, false, false, null],
+            ['dev/debug/template_hints_admin', false, false, false, null],
+            ['dev/debug/template_hints_admin', false, true, false, null],
+            ['dev/debug/template_hints_admin', true, false, false, null],
         ];
     }
 

--- a/app/code/Magento/Developer/Test/Unit/Model/TemplateEngine/Plugin/DebugHintsTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Model/TemplateEngine/Plugin/DebugHintsTest.php
@@ -63,7 +63,7 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
     public function testAfterCreateActive(
         $debugHintsPath,
         $showBlockHints,
-        $debugHintsShowWithParameter,
+        $debugHintsWithParam,
         $debugHintsParameter
     ) {
         $this->devHelperMock->expects($this->once())
@@ -101,7 +101,7 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
             $this->debugHintsFactory,
             $debugHintsPath,
             $this->httpMock,
-            $debugHintsShowWithParameter,
+            $debugHintsWithParam,
             $debugHintsParameter
         );
 
@@ -132,7 +132,7 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
         $debugHintsPath,
         $isDevAllowed,
         $showTemplateHints,
-        $debugHintsShowWithParameter,
+        $debugHintsWithParam,
         $debugHintsParameter
     ) {
         $this->devHelperMock->expects($this->any())
@@ -156,7 +156,7 @@ class DebugHintsTest extends \PHPUnit\Framework\TestCase
             $this->debugHintsFactory,
             $debugHintsPath,
             $this->httpMock,
-            $debugHintsShowWithParameter,
+            $debugHintsWithParam,
             $debugHintsParameter
         );
 

--- a/app/code/Magento/Developer/etc/adminhtml/di.xml
+++ b/app/code/Magento/Developer/etc/adminhtml/di.xml
@@ -12,6 +12,8 @@
     <type name="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints">
         <arguments>
             <argument name="debugHintsPath" xsi:type="string">dev/debug/template_hints_admin</argument>
+            <argument name="debugHintsShowWithParameter" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
+            <argument name="debugHintsParameter" xsi:type="string">dev/debug/template_hints_parameter_value</argument>
         </arguments>
     </type>
 </config>

--- a/app/code/Magento/Developer/etc/adminhtml/di.xml
+++ b/app/code/Magento/Developer/etc/adminhtml/di.xml
@@ -12,7 +12,7 @@
     <type name="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints">
         <arguments>
             <argument name="debugHintsPath" xsi:type="string">dev/debug/template_hints_admin</argument>
-            <argument name="debugHintsShowWithParameter" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
+            <argument name="debugHintsWithParam" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
             <argument name="debugHintsParameter" xsi:type="string">dev/debug/template_hints_parameter_value</argument>
         </arguments>
     </type>

--- a/app/code/Magento/Developer/etc/config.xml
+++ b/app/code/Magento/Developer/etc/config.xml
@@ -8,6 +8,10 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <dev>
+            <debug>
+                <template_hints_storefront_show_with_parameter>0</template_hints_storefront_show_with_parameter>
+                <template_hints_parameter_value>magento</template_hints_parameter_value>
+            </debug>
             <restrict>
                 <allow_ips />
             </restrict>

--- a/app/code/Magento/Developer/etc/frontend/di.xml
+++ b/app/code/Magento/Developer/etc/frontend/di.xml
@@ -12,7 +12,7 @@
     <type name="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints">
         <arguments>
             <argument name="debugHintsPath" xsi:type="string">dev/debug/template_hints_storefront</argument>
-            <argument name="debugHintsShowWithParameter" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
+            <argument name="debugHintsWithParam" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
             <argument name="debugHintsParameter" xsi:type="string">dev/debug/template_hints_parameter_value</argument>
         </arguments>
     </type>

--- a/app/code/Magento/Developer/etc/frontend/di.xml
+++ b/app/code/Magento/Developer/etc/frontend/di.xml
@@ -12,6 +12,8 @@
     <type name="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints">
         <arguments>
             <argument name="debugHintsPath" xsi:type="string">dev/debug/template_hints_storefront</argument>
+            <argument name="debugHintsShowWithParameter" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
+            <argument name="debugHintsParameter" xsi:type="string">dev/debug/template_hints_parameter_value</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
The recent addition to allow template hints to be toggled via the CLI is a step in the right direction as doing so via the admin is time consuming.  However frontend development can be streamlined further with this additional feature.  

### Description
Within admin user is given option to enable template hints on frontend with a configurable URL parameter.  So when enabled can pass ?templatehints=[parameter_value] to enable template hints providing they're enabled and the additional new option is enabled.  Also for security the parameter value is configurable.

We often find ourselves in two situations
  -  Dev 1 working on site wants template hints enabled, Dev 2 doesn't
  -  Dev 1 on 1 screen wants template hints, on Dev 1 on screen 2 doesn't

This update easily allows for this.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Within Magento backend under Advanced | Developer 
2. Enabled Template Path Hints for Storefront - Yes
2. Enable Hints for Storefront with URL Parameter - Yes
3. Configure Parameter Value - magento
4. On frontend Storeview enable template hints with parameter ?templatehints=magento

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
