### PR TITLE
phpDocumentor Return tag must be an int

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1774,17 +1774,17 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      */
     public function hasInvoices()
     {
-        return $this->getInvoiceCollection()->count();
+        return (bool)$this->getInvoiceCollection()->count();
     }
 
     /**
      * Check order shipments availability
      *
-     * @return int
+     * @return bool
      */
     public function hasShipments()
     {
-        return $this->getShipmentsCollection()->count();
+        return (bool)$this->getShipmentsCollection()->count();
     }
 
     /**
@@ -1794,7 +1794,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      */
     public function hasCreditmemos()
     {
-        return $this->getCreditmemosCollection()->count();
+        return (bool)$this->getCreditmemosCollection()->count();
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1780,7 +1780,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Check order shipments availability
      *
-     * @return bool
+     * @return int
      */
     public function hasShipments()
     {


### PR DESCRIPTION
Because count() gives an int, hasShipment returns an int. Now i can't do this:
```if ($view->getOrder()->hasShipments() === true) {```