### PR TITLE
Added ability to set 'rows' property for wysiwyg elements.

### DIFF
--- a/app/code/Magento/Ui/Component/Form/Element/Wysiwyg.php
+++ b/app/code/Magento/Ui/Component/Form/Element/Wysiwyg.php
@@ -55,7 +55,7 @@ class Wysiwyg extends AbstractElement
             \Magento\Framework\Data\Form\Element\Editor::class,
             [
                 'force_load' => true,
-                'rows' => 20,
+                'rows' => isset($config['rows']) ? $config['rows'] : 20,
                 'name' => $data['name'],
                 'config' => $wysiwygConfig->getConfig($wysiwygConfigData),
                 'wysiwyg' => isset($config['wysiwyg']) ? $config['wysiwyg'] : null,


### PR DESCRIPTION
### Description
Read and apply `rows` property from config data for WYSIWYG fields.

### Manual testing scenarios
1. Open Category edit form in Magento backend
2. As you see, Description field is very large and it has `rows=20` property
3. Open `app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml` and find field settings. It has `<item name="rows" xsi:type="number">8</item>` config, but it does not work.
4. Apply the patch and it will work.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
