### PR TITLE
Enable livereload for watch:<theme> commands

### DIFF
--- a/dev/tools/grunt/configs/watch.js
+++ b/dev/tools/grunt/configs/watch.js
@@ -13,6 +13,9 @@ var themeOptions = {};
 
 _.each(themes, function(theme, name) {
     themeOptions[name] = {
+        'options': {
+            livereload: true
+        },
         'files': [
             '<%= combo.autopath(\''+name+'\', path.pub) %>/**/*.less'
         ],


### PR DESCRIPTION
Start the LiveReload server for `grunt watch:<theme>` commands.

### Description
When running `grunt watch` from the Magento root directory, LiveReload is started. When watching a specific theme by using `grunt watch:<theme>` (eg `grunt watch:luma`), it would not start LiveReload. With this change is starts LiveReload for both commands.

### Manual testing scenarios
1. Run `npm install`.
2. Run `grunt watch`.
3. On http://localhost:35729/livereload.js you will get the LiveReload script.
4. Quit the `grunt watch` command.
5. Now start a specific theme watch, eg Luma: `grunt watch:luma`.
6. On https://localhost:35729/livereload.js you now still get the LiveReload script.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
