### PR TITLE
Created memory efficient iterator for importexport_importdata table

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/CustomerComposite/Data.php
+++ b/app/code/Magento/CustomerImportExport/Model/ResourceModel/Import/CustomerComposite/Data.php
@@ -28,16 +28,18 @@ class Data extends \Magento\ImportExport\Model\ResourceModel\Import\Data
      *
      * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
      * @param \Magento\Framework\Json\Helper\Data $coreHelper
+     * @param \Magento\ImportExport\Model\ResourceModel\Import\Data\IteratorFactory $iteratorFactory,
      * @param string $connectionName
      * @param array $arguments
      */
     public function __construct(
         \Magento\Framework\Model\ResourceModel\Db\Context $context,
         \Magento\Framework\Json\Helper\Data $jsonHelper,
+        \Magento\ImportExport\Model\ResourceModel\Import\Data\IteratorFactory $iteratorFactory,
         $connectionName = null,
         array $arguments = []
     ) {
-        parent::__construct($context, $jsonHelper, $connectionName);
+        parent::__construct($context, $jsonHelper, $iteratorFactory, $connectionName);
 
         if (isset($arguments['entity_type'])) {
             $this->_entityType = $arguments['entity_type'];

--- a/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data.php
+++ b/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data.php
@@ -26,6 +26,11 @@ class Data extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
     protected $jsonHelper;
 
     /**
+     * @var Data\IteratorFactory
+     */
+    protected $iteratorFactory;
+
+    /**
      * Class constructor
      *
      * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
@@ -35,10 +40,13 @@ class Data extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
     public function __construct(
         \Magento\Framework\Model\ResourceModel\Db\Context $context,
         \Magento\Framework\Json\Helper\Data $jsonHelper,
+        \Magento\ImportExport\Model\ResourceModel\Import\Data\IteratorFactory $iteratorFactory,
         $connectionName = null
     ) {
         parent::__construct($context, $connectionName);
+
         $this->jsonHelper = $jsonHelper;
+        $this->iteratorFactory = $iteratorFactory;
     }
 
     /**
@@ -58,20 +66,7 @@ class Data extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
      */
     public function getIterator()
     {
-        $connection = $this->getConnection();
-        $select = $connection->select()->from($this->getMainTable(), ['data'])->order('id ASC');
-        $stmt = $connection->query($select);
-
-        $stmt->setFetchMode(\Zend_Db::FETCH_NUM);
-        if ($stmt instanceof \IteratorAggregate) {
-            $iterator = $stmt->getIterator();
-        } else {
-            // Statement doesn't support iterating, so fetch all records and create iterator ourself
-            $rows = $stmt->fetchAll();
-            $iterator = new \ArrayIterator($rows);
-        }
-
-        return $iterator;
+        return $this->iteratorFactory->create();
     }
 
     /**

--- a/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data/DataProvider.php
+++ b/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data/DataProvider.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ImportExport\Model\ResourceModel\Import\Data;
+
+/**
+ * DataProvider for import data
+ */
+class DataProvider extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    /**
+     * Ids of rows in table
+     * @var array
+     */
+    protected $rowsIds = [];
+
+    /**
+     * DataProvider constructor.
+     * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
+     * @param string $connectionName
+     */
+    public function __construct(
+        \Magento\Framework\Model\ResourceModel\Db\Context $context,
+        $connectionName = null
+    ) {
+        parent::__construct($context, $connectionName);
+    }
+
+    /**
+     * Resource initialization
+     */
+    protected function _construct()
+    {
+        $this->_init('importexport_importdata', 'id');
+    }
+
+    /**
+     * Get all existing rows ids to use them later for efficient data retrieval
+     * @return array
+     */
+    protected function getRowsIds()
+    {
+        if(empty($this->rowsIds)) {
+            $connection = $this->getConnection();
+
+            $select = $connection
+                ->select()
+                ->from('importexport_importdata', ['id'])
+                ->order('id ASC');
+
+            $this->rowsIds = $connection->fetchCol($select);
+        }
+
+        return $this->rowsIds;
+    }
+
+    /**
+     * Returns import data row by $index
+     *
+     * @param $index int
+     * @return array
+     */
+    public function getImportDataRow($index)
+    {
+        $rowsIds = $this->getRowsIds();
+
+        if(!isset($rowsIds[$index])) {
+            return null;
+        }
+
+        $connection = $this->getConnection();
+
+        $select = $connection
+            ->select()
+            ->from('importexport_importdata', ['data'])
+            ->order('id ASC')
+            ->where('id = ?', $rowsIds[$index]);
+
+        $statement = $connection->query($select);
+
+        $row = $statement->fetch();
+
+        return [$row['data']];
+    }
+}

--- a/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data/DataProvider.php
+++ b/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data/DataProvider.php
@@ -47,7 +47,7 @@ class DataProvider extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
             $select = $connection
                 ->select()
-                ->from('importexport_importdata', ['id'])
+                ->from($this->getMainTable(), ['id'])
                 ->order('id ASC');
 
             $this->rowsIds = $connection->fetchCol($select);
@@ -74,7 +74,7 @@ class DataProvider extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
         $select = $connection
             ->select()
-            ->from('importexport_importdata', ['data'])
+            ->from($this->getMainTable(), ['data'])
             ->order('id ASC')
             ->where('id = ?', $rowsIds[$index]);
 

--- a/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data/Iterator.php
+++ b/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data/Iterator.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ImportExport\Model\ResourceModel\Import\Data;
+
+/**
+ * Import data iterator
+ */
+class Iterator extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    /**
+     * Ids of rows in table
+     * @var array
+     */
+    protected $rowsIds = [];
+
+    /**
+     * Count of all rows in table
+     * @var int
+     */
+    protected $rowsCount = 0;
+
+    /**
+     * Current iterator index
+     * @var int
+     */
+    protected $currentIndex = 0;
+
+    /**
+     * Iterator constructor.
+     * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
+     * @param null $connectionName
+     */
+    public function __construct(
+        \Magento\Framework\Model\ResourceModel\Db\Context $context,
+        $connectionName = null
+    ) {
+        parent::__construct($context, $connectionName);
+
+        $this->rowsIds = $this->getRowsIds();
+        $this->rowsCount = count($this->rowsIds);
+    }
+
+    /**
+     * Resource initialization
+     */
+    protected function _construct()
+    {
+        $this->_init('importexport_importdata', 'id');
+    }
+
+    /**
+     * Get all existing rows ids to use them later for efficient iteration
+     * @return array
+     */
+    protected function getRowsIds() {
+        $connection = $this->getConnection();
+
+        $select = $connection
+            ->select()
+            ->from('importexport_importdata', ['id'])
+            ->order('id ASC');
+
+        return $connection->fetchCol($select);
+    }
+
+    /**
+     * Returns current row
+     *
+     * @return array
+     */
+    public function current()
+    {
+        $connection = $this->getConnection();
+
+        $select = $connection
+            ->select()
+            ->from('importexport_importdata', ['data'])
+            ->order('id ASC')
+            ->where('id = ?', $this->rowsIds[$this->currentIndex]);
+
+        $statement = $connection->query($select);
+
+        $row = $statement->fetch();
+
+        return [$row['data']];
+    }
+
+    /**
+     * Moves iterator to next row
+     */
+    public function next()
+    {
+        $this->currentIndex++;
+    }
+
+    /**
+     * Gets current row key
+     * @return int
+     */
+    public function key()
+    {
+        return $this->rowsIds[$this->currentIndex];
+    }
+
+    /**
+     * Returns if current row is valid
+     * @return int
+     */
+    public function valid()
+    {
+        return $this->currentIndex < $this->rowsCount;
+    }
+
+    /**
+     * Rewinds iterator to first row
+     */
+    public function rewind()
+    {
+        $this->currentIndex = 0;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/ResourceModel/Import/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/ResourceModel/Import/DataTest.php
@@ -17,13 +17,28 @@ class DataTest extends \PHPUnit\Framework\TestCase
      */
     protected $_model;
 
+    /**
+     * @var \Magento\TestFramework\ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * @var array
+     */
+    protected $expectedBunches;
+
     protected function setUp()
     {
         parent::setUp();
 
-        $this->_model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\ImportExport\Model\ResourceModel\Import\Data::class
-        );
+        $this->_model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+            ->create(\Magento\ImportExport\Model\ResourceModel\Import\Data::class);
+
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+        $this->expectedBunches = $this->objectManager
+            ->get(\Magento\Framework\Registry::class)
+            ->registry('_fixture/Magento_ImportExport_Import_Data');
     }
 
     /**
@@ -31,16 +46,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetUniqueColumnData()
     {
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-
-        $expectedBunches = $objectManager->get(
-            \Magento\Framework\Registry::class
-        )->registry(
-            '_fixture/Magento_ImportExport_Import_Data'
-        );
-
-        $this->assertEquals($expectedBunches[0]['entity'], $this->_model->getUniqueColumnData('entity'));
+        $this->assertEquals($this->expectedBunches[0]['entity'], $this->_model->getUniqueColumnData('entity'));
     }
 
     /**
@@ -58,16 +64,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetBehavior()
     {
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-
-        $expectedBunches = $objectManager->get(
-            \Magento\Framework\Registry::class
-        )->registry(
-            '_fixture/Magento_ImportExport_Import_Data'
-        );
-
-        $this->assertEquals($expectedBunches[0]['behavior'], $this->_model->getBehavior());
+        $this->assertEquals($this->expectedBunches[0]['behavior'], $this->_model->getBehavior());
     }
 
     /**
@@ -75,15 +72,24 @@ class DataTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetEntityTypeCode()
     {
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->assertEquals($this->expectedBunches[0]['entity'], $this->_model->getEntityTypeCode());
+    }
 
-        $expectedBunches = $objectManager->get(
-            \Magento\Framework\Registry::class
-        )->registry(
-            '_fixture/Magento_ImportExport_Import_Data'
-        );
+    /**
+     * Test successful getNextBunch()
+     */
+    public function testGetNextBunch()
+    {
+        $firstBunch = $this->_model->getNextBunch();
+        $secondBunch = $this->_model->getNextBunch();
+        $thirdBunch = $this->_model->getNextBunch();
 
-        $this->assertEquals($expectedBunches[0]['entity'], $this->_model->getEntityTypeCode());
+        $this->assertCount(2, $firstBunch);
+        $this->assertCount(1, $secondBunch);
+
+        $this->assertEquals($this->expectedBunches[0]['data'], $firstBunch);
+        $this->assertEquals($this->expectedBunches[1]['data'], $secondBunch);
+
+        $this->assertNull($thirdBunch);
     }
 }


### PR DESCRIPTION
Default iterator for importexport_importdata table was loading whole table contents to memory, resulting in huge memory usage when importing large numbers of products.

### Description
Additional iterator was created. It gets all rows ids from table and then uses them to return "current" row in memory optimized way.

### Fixed Issues (if relevant)
1. magento/magento2#10914: Huge memory usage when importing large quantities of products

### Manual testing scenarios
1. 1 500 000 entities import should easily run on 8GB RAM server

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
