### PR TITLE
Fix LowStock report in All Websites view

### DIFF
--- a/app/code/Magento/Reports/Block/Adminhtml/Product/Lowstock/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Product/Lowstock/Grid.php
@@ -53,14 +53,12 @@ class Grid extends \Magento\Backend\Block\Widget\Grid
         } elseif ($store) {
             $storeId = (int)$store;
         } else {
-            $storeId = '';
+            $storeId = null;
         }
 
         /** @var $collection \Magento\Reports\Model\ResourceModel\Product\Lowstock\Collection  */
         $collection = $this->_lowstocksFactory->create()->addAttributeToSelect(
             '*'
-        )->setStoreId(
-            $storeId
         )->filterByIsQtyProductTypes()->joinInventoryItem(
             'qty'
         )->useManageStockFilter(


### PR DESCRIPTION
Fix issue #10595 . 

### Description
The issue was that lowstock report didn't display products on All Websites view.
The reason is that $storeId variable was not correctly initialized as null and that store filter was applied even if $storeId was null.

### Fixed Issues (if relevant)
1. magento/magento2#10595: Low Stock Report Grid Empty

### Manual testing scenarios

#### Before Fix
1. Create new Simple product with qty=0 and Out Of Stock
2. Open Report->Low Stock
3. You will not see your product on the grid. You can see it if you will change Scope to storeview

#### After Fix
1. Create new Simple product with qty=0 and Out Of Stock
2. Open Report->Low Stock
3. You should see your newly created product
4. Additionally you can create new website with new store and storeview. Then assign product to newly created website and check if grid still works correctly (display product on All Websites and on newly created website, but not on the website where products is not assigned to).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
