### PR TITLE
refs #10725 removing and creating url rewrites

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
@@ -123,15 +123,18 @@ class ProductUrlRewriteGenerator
      *
      * @param \Magento\Catalog\Model\Product $product
      * @param int|null $rootCategoryId
+     * @param int|null $storeId
      * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[]
      */
-    public function generate(Product $product, $rootCategoryId = null)
+    public function generate(Product $product, $rootCategoryId = null,$storeId = null)
     {
-        if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
-            return [];
+        if (is_null($storeId)) {
+            if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
+                return [];
+            }
+            $storeId = $product->getStoreId();
         }
-
-        $storeId = $product->getStoreId();
+        
 
         $productCategories = $product->getCategoryCollection()
             ->addAttributeToSelect('url_key')

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
@@ -44,21 +44,41 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
     {
         /** @var Product $product */
         $product = $observer->getEvent()->getProduct();
-
+        
         if ($product->dataHasChangedFor('url_key')
             || $product->getIsChangedCategories()
             || $product->getIsChangedWebsites()
             || $product->dataHasChangedFor('visibility')
         ) {
-            $this->urlPersist->deleteByData([
+            $params = [            
                 UrlRewrite::ENTITY_ID => $product->getId(),
                 UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
-                UrlRewrite::REDIRECT_TYPE => 0,
-                UrlRewrite::STORE_ID => $product->getStoreId()
-            ]);
-
-            if ($product->isVisibleInSiteVisibility()) {
-                $this->urlPersist->replace($this->productUrlRewriteGenerator->generate($product));
+                UrlRewrite::REDIRECT_TYPE => 0
+            ];
+            // category and websites are global - but we can change it from store view
+            // @todo getIsChangedCategories() works wrong. [works only after add category, after remove returns false]
+            if ($product->getIsChangedCategories() || 
+                $product->getIsChangedWebsites()) {
+                $store = 0;   
+            } else {
+                if ($store = $product->getStoreId()) {
+                    $params[UrlRewrite::STORE_ID] = $store;  // we are in specific store
+                }
+            }
+            $this->urlPersist->deleteByData($params);
+            if (!$store) {
+                $stores = $product->getStoreIds();  // after global change, we should rebuild url for all visible stores              
+            } else {
+                $stores = [$store];
+            }
+            $productResource = $product->getResource();
+            $siteVisibilities = $product->getVisibleInSiteVisibilities();
+            $productId = $product->getId();
+            foreach ($stores as $storeId) {     
+                $visible = $productResource->getAttributeRawValue($productId,'visibility',$storeId);
+                if (in_array($visible,$siteVisibilities)) {
+                    $this->urlPersist->replace($this->productUrlRewriteGenerator->generate($product,null,$storeId));
+                }
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fix an issue #10725 
### Description
<!--- Provide a description of the changes proposed in the pull request -->
This problem concerns not only visibility. This bug appears when we changed product category, url_key and website. When we saving the product from admin (default store view) magento try to remove urls from product->storeId = 0. In the database there are no such entries. From the other side, when we want to change categories after save we should to remove and rebuild all urls (category is global attribute), but when admin is set to a specific store, magento rebuilds only links for this store. It's not a good idea to get storeId from product to rebuild url rewrites. 
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. #10725 after changing visibility from default store view all stores uses default settings will be refreshed (removed or rebuilded)
2. Change category/website from specific store rebuilds product urls for all stores
3. Changing visibility and url_key from specific store works like before

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create website with at least two stores view.
2. Create a product that is disabled and has visibilty set to 'not visible individually'
3. Check the URL rewrite table. It should not have a URL rewrite (Magento creates those only for visible products).
4. Edit the product, setting visibility to 'Category & Search'.
5. Check the URL Rewrite table. A record should be added.
6. Edit the product, setting visibility back to 'Not visible individually' 
7. Check the URL Rewrite table. All records should be removed.
8. Change store view to a specific store.
9. Disable "use default value checkbox"
10. Change visibility to "Category & Search"
11. Check URL Rewrite table. Should be only records from that store
12. Change visibility to "Not visible individually"
13. Change store to "All Store Views"
14. Change visibility to "Category & Search". 
15. Check URL Rewrite table. Should be all records expect that disabled store
16. Change category (only adding works - it should be new issue)
17. Check URL Rewrite table, all entries should be changed.
18. Change store to "disabled" store
19. Change category. 
20. Check URL Rewrite table, all entries should be changed (like on default store)
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
