### PR TITLE
don't add error on setup:cron:run when composer.json is missing

### DIFF
--- a/setup/src/Magento/Setup/Model/Cron/ReadinessCheck.php
+++ b/setup/src/Magento/Setup/Model/Cron/ReadinessCheck.php
@@ -143,7 +143,6 @@ class ReadinessCheck
         } catch (\Exception $e) {
             $errorMessage = $e->getMessage();
             $resultJsonRawData[self::KEY_FILE_PATHS][self::KEY_LIST] = [];
-            $errorLogMessages[] = $errorMessage;
         }
         $resultJsonRawData[self::KEY_FILE_PATHS][self::KEY_ERROR] = $errorMessage;
 


### PR DESCRIPTION
In BasePackageInfo ther is a check to add
magento/magento2-base/compser.json, but usually this file is not
available. When used in scripting the error is added and causes a non 0
result. To avoid this, remove the "error" because its no acutal failure.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
