### PR TITLE
Removed double tag from configuration XML. Fixes #11000

### DIFF
--- a/app/code/Magento/Tax/etc/config.xml
+++ b/app/code/Magento/Tax/etc/config.xml
@@ -20,7 +20,6 @@
                 <based_on>shipping</based_on>
                 <price_includes_tax>0</price_includes_tax>
                 <shipping_includes_tax>0</shipping_includes_tax>
-                <discount_tax>0</discount_tax>
                 <apply_tax_on>0</apply_tax_on>
             </calculation>
             <defaults>


### PR DESCRIPTION
### Description

The `config.xml` of the `Magento_Tax` module had a double tag which caused unwanted results.

### Fixed Issues

1. magento/magento2#11000

