### PR TITLE
Make labels translatable for Overview and Details sections on product…

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -94,7 +94,7 @@
                         <argument name="at_call" xsi:type="string">getShortDescription</argument>
                         <argument name="at_code" xsi:type="string">short_description</argument>
                         <argument name="css_class" xsi:type="string">overview</argument>
-                        <argument name="at_label" xsi:type="string">none</argument>
+                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Overview</argument>
                         <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
                     </arguments>
@@ -135,7 +135,7 @@
                         <argument name="at_call" xsi:type="string">getDescription</argument>
                         <argument name="at_code" xsi:type="string">description</argument>
                         <argument name="css_class" xsi:type="string">description</argument>
-                        <argument name="at_label" xsi:type="string">none</argument>
+                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Details</argument>
                     </arguments>
                 </block>


### PR DESCRIPTION
… page. Refs #10739

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Make `at_label` translatable for Details and Overview sections in `catalog_product_view.xml`.
 As #10739 (fix applied in template to compare translated labels) was merged into develop so #6257 change is removed in this pull request. I also added fix for details section.


### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10739: Empty attribute label is displayed on product page when other language used
