### PR TITLE
Backport of MAGETWO-52102 for Magento 2.1: [Github] Custom theme stat…

### DIFF
--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -890,6 +890,16 @@ class Files
                         throw new \UnexpectedValueException("Could not parse theme static file '$file'");
                     }
                 }
+
+                if (!$files) {
+                    $result[] = [
+                        $themeArea,
+                        $themePackage->getVendor() . '/' . $themePackage->getName(),
+                        null,
+                        null,
+                        null,
+                    ];
+                }
             }
         }
     }


### PR DESCRIPTION
…ic content won't deploy without overriding at least one static content file #3754

(cherry picked from commit 6a9744dcd6d99cd65992374198df82fdb1eac758)

### Description
This is a backport of MAGETWO-52102 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/3754: Must override at least one static content file or custom theme static content won't deploy
2. https://github.com/magento/magento2/issues/4725: Static files are not generated for custom theme
3. https://github.com/magento/magento2/issues/7569: Theme with no static files won't get deployed
