### PR TITLE
#10611 Ignore request key check for error page to avoid redirect loop

### DIFF
--- a/app/code/Magento/Backend/Controller/Adminhtml/Noroute/Index.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Noroute/Index.php
@@ -39,4 +39,14 @@ class Index extends \Magento\Backend\App\Action
         $resultPage->addHandle('adminhtml_noroute');
         return $resultPage;
     }
+
+    /**
+     * Error page should be public accessible. Do not check keys to avoid redirect loop
+     *
+     * @return bool
+     */
+    protected function _validateSecretKey()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Problems described in the issue was caused by redirect occuring when request made to the application had incorrect URL key. This specific situation took place only when user had no access to any part of application. So finally trying to get access to `adminhtml/index` controller, he got redirected to `adminhtml/noroute/denied` that he also have no access because of incorrect URL key.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10611 Magento admin gets in redirect loop when I login with a role that has no resources assigned

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a user role with no resources assigned to it.
2. Create an admin user with that role.
3. Log in with that user.

### Contribution checklist
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ - ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x ] All automated tests passed successfully (all builds on Travis CI are green)
