### PR TITLE
Properly compute module load order

### DIFF
--- a/lib/internal/Magento/Framework/Data/Graph.php
+++ b/lib/internal/Magento/Framework/Data/Graph.php
@@ -263,7 +263,7 @@ class Graph
         return array_diff($this->_nodes, $nodesWithIncomingEdges);
     }
 
-        /**
+    /**
      * Recursive sub-routine of dfs()
      *
      * @param string|int $fromNode

--- a/lib/internal/Magento/Framework/Data/Graph.php
+++ b/lib/internal/Magento/Framework/Data/Graph.php
@@ -210,7 +210,7 @@ class Graph
     public function topoSort()
     {
         $sortedElements = [];
-        $nodeSet = $this->_findStartNodes();
+        $nodeSet = $this->findStartNodes();
 
         while (!empty($nodeSet)) {
             $cur = array_shift($nodeSet);
@@ -264,7 +264,7 @@ class Graph
      *
      * @return array
      */
-    protected function _findStartNodes()
+    public function findStartNodes()
     {
         $incomingEdgeNodes = array_keys($this->_to);
         return array_diff($this->_nodes, $incomingEdgeNodes);

--- a/lib/internal/Magento/Framework/Data/Graph.php
+++ b/lib/internal/Magento/Framework/Data/Graph.php
@@ -213,15 +213,15 @@ class Graph
         $nodeSet = $this->findStartNodes();
 
         while (!empty($nodeSet)) {
-            $cur = array_shift($nodeSet);
-            array_unshift($sortedElements, $cur);
+            $cur = array_pop($nodeSet);
+            $sortedElements[] = $cur;
             if (!isset($this->_from[$cur])) {
                 continue;
             }
             foreach ($this->_from[$cur] as $parent) {
                 $this->removeRelation($cur, $parent);
                 if (empty($this->_to[$parent])) {
-                    array_push($nodeSet, $parent);
+                    $nodeSet[] = $parent;
                 }
             }
         }
@@ -232,7 +232,7 @@ class Graph
             throw new \Exception($message);
         }
 
