### PR TITLE
FIX for issue 9930 - Asymmetric Transaction Error with ElasticSearch

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
@@ -193,6 +193,7 @@ class Processor
         $mediaGalleryData['images'][] = [
             'file' => $fileName,
             'position' => $position,
+            'media_type' => 'image',
             'label' => '',
             'disabled' => (int)$exclude,
         ];


### PR DESCRIPTION
Asymmetric Transaction error while adding products promatically with ElasticSearch.

### Description
While using ElasticSearch as search engine, we may get an "Asymmetric Trasnsaction" error on reindex.
This is caused by an undefined index trying to get `media_type` value from the image attribute.

This does not happen while uploading images via browser, but it happens adding products programmatically and using `\Magento\Catalog\Model\Product\Gallery\Processor::addImage` core method.

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9930: FIX for Asymmetric Transaction Error with ElasticSearch

### Manual testing scenarios
1. Configure ElasticSearch
2. Programmatically add a product image using \Magento\Catalog\Model\Product\Gallery\Processor::addImage
3. Save the product

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
