### PR TITLE
 Cron generation / cleanup, some minutes are skipped

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -329,12 +329,13 @@ class ProcessCronQueueObserver implements ObserverInterface
          * check if schedule generation is needed
          */
         $lastRun = (int)$this->_cache->load(self::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . $groupId);
+        $currentTime = $this->dateTime->gmtTimestamp(strftime('%Y-%m-%d %H:%M'));
         $rawSchedulePeriod = (int)$this->_scopeConfig->getValue(
             'system/cron/' . $groupId . '/' . self::XML_PATH_SCHEDULE_GENERATE_EVERY,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
         $schedulePeriod = $rawSchedulePeriod * self::SECONDS_IN_MINUTE;
-        if ($lastRun > $this->dateTime->gmtTimestamp() - $schedulePeriod) {
+        if ($lastRun > $currentTime - $schedulePeriod) {
             return $this;
         }
 
@@ -357,7 +358,7 @@ class ProcessCronQueueObserver implements ObserverInterface
          * save time schedules generation was ran with no expiration
          */
         $this->_cache->save(
-            $this->dateTime->gmtTimestamp(),
+            $currentTime,
             self::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . $groupId,
             ['crontab'],
             null
@@ -400,11 +401,12 @@ class ProcessCronQueueObserver implements ObserverInterface
 
         // check if history cleanup is needed
         $lastCleanup = (int)$this->_cache->load(self::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . $groupId);
+        $currentTime = $this->dateTime->gmtTimestamp(strftime('%Y-%m-%d %H:%M'));
         $historyCleanUp = (int)$this->_scopeConfig->getValue(
             'system/cron/' . $groupId . '/' . self::XML_PATH_HISTORY_CLEANUP_EVERY,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
-        if ($lastCleanup > $this->dateTime->gmtTimestamp() - $historyCleanUp * self::SECONDS_IN_MINUTE) {
+        if ($lastCleanup > $currentTime - $historyCleanUp * self::SECONDS_IN_MINUTE) {
             return $this;
         }
 
@@ -449,7 +451,7 @@ class ProcessCronQueueObserver implements ObserverInterface
 
         // save time history cleanup was ran with no expiration
         $this->_cache->save(
-            $this->dateTime->gmtTimestamp(),
+            $currentTime,
             self::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . $groupId,
             ['crontab'],
             null


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Because cron jobs generation compare last run and current time using seconds, if next job run seconds later its schedule won't be generated. It happen in cron cleanup also
### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Configure cron jobs to generate schedules every minute (index default configuration)

![image](https://user-images.githubusercontent.com/22668934/29950852-2afa6a06-8e84-11e7-9187-c5301be39474.png)

2. See cron_schedule table and wait
3. After few minutes some cron schedules won't be created

![image](https://user-images.githubusercontent.com/22668934/29951262-2c8792ba-8e87-11e7-8d84-382df681ba50.png)

In this example minutes 19:49 and 19:54 was skipped, this happen because creation method was executed few seconds after.

### Expected result
Schedules should be generated each minute, with this solution we get it.

![image](https://user-images.githubusercontent.com/22668934/29951851-2b7fc564-8e8b-11e7-9f78-0995fd3fe651.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
