### PR TITLE
Add EventPrefix and EventObject to CMS Page/Block Collection

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
@@ -19,6 +19,13 @@ class Collection extends AbstractCollection
     protected $_idFieldName = 'block_id';
 
     /**
+     * Event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'cms_block_collection';
+
+    /**
      * Perform operations after collection load
      *
      * @return $this

--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
@@ -26,6 +26,13 @@ class Collection extends AbstractCollection
     protected $_eventPrefix = 'cms_block_collection';
 
     /**
+     * Event object
+     *
+     * @var string
+     */
+    protected $_eventObject = 'block_collection';
+
+    /**
      * Perform operations after collection load
      *
      * @return $this

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -26,6 +26,13 @@ class Collection extends AbstractCollection
     protected $_previewFlag;
 
     /**
+     * Event prefix
+     *
+     * @var string
+     */
+    //protected $_eventPrefix = 'cms_page_collection';
+
+    /**
      * Define resource model
      *
      * @return void

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -30,7 +30,7 @@ class Collection extends AbstractCollection
      *
      * @var string
      */
-    //protected $_eventPrefix = 'cms_page_collection';
+    protected $_eventPrefix = 'cms_page_collection';
 
     /**
      * Define resource model

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -30,14 +30,14 @@ class Collection extends AbstractCollection
      *
      * @var string
      */
-    protected $_eventPrefix = 'page_collection';
+    protected $_eventPrefix = 'cms_page_collection';
 
     /**
      * Event object
      *
      * @var string
      */
-    protected $_eventObject = 'order_item_collection';
+    protected $_eventObject = 'page_collection';
 
     /**
      * Define resource model

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -30,7 +30,14 @@ class Collection extends AbstractCollection
      *
      * @var string
      */
-    protected $_eventPrefix = 'cms_page_collection';
+    protected $_eventPrefix = 'page_collection';
+
+    /**
+     * Event object
+     *
+     * @var string
+     */
+    protected $_eventObject = 'order_item_collection';
 
     /**
      * Define resource model


### PR DESCRIPTION
Add EventPrefix to CMS Page Collection and CMS Block Collection

### Description
Added EvenPrefix and EventObject for CMS Collections for instantiate observer for `$this->_eventPrefix . '_load_after'` and `$this->_eventPrefix . '_load_before'`

### Fixed Issues (if relevant)
1. #9900

### Manual testing scenarios
1. Add Observer for Event: cms_page_collection_load_after
2. Check Observer code is executed

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
