### PR TITLE
Checkout page could hang for Javascript error

### DIFF
--- a/lib/web/mage/utils/arrays.js
+++ b/lib/web/mage/utils/arrays.js
@@ -101,7 +101,7 @@ define([
                 newIndex,
                 target;
 
-            if (typeof position === 'undefined') {
+            if (typeof position === 'undefined' || position == null) {
                 position = -1;
             } else if (typeof position === 'string') {
                 position = isNaN(+position) ? position : +position;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Wrong evaluating check comparison with 'undefined' of variable 'position' let hang Checkout Page
https://stackoverflow.com/a/5076962 (difference between null and undefined in JavaScript)

### Fixed Issues (if relevant)
in lib/web/mage/utils/arrays.js
Line 104 to 128

    if (typeof position === 'undefined') { // line 104 - fixed issue transcribed below
        position = -1;
    } else if (typeof position === 'string') {
        position = isNaN(+position) ? position : +position;
    }

    newIndex = position;

    if (~currentIndex) {
        target = container.splice(currentIndex, 1)[0];

        if (typeof item === 'string') {
            item = target;
        }
    }

    if (typeof position !== 'number') {
        target = position.after || position.before || position; // line 121

        newIndex = getIndex(target, container);

        if (~newIndex && (position.after || newIndex >= currentIndex)) {
            newIndex++;
        }
    }
Error in line 121 because position value is NULL and this value is not managed in the script

This is the only change to apply:
lib/web/mage/utils/arrays.js
Line 104
from
if (typeof position === 'undefined') {
to
if (typeof position === 'undefined' || position == null) {
### Contribution checklist
 - [ ] Evidence of faulty javascript comparison
 - [ ] https://stackoverflow.com/a/5076962

