### PR TITLE
Add Austria and Finland to countries that do not require region/state

### DIFF
--- a/app/code/Magento/Directory/etc/di.xml
+++ b/app/code/Magento/Directory/etc/di.xml
@@ -37,6 +37,8 @@
             <argument name="countriesWithNotRequiredStates" xsi:type="array">
                 <item name="FR" xsi:type="string">FR</item>
                 <item name="DE" xsi:type="string">DE</item>
+                <item name="AT" xsi:type="string">AT</item>
+                <item name="FI" xsi:type="string">FI</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description
Both Austria and Finland do not require a region/state in the address. Every merchant I have worked with has had to manually change the config setting in the admin. Instead of requiring every merchant in those countries (or that ships to those countries) to do this, the default should be updated. Obviously, this will resolve the issue for new installs only.

### Manual testing scenarios
1. Install Magento 2.2
2. Verify that **Stores->Configuration->General->State Options->State is Required for** does not show Austria or Finland as selected