### PR TITLE
Fix spelling mistake in the code generator

### DIFF
--- a/lib/internal/Magento/Framework/Code/Generator.php
+++ b/lib/internal/Magento/Framework/Code/Generator.php
@@ -199,7 +199,7 @@ class Generator
     {
         if (!$resultEntityType || !$sourceClassName) {
             return self::GENERATION_ERROR;
-        } elseif ($this->definedClasses->isClassLoadableFromDisc($resultClass)) {
+        } elseif ($this->definedClasses->isClassLoadableFromDisk($resultClass)) {
             $generatedFileName = $this->_ioObject->generateResultFileName($resultClass);
             /**
              * Must handle two edge cases: a competing process has generated the class and written it to disc already,

--- a/lib/internal/Magento/Framework/Code/Generator/DefinedClasses.php
+++ b/lib/internal/Magento/Framework/Code/Generator/DefinedClasses.php
@@ -21,7 +21,7 @@ class DefinedClasses
      */
     public function isClassLoadable($className)
     {
-        return $this->isClassLoadableFromMemory($className) || $this->isClassLoadableFromDisc($className);
+        return $this->isClassLoadableFromMemory($className) || $this->isClassLoadableFromDisk($className);
     }
 
     /**
@@ -36,12 +36,24 @@ class DefinedClasses
     }
 
     /**
-     * Determine if a class exists on disc
+     * Determine if a class exists on disk
+     *
+     * @param string $className
+     * @return bool
+     * @deprecated
+     */
+    public function isClassLoadableFromDisc($className)
+    {
+        return $this->isClassLoadableFromDisk($className);
+    }
+
+    /**
+     * Determine if a class exists on disk
      *
      * @param string $className
      * @return bool
      */
-    public function isClassLoadableFromDisc($className)
+    public function isClassLoadableFromDisk($className)
     {
         try {
             return (bool)AutoloaderRegistry::getAutoloader()->findFile($className);

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Generator/EntityAbstractTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Generator/EntityAbstractTest.php
@@ -233,7 +233,7 @@ class EntityAbstractTest extends \PHPUnit\Framework\TestCase
             ->willReturn($sourceClassExists);
         if ($resultClassExists) {
             $definedClassesMock->expects($this->once())
-                ->method('isClassLoadableFromDisc')
+                ->method('isClassLoadableFromDisk')
                 ->with($this->resultClass)
                 ->willReturn($resultClassExists);
         }

--- a/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
@@ -114,7 +114,7 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGenerateClassWithExistName($fileExists)
     {
         $this->definedClassesMock->expects($this->any())
-            ->method('isClassLoadableFromDisc')
+            ->method('isClassLoadableFromDisk')
             ->willReturn(true);
 
         $resultClassFileName = '/Magento/Path/To/Class.php';


### PR DESCRIPTION
- Fixed spelling mistake, changed function isClassLoadableFromDisc to isClassLoadableFromDisk.
- Fowarded old function to the new function so that it is fully backward compatible.
- Deprecated old function with spelling mistake.

From Grammarist.com:
Disk is indisputably the correct spelling for computer storage drives
http://grammarist.com/spelling/disc-disk/
