### PR TITLE
allow use of changed baseurl instead of storecode append

### DIFF
--- a/app/code/Magento/Store/App/Request/PathInfoProcessor.php
+++ b/app/code/Magento/Store/App/Request/PathInfoProcessor.php
@@ -38,7 +38,20 @@ class PathInfoProcessor implements \Magento\Framework\App\Request\PathInfoProces
             /** @var \Magento\Store\Api\Data\StoreInterface $store */
             $store = $this->storeManager->getStore($storeCode);
         } catch (NoSuchEntityException $e) {
-            return $pathInfo;
+            try {
+                /** get the store by url */
+                $requestUri = $request->getUri();
+                if (empty($requestUri)) {
+                    return $pathInfo;
+                }
+                $store = $this->storeManager->getStoreByUrl($requestUri);
+                $storeBaseUrl = $store->getBaseUrl();
+                $baseUrlUri = \Zend\Uri\UriFactory::factory($storeBaseUrl);
+                $baseUrlPath = $baseUrlUri->getPath();
+                $pathInfo = preg_replace('#^' . $baseUrlPath . '#', '', $pathInfo);
+            } catch (NoSuchEntityException $e) {
+                return $pathInfo;
+            }
         }
 
         if ($store->isUseStoreInUrl()) {

--- a/app/code/Magento/Store/Model/StoreManager.php
+++ b/app/code/Magento/Store/Model/StoreManager.php
@@ -8,6 +8,7 @@ namespace Magento\Store\Model;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Api\StoreResolverInterface;
 use Magento\Store\Model\ResourceModel\StoreWebsiteRelation;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Service contract, which manage scopes
@@ -168,6 +169,27 @@ class StoreManager implements
             : $this->storeRepository->get($storeId);
 
         return $store;
+    }
+
+    public function getStoreByUrl(\Zend\Uri\UriInterface $requestUri)
+    {
+        $uriString = $requestUri->toString();
+        $stores = $this->getStores();
+        $detectedStore = null;
+        $currentBase = '';
+        foreach ($stores as $store) {
+            if (false !== stristr($uriString, $store->getBaseUrl())) {
+                $newBase = $store->getBaseUrl();
+                if (strlen($newBase) > strlen($currentBase)) {
+                    $currentBase = $newBase;
+                    $detectedStore = $store;
+                }
+            }
+        }
+        if (null === $detectedStore) {
+            throw new NoSuchEntityException(__('Requested store is not found'));
+        }
+        return $detectedStore;
     }
 
     /**


### PR DESCRIPTION
Our case:

We want the "default store" to use the website url without appending the
store code.

nl: http://magento2.test/
fr: http://magento2.test/fr/
en: http://magento2.test/en/

The issue:

when you configure your storeview baseurl's as described above you get
404's when switching to the en or fr storeview.

The solution:

When no store is found based on the storecode, try to find and match a
store based on the url given. For our example configuration you also
have to match the longest since the nl store given will also match when
going to the fr or en store.

Append Storecode:

Since the storecode is mandatory in magento we cannot use the append
storecode to achieve our goal.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
