### PR TITLE
Issue #10645 - Allow BEM class via attribute tag. Public

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -463,7 +463,7 @@ class Config
      */
     public function addBodyClass($className)
     {
-        $className = preg_replace('#[^a-z0-9-]+#', '-', strtolower($className));
+        $className = preg_replace('#[^a-z0-9-_]+#', '-', strtolower($className));
         $bodyClasses = $this->getElementAttribute(self::ELEMENT_TYPE_BODY, self::BODY_ATTRIBUTE_CLASS);
         $bodyClasses = $bodyClasses ? explode(' ', $bodyClasses) : [];
         $bodyClasses[] = $className;

--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -463,7 +463,7 @@ class Config
      */
     public function addBodyClass($className)
     {
-        $className = preg_replace('#[^a-z0-9]+#', '-', strtolower($className));
+        $className = preg_replace('#[^a-z0-9-]+#', '-', strtolower($className));
         $bodyClasses = $this->getElementAttribute(self::ELEMENT_TYPE_BODY, self::BODY_ATTRIBUTE_CLASS);
         $bodyClasses = $bodyClasses ? explode(' ', $bodyClasses) : [];
         $bodyClasses[] = $className;

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/BodyTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/BodyTest.php
@@ -57,13 +57,13 @@ class BodyTest extends \PHPUnit\Framework\TestCase
             ->method('getPageConfigStructure')
             ->willReturn($structureMock);
 
-        $bodyClasses = ['class_1', 'class_2'];
+        $bodyClasses = ['class_1', 'class--2'];
         $structureMock->expects($this->once())
             ->method('getBodyClasses')
             ->will($this->returnValue($bodyClasses));
         $this->pageConfigMock->expects($this->exactly(2))
             ->method('addBodyClass')
-            ->withConsecutive(['class_1'], ['class_2']);
+            ->withConsecutive(['class_1'], ['class--2']);
 
         $this->assertEquals(
             $this->bodyGenerator,

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/StructureTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/StructureTest.php
@@ -58,7 +58,7 @@ class StructureTest extends \PHPUnit\Framework\TestCase
     public function testSetBodyClass()
     {
         $class1 = 'class_1';
-        $class2 = 'class_2';
+        $class2 = 'class--2';
         $expected = [$class1, $class2];
         $this->structure->setBodyClass($class1);
         $this->structure->setBodyClass($class2);


### PR DESCRIPTION
### Description
Before the fix, classes with -- in them was replaced with a single - so result with input class--1 appears as class-1, breaking the BEM convention.

### Fixed Issues
1. magento/magento2#10645: Adding BEM class in XML via attribute tag causes class to be rewritten

### Manual testing scenarios
1. Go to default.xml
2. Add attribute tag with a class to the body element i.e. `<attribute name="class" value="class--1" />`
3. Clear cache and reload page

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
