### PR TITLE
Remove deprecation without alternative

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -13,9 +13,10 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Shopping cart model
+ *
  * @api
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- * @deprecated 100.1.0
+ * @deprecated 100.1.0 Use \Magento\Quote\Model\Quote instead
  */
 class Cart extends DataObject implements CartInterface
 {

--- a/app/code/Magento/Checkout/Model/Cart/CartInterface.php
+++ b/app/code/Magento/Checkout/Model/Cart/CartInterface.php
@@ -12,7 +12,7 @@ use Magento\Quote\Model\Quote;
  *
  * @api
  * @author      Magento Core Team <core@magentocommerce.com>
- * @deprecated 100.1.0
+ * @deprecated 100.1.0 Use \Magento\Quote\Model\Quote instead
  */
 interface CartInterface
 {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

The `Cart` and `CartInterface`  have been deprecated a while ago without ever providing useful alternatives, causing much confusion amongst developers.

Later, deprecation guidelines were introduced:

>Use the @deprecated tag to mark methods as deprecated and follow it up with an explanation.
>
>Use the  @see tag to recommend the new API to use instead of the old one.

We should update deprecation annotations accordingly and "un-deprecate" classes and methods that do not have any alternatives yet.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10133: Please add your expectations for @deprecated annotations 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
