### PR TITLE
Remove app/etc/config.php from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ atlassian*
 /.idea
 /.gitattributes
 /app/config_sandbox
-/app/etc/config.php
 /app/etc/env.php
 /app/code/Magento/TestModule*
 /lib/internal/flex/uploader/.actionScriptProperties


### PR DESCRIPTION
### Description
Remove app/etc/config.php from .gitignore because it should be in
version control for pipeline deployment.

Accodring to [Development System Setup](http://devdocs.magento.com/guides/v2.2/config-guide/deployment/pipeline/development-system.html) step in the DevDocs
the most prerequisites are given im Magento's `.gitignore` and in DevDocs'
 [.gitignore reference](http://devdocs.magento.com/guides/v2.2/config-guide/prod/config-reference-gitignore.html) no changes for `app/etc/config.php` are mentioned.

### Manual testing scenarios
1. Export config.php using `bin/magento app:config:dump`
2. Verify that version control asks you to version `app/etc/config.php`
