### PR TITLE
Backport of MAGETWO-65607 for Magento 2.1: [GitHub][PR] Check return …

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Price.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Price.php
@@ -39,10 +39,15 @@ class Price extends \Magento\Catalog\Model\Product\Type\Price
      */
     public function getPrice($product)
     {
-        if ($product->getCustomOption('simple_product')) {
-            return $product->getCustomOption('simple_product')->getProduct()->getPrice();
-        } else {
-            return 0;
+        if (!empty($product)) {
+            $simpleProductOption = $product->getCustomOption('simple_product');
+            if (!empty($simpleProductOption)) {
+                $simpleProduct = $simpleProductOption->getProduct();
+                if (!empty($simpleProduct)) {
+                    return $simpleProduct->getPrice();
+                }
+            }
         }
+        return 0;
     }
 }


### PR DESCRIPTION
…value for getProduct() in getPrice(). magento/magento2#7794

 - Merge Pull Request magento/magento2#7794 from pbaylies/magento2:patch-2

(cherry picked from commit 67529688229608a682d049064ae292eb51c38292)

### Description
This is a backport of https://github.com/magento/magento2/pull/7794 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/5519: Getting PHP Fatal Error on getPrice()
2. https://github.com/magento/magento2/issues/10206: Getting PHP Fatal Error on getPrice()

Watch out @heldchen points out in https://github.com/magento/magento2/issues/10206#issuecomment-325627856 that there are other places where this problem can still occur.