### PR TITLE
Backport of MAGETWO-52577 for Magento 2.1: [GitHub] Set Product as Ne…

### DIFF
--- a/app/code/Magento/Catalog/Model/Attribute/Backend/Startdate.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Backend/Startdate.php
@@ -44,12 +44,6 @@ class Startdate extends \Magento\Eav\Model\Entity\Attribute\Backend\Datetime
     {
         $attributeName = $this->getAttribute()->getName();
         $startDate = $object->getData($attributeName);
-        if ($startDate === false) {
-            return false;
-        }
-        if ($startDate == '' && $object->getSpecialPrice()) {
-            $startDate = $this->_localeDate->date();
-        }
 
         return $startDate;
     }

--- a/app/code/Magento/Catalog/Observer/SetSpecialPriceStartDate.php
+++ b/app/code/Magento/Catalog/Observer/SetSpecialPriceStartDate.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Catalog\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ *  Set value for Special Price start date
+ */
+class SetSpecialPriceStartDate implements ObserverInterface
+{
+    /**
+     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     */
+    private $localeDate;
+
+    /**
+     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
+     * @codeCoverageIgnore
+     */
+    public function __construct(\Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate)
+    {
+        $this->localeDate = $localeDate;
+    }
+
+    /**
+     * Set the current date to Special Price From attribute if it empty
+     *
+     * @param \Magento\Framework\Event\Observer $observer
+     * @return $this
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        /** @var  $product \Magento\Catalog\Model\Product */
+        $product = $observer->getEvent()->getProduct();
+        if ($product->getSpecialPrice() && !$product->getSpecialFromDate()) {
+            $product->setData('special_from_date', $this->localeDate->date());
+        }
+
+        return $this;
+    }
+}

--- a/app/code/Magento/Catalog/etc/events.xml
+++ b/app/code/Magento/Catalog/etc/events.xml
@@ -54,4 +54,7 @@
     <event name="admin_system_config_changed_section_catalog">
         <observer name="catalog_update_price_attribute" instance="Magento\Catalog\Observer\SwitchPriceAttributeScopeOnConfigChange" />
     </event>
+    <event name="catalog_product_save_before">
+        <observer name="set_special_price_start_date" instance="Magento\Catalog\Observer\SetSpecialPriceStartDate" />
+    </event>
 </config>

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
@@ -21,6 +21,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
     const RESOURCE_PATH = '/V1/products';
 
     const KEY_TIER_PRICES = 'tier_prices';
+    const KEY_SPECIAL_PRICE = 'special_price';
 
     /**
      * @var array
@@ -827,5 +828,22 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
             StockItemInterface::IS_DECIMAL_DIVIDED => 0,
             StockItemInterface::STOCK_STATUS_CHANGED_AUTO => 0,
         ];
+    }
+
+    public function testSpecialPrice()
+    {
+        $productData = $this->getSimpleProductData();
+        $productData['custom_attributes'] = [
+            ['attribute_code' => self::KEY_SPECIAL_PRICE, 'value' => '1']
+        ];
+        $this->saveProduct($productData);
+        $response = $this->getProduct($productData[ProductInterface::SKU]);
+        $customAttributes = $response['custom_attributes'];
+        $this->assertNotEmpty($customAttributes);
+        $missingAttributes = ['news_from_date', 'custom_design_from'];
+        $expectedAttribute = ['special_price', 'special_from_date'];
+        $attributeCodes = array_column($customAttributes, 'attribute_code');
+        $this->assertEquals(0, count(array_intersect($attributeCodes, $missingAttributes)));
+        $this->assertEquals(2, count(array_intersect($attributeCodes, $expectedAttribute)));
     }
 }

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/ProductForm.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/ProductForm.xml
@@ -45,7 +45,10 @@
             <visibility>
                 <input>select</input>
             </visibility>
-            <news_from_date />
+            <news_from_date>
+                <selector>[name="product[news_from_date]"]</selector>
+                <strategy>css selector</strategy>
+            </news_from_date>
             <news_to_date>
                 <selector>[name="product[news_to_date]"]</selector>
                 <strategy>css selector</strategy>
@@ -178,6 +181,12 @@
         <class>\Magento\Ui\Test\Block\Adminhtml\Section</class>
         <selector>[data-index='schedule-design-update']</selector>
         <strategy>css selector</strategy>
+        <fields>
+            <custom_design_from>
+                <selector>[name="product[custom_design_from]"]</selector>
+                <strategy>css selector</strategy>
+            </custom_design_from>
+        </fields>
     </schedule-design-update>
     <customer-options>
         <class>\Magento\Catalog\Test\Block\Adminhtml\Product\Edit\Section\Options</class>

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/CatalogProductSimple.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/CatalogProductSimple.xml
@@ -29,8 +29,8 @@
         <field name="country_of_manufacture" is_required="0" />
         <field name="created_at" is_required="1" />
         <field name="custom_design" is_required="0" />
-        <field name="custom_design_from" is_required="0" />
-        <field name="custom_design_to" is_required="0" />
+        <field name="custom_design_from" is_required="0" group="schedule-design-update" source="Magento\Backend\Test\Fixture\Source\Date" />
+        <field name="custom_design_to" is_required="0" group="schedule-design-update" source="Magento\Backend\Test\Fixture\Source\Date" />
         <field name="custom_layout_update" is_required="0" />
         <field name="description" is_required="0" group="content" />
         <field name="gallery" is_required="0" />

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/CreateSimpleProductEntityTest.xml
@@ -55,11 +55,14 @@
             <data name="product/data/short_description" xsi:type="string">Simple Product short_description %isolation%</data>
             <data name="product/data/description" xsi:type="string">Simple Product description %isolation%</data>
             <data name="product/data/weight" xsi:type="string">52</data>
+            <data name="product/data/news_from_date" xsi:type="string"></data>
+            <data name="product/data/custom_design_from" xsi:type="string"></data>
             <data name="product/data/quantity_and_stock_status/qty" xsi:type="string">659</data>
             <data name="product/data/custom_options/dataset" xsi:type="string">drop_down_with_one_option_fixed_price</data>
             <data name="product/data/checkout_data/dataset" xsi:type="string">simple_drop_down_with_one_option_fixed_price</data>
             <data name="product/data/price/dataset" xsi:type="string">MAGETWO-23029</data>
             <constraint name="Magento\Catalog\Test\Constraint\AssertProductSaveMessage" />
+            <constraint name="Magento\Catalog\Test\Constraint\AssertProductForm" />
             <constraint name="Magento\Catalog\Test\Constraint\AssertProductInGrid" />
             <constraint name="Magento\Catalog\Test\Constraint\AssertProductInCategory" />
             <constraint name="Magento\Catalog\Test\Constraint\AssertProductPage" />


### PR DESCRIPTION
…w from Date and Design Active From is set when setting Special Price #4387

(cherry picked from commit a2d59ac0316b427ce79ea386675cda53dfa4bcb4)

### Description
This is a backport of MAGETWO-52577 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/4387: News From Date and Design Active From is set when setting Special Price for product.
2. https://github.com/magento/magento2/issues/7448: Can't remove "Set Product as New From" value
