### PR TITLE
Fix: Consistently use verbose option when running tests

### DIFF
--- a/dev/tests/api-functional/phpunit.xml.dist
+++ b/dev/tests/api-functional/phpunit.xml.dist
@@ -12,6 +12,7 @@
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
+         verbose="true"
 >
     <!-- Test suites definition -->
     <testsuites>

--- a/dev/tests/integration/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/integration/framework/tests/unit/phpunit.xml.dist
@@ -10,6 +10,7 @@
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
+         verbose="true"
 >
     <!-- Test suites definition -->
     <testsuites>

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -11,6 +11,7 @@
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
          stderr="true"
+         verbose="true"
 >
     <!-- Test suites definition -->
     <testsuites>

--- a/dev/tests/static/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/static/framework/tests/unit/phpunit.xml.dist
@@ -10,6 +10,7 @@
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="../../bootstrap.php"
+         verbose="true"
 >
     <testsuites>
         <testsuite name="Magento Unit Tests for Static Code Analysis Framework">

--- a/dev/tests/static/phpunit-all.xml.dist
+++ b/dev/tests/static/phpunit-all.xml.dist
@@ -11,6 +11,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          colors="true"
          bootstrap="./framework/bootstrap.php"
+         verbose="true"
 >
     <testsuites>
         <testsuite name="All Static Code Analysis Tests">

--- a/dev/tests/static/phpunit.xml.dist
+++ b/dev/tests/static/phpunit.xml.dist
@@ -12,6 +12,7 @@
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
+         verbose="true"
 >
     <testsuites>
         <testsuite name="Less Static Code Analysis">

--- a/dev/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/phpunit.xml.dist
@@ -10,6 +10,7 @@
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
+         verbose="true"
         >
     <testsuite name="Magento Unit Tests">
         <directory suffix="Test.php">../../../app/code/*/*/Test/Unit</directory>


### PR DESCRIPTION
### Description

The `verbose` option is already configured in [`dev/tests/functional/phpunit.xml.dist`](https://github.com/magento/magento2/blob/c2810e0d6014fd8aa787d24e5d46c6593437f00a/dev/tests/functional/phpunit.xml.dist#L13). 

This PR consistently applies it to all `phpunit` configurations.

For reference, see https://phpunit.de/manual/current/en/textui.html#textui.clioptions:

>`--verbose`
>Output more verbose information, for instance the names of tests that were incomplete or have been skipped.

### Fixed Issues (if relevant)

n/a

### Manual testing scenarios

n/a

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

Somewhat related to #10779.