### PR TITLE
Removed deprecated Zend\Stdlib\JsonSerializable references

### DIFF
--- a/app/code/Magento/Customer/Ui/Component/MassAction/Group/Options.php
+++ b/app/code/Magento/Customer/Ui/Component/MassAction/Group/Options.php
@@ -7,13 +7,12 @@ namespace Magento\Customer\Ui\Component\MassAction\Group;
 
 use Magento\Framework\Phrase;
 use Magento\Framework\UrlInterface;
-use Zend\Stdlib\JsonSerializable;
 use Magento\Customer\Model\ResourceModel\Group\CollectionFactory;
 
 /**
  * Class Options
  */
-class Options implements JsonSerializable
+class Options implements \JsonSerializable
 {
     /**
      * @var array

--- a/app/code/Magento/Ui/Component/Action.php
+++ b/app/code/Magento/Ui/Component/Action.php
@@ -6,7 +6,6 @@
 namespace Magento\Ui\Component;
 
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
-use Zend\Stdlib\JsonSerializable;
 
 /**
  * Class Action
@@ -16,7 +15,7 @@ class Action extends AbstractComponent
     const NAME = 'action';
 
     /**
-     * @var array|JsonSerializable
+     * @var array|\JsonSerializable
      */
     protected $actions;
 
@@ -24,7 +23,7 @@ class Action extends AbstractComponent
      * @param ContextInterface $context
      * @param array $components
      * @param array $data
-     * @param array|JsonSerializable $actions
+     * @param array|\JsonSerializable $actions
      */
     public function __construct(
         ContextInterface $context,

--- a/lib/internal/Magento/Framework/DB/Sql/Expression.php
+++ b/lib/internal/Magento/Framework/DB/Sql/Expression.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\DB\Sql;
 
-
 /**
  * Class is wrapper over Zend_Db_Expr for implement JsonSerializable interface.
  */

--- a/lib/internal/Magento/Framework/DB/Sql/Expression.php
+++ b/lib/internal/Magento/Framework/DB/Sql/Expression.php
@@ -5,12 +5,11 @@
  */
 namespace Magento\Framework\DB\Sql;
 
-use Zend\Stdlib\JsonSerializable;
 
 /**
  * Class is wrapper over Zend_Db_Expr for implement JsonSerializable interface.
  */
-class Expression extends \Zend_Db_Expr implements ExpressionInterface, JsonSerializable
+class Expression extends \Zend_Db_Expr implements ExpressionInterface, \JsonSerializable
 {
     /**
      * @inheritdoc


### PR DESCRIPTION
Removed all other references to deprecated Zend\Stdlib\JsonSerializable which has been deprecated since 20 october 2015. See this commit: zendframework/zend-stdlib@6da50a9#diff-c958cc2b645be4b72d33e0d6dd23c070

Since Magento 2 system requirements are PHP 5.6 or newer we can safely depend on the PHP native JsonSerializable interface since it has been present since PHP 5.4