### PR TITLE
Enhancement: Configure preferred installation source in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ cache:
     - $HOME/node_modules
     - $HOME/yarn.lock
 before_install: ./dev/travis/before_install.sh
-install: composer install --no-interaction --prefer-dist
+install: composer install --no-interaction
 before_script: ./dev/travis/before_script.sh
 script:
   # Set arguments for variants of phpunit based tests; '|| true' prevents failing script when leading test fails

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
         "OSL-3.0",
         "AFL-3.0"
     ],
+    "config": {
+        "preferred-install": "dist"
+    },
     "require": {
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "zendframework/zend-stdlib": "^2.7.7",


### PR DESCRIPTION
### Description

By configuring the preferred method of installation in `composer.json`, none of the flags

* `--prefer-dist`
* `--prefer-source`

need to be specified when installing dependencies.

Since it is indicated in [`.travis.yml`](https://github.com/magento/magento2/blob/c2810e0d6014fd8aa787d24e5d46c6593437f00a/.travis.yml#L51) that dependencies should be installed from `dist` (which of course makes the most sense), this PR configures the `preferred-install` method accordingly.

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#preferred-install.

### Fixed Issues (if relevant)

n/a

### Manual testing scenarios

n/a

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

Somewhat related to #10769.
