### PR TITLE
Sales order view item renderer name for block

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
@@ -41,7 +41,7 @@
                                 <item name="total" xsi:type="string" translate="true">Row Total</item>
                             </argument>
                         </arguments>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/view/items/renderer/default.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer" as="default" name="item_renderer" template="Magento_Sales::order/view/items/renderer/default.phtml">
                         <arguments>
                             <argument name="columns" xsi:type="array">
                                 <item name="product" xsi:type="string" translate="false">col-product</item>


### PR DESCRIPTION
Sales order view item renderer name for block

### Description
Creation of identification name for the block to render the information of the items in the order view in adminhtml. Required to create a custom extends in layouts.

### Manual testing scenarios
1. Create custom module
2. Rewrite adminhtml/sales_order_view.xml layout
3. Add new custom column in the order_items
4. Unable to reference to block of the values (class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer")

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)