### PR TITLE
Fix rounding error

### DIFF
--- a/app/code/Magento/Directory/Model/PriceCurrency.php
+++ b/app/code/Magento/Directory/Model/PriceCurrency.php
@@ -155,6 +155,6 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      */
     public function round($price)
     {
-        return round($price, 2);
+        return round($price, 4);
     }
 }


### PR DESCRIPTION
### Description
Prices should only rounded to two decimal places in view.

I doubt 2 decimal places is correct here.
If I want a product price of "165" and thus set a base price of "138.6554" with a tax of 19% I get "165.01" because of the rounding to 2 decimal places here.
Setting this to 4 decimal places fixes that issue.

The fact that it is not possible to set a price with 4 decimal places in the backend is another issue that needs to be set separately I suppose.

### Manual testing scenarios
1. set a product price of 138.6554
2. set tax to 19%
3. go to checkout cart
4. final price is 165.01 instead of 165.00