### PR TITLE
Prevent invoice cancelation multiple times

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -410,7 +410,6 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
         if (!$this->canCancel()) {
             return $this;
         }
-        
         $order = $this->getOrder();
         $order->getPayment()->cancelInvoice($this);
         foreach ($this->getAllItems() as $item) {

--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -407,6 +407,10 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
      */
     public function cancel()
     {
+        if (!$this->canCancel()) {
+            return $this;
+        }
+        
         $order = $this->getOrder();
         $order->getPayment()->cancelInvoice($this);
         foreach ($this->getAllItems() as $item) {

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceTest.php
@@ -425,9 +425,13 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
         $this->order->expects($this->once())->method('getPayment')->willReturn($this->paymentMock);
         $this->order->expects($this->once())->method('getConfig')->willReturn($orderConfigMock);
 
-        $this->paymentMock->expects($this->once())->method('cancelInvoice')->willReturn($this->paymentMock);
+        $this->paymentMock->expects($this->once())
+            ->method('cancelInvoice')
+            ->willReturn($this->paymentMock);
 
-        $this->eventManagerMock->expects($this->once())->method('dispatch')->with('sales_order_invoice_cancel');
+        $this->eventManagerMock->expects($this->once())
+            ->method('dispatch')
+            ->with('sales_order_invoice_cancel');
 
         $this->model->setData(InvoiceInterface::ITEMS, []);
         $this->model->setState(Invoice::STATE_OPEN);
@@ -440,19 +444,21 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
      * Assert open invoice can be canceled, and its status changes
      *
      * @param $initialInvoiceStatus
-     * @param $expectedInvoiceStatus
+     * @param $finalInvoiceStatus
      * @dataProvider getNotOpenedInvoiceStatuses
      */
-    public function testCannotCancelNotOpenedInvoice($initialInvoiceStatus, $expectedInvoiceStatus)
+    public function testCannotCancelNotOpenedInvoice($initialInvoiceStatus, $finalInvoiceStatus)
     {
         $this->order->expects($this->never())->method('getPayment');
         $this->paymentMock->expects($this->never())->method('cancelInvoice');
-        $this->eventManagerMock->expects($this->never())->method('dispatch')->with('sales_order_invoice_cancel');
+        $this->eventManagerMock->expects($this->never())
+            ->method('dispatch')
+            ->with('sales_order_invoice_cancel');
 
         $this->model->setState($initialInvoiceStatus);
         $this->model->cancel();
 
-        self::assertEquals($expectedInvoiceStatus, $this->model->getState());
+        self::assertEquals($finalInvoiceStatus, $this->model->getState());
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceTest.php
@@ -8,12 +8,12 @@
 
 namespace Magento\Sales\Test\Unit\Model\Order;
 
-use Magento\Sales\Model\Order\Invoice;
-use Magento\Sales\Model\ResourceModel\OrderFactory;
+use Magento\Sales\Api\Data\InvoiceInterface;
 use Magento\Sales\Model\Order;
-use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\ResourceModel\Order\Invoice\Collection as InvoiceCollection;
+use Magento\Sales\Model\ResourceModel\OrderFactory;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class InvoiceTest
@@ -72,7 +72,7 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
             ->setMethods(
                 [
                     'getPayment', '__wakeup', 'load', 'setHistoryEntityName', 'getStore', 'getBillingAddress',
-                    'getShippingAddress'
+                    'getShippingAddress', 'getConfig',
                 ]
             )
             ->getMock();
@@ -83,7 +83,7 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
         $this->paymentMock = $this->getMockBuilder(
             \Magento\Sales\Model\Order\Payment::class
         )->disableOriginalConstructor()->setMethods(
-            ['canVoid', '__wakeup', 'canCapture', 'capture', 'pay']
+            ['canVoid', '__wakeup', 'canCapture', 'capture', 'pay', 'cancelInvoice']
         )->getMock();
 
         $this->orderFactory = $this->createPartialMock(\Magento\Sales\Model\OrderFactory::class, ['create']);
@@ -406,5 +406,63 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
         $refProperty->setValue($this->order, $collection);
 
         return $collection;
+    }
+
+    /**
+     * Assert open invoice can be canceled, and its status changes
+     */
+    public function testCancelOpenInvoice()
+    {
+        $orderConfigMock = $this->getMockBuilder(\Magento\Sales\Model\Order\Config::class)
+            ->disableOriginalConstructor()->setMethods(
+                ['getStateDefaultStatus']
+            )->getMock();
+
+        $orderConfigMock->expects($this->once())->method('getStateDefaultStatus')
+            ->with(Order::STATE_PROCESSING)
+            ->willReturn(Order::STATE_PROCESSING);
+
+        $this->order->expects($this->once())->method('getPayment')->willReturn($this->paymentMock);
+        $this->order->expects($this->once())->method('getConfig')->willReturn($orderConfigMock);
+
+        $this->paymentMock->expects($this->once())->method('cancelInvoice')->willReturn($this->paymentMock);
+
+        $this->eventManagerMock->expects($this->once())->method('dispatch')->with('sales_order_invoice_cancel');
+
+        $this->model->setData(InvoiceInterface::ITEMS, []);
+        $this->model->setState(Invoice::STATE_OPEN);
+        $this->model->cancel();
+
+        self::assertEquals(Invoice::STATE_CANCELED, $this->model->getState());
+    }
+
+    /**
+     * Assert open invoice can be canceled, and its status changes
+     *
+     * @param $initialInvoiceStatus
+     * @param $expectedInvoiceStatus
+     * @dataProvider getNotOpenedInvoiceStatuses
+     */
+    public function testCannotCancelNotOpenedInvoice($initialInvoiceStatus, $expectedInvoiceStatus)
+    {
+        $this->order->expects($this->never())->method('getPayment');
+        $this->paymentMock->expects($this->never())->method('cancelInvoice');
+        $this->eventManagerMock->expects($this->never())->method('dispatch')->with('sales_order_invoice_cancel');
+
+        $this->model->setState($initialInvoiceStatus);
+        $this->model->cancel();
+
+        self::assertEquals($expectedInvoiceStatus, $this->model->getState());
+    }
+
+    /**
+     * @return array
+     */
+    public function getNotOpenedInvoiceStatuses()
+    {
+        return [
+            [Invoice::STATE_PAID, Invoice::STATE_PAID],
+            [Invoice::STATE_CANCELED, Invoice::STATE_CANCELED],
+        ];
     }
 }


### PR DESCRIPTION
Add Guard Clause to check if invoice has been canceled previously

### Description
The invoice gets canceled twice, so order amounts are also being adjusted twice.

With same approach of `Magento\Sales\Model\Order::cancel` added guard clause to avoid recancel order.

### Fixed Issues (if relevant)
1. #9968

### Manual testing scenarios
1. Load Invoice programmatically
2. Cancel Invoice
3. Try to Cancel the same invoice

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
