### PR TITLE
#10922 add is_active to Magento\Store\Api\Data\StoreInterface

### DIFF
--- a/app/code/Magento/Store/Api/Data/StoreInterface.php
+++ b/app/code/Magento/Store/Api/Data/StoreInterface.php
@@ -67,6 +67,17 @@ interface StoreInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     public function getStoreGroupId();
 
     /**
+     * @param int $isActive
+     * @return $this
+     */
+    public function setIsActive($isActive);
+
+    /**
+     * @return int
+     */
+    public function getIsActive();
+
+    /**
      * @param int $storeGroupId
      * @return $this
      */

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -27,7 +27,6 @@ use Magento\Store\Api\Data\StoreInterface;
  * @method int getSortOrder()
  * @method int getStoreId()
  * @method Store setSortOrder($value)
- * @method Store setIsActive($value)
  *
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -1086,6 +1085,22 @@ class Store extends AbstractExtensibleModel implements
     public function setStoreGroupId($storeGroupId)
     {
         return $this->setGroupId($storeGroupId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getIsActive()
+    {
+        return $this->_getData('is_active');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setIsActive($isActive)
+    {
+        return $this->setData('is_active', $isActive);
     }
 
     /**


### PR DESCRIPTION
add is_active to Magento\Store\Api\Data\StoreInterface to show it in the rest endpoint

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Magento\Store\Api\Data\StoreInterface had no get and set method defined for is_active flag and thus the value did not appear in the V1/store/storeViews endpoint with the store view data

### Fixed Issues (if relevant)
1. magento/magento2#10922: REST endpoint /V1/store/storeViews is missing is_active value in store data

### Manual testing scenarios
1. Perform a rest call to http://store.domain/rest/[store-view-code]/V1/store/storeViews

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
