### PR TITLE
[Merged] Don't append a colon after payment method title in checkout.

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/payment/list.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/payment/list.js
@@ -193,7 +193,7 @@ define([
                 title = this.defaultGroupTitle;
             }
 
-            return title + ':';
+            return title;
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/template/payment-methods/list.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/payment-methods/list.html
@@ -11,7 +11,7 @@
         <div if="getRegion($group().displayArea)().length"
              class="step-title"
              data-role="title">
-            <!-- ko i18n: getGroupTitle($group) --><!-- /ko -->:
+            <translate args="getGroupTitle($group)"/>:
         </div>
         <each args="data: getRegion($group().displayArea), as: 'method'" render=""/>
     </div>

--- a/app/code/Magento/Checkout/view/frontend/web/template/payment-methods/list.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/payment-methods/list.html
@@ -9,9 +9,9 @@
     <div repeat="foreach: paymentGroupsList, item: '$group'"
          class="payment-group">
         <div if="getRegion($group().displayArea)().length"
-             translate="getGroupTitle($group)"
              class="step-title"
              data-role="title">
+            <!-- ko i18n: getGroupTitle($group) --><!-- /ko -->:
         </div>
         <each args="data: getRegion($group().displayArea), as: 'method'" render=""/>
     </div>


### PR DESCRIPTION
### Description

The get method for payment methods title adds a colon. It's inconsistent with other checkout step titles. It is hard to remove it when customizing a theme.

### Manual testing scenarios
1. In default site with sample data, add items to cart
2. Proceed to checkout
3. Proceed to payment step. The 'Payment Methods' title should appear without the colon.