### PR TITLE
allow digits in event names

### DIFF
--- a/lib/internal/Magento/Framework/Event/etc/events.xsd
+++ b/lib/internal/Magento/Framework/Event/etc/events.xsd
@@ -60,11 +60,11 @@
     <xs:simpleType name="eventName">
         <xs:annotation>
             <xs:documentation>
-                Event name can contain only [a-zA-Z_].
+                Event name can contain only [a-zA-Z0-9_].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
At the moment it is not allowed to have event names containing digits, though this was possible in Magento1. 
For example a event name like `mwltr83_my_event` is not allowed within the events.xsd.

### Description
This pull requests updates the events.xsd and adds 0-9 to allowed values in the regex.

### Fixed Issues (if relevant)
void

### Manual testing scenarios
void

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
