### PR TITLE
Bugfix - Multiple filter_url_params 

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/UiComponent/DataProvider/DataProvider.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/DataProvider/DataProvider.php
@@ -123,7 +123,7 @@ class DataProvider implements DataProviderInterface
             }
             if ($paramValue) {
                 $this->data['config']['update_url'] = sprintf(
-                    '%s%s/%s',
+                    '%s%s/%s/',
                     $this->data['config']['update_url'],
                     $paramName,
                     $paramValue


### PR DESCRIPTION
Allow multiple filter_url_params params. 

### Description
Passing multiple filter parameters doesnt work because of missing trailing backslash when processing parameters.

Add missing trailing backslash after each url argument.

Backporting bugfix from 2.2-dev branch. ref commit https://github.com/magento/magento2/commit/ca543ebbcda07c4c14b2efad54303e84e7b7d728

### Manual testing scenarios
Create a uiComponent and add multiple filter_url_params to the DataSource component. The generation of URL will not be correct in prepareUpdateUrl() in Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
