### PR TITLE
Make returned object of Order::getShippingMethod() more explicit

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1208,7 +1208,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         if (!$asObject) {
             return $shippingMethod;
         } else {
-            return new ShippingMethod($shippingMethod);
+            return ShippingMethod::fromFullShippingMethodCode($shippingMethod);
         }
     }
 

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -13,6 +13,7 @@ use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderStatusHistoryInterface;
 use Magento\Sales\Model\Order\Payment;
+use Magento\Sales\Model\Order\ShippingMethod;
 use Magento\Sales\Model\ResourceModel\Order\Address\Collection;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo\Collection as CreditmemoCollection;
 use Magento\Sales\Model\ResourceModel\Order\Invoice\Collection as InvoiceCollection;
@@ -1199,7 +1200,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Retrieve shipping method
      *
      * @param bool $asObject return carrier code and shipping method data as object
-     * @return string|\Magento\Framework\DataObject
+     * @return string|ShippingMethod
      */
     public function getShippingMethod($asObject = false)
     {
@@ -1207,8 +1208,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         if (!$asObject) {
             return $shippingMethod;
         } else {
-            list($carrierCode, $method) = explode('_', $shippingMethod, 2);
-            return new \Magento\Framework\DataObject(['carrier_code' => $carrierCode, 'method' => $method]);
+            return new ShippingMethod($shippingMethod);
         }
     }
 

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -66,4 +66,31 @@ class ShippingMethod
     {
         return $this->method;
     }
+
+    /**
+     * Changes carrier code
+     *
+     * @deprecated The value object should be immutable.
+     * @param string $code
+     * @return ShippingMethod
+     */
+    public function setCarrierCode(string $code) : ShippingMethod
+    {
+        $this->carrierCode = $code;
+        return $this;
+    }
+
+    /**
+     * Changes method code
+     *
+     * @deprecated The value object should be immutable.
+     * @param string $medhod
+     * @return ShippingMethod
+     */
+    public function setMethod(string $medhod) : ShippingMethod
+    {
+        $this->method = $medhod;
+        return $this;
+    }
+
 }

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -5,32 +5,65 @@
  */
 namespace Magento\Sales\Model\Order;
 
-use Magento\Framework\DataObject;
-
 /**
  * Value object for shipping_method order attribute
- *
- * @method string getCarrierCode()
- * @method string getMethod()
  */
-class ShippingMethod extends DataObject
+class ShippingMethod
 {
+    /**
+     * @var
+     */
+    private $carrierCode;
+    /**
+     * @var
+     */
+    private $method;
+
+    public function __construct(string $carrierCode, string $method)
+    {
+        $this->carrierCode = $carrierCode;
+        $this->method = $method;
+    }
+
     /**
      * Shipping method as in shipping_method order attribute
      *
-     * @var string
+     * @param string $fullShippingMethod
+     * @return ShippingMethod
      */
-    private $fullShippingMethod;
-
-    public function __construct(string $fullShippingMethod)
+    public static function fromFullShippingMethodCode(string $fullShippingMethod) : ShippingMethod
     {
-        $this->fullShippingMethod = $fullShippingMethod;
         list($carrierCode, $method) = explode('_', $fullShippingMethod, 2);
-        parent::__construct(['carrier_code' => $carrierCode, 'method' => $method]);
+        return new self($carrierCode, $method);
     }
 
+    /**
+     * Shipping method as in shipping_method order attribute
+     *
+     * @return string
+     */
     public function __toString() : string
     {
-        return $this->fullShippingMethod;
+        return "{$this->carrierCode}_{$this->method}";
+    }
+
+    /**
+     * Returns carrier code
+     *
+     * @return string
+     */
+    public function getCarrierCode() : string
+    {
+        return $this->carrierCode;
+    }
+
+    /**
+     * Returns shipping method code without carrier
+     *
+     * @return string
+     */
+    public function getMethod() : string
+    {
+        return $this->method;
     }
 }

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -92,5 +92,4 @@ class ShippingMethod
         $this->method = $medhod;
         return $this;
     }
