### PR TITLE
Make default sorting fully working when setup on category level

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/ProductList.php
+++ b/app/code/Magento/Catalog/Helper/Product/ProductList.php
@@ -101,7 +101,7 @@ class ProductList
     public function getDefaultSortField()
     {
         $currentCategory = $this->coreRegistry->registry('current_category');
-        if($currentCategory){
+        if ($currentCategory) {
             $currentCategorySortBy = $currentCategory->getDefaultSortBy();
             return $currentCategorySortBy;
         }

--- a/app/code/Magento/Catalog/Helper/Product/ProductList.php
+++ b/app/code/Magento/Catalog/Helper/Product/ProductList.php
@@ -29,7 +29,11 @@ class ProductList
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfig;
-    protected $coreRegistry;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $coreRegistry;
 
     /**
      * Default limits per page
@@ -43,10 +47,10 @@ class ProductList
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Framework\Registry $coreRegistry
+        \Magento\Framework\Registry $coreRegistry = null
     ) {
         $this->scopeConfig = $scopeConfig;
-        $this->coreRegistry = $coreRegistry;
+        $this->coreRegistry = $coreRegistry ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Registry::class);
     }
 
     /**
@@ -102,8 +106,7 @@ class ProductList
     {
         $currentCategory = $this->coreRegistry->registry('current_category');
         if ($currentCategory) {
-            $currentCategorySortBy = $currentCategory->getDefaultSortBy();
-            return $currentCategorySortBy;
+            return $currentCategory->getDefaultSortBy();
         }
 
         return $this->scopeConfig->getValue(

--- a/app/code/Magento/Catalog/Helper/Product/ProductList.php
+++ b/app/code/Magento/Catalog/Helper/Product/ProductList.php
@@ -29,6 +29,7 @@ class ProductList
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfig;
+    protected $coreRegistry;
 
     /**
      * Default limits per page
@@ -41,9 +42,11 @@ class ProductList
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Registry $coreRegistry
     ) {
         $this->scopeConfig = $scopeConfig;
+        $this->coreRegistry = $coreRegistry;
     }
 
     /**
@@ -97,6 +100,12 @@ class ProductList
      */
     public function getDefaultSortField()
     {
+        $currentCategory = $this->coreRegistry->registry('current_category');
+        if($currentCategory){
+            $currentCategorySortBy = $currentCategory->getDefaultSortBy();
+            return $currentCategorySortBy;
+        }
+
         return $this->scopeConfig->getValue(
             \Magento\Catalog\Model\Config::XML_PATH_LIST_DEFAULT_SORT_BY,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE


### PR DESCRIPTION
Fix an issue #10772. 

### Description
Problem is that category has own configuration to setup Default Sort Attribute, but method to get default sorting attribute didn't take it into consideration and get it from config only.

### Fixed Issues
1. magento/magento2#10772: Unable to sort by store configuration default field when different to category's default sorting field

### Manual testing scenarios

1. In backend, go to Stores => Configuration => Catalog => Catalog
2. Make sure that within the tab "Storefront" the "Product Listing Sort By" is set to "Position".
3. In backend, go to Products => Categories
4. Go ahead and select a category to edit that has at least one product assigned to
5. Within "Display Settings" update the "Default Sort By" to be "Name" and save
6. In frontend, browse to the just changed category
7. Make sure that the default sorting is now by "Name"
8. Change that to sort by "Position"

Before fix, we had 'position' param removed from url and sorting was not applied.
After fix it should work correctly.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
