### PR TITLE
Removed use of 'Magento\Framework\Filesystem'

### DIFF
--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -9,7 +9,6 @@ namespace Magento\Framework\Module;
 
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
-use Magento\Framework\Filesystem;
 
 /**
  * Class \Magento\Framework\Module\Dir


### PR DESCRIPTION
Removed use of 'Magento\Framework\Filesystem', this reference is not used in this class, so can be safely removed.