### PR TITLE
FIX Medium date time (international month name) in newsletter queue

### DIFF
--- a/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Edit/Form.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Edit/Form.php
@@ -78,7 +78,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         );
 
         $dateFormat = $this->_localeDate->getDateFormat(
-            \IntlDateFormatter::MEDIUM
+            \IntlDateFormatter::SHORT
         );
         $timeFormat = $this->_localeDate->getTimeFormat(
             \IntlDateFormatter::MEDIUM


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#4642: Newsletter date translation
