### PR TITLE
Only prompt for deploy command in production mode

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/UpgradeCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/UpgradeCommand.php
@@ -6,6 +6,7 @@
 namespace Magento\Setup\Console\Command;
 
 use Magento\Deploy\Console\Command\App\ConfigImportCommand;
+use Magento\Framework\App\State as AppState;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Setup\ConsoleLogger;
@@ -38,15 +39,24 @@ class UpgradeCommand extends AbstractSetupCommand
     private $deploymentConfig;
 
     /**
+     * @var AppState
+     */
+    private $appState;
+
+    /**
      * Constructor
      *
      * @param InstallerFactory $installerFactory
      * @param DeploymentConfig $deploymentConfig
      */
-    public function __construct(InstallerFactory $installerFactory, DeploymentConfig $deploymentConfig = null)
-    {
+    public function __construct(
+        InstallerFactory $installerFactory,
+        DeploymentConfig $deploymentConfig = null,
+        AppState $appState = null
+    ) {
         $this->installerFactory = $installerFactory;
         $this->deploymentConfig = $deploymentConfig ?: ObjectManager::getInstance()->get(DeploymentConfig::class);
+        $this->appState = $appState ?: ObjectManager::getInstance()->get(AppState::class);
         parent::__construct();
     }
 
@@ -90,7 +100,7 @@ class UpgradeCommand extends AbstractSetupCommand
                 $importConfigCommand->run($arrayInput, $output);
             }
 
-            if (!$keepGenerated) {
+            if (!$keepGenerated && $this->appState->getMode() === AppState::MODE_PRODUCTION) {
                 $output->writeln(
                     '<info>Please re-run Magento compile command. Use the command "setup:di:compile"</info>'
                 );

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Setup\Test\Unit\Console\Command;
 
 use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\State as AppState;
 use Magento\Framework\Console\Cli;
 use Magento\Setup\Console\Command\UpgradeCommand;
 use Magento\Setup\Model\Installer;
@@ -30,10 +31,14 @@ class UpgradeCommandTest extends \PHPUnit\Framework\TestCase
     private $installerMock;
 
     /**
+     * @var AppState|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $appStateMock;
+
+    /**
      * @var UpgradeCommand
      */
     private $upgradeCommand;
-
     /**
      * @var CommandTester
      */
@@ -56,16 +61,24 @@ class UpgradeCommandTest extends \PHPUnit\Framework\TestCase
         $this->installerFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($this->installerMock);
+        $this->appStateMock = $this->getMockBuilder(AppState::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->upgradeCommand = new UpgradeCommand($this->installerFactoryMock, $this->deploymentConfigMock);
+        $this->upgradeCommand = new UpgradeCommand(
+            $this->installerFactoryMock,
+            $this->deploymentConfigMock,
+            $this->appStateMock
+        );
         $this->commandTester = new CommandTester($this->upgradeCommand);
     }
 
     /**
      * @dataProvider executeDataProvider
      */
-    public function testExecute($options, $expectedString = '')
+    public function testExecute($options, $deployMode, $expectedString = '')
     {
+        $this->appStateMock->method('getMode')->willReturn($deployMode);
         $this->installerMock->expects($this->at(0))
             ->method('updateModulesSequence');
         $this->installerMock->expects($this->at(1))
@@ -85,11 +98,23 @@ class UpgradeCommandTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 'options' => [],
+                'deployMode' => \Magento\Framework\App\State::MODE_PRODUCTION,
                 'expectedString' => 'Please re-run Magento compile command. Use the command "setup:di:compile"'
                     . PHP_EOL
             ],
             [
                 'options' => ['--keep-generated' => true],
+                'deployMode' => \Magento\Framework\App\State::MODE_PRODUCTION,
+                'expectedString' => ''
+            ],
+            [
+                'options' => [],
+                'deployMode' => \Magento\Framework\App\State::MODE_DEVELOPER,
+                'expectedString' => ''
+            ],
+            [
+                'options' => [],
+                'deployMode' => \Magento\Framework\App\State::MODE_DEFAULT,
                 'expectedString' => ''
             ],
         ];


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
After running `setup:upgrade` command, the message "Please rerun Magento compile command" only shows up in production mode

### Fixed Issues (if relevant)
1. magento/magento2#11044: magento setup:upgrade prompts to run compilation, even in developer mode

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. run `bin/magento setup:upgrade` in developer or default mode

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
