### PR TITLE
add new field to order grid: payment_cctype

### DIFF
--- a/app/code/Magento/Payment/Ui/Component/Listing/Column/CcType/Options.php
+++ b/app/code/Magento/Payment/Ui/Component/Listing/Column/CcType/Options.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Magento\Payment\Ui\Component\Listing\Column\CcType;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * Class Options
+ */
+class Options implements OptionSourceInterface
+{
+    /**
+     * @var \Magento\Sales\Model\ResourceModel\Order\Grid\Collection
+     */
+    protected $salesCollection;
+
+    protected $options;
+    
+    public function __construct(
+        \Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory $collectionFactory
+    ) {
+        $this->salesCollection = $collectionFactory->getReport("sales_order_grid_data_source");
+    }
+
+    public function toOptionArray()
+    {
+        if ($this->options === null) {
+
+            $cctype_collection = $this->salesCollection->setOrder('payment_cctype', 'ASC')->addFieldToSelect('payment_cctype')->distinct(true);
+            foreach ($cctype_collection as $order) {
+                $ccType = $order->getPaymentCctype();
+                $this->options[] = [
+                    'value' => $ccType,
+                    'label' => $ccType
+                ];
+            }
+        }
+        
+        return $this->options;
+    }
+
+}

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -510,6 +510,7 @@
                 <item name="shipping_and_handling" xsi:type="string">sales_order.base_shipping_amount</item>
                 <item name="customer_name" xsi:type="object">CustomerNameAggregator</item>
                 <item name="payment_method" xsi:type="string">sales_order_payment.method</item>
+                <item name="payment_cctype" xsi:type="string">sales_order_payment.cc_type</item>
                 <item name="total_refunded" xsi:type="string">sales_order.total_refunded</item>
             </argument>
         </arguments>

--- a/app/code/Magento/Sales/etc/module.xml
+++ b/app/code/Magento/Sales/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Sales" setup_version="2.0.3">
+    <module name="Magento_Sales" setup_version="2.0.4">
         <sequence>
             <module name="Magento_Rule"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -323,6 +323,18 @@
                 </item>
             </argument>
         </column>
+        <column name="payment_cctype">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="object">Magento\Payment\Ui\Component\Listing\Column\CcType\Options</item>
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">select</item>
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/select</item>
+                    <item name="visible" xsi:type="boolean">false</item>
+                    <item name="dataType" xsi:type="string">select</item>
+                    <item name="label" xsi:type="string" translate="true">Payment Details</item>
+                </item>
+            </argument>
+        </column>
         <column name="total_refunded" class="Magento\Sales\Ui\Component\Listing\Column\Price">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">


### PR DESCRIPTION
### Description

My idea is to add the cc_type information to the order grid in admin. This information is taken from `sales_order_payment.cc_type`. The new field is `sales_order_grid.payment_cctype`.

This is very useful for payment methods that save in `cc_type` relevant data that are useful to display and filter in the order grid. I am referring in particular to Adyen HPP, which stores "adyen_hpp" in "payment_method", but the real payment method (for example: banktransfer_iban, mastercard, ideal) is stored into cc_type column.

I added a particular feature: the filter loads the options from the table itself so that only existing cc_type(s) will be available to the filter. This is necessary for those payment methods that store dynamic values into `cc_type`.

