### PR TITLE
Issue #5144 - fix add to cart product and validation required attribute for version CE 2.1

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -28,7 +28,7 @@
             </div>
         </div>
         <?php endif; ?>
-        <div class="actions">
+        <div class="actions siedem">
             <button type="submit"
                     title="<?php /* @escapeNotVerified */ echo $buttonTitle ?>"
                     class="action primary tocart"
@@ -54,7 +54,7 @@
     {
         "#product_addtocart_form": {
             "catalogAddToCart": {
-                "bindSubmit": false
+                "bindSubmit": true
             }
         }
     }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -28,7 +28,7 @@
             </div>
         </div>
         <?php endif; ?>
-        <div class="actions siedem">
+        <div class="actions">
             <button type="submit"
                     title="<?php /* @escapeNotVerified */ echo $buttonTitle ?>"
                     class="action primary tocart"

--- a/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
@@ -33,9 +33,12 @@ define([
 
         _bindSubmit: function() {
             var self = this;
+            this.element.mage('validation');
             this.element.on('submit', function(e) {
                 e.preventDefault();
-                self.submitForm($(this));
+                if(self.element.valid()) {
+                    self.submitForm($(this));
+                }
             });
         },
 


### PR DESCRIPTION
Fix add to cart product and validation required attribute for version CE 2.1

### Description
While ajax add to cart on product page is enable, the validation of required arguments not working properly - is doubled, first it shows errors message in empty inputs, then reload the page. 
In version 2.2. this problem doesn't appear.  

### Fixed Issues (if relevant)

#5144

1. magento/magento2#5144: Ajax cart doesn't work

### Manual testing scenarios

1.  Add configurable product to cart from product page with required attributes chosen
2. Add configurable product to cart from product page without required attributes chosen
