### PR TITLE
Allow ID and data-* tags in TinyMCE

### DIFF
--- a/app/code/Magento/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Config.php
@@ -184,6 +184,7 @@ class Config extends \Magento\Framework\DataObject implements ConfigInterface
                 'width' => '100%',
                 'height' => '500px',
                 'plugins' => [],
+                'extended_valid_elements' => '+@[id|data-*]',
             ]
         );
 


### PR DESCRIPTION
Allow ID-tag and data-* tag in HTML. 

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/10353

### Manual testing scenarios
1. CMS Pages / Blocks
2. Add image
3. Edit HTML
4. Add id-tag or data-*="tag"
5. Error will throw up

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
