### PR TITLE
Backport to 2.2 of #10824: add name for order items grid default renderer block

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
@@ -41,21 +41,21 @@
                                 <item name="total" xsi:type="string" translate="true">Row Total</item>
                             </argument>
                         </arguments>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/view/items/renderer/default.phtml">
-                        <arguments>
-                            <argument name="columns" xsi:type="array">
-                                <item name="product" xsi:type="string" translate="false">col-product</item>
-                                <item name="status" xsi:type="string" translate="false">col-status</item>
-                                <item name="price-original" xsi:type="string" translate="false">col-price-original</item>
-                                <item name="price" xsi:type="string" translate="false">col-price</item>
-                                <item name="qty" xsi:type="string" translate="false">col-ordered-qty</item>
-                                <item name="subtotal" xsi:type="string" translate="false">col-subtotal</item>
-                                <item name="tax-amount" xsi:type="string" translate="false">col-tax-amount</item>
-                                <item name="tax-percent" xsi:type="string" translate="false">col-tax-percent</item>
-                                <item name="discont" xsi:type="string" translate="false">col-discont</item>
-                                <item name="total" xsi:type="string" translate="false">col-total</item>
-                            </argument>
-                        </arguments>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer" as="default" name="default_order_items_renderer" template="Magento_Sales::order/view/items/renderer/default.phtml">
+                            <arguments>
+                                <argument name="columns" xsi:type="array">
+                                    <item name="product" xsi:type="string" translate="false">col-product</item>
+                                    <item name="status" xsi:type="string" translate="false">col-status</item>
+                                    <item name="price-original" xsi:type="string" translate="false">col-price-original</item>
+                                    <item name="price" xsi:type="string" translate="false">col-price</item>
+                                    <item name="qty" xsi:type="string" translate="false">col-ordered-qty</item>
+                                    <item name="subtotal" xsi:type="string" translate="false">col-subtotal</item>
+                                    <item name="tax-amount" xsi:type="string" translate="false">col-tax-amount</item>
+                                    <item name="tax-percent" xsi:type="string" translate="false">col-tax-percent</item>
+                                    <item name="discont" xsi:type="string" translate="false">col-discont</item>
+                                    <item name="total" xsi:type="string" translate="false">col-total</item>
+                                </argument>
+                            </arguments>
                         </block>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>


### PR DESCRIPTION
Backport to 2.2 of #10824

### Description
Add name for default renderer block of order items to allow other modules reference it.

### Fixed Issues (if relevant)
1. magento/magento2#10824: Cannot add new columns to item grid in admin sales_order_view layout

### Manual testing scenarios
1. In custom module create file view/adminhtml/layout/sales_order_view.xml with the following content
```
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <body>
        <referenceBlock name="order_items">
            <arguments>
                <argument name="columns" xsi:type="array">
                    <item name="test_column" xsi:type="string" translate="true">Test Header</item>
                </argument>
            </arguments>
            <referenceBlock name="default_order_items_renderer">
                <arguments>
                    <argument name="columns" xsi:type="array">
                        <item name="test_column" xsi:type="string" translate="true">col-test</item>
                    </argument>
                </arguments>
            </referenceBlock>

            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn"
                   name="column_test_column"
                   template="Vendor_Module::test.phtml" group="column" />
        </referenceBlock>
    </body>
</page>
```
2. create file view/adminhtml/templates/test.phtml file with content
```
Test column
```

3. Go to the order view page.

4. Column with header "Test Header" is shown with content "Test column"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
