### PR TITLE
Close PayPal popup window in case of rejected request

### DIFF
--- a/app/code/Magento/Paypal/view/frontend/web/js/view/payment/method-renderer/in-context/checkout-express.js
+++ b/app/code/Magento/Paypal/view/frontend/web/js/view/payment/method-renderer/in-context/checkout-express.js
@@ -78,7 +78,9 @@ define(
                                     $('body').trigger('processStop');
                                     customerData.invalidate(['cart']);
                                 });
-                            }.bind(this));
+                            }.bind(this)).fail(function() {
+                                paypalExpressCheckout.checkout.closeFlow();
+                            });
                         }
                     }
                 }

--- a/app/code/Magento/Paypal/view/frontend/web/js/view/payment/method-renderer/in-context/checkout-express.js
+++ b/app/code/Magento/Paypal/view/frontend/web/js/view/payment/method-renderer/in-context/checkout-express.js
@@ -78,7 +78,7 @@ define(
                                     $('body').trigger('processStop');
                                     customerData.invalidate(['cart']);
                                 });
-                            }.bind(this)).fail(function() {
+                            }.bind(this)).fail(function () {
                                 paypalExpressCheckout.checkout.closeFlow();
                             });
                         }


### PR DESCRIPTION
### Description
PayPal express pop-up stays opened when the 'setPaymentMethodAction' request was rejected.

### Manual testing scenarios
1. Trigger an error on the server side for the `set-payment-information` action
2. Place an order using PayPal Express in-context mode.
3. Popup will stay opened and the whole screen dimmed.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