-
 }

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -8,7 +8,7 @@ namespace Magento\Sales\Model\Order;
 /**
  * Value object for shipping_method order attribute
  */
-class ShippingMethod
+class ShippingMethod extends \Magento\Framework\DataObject
 {
     /**
      * @var
@@ -92,4 +92,236 @@ class ShippingMethod
         $this->method = $medhod;
         return $this;
     }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function addData(array $arr)
+    {
+        return parent::addData($arr);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function setData($key, $value = null)
+    {
+        return parent::setData($key, $value);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function unsetData($key = null)
+    {
+        return parent::unsetData($key);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function getData($key = '', $index = null)
+    {
+        return parent::getData($key, $index);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function getDataByPath($path)
+    {
+        return parent::getDataByPath($path);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function getDataByKey($key)
+    {
+        return parent::getDataByKey($key);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function setDataUsingMethod($key, $args = [])
+    {
+        return parent::setDataUsingMethod($key, $args);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function getDataUsingMethod($key, $args = null)
+    {
+        return parent::getDataUsingMethod($key, $args);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function hasData($key = '')
+    {
+        return parent::hasData($key);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function toArray(array $keys = [])
+    {
+        return parent::toArray($keys);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function convertToArray(array $keys = [])
+    {
+        return parent::convertToArray($keys);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function toXml(array $keys = [], $rootName = 'item', $addOpenTag = false, $addCdata = true)
+    {
+        return parent::toXml($keys, $rootName, $addOpenTag, $addCdata);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function convertToXml(
+        array $arrAttributes = [],
+        $rootName = 'item',
+        $addOpenTag = false,
+        $addCdata = true
+    ) {
+        return parent::convertToXml(
+            $arrAttributes,
+            $rootName,
+            $addOpenTag,
+            $addCdata
+        );
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function toJson(array $keys = [])
+    {
+        return parent::toJson($keys);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function convertToJson(array $keys = [])
+    {
+        return parent::convertToJson($keys);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function toString($format = '')
+    {
+        return parent::toString($format);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function __call($method, $args)
+    {
+        return parent::__call($method, $args);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function isEmpty()
+    {
+        return parent::isEmpty();
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function serialize($keys = [], $valueSeparator = '=', $fieldSeparator = ' ', $quote = '"')
+    {
+        return parent::serialize(
+            $keys,
+            $valueSeparator,
+            $fieldSeparator,
+            $quote
+        );
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function debug($data = null, &$objects = [])
+    {
+        return parent::debug($data, $objects);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function offsetSet($offset, $value)
+    {
+        parent::offsetSet($offset, $value);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function offsetExists($offset)
+    {
+        return parent::offsetExists($offset);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function offsetUnset($offset)
+    {
+        parent::offsetUnset($offset);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated DataObject inheritance will be removed
+     */
+    public function offsetGet($offset)
+    {
+        return parent::offsetGet($offset);
+    }
+
+
 }

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -30,10 +30,17 @@ class ShippingMethod extends \Magento\Framework\DataObject
      *
      * @param string $fullShippingMethod
      * @return ShippingMethod
+     * @throws \InvalidArgumentException
      */
     public static function fromFullShippingMethodCode(string $fullShippingMethod) : ShippingMethod
     {
-        list($carrierCode, $method) = explode('_', $fullShippingMethod, 2);
+        list($carrierCode, $method) = explode('_', $fullShippingMethod, 2) + ['', ''];
+        if (empty($carrierCode) || empty($method)) {
+            throw new \InvalidArgumentException(
+                'Invalid shipping method code "' . $fullShippingMethod .
+                '". It should be carrier and method, separated by underscore'
+            );
+        }
         return new self($carrierCode, $method);
     }
 
@@ -322,6 +329,4 @@ class ShippingMethod extends \Magento\Framework\DataObject
     {
         return parent::offsetGet($offset);
     }
