### PR TITLE
Fix spelling mistake in AddressTest.php

### DIFF
--- a/app/code/Magento/Customer/Test/Unit/Model/AddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AddressTest.php
@@ -82,7 +82,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
 
     public function testCustomer()
     {
-        $this->address->unsetData('cusomer_id');
+        $this->address->unsetData('customer_id');
         $this->assertFalse($this->address->getCustomer());
 
         $this->address->setCustomerId(self::ORIG_CUSTOMER_ID);


### PR DESCRIPTION
Added the T to customer which shouldn't affect the test unit as it sets the customer ID later (Line: 88) but it's better to correct the spelling mistake. 
