### PR TITLE
website scope prices can be randomly deleted by cron

### DIFF
--- a/app/code/Magento/Catalog/Cron/DeleteOutdatedPriceValues.php
+++ b/app/code/Magento/Catalog/Cron/DeleteOutdatedPriceValues.php
@@ -55,7 +55,8 @@ class DeleteOutdatedPriceValues
     public function execute()
     {
         $priceScope = $this->scopeConfig->getValue(Store::XML_PATH_PRICE_SCOPE);
-        if ($priceScope == Store::PRICE_SCOPE_GLOBAL) {
+        $priceScope = $priceScope === null ? null : (int)$priceScope;
+        if ($priceScope === Store::PRICE_SCOPE_GLOBAL) {
             /** @var \Magento\Catalog\Model\ResourceModel\Eav\Attribute $priceAttribute */
             $priceAttribute = $this->attributeRepository
                 ->get(ProductAttributeInterface::ENTITY_TYPE_CODE, ProductAttributeInterface::CODE_PRICE);


### PR DESCRIPTION
### Description
On at least 2 of our projects we face the issue that suddenly all website scope prices are deleted from "catalog_product_entity_decimal" table.
The issue is tracked back to 'catalog_product_outdated_price_values_cleanup' cron job, which under a request where config cache is corrupted can delete website prices due to a loose comparison of null == 0
We have added logs that show us:
$this->scopeConfig->getValue(Store::XML_PATH_PRICE_SCOPE);
can return null while direct SQL query to config table returns 1 for price scope.

I can not prove that config cache can be corrupted but please take my word on that, we had the same issue with M1 for years where locking mechanism of config cache generation goes wrong and we face cache stampede, seems like we have same issue in M2 (I can send you our fix for M1 for checking)

### Manual testing scenarios
1. change config for price scope from website to global and make sure not needed prices are deleted by cron job
2. change config for price scope from global to website, let cron job run and make sure website scope prices are not deleted

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