-
-
 }

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Sales\Model\Order;
+
+use Magento\Framework\DataObject;
+
+/**
+ * Value object for shipping_method order attribute
+ * 
+ * @method string getCarrierCode()
+ * @method string getMethod()
+ */
+class ShippingMethod extends DataObject
+{
+    /**
+     * Shipping method as in shipping_method order attribute
+     *
+     * @var string
+     */
+    private $fullShippingMethod;
+
+    public function __construct(string $fullShippingMethod)
+    {
+        $this->fullShippingMethod = $fullShippingMethod;
+        list($carrierCode, $method) = explode('_', $fullShippingMethod, 2);
+        parent::__construct(['carrier_code' => $carrierCode, 'method' => $method]);
+    }
+
+    public function __toString() : string
+    {
+        return $this->fullShippingMethod;
+    }
+}

--- a/app/code/Magento/Sales/Model/Order/ShippingMethod.php
+++ b/app/code/Magento/Sales/Model/Order/ShippingMethod.php
@@ -9,7 +9,7 @@ use Magento\Framework\DataObject;
 
 /**
  * Value object for shipping_method order attribute
- * 
+ *
  * @method string getCarrierCode()
  * @method string getMethod()
  */

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ShippingMethodTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ShippingMethodTest.php
@@ -24,12 +24,22 @@ class ShippingMethodTest extends TestCase
     {
         $this->methodObject = new ShippingMethod(self::CARRIER_CODE, self::METHOD_CODE);
     }
+
     public function testCanBeInstantiatedFromFullMethodCode()
     {
         $this->assertEquals(
             new ShippingMethod(self::CARRIER_CODE, self::METHOD_CODE),
             ShippingMethod::fromFullShippingMethodCode(self::FULL_CODE)
         );
+    }
+
+    public function testFailsToInstantiateFromIncompleteMethodCode()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid shipping method code "nounderscores". It should be carrier and method, separated by underscore'
+        );
+        ShippingMethod::fromFullShippingMethodCode('nounderscores');
     }
 
     public function testCanBeUsedAsString()

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ShippingMethodTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ShippingMethodTest.php
@@ -46,5 +46,4 @@ class ShippingMethodTest extends TestCase
     {
         $this->assertEquals(self::METHOD_CODE, $this->methodObject->getMethod());
     }
-
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ShippingMethodTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ShippingMethodTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Sales\Test\Unit\Model\Order;
+
+use Magento\Sales\Model\Order\ShippingMethod;
+use PHPUnit\Framework\TestCase;
+
+class ShippingMethodTest extends TestCase
+{
+    /**
+     * @var ShippingMethod
+     */
+    private $methodObject;
+
+    const CARRIER_CODE = 'tablerate';
+    const METHOD_CODE = 'bestway';
+    const FULL_CODE = self::CARRIER_CODE . '_' . self::METHOD_CODE;
+
+    protected function setUp()
+    {
+        $this->methodObject = new ShippingMethod(self::CARRIER_CODE, self::METHOD_CODE);
+    }
+    public function testCanBeInstantiatedFromFullMethodCode()
+    {
+        $this->assertEquals(
+            new ShippingMethod(self::CARRIER_CODE, self::METHOD_CODE),
+            ShippingMethod::fromFullShippingMethodCode(self::FULL_CODE)
+        );
+    }
+
+    public function testCanBeUsedAsString()
+    {
+        $this->assertEquals(self::FULL_CODE, $this->methodObject);
+    }
+
+    public function testProvidesCarrierCode()
+    {
+        $this->assertEquals(self::CARRIER_CODE, $this->methodObject->getCarrierCode());
+    }
+
+    public function testProvidesMethodCode()
+    {
+        $this->assertEquals(self::METHOD_CODE, $this->methodObject->getMethod());
+    }
+
+}


### PR DESCRIPTION
Replaced the generic `DataObject` with an explicit value object for better developer experience.

### Description
This is a minor refactoring. The new class extends `DataObject` for full backwards compatibility. The magic getters are documented with `@method`, so that static analyzers recognize them.

A `__toString` method is added, so that the `$asObject` parameter in `\Magento\Sales\Model\Order::getShippingMethod()` might be dropped in a later release

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
