### PR TITLE
fix for lost template when creating a preference for Magento\Checkout\Block\Cart\Item\Renderer

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -9,13 +9,13 @@
     <update handle="checkout_item_price_renderers"/>
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="cart/item/default.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.default.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.default.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.default.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>
                 </block>
             </block>
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="simple" template="cart/item/default.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="simple" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.simple.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.simple.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.simple.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

This fixes an issue with finding the template when creating a preference for Magento\Checkout\Block\Cart\Item\Renderer
<!--- Provide a description of the changes proposed in the pull request -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ... create a preference for Magento\Checkout\Block\Cart\Item\Renderer

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
