### PR TITLE
Backport of MAGETWO-55900 for Magento 2.1: [GitHub] Translate message…

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/catalog/product-attributes.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/catalog/product-attributes.js
@@ -6,7 +6,8 @@ define([
     'jquery',
     'underscore',
     'uiRegistry',
-    'jquery/ui'
+    'jquery/ui',
+    'mage/translate'
 ], function ($, _, registry) {
     'use strict';
 

--- a/app/code/Magento/Catalog/view/adminhtml/web/component/image-size-field.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/component/image-size-field.js
@@ -7,7 +7,8 @@ define([
     'jquery',
     'Magento_Ui/js/lib/validation/utils',
     'Magento_Ui/js/form/element/abstract',
-    'Magento_Ui/js/lib/validation/validator'
+    'Magento_Ui/js/lib/validation/validator',
+    'mage/translate'
 ], function ($, utils, Abstract, validator) {
     'use strict';
 

--- a/app/code/Magento/Catalog/view/frontend/web/js/view/compare-products.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/view/compare-products.js
@@ -4,7 +4,8 @@
  */
 define([
     'uiComponent',
-    'Magento_Customer/js/customer-data'
+    'Magento_Customer/js/customer-data',
+    'mage/translate'
 ], function (Component, customerData) {
     'use strict';
 
@@ -12,23 +13,22 @@ define([
 
     function initSidebar() {
         if (sidebarInitialized) {
-            return ;
+            return;
         }
         sidebarInitialized = true;
         require([
             'jquery',
             'mage/mage'
         ], function ($) {
+            /*eslint-disable max-len*/
             $('[data-role=compare-products-sidebar]').mage('compareItems', {
-                "removeConfirmMessage": $.mage.__(
-                    "Are you sure you want to remove this item from your Compare Products list?"
-                ),
-                "removeSelector": "#compare-items a.action.delete",
-                "clearAllConfirmMessage": $.mage.__(
-                    "Are you sure you want to remove all items from your Compare Products list?"
-                ),
-                "clearAllSelector": "#compare-clear-all"
+                'removeConfirmMessage': $.mage.__('Are you sure you want to remove this item from your Compare Products list?'),
+                'removeSelector': '#compare-items a.action.delete',
+                'clearAllConfirmMessage': $.mage.__('Are you sure you want to remove all items from your Compare Products list?'),
+                'clearAllSelector': '#compare-clear-all'
             });
+
+            /*eslint-enable max-len*/
         });
     }
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -224,7 +224,7 @@ define([
 
                         if (msg) {
                             alert({
-                                content: $.mage.__(msg)
+                                content: msg
                             });
                         }
                     }

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
@@ -70,9 +70,7 @@ define([
                 'qty': ':input.cart-item-qty',
                 'button': ':button.update-cart-item'
             },
-            'confirmMessage': $.mage.__(
-                'Are you sure you would like to remove this item from the shopping cart?'
-            )
+            'confirmMessage': $.mage.__('Are you sure you would like to remove this item from the shopping cart?')
         });
     }
 

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -29,7 +29,8 @@ require([
     'jquery',
     'mage/template',
     'jquery/file-uploader',
-    'domReady!'
+    'domReady!',
+    'mage/translate'
 ], function ($, mageTemplate) {
     $('#<?php echo $block->getHtmlId() ?> .fileupload').fileupload({
         dataType: 'json',

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/product-grid.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/product-grid.js
@@ -8,7 +8,8 @@ define([
     'jquery',
     'Magento_Ui/js/core/app',
     'underscore',
-    'notification'
+    'notification',
+    'mage/translate'
 ], function (Component, $, bootstrap, _) {
     'use strict';
 
@@ -221,9 +222,7 @@ define([
 
             if (data.items.length) {
                 this.productsModal.notification('add', {
-                    message: $.mage.__(
-                        'Choose a new product to delete and replace the current product configuration.'
-                    ),
+                    message: $.mage.__('Choose a new product to delete and replace the current product configuration.'),
                     messageContainer: this.gridSelector
                 });
             } else {

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/select_attributes.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/select_attributes.js
@@ -51,9 +51,13 @@ define([
             this.setNotificationMessage();
         },
         setNotificationMessage: function () {
+            /*eslint-disable max-len*/
+            var msg = $.mage.__('When you remove or add an attribute, we automatically update all configurations and you will need to recreate current configurations manually.');
+
+            /*eslint-enable max-len*/
+
             if (this.mode === 'edit') {
-                this.wizard.setNotificationMessage($.mage.__('When you remove or add an attribute, we automatically ' +
-                'update all configurations and you will need to recreate current configurations manually.'));
+                this.wizard.setNotificationMessage(msg);
             }
         },
         doSelectSavedAttributes: function () {

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
@@ -104,7 +104,8 @@ require([
     'mage/template',
     'jquery/file-uploader',
     'mage/mage',
-    'prototype'
+    'prototype',
+    'mage/translate'
 ], function(jQuery, registry, mageTemplate){
     registry.get('downloadable', function (Downloadable) {
         var linkTemplate = '<tr>'+

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
@@ -63,7 +63,8 @@ require([
     'uiRegistry',
     'mage/template',
     'jquery/file-uploader',
-    'prototype'
+    'prototype',
+    'mage/translate'
 ], function (jQuery, registry, mageTemplate) {
     registry.get('downloadable', function (Downloadable) {
         var sampleTemplate = '<tr>'+

--- a/app/code/Magento/Paypal/view/frontend/web/order-review.js
+++ b/app/code/Magento/Paypal/view/frontend/web/order-review.js
@@ -132,7 +132,7 @@ define([
                                 }
                             }
                             alert({
-                                content: $.mage.__(msg)
+                                content: msg
                             });
                             return false;
                         }

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -6,7 +6,8 @@
 define([
     'jquery',
     'Magento_Ui/js/modal/alert',
-    'jquery/ui'
+    'jquery/ui',
+    'mage/translate'
 ], function ($, alert) {
         'use strict';
 

--- a/app/code/Magento/Swatches/view/adminhtml/web/js/type-change.js
+++ b/app/code/Magento/Swatches/view/adminhtml/web/js/type-change.js
@@ -3,7 +3,8 @@
  * See COPYING.txt for license details.
  */
 require([
-    'jquery'
+    'jquery',
+    'mage/translate'
 ], function ($) {
     'use strict';
 

--- a/app/code/Magento/Theme/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/browser/content/uploader.phtml
@@ -33,7 +33,8 @@ require([
     'jquery',
     'mage/template',
     'jquery/file-uploader',
-    'domReady!'
+    'domReady!',
+    'mage/translate'
 ], function ($, mageTemplate) {
 
     $('#fileupload').fileupload({

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/thumbnail.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/thumbnail.js
@@ -7,7 +7,8 @@ define([
     'jquery',
     'mage/template',
     'text!Magento_Ui/templates/grid/cells/thumbnail/preview.html',
-    'Magento_Ui/js/modal/modal'
+    'Magento_Ui/js/modal/modal',
+    'mage/translate'
 ], function (Column, $, mageTemplate, thumbnailPreviewTemplate) {
     'use strict';
 

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -430,10 +430,10 @@ define([
                 var pass = $.trim(v);
                 var result = pass.length >= passwordMinLength;
                 if (result == false) {
-                    validator.passwordErrorMessage = $.mage.__(
-                        "Minimum length of this field must be equal or greater than %1 symbols." +
-                        " Leading and trailing spaces will be ignored."
-                    ).replace('%1', passwordMinLength);
+                    /*eslint-disable max-len*/
+                    validator.passwordErrorMessage = $.mage.__('Minimum length of this field must be equal or greater than %1 symbols. Leading and trailing spaces will be ignored.').replace('%1', passwordMinLength);
+
+                    /*eslint-enable max-len*/
                     return result;
                 }
                 if (pass.match(/\d+/)) {
@@ -450,10 +450,11 @@ define([
                 }
                 if (counter < passwordMinCharacterSets) {
                     result = false;
-                    validator.passwordErrorMessage = $.mage.__(
-                        "Minimum of different classes of characters in password is %1." +
-                        " Classes of characters: Lower Case, Upper Case, Digits, Special Characters."
-                    ).replace('%1', passwordMinCharacterSets);
+
+                    /*eslint-disable max-len*/
+                    validator.passwordErrorMessage = $.mage.__('Minimum of different classes of characters in password is %1. Classes of characters: Lower Case, Upper Case, Digits, Special Characters.').replace('%1', passwordMinCharacterSets);
+
+                    /*eslint-enable max-len*/
                 }
                 return result;
             }, function () {
@@ -741,7 +742,8 @@ define([
                     }
                 }
                 return true;
-            }, "Please enter valid email addresses, separated by commas. For example, johndoe@domain.com, johnsmith@domain.com."
+            },
+            $.mage.__('Please enter valid email addresses, separated by commas. For example, johndoe@domain.com, johnsmith@domain.com.')
         ],
         "validate-cc-number": [
             /**

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -545,10 +545,10 @@
                 var pass = $.trim(v);
                 var result = pass.length >= passwordMinLength;
                 if (result == false) {
-                    validator.passwordErrorMessage = $.mage.__(
-                        "Minimum length of this field must be equal or greater than %1 symbols." +
-                        " Leading and trailing spaces will be ignored."
-                    ).replace('%1', passwordMinLength);
+                    /*eslint-disable max-len*/
+                    validator.passwordErrorMessage = $.mage.__('Minimum length of this field must be equal or greater than %1 symbols. Leading and trailing spaces will be ignored.').replace('%1', passwordMinLength);
+
+                    /*eslint-enable max-len*/
                     return result;
                 }
                 if (pass.match(/\d+/)) {
@@ -565,10 +565,11 @@
                 }
                 if (counter < passwordMinCharacterSets) {
                     result = false;
-                    validator.passwordErrorMessage = $.mage.__(
-                        "Minimum of different classes of characters in password is %1." +
-                        " Classes of characters: Lower Case, Upper Case, Digits, Special Characters."
-                    ).replace('%1', passwordMinCharacterSets);
+
+                    /*eslint-disable max-len*/
+                    validator.passwordErrorMessage = $.mage.__('Minimum of different classes of characters in password is %1. Classes of characters: Lower Case, Upper Case, Digits, Special Characters.').replace('%1', passwordMinCharacterSets);
+
+                    /*eslint-enable max-len*/
                 }
                 return result;
             }, function () {
@@ -983,7 +984,7 @@
 
                 return !!container.querySelectorAll(selector).length;
             },
-            'Please select one of the options.'
+            $.mage.__('Please select one of the options.')
         ],
         "less-than-equals-to": [
             function (value, element, params) {


### PR DESCRIPTION
…s on password strength #5509 #5883 #5861

(cherry picked from commit f67e5989f5efb36ca331e5cc28ee109961fcb99c)

Not included validation messages from https://github.com/magento/magento2/commit/6ce2b5fcbddb5584a4bc3e454d90e2295da4f4ff (MAGETWO-42994)

### Description
Backported MAGETWO-55900 for Magento 2.1

**Important**: there were 2 validation messages which got added by MAGETWO-42994 which got fixed by MAGETWO-55900, but I haven't included them in this PR, since MAGETWO-42994 hasn't been backported yet. See this commit: https://github.com/magento/magento2/commit/6ce2b5fcbddb5584a4bc3e454d90e2295da4f4ff (file `lib/web/mage/validation.js`)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/4883: Not translated "Please enter a valid email address (Ex: johndoe@domain.com)."
2. https://github.com/magento/magento2/issues/5509: Translate messages on password strength
3. https://github.com/magento/magento2/issues/5820: js validation messages translation not working in customer account
4. https://github.com/magento/magento2/issues/5861: [Magento 2.1.0] Translation
5. https://github.com/magento/magento2/issues/5883: Untranslatable string "Minimum length of this field must be equal..."
6. https://github.com/magento/magento2/issues/5995: JS translation not working for some fields
7. https://github.com/magento/magento2/issues/6022: Translation Issue on Magento 2.1v
8. https://github.com/magento/magento2/issues/7525: Magento 2.1.0 Js Translations Not Working
9. https://github.com/magento/magento2/issues/9967: Some messages in Customer Account Create not translated

I might have missed some though.
