### PR TITLE
Translate country name to store locale in store information object

### DIFF
--- a/app/code/Magento/Store/Model/Information.php
+++ b/app/code/Magento/Store/Model/Information.php
@@ -19,7 +19,7 @@ use Magento\Store\Model\Address\Renderer;
  */
 class Information
 {
-    /**#@+
+    /**
      * Configuration paths
      */
     const XML_PATH_STORE_INFO_NAME = 'general/store_information/name';
@@ -41,9 +41,10 @@ class Information
     const XML_PATH_STORE_INFO_COUNTRY_CODE = 'general/store_information/country_id';
 
     const XML_PATH_STORE_INFO_VAT_NUMBER = 'general/store_information/merchant_vat_number';
-    /**#@-*/
 
-    /**#@-*/
+    /**
+     * @var Renderer
+     */
     protected $renderer;
 
     /**
@@ -97,7 +98,11 @@ class Information
         }
 
         if ($info->getCountryId()) {
-            $info->setCountry($this->countryFactory->create()->loadByCode($info->getCountryId())->getName());
+            $locale = $store->getConfig(
+                \Magento\Config\Model\Config\Backend\Admin\Custom::XML_PATH_GENERAL_LOCALE_CODE
+            );
+
+            $info->setCountry($this->countryFactory->create()->loadByCode($info->getCountryId())->getName($locale));
         }
 
         return $info;


### PR DESCRIPTION
### Description
Using `{{var store.getFormattedAddress()}}` in emails will output store information but won't translate the country name. This PR pulls the store locale from config and uses it to translate the country name.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Set store locale to `Dutch (nl_NL)`.
2. `{{var store.getFormattedAddress()}}` will output `Netherlands` instead of `Nederland`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
