### PR TITLE
Always use https for Vimeo video's.

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -302,7 +302,7 @@ define([
                     additionalParams += '&autoplay=1';
                 }
 
-                src = window.location.protocol + '//player.vimeo.com/video/' +
+                src = 'https://player.vimeo.com/video/' +
                     this._code + '?api=1&player_id=vimeo' +
                     this._code +
                     timestamp +
@@ -525,7 +525,7 @@ define([
                     );
                 } else if (type === 'vimeo') {
                     $.ajax({
-                        url: window.location.protocol + '//www.vimeo.com/api/v2/video/' + id + '.json',
+                        url: 'https://www.vimeo.com/api/v2/video/' + id + '.json',
                         dataType: 'jsonp',
                         data: {
                             format: 'json'

--- a/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
@@ -317,7 +317,7 @@ define(['jquery', 'jquery/ui'], function ($) {
             if (this._loop) {
                 additionalParams += '&loop=1';
             }
-            src = window.location.protocol + '//player.vimeo.com/video/' +
+            src = 'https://player.vimeo.com/video/' +
                 this._code + '?api=1&player_id=vimeo' +
                 this._code +
                 timestamp +


### PR DESCRIPTION
### Description
Instead of using the current protocol being used by Magento (http or https), always go for https. Since Vimeo redirects all non-https traffic to https.
See discussion with @orlangur in https://github.com/magento/magento2/pull/10748

This still happens in the fotorama library though: https://github.com/magento/magento2/blob/a232e0753026b081a83f1aa6fd47800da125a8c6/lib/web/fotorama/fotorama.js#L853-L858
Not sure if this needs to be changed as well?



Watch out, I didn't test these changes, so please test before approving if possible :)

Once this is in the `develop` branch and backported to Magento 2.2 by someone, I'll update https://github.com/magento/magento2/pull/10748 so this also gets into Magento 2.1
I don't want to have an awkward situation where this is merged in `develop` and `2.1` but not in `2.2`

### Fixed Issues (if relevant)
None

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
