### PR TITLE
Expanded ReadInterface

### DIFF
--- a/app/code/Magento/Email/Model/Template/Config/FileIterator.php
+++ b/app/code/Magento/Email/Model/Template/Config/FileIterator.php
@@ -47,7 +47,6 @@ class FileIterator extends \Magento\Framework\Config\FileIterator
             );
         }
 
-        /** @var \Magento\Framework\Filesystem\File\Read $fileRead */
         $fileRead = $this->fileReadFactory->create($this->key(), DriverPool::FILE);
         $contents = $fileRead->readAll();
         return str_replace('<template ', '<template module="' . $moduleName . '" ', $contents);

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -103,7 +103,6 @@ class DataProvider implements DataProviderInterface
 
         $dictionary = [];
         foreach ($files as $filePath) {
-            /** @var \Magento\Framework\Filesystem\File\Read $read */
             $read = $this->fileReadFactory->create($filePath[0], \Magento\Framework\Filesystem\DriverPool::FILE);
             $content = $read->readAll();
             foreach ($this->getPhrases($content) as $phrase) {

--- a/lib/internal/Magento/Framework/Config/FileIterator.php
+++ b/lib/internal/Magento/Framework/Config/FileIterator.php
@@ -66,7 +66,6 @@ class FileIterator implements \Iterator, \Countable
      */
     public function current()
     {
-        /** @var \Magento\Framework\Filesystem\File\Read $fileRead */
         $fileRead = $this->fileReadFactory->create($this->key(), DriverPool::FILE);
         return $fileRead->readAll();
     }

--- a/lib/internal/Magento/Framework/Filesystem/File/ReadInterface.php
+++ b/lib/internal/Magento/Framework/Filesystem/File/ReadInterface.php
@@ -20,6 +20,15 @@ interface ReadInterface
     public function read($length);
 
     /**
+     * Returns the complete content of the file.
+     *
+     * @param string|null $flag
+     * @param resource|null $context
+     * @return string
+     */
+    public function readAll($flag = null, $context = null);
+
+    /**
      * Reads the line with specified number of bytes from the current position.
      *
      * @param int $length The number of bytes to read


### PR DESCRIPTION
- Expanded to ReadInterface to include the readAll function, since a class implementing the ReadInterface should have this function in order to substitute the Read class.

- Removed comment variable declarations from other file where the type is declared. This was necessary due to the missing function in the interface. Autocompleting this function now works properly, so these comments can be removed.