### PR TITLE
Fix issue when non-cacheable block added using invalid reference makes page non-cacheable

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout.php
+++ b/lib/internal/Magento/Framework/View/Layout.php
@@ -1094,8 +1094,20 @@ class Layout extends \Magento\Framework\Simplexml\Config implements \Magento\Fra
     public function isCacheable()
     {
         $this->build();
-        $cacheableXml = !(bool)count($this->getXml()->xpath('//' . Element::TYPE_BLOCK . '[@cacheable="false"]'));
-        return $this->cacheable && $cacheableXml;
+
+        $elements = $this->getXml()->xpath('//' . Element::TYPE_BLOCK . '[@cacheable="false"]');
+        foreach ($elements as $element) {
+            $attributes = $element->attributes();
+            if (empty($attributes['name'])) {
+                return false;
+            }
+            $elementId = (string) $attributes['name'];
+            if ($this->structure->hasElement($elementId)) {
+                return false;
+            }
+        }
+
+        return $this->cacheable;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
@@ -706,11 +706,15 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param string $xmlString
+     * @param bool $hasNonCacheableElement
      * @param bool $result
      * @dataProvider isCacheableDataProvider
      */
-    public function testIsCacheable($xmlString, $result)
+    public function testIsCacheable($xmlString, $hasNonCacheableElement, $result)
     {
+        $this->structureMock->method('hasElement')
+            ->with($this->equalTo('non_cacheable_block'))
+            ->willReturn($hasNonCacheableElement);
         $xml = simplexml_load_string($xmlString, \Magento\Framework\View\Layout\Element::class);
         $this->assertSame($this->model, $this->model->setXml($xml));
         $this->assertSame($result, $this->model->isCacheable());
@@ -725,11 +729,45 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
             [
                 '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
                 . '<block></block></layout>',
+                false,
                 true,
             ],
             [
                 '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
                 . '<block cacheable="false"></block></layout>',
+                false,
+                false
+            ],
+            [
+                '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+                . '<referenceBlock name="not_existing_block">'
+                . '<block name="non_cacheable_block" cacheable="false"></block>'
+                . '</referenceBlock></layout>',
+                false,
+                true
+            ],
+            [
+                '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+                . '<referenceContainer name="not_existing_container">'
+                . '<block name="non_cacheable_block" cacheable="false"></block>'
+                . '</referenceContainer></layout>',
+                false,
+                true
+            ],
+            [
+                '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+                . '<referenceBlock name="existing_block">'
+                . '<block name="non_cacheable_block" cacheable="false"></block>'
+                . '</referenceBlock></layout>',
+                true,
+                false
+            ],
+            [
+                '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+                . '<referenceContainer name="existing_container">'
+                . '<block name="non_cacheable_block" cacheable="false"></block>'
+                . '</referenceContainer></layout>',
+                true,
                 false
             ],
         ];

--- a/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
@@ -706,15 +706,15 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param string $xmlString
-     * @param bool $hasNonCacheableElement
+     * @param bool $nonCacheableElement
      * @param bool $result
      * @dataProvider isCacheableDataProvider
      */
-    public function testIsCacheable($xmlString, $hasNonCacheableElement, $result)
+    public function testIsCacheable($xmlString, $nonCacheableElement, $result)
     {
         $this->structureMock->method('hasElement')
             ->with($this->equalTo('non_cacheable_block'))
-            ->willReturn($hasNonCacheableElement);
+            ->willReturn($nonCacheableElement);
         $xml = simplexml_load_string($xmlString, \Magento\Framework\View\Layout\Element::class);
         $this->assertSame($this->model, $this->model->setXml($xml));
         $this->assertSame($result, $this->model->isCacheable());


### PR DESCRIPTION
### Description
After applying this pull request all layout blocks added using invalid container or block reference (not existing in the current page context) are ignored while resolving the `cacheable` flag for page cache.
Unfortunately this solution doesn't handle cases when the same scenario is done using a block without name. It's not possible, because we can't identify this kind of blocks in the base layout xml and next in the layout structure (they aren't included in `Magento\Framework\View\Layout\Data\Structure::exportElements()`).

### Fixed Issues
1. magento/magento2#9041: Non-cacheable block added to default handle makes every page non-cacheable

### Manual testing scenarios
1. Create an extension. Add the layout update to the default handle via `Vendor/Module/view/frontend/layout/default.xml`
2. Reference some container which appears on the checkout page and add the layout update with the non-cacheable block:
```
<referenceContainer name="order.success.additional.info">
    <block class="Magento\Framework\View\Element\Template" name="test_block" cacheable="false"/>
</referenceContainer>
```
3. Flush cache.
4. Run the home page.
5. Refresh the page and check was it cached in full page cache.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)