### PR TITLE
Remove the usage of the DataObject for response management

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Validate.php
@@ -36,11 +36,8 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Category
      */
     public function execute()
     {
-        $response = new \Magento\Framework\DataObject();
-        $response->setError(0);
-
         $resultJson = $this->resultJsonFactory->create();
-        $resultJson->setData($response);
+        $resultJson->setData(['error' => 0]);
         
         return $resultJson;
     }


### PR DESCRIPTION
### Description

In the class `code/Magento/Catalog/Controller/Adminhtml/Category/Validate.php` the `DataObject` is used but it really does not need to be used. This controller seems to be a very simple controller which always returns the same response. For this case setting the appropriate array to the `$resultJson` seems to be a good replacement.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
