### PR TITLE
Fix for translated attribute label comparisson.

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -34,7 +34,7 @@ if ($_attributeType && $_attributeType == 'text') {
 
 <?php if ($_attributeValue): ?>
 <div class="product attribute <?= /* @escapeNotVerified */ $_className ?>">
-    <?php if ($_attributeLabel != 'none'): ?><strong class="type"><?= /* @escapeNotVerified */ $_attributeLabel ?></strong><?php endif; ?>
+    <?php if ($_attributeLabel != __('none')): ?><strong class="type"><?= /* @escapeNotVerified */ $_attributeLabel ?></strong><?php endif; ?>
     <div class="value" <?= /* @escapeNotVerified */ $_attributeAddAttribute ?>><?= /* @escapeNotVerified */ $_attributeValue ?></div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->
<!--- Before adding new issues, please, check this article https://github.com/magento/magento2/wiki/Issue-reporting-guidelines-->

### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Clean instance of Magento 2.1.8
2. Store displayed in some foreign languege i.e. pl_PL
3. Simple product with some attribute visible on product page.

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Go to product page.
2. See attribute label ('none' translated to your foreign language) in the attributes section/

### Expected result
<!--- Tell us what should happen -->
1. 'none' label translated to other languages i.e. polish lang - 'brak' should not be displayed
2. comparisson in line 37 of app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml is changed to if ($_attributeLabel != __('none')) in order to not display 'none' translated to foreign language

### Actual result
<!--- Tell us what happens instead -->
1. In the template app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml line 37 you have followin comparisson: if ($_attributeLabel != 'none') but at this part of code $_attributeLabel is already translated.

<!--- (This may be platform independent comment) -->
