### PR TITLE
Backport #10739 - fix for translated attribute label comparison.

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -109,7 +109,7 @@
                         <argument name="at_call" xsi:type="string">getDescription</argument>
                         <argument name="at_code" xsi:type="string">description</argument>
                         <argument name="css_class" xsi:type="string">description</argument>
-                        <argument name="at_label" xsi:type="string">none</argument>
+                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Details</argument>
                     </arguments>
                 </block>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -34,7 +34,7 @@ if ($_attributeType && $_attributeType == 'text') {
 
 <?php if ($_attributeValue): ?>
 <div class="product attribute <?php /* @escapeNotVerified */ echo $_className?>">
-    <?php if ($_attributeLabel != 'none'): ?><strong class="type"><?php /* @escapeNotVerified */ echo $_attributeLabel?></strong><?php endif; ?>
+    <?php if ($_attributeLabel != __('none')): ?><strong class="type"><?php /* @escapeNotVerified */ echo $_attributeLabel?></strong><?php endif; ?>
     <div class="value" <?php /* @escapeNotVerified */ echo $_attributeAddAttribute;?>><?php /* @escapeNotVerified */ echo $_attributeValue; ?></div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Backport fix from #10739 plus make also `Details` section translatable that uses also `attributes.phtml`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10738: https://github.com/magento/magento2/issues/10738


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. set store to use other lang
2. set/create attribute with locale translation label for ex instead of "none" "brak" (polish translation)
3. assing attribute to product
4. on product page in short description and in detail tabs content shouldn't be displayed "none/brak" attribute
