### PR TITLE
Fix: Use all columns when running tests

### DIFF
--- a/dev/tests/api-functional/phpunit.xml.dist
+++ b/dev/tests/api-functional/phpunit.xml.dist
@@ -10,6 +10,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
 >

--- a/dev/tests/functional/phpunit.xml.dist
+++ b/dev/tests/functional/phpunit.xml.dist
@@ -8,6 +8,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          bootstrap="bootstrap.php"
          backupGlobals="false"
          verbose="true"

--- a/dev/tests/integration/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/integration/framework/tests/unit/phpunit.xml.dist
@@ -8,6 +8,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
 >

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -8,6 +8,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
          stderr="true"

--- a/dev/tests/static/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/static/framework/tests/unit/phpunit.xml.dist
@@ -8,6 +8,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="../../bootstrap.php"
 >

--- a/dev/tests/static/phpunit-all.xml.dist
+++ b/dev/tests/static/phpunit-all.xml.dist
@@ -10,6 +10,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          bootstrap="./framework/bootstrap.php"
 >
     <testsuites>

--- a/dev/tests/static/phpunit.xml.dist
+++ b/dev/tests/static/phpunit.xml.dist
@@ -10,6 +10,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
 >

--- a/dev/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/phpunit.xml.dist
@@ -8,6 +8,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
         >


### PR DESCRIPTION
### Description

It has been possible for a while to configure the number of columns `phpunit` should use for rendering progress output.

While [`80`](https://github.com/sebastianbergmann/phpunit/blob/6.2/phpunit.xsd#L205) is the default, we can also set it to [`max`](https://github.com/sebastianbergmann/phpunit/blob/6.2/phpunit.xsd#L102-L113), which means that `phpunit` will use the entire width of the screen if it has been able to detect it.

Since most of the screens we use today have more than `80` columns, this has the advantage that we we can fit more output on a screen, requiring less scrolling if needed.

For reference, see https://phpunit.de/manual/current/en/textui.html#textui.clioptions:

>`--columns`
>Defines the number of columns to use for progress output. If `max` is defined as value, the number of columns will be maximum of the current terminal.

### Fixed Issues (if relevant)

n/a

### Manual testing scenarios

n/a

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

Somewhat related to #10779.
