### PR TITLE
Redirect to checkout after popup login

### DIFF
--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -60,6 +60,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
             'autocomplete' => $this->escapeHtml($this->isAutocompleteEnabled()),
             'customerRegisterUrl' => $this->escapeUrl($this->getCustomerRegisterUrlUrl()),
             'customerForgotPasswordUrl' => $this->escapeUrl($this->getCustomerForgotPasswordUrl()),
+            'redirectUrl' => $this->escapeUrl($this->getRedirectUrl()),
             'baseUrl' => $this->escapeUrl($this->getBaseUrl())
         ];
     }
@@ -118,5 +119,15 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
     public function getCustomerForgotPasswordUrl()
     {
         return $this->getUrl('customer/account/forgotpassword');
+    }
+
+    /**
+     * Get checkout url
+     *
+     * @return string
+     */
+    public function getRedirectUrl()
+    {
+        return $this->getUrl('checkout');
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Block/Account/AuthenticationPopupTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Account/AuthenticationPopupTest.php
@@ -90,12 +90,13 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
      * @param string $baseUrl
      * @param string $registerUrl
      * @param string $forgotUrl
+     * @param string $redirectUrl
      * @param array $result
      * @throws \PHPUnit\Framework\Exception
      *
      * @dataProvider dataProviderGetConfig
      */
-    public function testGetConfig($isAutocomplete, $baseUrl, $registerUrl, $forgotUrl, array $result)
+    public function testGetConfig($isAutocomplete, $baseUrl, $registerUrl, $forgotUrl, $redirectUrl, array $result)
     {
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
@@ -122,6 +123,7 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
                 [
                     ['customer/account/create', [], $registerUrl],
                     ['customer/account/forgotpassword', [], $forgotUrl],
+                    ['checkout', [], $redirectUrl],
                 ]
             );
 
@@ -136,10 +138,12 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
                 'base',
                 'reg',
                 'forgot',
+                '',
                 [
                     'autocomplete' => 'escapeHtmloff',
                     'customerRegisterUrl' => 'escapeUrlreg',
                     'customerForgotPasswordUrl' => 'escapeUrlforgot',
+                    'redirectUrl' => 'escapeUrl',
                     'baseUrl' => 'escapeUrlbase',
                 ],
             ],
@@ -148,10 +152,12 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
                 '',
                 'reg',
                 'forgot',
+                'redirect',
                 [
                     'autocomplete' => 'escapeHtmlon',
                     'customerRegisterUrl' => 'escapeUrlreg',
                     'customerForgotPasswordUrl' => 'escapeUrlforgot',
+                    'redirectUrl' => 'escapeUrlredirect',
                     'baseUrl' => 'escapeUrl',
                 ],
             ],
@@ -160,10 +166,12 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
                 'base',
                 '',
                 'forgot',
+                'redirect',
                 [
                     'autocomplete' => 'escapeHtmloff',
                     'customerRegisterUrl' => 'escapeUrl',
                     'customerForgotPasswordUrl' => 'escapeUrlforgot',
+                    'redirectUrl' => 'escapeUrlredirect',
                     'baseUrl' => 'escapeUrlbase',
                 ],
             ],
@@ -172,10 +180,12 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
                 'base',
                 'reg',
                 '',
+                'redirect',
                 [
                     'autocomplete' => 'escapeHtmlon',
                     'customerRegisterUrl' => 'escapeUrlreg',
                     'customerForgotPasswordUrl' => 'escapeUrl',
+                    'redirectUrl' => 'escapeUrlredirect',
                     'baseUrl' => 'escapeUrlbase',
                 ],
             ],
@@ -187,13 +197,20 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
      * @param string $baseUrl
      * @param string $registerUrl
      * @param string $forgotUrl
+     * @param string $redirectUrl
      * @param array $result
      * @throws \PHPUnit\Framework\Exception
      *
      * @dataProvider dataProviderGetConfig
      */
-    public function testGetSerializedConfig($isAutocomplete, $baseUrl, $registerUrl, $forgotUrl, array $result)
-    {
+    public function testGetSerializedConfig(
+        $isAutocomplete,
+        $baseUrl,
+        $registerUrl,
+        $forgotUrl,
+        $redirectUrl,
+        array $result
+    ) {
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
             ->with(Form::XML_PATH_ENABLE_AUTOCOMPLETE, ScopeInterface::SCOPE_STORE, null)
@@ -219,6 +236,7 @@ class AuthenticationPopupTest extends \PHPUnit\Framework\TestCase
                 [
                     ['customer/account/create', [], $registerUrl],
                     ['customer/account/forgotpassword', [], $forgotUrl],
+                    ['checkout', [], $redirectUrl],
                 ]
             );
         $this->serializerMock->expects($this->any())->method('serialize')

--- a/app/code/Magento/Customer/view/frontend/web/js/view/authentication-popup.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/view/authentication-popup.js
@@ -20,6 +20,7 @@ define([
     return Component.extend({
         registerUrl: window.authenticationPopup.customerRegisterUrl,
         forgotPasswordUrl: window.authenticationPopup.customerForgotPasswordUrl,
+        redirectUrl: window.authenticationPopup.redirectUrl,
         autocomplete: window.authenticationPopup.autocomplete,
         modalWindow: null,
         isLoading: ko.observable(false),
@@ -85,7 +86,7 @@ define([
                 formElement.validation('isValid')
             ) {
                 this.isLoading(true);
-                loginAction(loginData);
+                loginAction(loginData, this.redirectUrl);
             }
 
             return false;

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Customer/frontend/js/view/authentication-popup.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Customer/frontend/js/view/authentication-popup.test.js
@@ -29,6 +29,7 @@ define(['squire'], function (Squire) {
         window.authenticationPopup = {
             customerRegisterUrl: 'register_url',
             customerForgotPasswordUrl: 'forgot_password_url',
+            redirectUrl: 'redirect_url',
             autocomplete: 'autocomplete_flag',
             baseUrl: 'base_url'
         };
@@ -75,7 +76,7 @@ define(['squire'], function (Squire) {
                 expect(obj.login(null, event)).toBeFalsy();
                 expect(mocks['Magento_Customer/js/action/login']).toHaveBeenCalledWith({
                     username: 'customer'
-                });
+                }, 'redirect_url');
             });
         });
     });


### PR DESCRIPTION
Redirect user to checkout after login with authentication popup

### Description
The authentication popup is used in the case that guest checkout is
disabled and the customer is not logged in when he clicks on "Proceed to
checkout". So after login it makes sense to redirect to user the
checkout

### Fixed Issues (if relevant)
1. magento/magento2#6015: logging-in in order to checkout when guest checkout is disabled

### Manual testing scenarios
1. Disable guest checkout (Sales/Checkout/Allow Guest Checkout = No)
2. Make sure you have a customer
3. Make sure you are logged out in the frontend
4. Add a product to the cart
5. Click on "Proceed to checkout" in the minicart or cart
6. You are directed to the checkout (before you staid on the same page)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
