### PR TITLE
Removed reference to deprecated Zend\Stdlib\JsonSerializable

### DIFF
--- a/lib/internal/Magento/Framework/Phrase.php
+++ b/lib/internal/Magento/Framework/Phrase.php
@@ -9,12 +9,11 @@ namespace Magento\Framework;
 
 use Magento\Framework\Phrase\Renderer\Placeholder as RendererPlaceholder;
 use Magento\Framework\Phrase\RendererInterface;
-use Zend\Stdlib\JsonSerializable;
 
 /**
  * @api
  */
-class Phrase implements JsonSerializable
+class Phrase implements \JsonSerializable
 {
     /**
      * Default phrase renderer. Allows stacking renderers that "don't know about each other"


### PR DESCRIPTION
Removed reference to deprecated Zend\Stdlib\JsonSerializable which has been deprecated since 20 october 2015. See this commit: https://github.com/zendframework/zend-stdlib/commit/6da50a93a0fe1f969c9b876f708d5c73eea9d6ad#diff-c958cc2b645be4b72d33e0d6dd23c070

Since Magento 2 system requirements are PHP 5.6 or newer we can safely depend on the PHP native JsonSerializable interface since it has been present since PHP 5.4