### PR TITLE
Fixes translations by re-running the loadData for its correct locale

### DIFF
--- a/app/code/Magento/Translation/Model/Json/PreProcessor.php
+++ b/app/code/Magento/Translation/Model/Json/PreProcessor.php
@@ -81,7 +81,7 @@ class PreProcessor implements PreProcessorInterface
 
             $area = $this->areaList->getArea($areaCode);
             $area->load(\Magento\Framework\App\Area::PART_TRANSLATE);
-    
+
             $this->translate->setLocale($context->getLocale())->loadData($areaCode, true);
 
             $chain->setContent(json_encode($this->dataProvider->getData($themePath)));

--- a/app/code/Magento/Translation/Model/Json/PreProcessor.php
+++ b/app/code/Magento/Translation/Model/Json/PreProcessor.php
@@ -77,11 +77,12 @@ class PreProcessor implements PreProcessorInterface
             if ($context instanceof FallbackContext) {
                 $themePath = $context->getThemePath();
                 $areaCode = $context->getAreaCode();
-                $this->translate->setLocale($context->getLocale());
             }
 
             $area = $this->areaList->getArea($areaCode);
             $area->load(\Magento\Framework\App\Area::PART_TRANSLATE);
+    
+            $this->translate->setLocale($context->getLocale())->loadData($areaCode, true);
 
             $chain->setContent(json_encode($this->dataProvider->getData($themePath)));
             $chain->setContentType('json');


### PR DESCRIPTION
### Description
When running `setup:static-content:deploy` with multiple languages specified, it will generate a js-translation.json. Even if the locale is set properly for each language, it will translate just based on 
`$this->translator->getData();`  in _Magento\Framework\Phrase\Renderer_

In other words it will use the data retrieved from the `loadData`  function in the _Framework/Translation.php_ 
This uses a constructor which sets the locale; `\Magento\Framework\Locale\ResolverInterface $locale` and obviously followed by `$this->_locale = $locale;`

The problem here is that the loadData only gets ran once on init. It will keep using this for every other locale as 'base'. Therefore a potential locale change should also re-run the loadData.

By forcing a "rebuild" of the loadData with the correct locale, we will parse the data with the correct translations. 

As extra because we are forcing the locale & rebuild we can remove the FallbackContext filler for the locale as we are setting it anyways.

### Fixed Issues 
1. magento/magento2#10673: [2.2.0-RC2.2] Static content deploy with multiple locales: js-translation.json files are the same


### Manual testing scenarios
1 Run `php bin/magento setup:static-content:deploy -f -t Magento/luma nl_NL fr_FR`
2 Run `diff -rwq pub/static/frontend/Magento/luma/nl_NL/ pub/static/frontend/Magento/luma/fr_FR/`
3 js-translation.json are now different from each other with the correct language translations