-        return $sortedElements;
+        return array_reverse($sortedElements);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Graph.php
+++ b/lib/internal/Magento/Framework/Data/Graph.php
@@ -209,19 +209,19 @@ class Graph
      */
     public function topoSort()
     {
-        $l = [];
-        $s = $this->_findStartNodes();
+        $sortedElements = [];
+        $nodeSet = $this->_findStartNodes();
 
-        while (!empty($s)) {
-            $n = array_shift($s);
-            array_unshift($l, $n);
-            if (!isset($this->_from[$n])) {
+        while (!empty($nodeSet)) {
+            $cur = array_shift($nodeSet);
+            array_unshift($sortedElements, $cur);
+            if (!isset($this->_from[$cur])) {
                 continue;
             }
-            foreach ($this->_from[$n] as $m) {
-                $this->removeRelation($n, $m);
-                if (empty($this->_to[$m])) {
-                    array_push($s, $m);
+            foreach ($this->_from[$cur] as $parent) {
+                $this->removeRelation($cur, $parent);
+                if (empty($this->_to[$parent])) {
+                    array_push($nodeSet, $parent);
                 }
             }
         }
@@ -232,9 +232,16 @@ class Graph
             throw new \Exception($message);
         }
 
-        return $l;
+        return $sortedElements;
     }
 
+    /**
+     * Determines whether the graph has edges.
+     *
+     * Returns true if the graph has edges. Returns false otherwise.
+     *
+     * @return bool
+     */
     public function hasEdges()
     {
         foreach ($this->_from as $from) {
@@ -259,8 +266,8 @@ class Graph
      */
     protected function _findStartNodes()
     {
-        $nodesWithIncomingEdges = array_keys($this->_to);
-        return array_diff($this->_nodes, $nodesWithIncomingEdges);
+        $incomingEdgeNodes = array_keys($this->_to);
+        return array_diff($this->_nodes, $incomingEdgeNodes);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -126,62 +126,30 @@ class Loader
      *
      * @param array $origList
      * @return array
-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     private function sortBySequence($origList)
     {
-        ksort($origList);
-        $expanded = [];
-        foreach ($origList as $moduleName => $value) {
-            $expanded[] = [
-                'name' => $moduleName,
-                'sequence' => $this->expandSequence($origList, $moduleName),
-            ];
-        }
+        $nodes = [];
+        $relations = [];
 
-        // Use "bubble sorting" because usort does not check each pair of elements and in this case it is important
-        $total = count($expanded);
-        for ($i = 0; $i < $total - 1; $i++) {
-            for ($j = $i; $j < $total; $j++) {
-                if (in_array($expanded[$j]['name'], $expanded[$i]['sequence'])) {
-                    $temp = $expanded[$i];
-                    $expanded[$i] = $expanded[$j];
-                    $expanded[$j] = $temp;
-                }
+        // collect graph nodes and edges
+        foreach($origList as $module) {
+            $nodes[] = $module['name'];
+            foreach ($module['sequence'] as $dependency) {
+                $relations[] = [$module['name'], $dependency];
             }
         }
 
+        // construct a graph and perform topological sort on it
+        $moduleGraph = new \Magento\Framework\Data\Graph($nodes, $relations);
+        $sortedResult = $moduleGraph->topoSort();
+
+        // re-attach version information to the linear ordering
         $result = [];
-        foreach ($expanded as $pair) {
-            $result[$pair['name']] = $origList[$pair['name']];
+        foreach ($sortedResult as $item) {
+            $result[$item] = $origList[$item];
         }
 
-        return $result;
-    }
-
-    /**
-     * Accumulate information about all transitive "sequence" references
-     *
-     * @param array $list
-     * @param string $name
-     * @param array $accumulated
-     * @return array
-     * @throws \Exception
-     */
-    private function expandSequence($list, $name, $accumulated = [])
-    {
-        $accumulated[] = $name;
-        $result = $list[$name]['sequence'];
-        foreach ($result as $relatedName) {
-            if (in_array($relatedName, $accumulated)) {
-                throw new \Exception("Circular sequence reference from '{$name}' to '{$relatedName}'.");
-            }
-            if (!isset($list[$relatedName])) {
-                continue;
-            }
-            $relatedResult = $this->expandSequence($list, $relatedName, $accumulated);
-            $result = array_unique(array_merge($result, $relatedResult));
-        }
         return $result;
     }
 }

--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -133,7 +133,7 @@ class Loader
         $relations = [];
 
         // collect graph nodes and edges
-        foreach($origList as $module) {
+        foreach ($origList as $module) {
             $nodes[] = $module['name'];
             foreach ($module['sequence'] as $dependency) {
                 $relations[] = [$module['name'], $dependency];

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/LoaderTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/LoaderTest.php
@@ -143,7 +143,7 @@ class LoaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Circular sequence reference from 'b' to 'a'
+     * @expectedExceptionMessage Dependency cycle detected: a -> b -> a
      */
     public function testLoadCircular()
     {


### PR DESCRIPTION
### Description
This PR replaces the ... _interesting_ ... choice of bubble sort for determining the order in which modules should be loaded.

The `sortBySequence` method now uses topological sorting to correctly linearize the sequence of modules. The topological sort algorithm implemented in the `Magento\Framework\Data\Graph` data structure is [Kahn's algorithm][kahn].

### Fixed Issues (if relevant)
1. magento/magento2#10112: Module names sorting issue?

### Manual testing scenarios
1. Create a module which contains frontend layout XML directives, and has a sequence dependency on `Magento_Customer`
2. Before, with bubble sort, the incorrect load order would cause those frontend layout directives to be processed before `Magento_Catalog`, causing all sorts of trouble.
3. Now, with topological sort, the load order is correct and no such trouble occurs.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

>All new or changed code is covered with unit/integration tests

The code is covered by existing unit tests. More tests can be added if desired.

[kahn]: https://en.wikipedia.org/wiki/Topological_sorting#Kahn.27s_algorithm