### PR TITLE
Add VAT number to email source variables

### DIFF
--- a/app/code/Magento/Email/Model/Source/Variables.php
+++ b/app/code/Magento/Email/Model/Source/Variables.php
@@ -47,6 +47,7 @@ class Variables implements \Magento\Framework\Option\ArrayInterface
             ['value' => 'general/store_information/city', 'label' => __('City')],
             ['value' => 'general/store_information/street_line1', 'label' => __('Street Address 1')],
             ['value' => 'general/store_information/street_line2', 'label' => __('Street Address 2')],
+            ['value' => 'general/store_information/merchant_vat_number', 'label' => __('VAT Number')],
         ];
     }
 

--- a/app/code/Magento/Email/Test/Unit/Model/Source/VariablesTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Source/VariablesTest.php
@@ -53,6 +53,7 @@ class VariablesTest extends \PHPUnit\Framework\TestCase
             ['value' => 'general/store_information/city', 'label' => __('City')],
             ['value' => 'general/store_information/street_line1', 'label' => __('Street Address 1')],
             ['value' => 'general/store_information/street_line2', 'label' => __('Street Address 2')],
+            ['value' => 'general/store_information/merchant_vat_number', 'label' => __('VAT Number')],
         ];
     }
 

--- a/app/code/Magento/Email/i18n/en_US.csv
+++ b/app/code/Magento/Email/i18n/en_US.csv
@@ -54,6 +54,7 @@ Region/State,Region/State
 City,City
 "Street Address 1","Street Address 1"
 "Street Address 2","Street Address 2"
+"VAT Number","VAT Number"
 "Store Contact Information","Store Contact Information"
 %1,%1
 "Template Variables","Template Variables"


### PR DESCRIPTION
### Description
In some countries (the netherlands) it's obligated to display your VAT Number in order/invoice emails/pdfs. This field isn't available in the `configVariables` and can't be shown using a config path.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Try to add your VAT Number using `{{config path="general/store_information/merchant_vat_number"}}`.
2. Empty value is shown.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
