### PR TITLE
Add explicit sequence dependency on Magento_Theme to Magento_Customer

### DIFF
--- a/app/code/Magento/Customer/etc/module.xml
+++ b/app/code/Magento/Customer/etc/module.xml
@@ -8,6 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Magento_Customer" setup_version="2.0.12">
         <sequence>
+            <module name="Magento_Theme"/>
             <module name="Magento_Eav"/>
             <module name="Magento_Directory"/>
         </sequence>


### PR DESCRIPTION
Since Magento_Customer references containers defined by Magento_Theme in layout XML, it should explicitly declare Magento_Theme as a sequence dependency.

It is possible (though highly difficult to predict) for a particular combination of custom extensions to result in Magento_Customer coming before Magento_Theme in the module sequence order.  This can create unintended side effects on the front-end.  If Magento_Customer layout is processed before Magento_Theme, the blocks added to the "content" container in Magento_Customer/view/frontend/layout/default.xml will result in the "content" container being processed and scheduled before the "content.top" container and to precede it in the list of children of "main".  

Ultimately, this will result in the children of "content" being output before the children of "content.top" on the final page.
