### PR TITLE
Fix: Run php-cs-fixer as part of static tests

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -24,7 +24,10 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('setup/vendor')
     ->exclude('var');
 
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
 return PhpCsFixer\Config::create()
+    ->setCacheFile($cacheDir . '/.php_cs.cache')
     ->setFinder($finder)
     ->setRules([
         '@PSR2' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.nvm
+    - $HOME/.php-cs-fixer
     - $HOME/node_modules
     - $HOME/yarn.lock
 before_install: ./dev/travis/before_install.sh

--- a/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
@@ -199,7 +199,7 @@ class LiveCodeTest extends \PHPUnit\Framework\TestCase
         return Files::init()->readLists(__DIR__ . '/_files/whitelist/common.txt');
     }
 
-    public function testCodeStyle()
+    public function testCodeStyleWithPhpCodeSniffer()
     {
         $reportFile = self::$reportDir . '/phpcs_report.txt';
         $codeSniffer = new CodeSniffer('Magento', $reportFile, new Wrapper());
@@ -207,6 +207,26 @@ class LiveCodeTest extends \PHPUnit\Framework\TestCase
             0,
             $result = $codeSniffer->run($this->getFullWhitelist()),
             "PHP Code Sniffer detected {$result} violation(s): " . PHP_EOL . file_get_contents($reportFile)
+        );
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     */
+    public function testCodeStyleWithPhpCsFixer()
+    {
+        $fixCommand = './vendor/bin/php-cs-fixer fix . --config=.php_cs.dist';
+        $checkCommand = $fixCommand . ' --dry-run 2> /dev/null';
+
+        exec($checkCommand, $output, $exitCode);
+
+        $this->assertEquals(
+            0,
+            $exitCode,
+            sprintf(
+                'php-cs-fixer detected violations, please run "%s"',
+                $fixCommand
+            )
         );
     }
 

--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -63,6 +63,8 @@ case $TEST_SUITE in
         cd ../../..
         ;;
     static)
+        mkdir -p "$HOME/.php-cs-fixer"
+
         cd dev/tests/static
 
         echo "==> preparing changed files list"


### PR DESCRIPTION
### Description

As of the moment, [`friendsofphp/php-cs-fixer`](https://github.com/magento/magento2/blob/c2810e0d6014fd8aa787d24e5d46c6593437f00a/composer.json#L81) is used within this project, but it is only run as part of the [`pre-commit`](https://github.com/magento/magento2/blob/c2810e0d6014fd8aa787d24e5d46c6593437f00a/dev/tools/Magento/Tools/StaticReview/pre-commit) hook.

This PR

* adds a new test that runs `php-cs-fixer` in `dry-run` mode and fails if the exit code is not `0`
* speeds up the build by caching `.php_cs.cache` between Travis builds
* runs `php-cs-fixer`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.2#caching.

### Fixed Issues (if relevant)

n/a

### Manual testing scenarios

n/a

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)