### PR TITLE
opportunistic fix for double ___store=xx&___store=xx

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -1138,6 +1138,15 @@ class Store extends AbstractExtensibleModel implements
     {
         $sidQueryParam = $this->_sidResolver->getSessionIdQueryParam($this->_getSession());
         $requestString = $this->_url->escape(ltrim($this->_request->getRequestString(), '/'));
+        $requestString = preg_replace(
+            '/___store=[a-zA-Z0-9]*/',
+            '',
+            $requestString
+        );
+        $requestString = str_replace('?&', '?', $requestString);
+        if ('?' ===  $requestString) {
+            $requestString = '';
+        }
 
         $storeUrl = $this->getUrl('', ['_secure' => $this->_storeManager->getStore()->isCurrentlySecure()]);
 


### PR DESCRIPTION
when we get the current url of the store, oppurtinistically remove the
___store parameter.

fixes #10908

the other issues related to parameters given to an url and being removed
during store switching should be handled in another ticket

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
