### PR TITLE
Fix bug with array attribute filters in addAttributeToFilter function

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -361,8 +361,8 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
 
         if (is_array($attribute)) {
             $sqlArr = [];
-            foreach ($attribute as $condition) {
-                $sqlArr[] = $this->_getAttributeConditionSql($condition['attribute'], $condition, $joinType);
+            foreach ($attribute as $key => $name) {
+                $sqlArr[] = $this->_getAttributeConditionSql($name, $condition[$key], $joinType);
             }
             $conditionSql = '(' . implode(') OR (', $sqlArr) . ')';
         } elseif (is_string($attribute)) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
With this fix is possible to create collections with multiple where options with logic OR like this one.

```php
$collection = $this->collectionFactory->create();
$collection->addFieldToFilter(
            array(attribute1, attribute2, attribute3), // columns
            array( // conditions
                array('eq' => value1),
                array('eq' => value2), // condition for field 2
                array('eq' => value3) // condition for field 3
            )
        );
```

And the result SQL query will be like this:

 ```sql
SELECT 
`e`.*,
`attribute1`.`value` AS `attribute1`,
 `attribute2`.`value` AS `attribute2`, 
`attribute3`.`value` AS `attribute3` 
FROM `customer_entity` AS `e`
INNER JOIN `customer_entity_text` AS `attribute1` ON (`attribute1`.`entity_id` = `e`.`entity_id`) 
AND (`attribute1`.`attribute_id` = 'X')
INNER JOIN `customer_entity_text` AS `attribute2` ON (`attribute2`.`entity_id` = `e`.`entity_id`) AND (`attribute2`.`attribute_id` = 'X') 
INNER JOIN `customer_entity_text` AS `attribute3` ON (`attribute3`.`entity_id` = `e`.`entity_id`) AND (`attribute3`.`attribute_id` = 'X') 
WHERE (attribute1.value = 'value1') OR (attribute2.value = 'value2') OR (attribute3.value = 'value3'))
```

### Manual testing scenarios
1. You have to declare one collection, like the example of this pull request, and check that before the fix it does not work and after applied it the collection will works.
