### PR TITLE
Add escaping of js translation version

### DIFF
--- a/app/code/Magento/Translation/view/base/templates/translate.phtml
+++ b/app/code/Magento/Translation/view/base/templates/translate.phtml
@@ -28,7 +28,7 @@
 
                 <?php $version = $block->getTranslationFileVersion(); ?>
 
-                if (versionObj.version !== '<?= /* @noEscape */ $version ?>') {
+                if (versionObj.version !== '<?php $block->escapeJsQuote($version) ?>') {
                     dependencies.push(
                         'text!<?= /* @noEscape */ Magento\Translation\Model\Js\Config::DICTIONARY_FILE_NAME ?>'
                     );
@@ -44,7 +44,7 @@
                             $.localStorage.set(
                                 'mage-translation-file-version',
                                 {
-                                    version: '<?= /* @noEscape */ $version ?>'
+                                    version: '<?php $block->escapeJsQuote($version) ?>'
                                 }
                             );
                         } else {


### PR DESCRIPTION
As it was discussed in https://github.com/magento/magento2/pull/10378#discussion_r136984136 - we need to escape js translation version.

### Description
Previously value of $version variable was always sha1, that can be not escaped, but from now it uses raw value from public method, that could be overridden by plugin.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Put following code to getTranslationFileVersion method (directly or via plugin):
```php
return "' || alert(1) || '";
```
2. Go to any page

**Actual result:**
1. Alert with message 1 is shown

**Expected result:**
1. Alert mustn't be shown

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
