### PR TITLE
[MERGED] Add a payload extender to the default shipping-save-processor

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -12,7 +12,8 @@ define([
     'Magento_Checkout/js/model/payment/method-converter',
     'Magento_Checkout/js/model/error-processor',
     'Magento_Checkout/js/model/full-screen-loader',
-    'Magento_Checkout/js/action/select-billing-address'
+    'Magento_Checkout/js/action/select-billing-address',
+    'Magento_Checkout/js/model/shipping-save-processor/payload-extender'
 ], function (
     ko,
     quote,
@@ -22,7 +23,8 @@ define([
     methodConverter,
     errorProcessor,
     fullScreenLoader,
-    selectBillingAddressAction
+    selectBillingAddressAction,
+    payloadExtender
 ) {
     'use strict';
 
@@ -45,6 +47,8 @@ define([
                     'shipping_carrier_code': quote.shippingMethod()['carrier_code']
                 }
             };
+
+            payloadExtender(payload);
 
             fullScreenLoader.startLoader();
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define(function () {
+    'use strict';
+
+    return function (payload) {
+        payload.addressInformation['extension_attributes'] = {};
+
+        return payload;
+    };
+});


### PR DESCRIPTION
### Description

This will allow third party extensions to modify the payload for the shipping address selection process, with the goal being the easy addition of extension_attributes with as few extension conflicts as possible.

By separating this out into it's own model (as opposed to including it in the result of the processor return), non-default processors will also be able to utilize it.

Usage would be like:

```javascript
// Your/Module/view/frontend/requirejs-config.js

var config = {
    "config": {
        "mixins": {
            "Magento_Checkout/js/model/shipping-save-processor/payload-extender": {
                "Your_Module/extender": true
            }
        }
    }
}
```

```javascript
// Your/Module/view/frontend/web/extender.js

define(['mage/utils/wrapper'], function (wrapper) {
    'use strict';
    
    return function (processor) {
        return wrapper.wrap(processor, function (proceed, payload) {
            payload = proceed(payload);
            payload.extension_attributes.yourAttribute = 'value';
            return payload;
        });
    };
});
```

### Fixed Issues (if relevant)

I did not find any public issues or feature requests when doing quick searches on the repository and Magento Forums

### Manual testing scenarios
1. When checking out, verify checking out continues to work successfully.
2. When clicking "Next" on the Shipping Step of checkout, verify the Request Payload to the shipping-information endpoint contains "extension_attributes"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
