### PR TITLE
#10510 - fix RWD with installed Sample Data

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_layout.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_layout.less
@@ -21,6 +21,7 @@
             .lib-vendor-prefix-flex-basis(100%);
             .lib-vendor-prefix-flex-grow(1);
             .lib-vendor-prefix-order(1);
+            width: 100%; 
         }
 
         .sidebar-main {


### PR DESCRIPTION
Fix RWD - version CE 2.1

### Description
Added appropriate styles for `.column.main` to make it responsive. 

### Fixed Issues (if relevant)
#10510 
1. magento/magento2#10510: Magento 2.1.8 w/Sample Data is not responsive in categories with text containers

### Manual testing scenarios
1. Open e.g. 'What's New' category
2. Resize your browser to the smallest width of the window
