### PR TITLE
Deprecated Magento\Store\Model\Store::$_isAdminSecure

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -207,6 +207,7 @@ class Store extends AbstractExtensibleModel implements
      * Flag that shows that backend URLs are secure
      *
      * @var boolean|null
+     * @deprecated unused protected property
      */
     protected $_isAdminSecure = null;
 


### PR DESCRIPTION
### Description
 - added `@depreated` tag to unused protected property
 - closing magento/magento2#4720

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4720: isAdminSecure never used or missing code

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
