### PR TITLE
Fix in stripped min length validation when value has special characters

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -244,7 +244,7 @@ define([
         ],
         'stripped-min-length': [
             function (value, param) {
-                return $(value).text().length >= param;
+                return value.length >= param;
             },
             $.mage.__('Please enter at least {0} characters')
         ],

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -244,7 +244,7 @@ define([
         ],
         'stripped-min-length': [
             function (value, param) {
-                return value.length >= param;
+                return _.isUndefined(value) || value.length === 0 || utils.stripHtml(value).length >= param;
             },
             $.mage.__('Please enter at least {0} characters')
         ],


### PR DESCRIPTION
Fix in stripped min length validation when value has special characters

### Description
When add a UI Component form with stripped-min-lenght validation and the input has special characters, the console shows a javascript error (Syntax error: Unrecognized expression...) because uses jQuery instead native Javascript function.

### Fixed Issues (if relevant)
1. #9920 

### Manual testing scenarios
1. Create a UI Component based form

2. Add the following validation to the XML form element definition

 ```
<item name="validation" xsi:type="array">
     <item name="required-entry" xsi:type="boolean">true</item>
     <item name="no-whitespace" xsi:type="boolean">true</item>
     <item name="stripped-min-length" xsi:type="string">4</item>
 </item>
```
3. Test in admin using value `a/b` or `ab/` or `a&c`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
