### PR TITLE
field lengths differ across many tables

### DIFF
--- a/app/code/Magento/Quote/Setup/InstallSchema.php
+++ b/app/code/Magento/Quote/Setup/InstallSchema.php
@@ -474,7 +474,7 @@ class InstallSchema implements InstallSchemaInterface
         )->addColumn(
             'telephone',
             \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-            20,
+            255,
             [],
             'Phone Number'
         )->addColumn(


### PR DESCRIPTION
### Description

I found numerous field lengths to be different across many tables. Thus strings get cut off.
In my case the "telephone" was cut off as someone set it to be just 20 characters in the quote_address table despite it being 255 characters wide in the sales_order_address table.
There are many other fields differing.

Someone seriously needs to check this! Unfortunately I do not have enough knowledge about all the fields.

In my case our customers want to enter not one phone number but sometimes their landline and mobile phone number into the telephone field. The field is not validated against any format.

### Fixed Issues (if relevant)
1. magento/magento2#10869: field lengths differ across many tables

### Manual testing scenarios
1. do not validate the telephone number against any format
2. place a new order
3. enter a telephone number wider than 20 characters
