### PR TITLE
Backport PR-9713 & PR-9711 for Magento 2.1 - Google Analytics fixes when Cookie Restrictions is enabled

### DIFF
--- a/app/code/Magento/Cookie/Helper/Cookie.php
+++ b/app/code/Magento/Cookie/Helper/Cookie.php
@@ -69,11 +69,22 @@ class Cookie extends \Magento\Framework\App\Helper\AbstractHelper
     public function isUserNotAllowSaveCookie()
     {
         $acceptedSaveCookiesWebsites = $this->_getAcceptedSaveCookiesWebsites();
+        return $this->isCookieRestrictionModeEnabled() &&
+            empty($acceptedSaveCookiesWebsites[$this->_website->getId()]);
+    }
+
+    /**
+     * Check if cookie restriction mode is enabled for this store
+     *
+     * @return bool
+     */
+    public function isCookieRestrictionModeEnabled()
+    {
         return $this->scopeConfig->getValue(
             self::XML_PATH_COOKIE_RESTRICTION,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $this->_currentStore
-        ) && empty($acceptedSaveCookiesWebsites[$this->_website->getId()]);
+        );
     }
 
     /**

--- a/app/code/Magento/Cookie/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/Cookie/view/frontend/templates/html/notices.phtml
@@ -8,7 +8,7 @@
 
 ?>
 <?php /** @var \Magento\Cookie\Block\Html\Notices $block */ ?>
-<?php if ($this->helper('Magento\Cookie\Helper\Cookie')->isUserNotAllowSaveCookie()): ?>
+<?php if ($this->helper('Magento\Cookie\Helper\Cookie')->isCookieRestrictionModeEnabled()): ?>
     <div class="message global cookie" id="notice-cookie-block" style="display: none">
         <div class="content">
             <p>

--- a/app/code/Magento/Cookie/view/frontend/web/js/notices.js
+++ b/app/code/Magento/Cookie/view/frontend/web/js/notices.js
@@ -20,7 +20,10 @@ define([
             $(this.options.cookieAllowButtonSelector).on('click', $.proxy(function() {
                 var cookieExpires = new Date(new Date().getTime() + this.options.cookieLifetime * 1000);
 
-                $.mage.cookies.set(this.options.cookieName, this.options.cookieValue, {expires: cookieExpires});
+                $.mage.cookies.set(this.options.cookieName, JSON.stringify(this.options.cookieValue), {
+                    expires: cookieExpires
+                });
+
                 if ($.mage.cookies.get(this.options.cookieName)) {
                     window.location.reload();
                 } else {


### PR DESCRIPTION
cherry picked from commits:
- a4daf56117493f62dad5a0d9decda75f3a67c4e2
- 058f287ce154ea4b0e81fca2132ec8aaf886121b

### Description
- Backport of https://github.com/magento/magento2/pull/9713 for Magento 2.1
- Backport of https://github.com/magento/magento2/pull/9711 for Magento 2.1

I also took over the reformatting of that line introduced in https://github.com/magento/magento2/commit/391bf420018039738671a4fe788c0f0db9fc9c02

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/5596: Google Universal Analytics does not track when Cookie Restriction is enabled
2. https://github.com/magento/magento2/issues/6441: Google Analytics Tracking Code cached by Varnish if Cookie Restriction Settings are active
3. https://github.com/magento/magento2/issues/6455: Cookie Restriction Mode Overlay is cached by Varnish

@bka: do you recommend to also include https://github.com/magento/magento2/pull/9711 in Magento 2.1, it seems like these two PR's are related?
I only backported https://github.com/magento/magento2/pull/9713 for now, because it fixed a specific issue in our case, we didn't need https://github.com/magento/magento2/pull/9711 to fix our issue (we aren't using Varnish, that might explain it), but it might make sense to include both of these in Magento 2.1?

*Update*: added backport for PR https://github.com/magento/magento2/pull/9711 and updated the issues list above with more issues involved with these fixes