### PR TITLE
Fix flat table failed to populate store level values

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
@@ -39,13 +39,6 @@ class TableBuilder
     private $tableBuilderFactory;
 
     /**
-     * Check whether builder was executed
-     *
-     * @var bool
-     */
-    protected $_isExecuted = false;
-
-    /**
      * Constructor
      *
      * @param \Magento\Catalog\Helper\Product\Flat\Indexer $productIndexerHelper
@@ -74,9 +67,6 @@ class TableBuilder
      */
     public function build($storeId, $changedIds, $valueFieldSuffix)
     {
-        if ($this->_isExecuted) {
-            return;
-        }
         $entityTableName = $this->_productIndexerHelper->getTable('catalog_product_entity');
         $attributes = $this->_productIndexerHelper->getAttributes();
         $eavAttributes = $this->_productIndexerHelper->getTablesStructure($attributes);
@@ -121,7 +111,6 @@ class TableBuilder
             //Fill temporary tables with attributes grouped by it type
             $this->_fillTemporaryTable($tableName, $columns, $changedIds, $valueFieldSuffix, $storeId);
         }
-        $this->_isExecuted = true;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fix null value (e.g., price) in flat tables bug by removing stateless caching of a stateful table builder

**IMPORTANT:** This issue can cause product price zero. If a store does not set a price on default store and only on specific store, when a changelog accumulated more than 500 products, first 500 products' price will become ZERO after flat table reindex and the zero price can go through checkout.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When a job executes more than 500 product updates, which is the threshold, the bug triggers.

1. The first 500 products will be updated against flat tables with ONLY store=0 values. Some data that only save on store level will show as NULL. When a price is subject to this issue, a NULL price will be treated as zero price, thus sometime appearing to be a zero price issue.

2. The 500+ products will NOT be able to update against flat tables and remain the old values, or
for new products, not exist at all.

### Discussion

Product attribute values store in eav value tables on store level and fallback to store=0 default
values.

In flat indexer, to accomplish the fallback, indexer populate store=0 values to temporary table
(empty value filled by NULL), and then populate store level value.

Probably because of the overhead of creating and populating temporary tables, indexer  is implemented with an in-memory cache flag to avoid repeated temp table creations.

```php
// \Magento\Catalog\Model\Indexer\Product\Flat\TableBuilder::build
public function build($storeId, $changedIds, $valueFieldSuffix)
{
    if ($this->_isExecuted) {
        return;
    }
    // ... Create temp tables and populate from store=0 value tables
    $this->_isExecuted = true;
}
```

The indexer however did not consider the stateful status (i.e. `$changedIds`) of this method and
implemented a stateless cache flag `$this->_isExecuted`.

When the flat indexer processes a job, it breaks up a large job into 500 products per processing unit.

```php
\Magento\Catalog\Model\Indexer\Product\Flat\Action\Rows::execute
public function execute($ids)
{
    // ...
    $idsBatches = array_chunk($ids, \Magento\Catalog\Helper\Product\Flat\Indexer::BATCH_SIZE);
    // ...
    $this->_reindex($store->getId(), $changedIds);
    // ...
}
```

The temp tables cached by `_isExecuted` will only be able to serve the first set of`$changedIds` got in, which is the first batch of jobs.

Therefore, the 500+ products then fail to insert store=0 entries into the temp tables. During store
level population, `Update from select` is used. Because there is no such entity entries, the 500+
entries are failed to set. Remain the original 500 default entries.

```php
// \Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::_updateTemporaryTableByStoreValues
protected function _updateTemporaryTableByStoreValues(
    array $tables,
    array $changedIds,
    $storeId,
    $valueFieldSuffix
) {
    // ...
    $sql = $select->crossUpdateFromSelect(['et' => $temporaryFlatTableName]);
    // ...
}
```

The indexer then finish processing the 500+ products by copying the temp flat table data to real
flat table.

In this batch, it is supposed to process the 500+ products. However, the temp flat table stored the
first 500 products' default values. For those attributes does not have default values will become
`Null`. Those with store level values as a result will get overwritten by the default values.

```
// \Magento\Catalog\Model\Indexer\Product\Flat\Action\Rows\TableData::move
public function move($flatTable, $flatDropName, $temporaryFlatTableName)
{
// ...
$select->from(['tf' => sprintf('%s_tmp_indexer', $flatTable)], $columns);
$sql = $select->insertFromSelect($flatTable, $columns);
$connection->query($sql);
// ...
}
```

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. So far, no M2 community issues found
2. This bug is a successor of this M1 issue https://github.com/AmpersandHQ/mage-ee-product-flat-test

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Make sure flat table is enabled

2. Make sure indexer are set to schedule

    ```
    php bin/magento indexer:set-mode schedule
    ```

3. Make sure you have two simple products set up

4. Leave the products' price NULL on default store view (i.e. store = 0)

5. Set the products' price to 100 on store view (i.e. store != 0)

6. Make sure both products are enabled and visible on both store views

7. **Hack** in and set BATCH_SIZE to 1

    (This hacking is to simplify the test. For the original batch size of 500, we will need at least 501 products to test, which is likely a pain)

    ```diff
    // \Magento\Catalog\Helper\Product\Flat\Indexer::BATCH_SIZE
    + const BATCH_SIZE = 1;
    - const BATCH_SIZE = 500;
    ```

8. Add the product to changelog

    ```sql
    INSERT INTO catalog_product_flat_cl (entity_id) VALUE ($FirstProductId), ($SecondProductId)
    ```

9. Make sure mview is not hanging

   ```sql
   UPDATE mview_state SET status = 'idle' WHERE view_id = 'catalog_product_flat'
   ```

10. Run incremental reindex

    ```
    magerun2 sys:cron:run indexer_update_all_views
    ```

#### Expected Result

`catalog_product_flat_{$storeId}` have `price = 100` for both products

#### Actual Result

- `catalog_product_flat_{$storeId}` have product of `$FirstProductId` with `price = NULL`
- `catalog_product_flat_{$storeId}` does NOT have product of `$SecondProductId`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
