### PR TITLE
#10803 update OrderService to return correct bool value for cancel me…

### DIFF
--- a/app/code/Magento/Sales/Model/Service/OrderService.php
+++ b/app/code/Magento/Sales/Model/Service/OrderService.php
@@ -87,7 +87,8 @@ class OrderService implements OrderManagementInterface
     public function cancel($id)
     {
         $order = $this->orderRepository->get($id);
-        if ((bool)$order->cancel()) {
+        if ((bool)$order->canCancel()) {
+            $order->cancel();
             $this->orderRepository->save($order);
             return true;
         }

--- a/app/code/Magento/Sales/Model/Service/OrderService.php
+++ b/app/code/Magento/Sales/Model/Service/OrderService.php
@@ -87,7 +87,7 @@ class OrderService implements OrderManagementInterface
     public function cancel($id)
     {
         $order = $this->orderRepository->get($id);
-        if ((bool)$order->canCancel()) {
+        if ($order->canCancel()) {
             $order->cancel();
             $this->orderRepository->save($order);
             return true;

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/OrderServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/OrderServiceTest.php
@@ -163,7 +163,28 @@ class OrderServiceTest extends \PHPUnit\Framework\TestCase
         $this->orderMock->expects($this->once())
             ->method('cancel')
             ->willReturn($this->orderMock);
+        $this->orderMock->expects($this->once())
+            ->method('canCancel')
+            ->willReturn(true);
         $this->assertTrue($this->orderService->cancel(123));
+    }
+
+    /**
+     * test for Order::cancel() fail case
+     */
+    public function testCancelFailed()
+    {
+        $this->orderRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with(123)
+            ->willReturn($this->orderMock);
+        $this->orderMock->expects($this->never())
+            ->method('cancel')
+            ->willReturn($this->orderMock);
+        $this->orderMock->expects($this->once())
+            ->method('canCancel')
+            ->willReturn(false);
+        $this->assertFalse($this->orderService->cancel(123));
     }
 
     public function testGetCommentsList()


### PR DESCRIPTION
…thod

Update OrderService to return correct bool value for cancel method

### Description
Magento/Sales/Model/Service/OrderService::cancel method was returning always true even if cancel method in Magento/Sales/Model/Order didn't do anything cause of canCancel validation.
OrderService cancel method will invoke canCancel to check if order can be canceled and return correct value.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10803: When canceling order with OrderService, the cancel method always saves the order and returns true, even if the order can not be canceled

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Requesting API rest endpoint /V1/orders/:id/cancel for the order which can not be canceled should return false

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
