### PR TITLE
Return minimal price for configurable products on /rest/V1/products

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -20,7 +20,6 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Framework\Exception\CouldNotSaveException;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -220,10 +219,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             }
             $product->load($productId);
 
-            /* Add price for configurable product */
-            if ($product->getTypeId() == Configurable::TYPE_CODE) {
-                $product->setMinimalPrice($product->getFinalPrice());
-            }
+            $product->setMinimalPrice($product->getFinalPrice());
 
             $this->instances[$sku][$cacheKey] = $product;
             $this->instancesById[$product->getId()][$cacheKey] = $product;

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -615,6 +615,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         }
         $collection->joinAttribute('status', 'catalog_product/status', 'entity_id', null, 'inner');
         $collection->joinAttribute('visibility', 'catalog_product/visibility', 'entity_id', null, 'inner');
+        $collection->addMinimalPrice();
 
         //Add filters from root filter group to the collection
         foreach ($searchCriteria->getFilterGroups() as $group) {

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -20,6 +20,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -218,6 +219,12 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 $product->setData('store_id', $storeId);
             }
             $product->load($productId);
+
+            /* Add price for configurable product */
+            if ($product->getTypeId() == Configurable::TYPE_CODE) {
+                $product->setMinimalPrice($product->getFinalPrice());
+            }
+
             $this->instances[$sku][$cacheKey] = $product;
             $this->instancesById[$product->getId()][$cacheKey] = $product;
         }

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Price.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Price.php
@@ -46,6 +46,8 @@ class Price extends \Magento\Catalog\Model\Product\Type\Price
                 if (!empty($simpleProduct)) {
                     return $simpleProduct->getPrice();
                 }
+            } elseif ($product->getMinimalPrice() !== null) {
+                return $product->getMinimalPrice();
             }
         }
         return 0;


### PR DESCRIPTION
### Description
Upon getting the products list via API (/rest/V1/products) configurable products always have zero price. Since in product listing on the storefront the minimal price is used as a configurable product price, it's a good idea to use it for product list fetched via API as well.

### Fixed Issues
1. magento/magento2#10644: REST API Configurable Product has price

### Manual testing scenarios
1. Create a configurable product accessible on the storefront
2. Get the products list via API using GET request to the `rest/V1/products?searchCriteria=`
3. You should get a minimal price for the configurable product instead of 0.
