### PR TITLE
Fix checking active carrier against store

### DIFF
--- a/app/code/Magento/Shipping/Model/CarrierFactory.php
+++ b/app/code/Magento/Shipping/Model/CarrierFactory.php
@@ -106,7 +106,8 @@ class CarrierFactory implements CarrierFactoryInterface
     {
         return $this->_scopeConfig->isSetFlag(
             'carriers/' . $carrierCode . '/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+             $storeId
         ) ? $this->create(
             $carrierCode,
             $storeId

--- a/app/code/Magento/Shipping/Model/CarrierFactory.php
+++ b/app/code/Magento/Shipping/Model/CarrierFactory.php
@@ -107,7 +107,7 @@ class CarrierFactory implements CarrierFactoryInterface
         return $this->_scopeConfig->isSetFlag(
             'carriers/' . $carrierCode . '/active',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-             $storeId
+            $storeId
         ) ? $this->create(
             $carrierCode,
             $storeId


### PR DESCRIPTION
When creating orders in backend we must use active store code when checking for available carriers.

### Description
The same bugfix was introduced in 2.2 dev branch with commit https://github.com/magento/magento2/commit/08b5177d6745596f2993400e8a6a9a6ada69308f


### Manual testing scenarios
Enable shipping method in some non-standard store or website, and create a new order in the backend. The shipping option should be listed as available.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
