### PR TITLE
Add static test to detect blocks without name attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ install: composer install --no-interaction
 before_script: ./dev/travis/before_script.sh
 script:
   # Set arguments for variants of phpunit based tests; '|| true' prevents failing script when leading test fails
-  - test $TEST_SUITE = "static" && TEST_FILTER='--filter "Magento\\Test\\Php\\LiveCodeTest"' || true
   - test $TEST_SUITE = "functional" && TEST_FILTER='dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php' || true
 
   # The scripts for grunt/phpunit type tests

--- a/app/code/Magento/AdminNotification/view/adminhtml/layout/adminhtml_notification_block.xml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/layout/adminhtml_notification_block.xml
@@ -20,14 +20,14 @@
                     <arguments>
                         <argument name="filter_visibility" xsi:type="string">0</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="severity">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.notification.container.grid.columnSet.severity" as="severity">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Severity</argument>
                             <argument name="index" xsi:type="string">severity</argument>
                             <argument name="renderer" xsi:type="string">Magento\AdminNotification\Block\Grid\Renderer\Severity</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="date_added">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.notification.container.grid.columnSet.date_added" as="date_added">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Date Added</argument>
                             <argument name="id" xsi:type="string">date_added</argument>
@@ -37,14 +37,14 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.notification.container.grid.columnSet.title" as="title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Message</argument>
                             <argument name="index" xsi:type="string">title</argument>
                             <argument name="renderer" xsi:type="string">Magento\AdminNotification\Block\Grid\Renderer\Notice</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="actions">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.notification.container.grid.columnSet.actions" as="actions">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Actions</argument>
                             <argument name="sortable" xsi:type="string">0</argument>

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_cache_block.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_cache_block.xml
@@ -42,7 +42,7 @@
                     <arguments>
                         <argument name="filter_visibility" xsi:type="string">0</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="cache_type">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.cache.grid.columnSet.cache_type" as="cache_type">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Cache Type</argument>
                             <argument name="index" xsi:type="string">cache_type</argument>
@@ -53,7 +53,7 @@
                             <argument name="translate" xsi:type="boolean">true</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="description">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.cache.grid.columnSet.description" as="description">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Description</argument>
                             <argument name="index" xsi:type="string">description</argument>
@@ -63,7 +63,7 @@
                             <argument name="translate" xsi:type="boolean">true</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="tags">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.cache.grid.columnSet.tags" as="tags">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Tags</argument>
                             <argument name="index" xsi:type="string">tags</argument>
@@ -73,7 +73,7 @@
                             <argument name="sortable" xsi:type="string">0</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Cache\Grid\Column\Statuses" as="status">
+                    <block class="Magento\Backend\Block\Cache\Grid\Column\Statuses" name="adminhtml.cache.grid.columnSet.status" as="status">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="index" xsi:type="string">status</argument>

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_system_design_grid_block.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_system_design_grid_block.xml
@@ -28,7 +28,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.system.design.grid.columnSet.store_id" as="store_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store</argument>
                             <argument name="width" xsi:type="string">100px</argument>
@@ -38,7 +38,7 @@
                             <argument name="index" xsi:type="string">store_id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="package">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.design.grid.columnSet.package" as="package">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Design</argument>
                             <argument name="type" xsi:type="string">options</argument>
@@ -47,7 +47,7 @@
                             <argument name="index" xsi:type="string">design</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="date_from">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.design.grid.columnSet.date_from" as="date_from">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Date From</argument>
                             <argument name="align" xsi:type="string">left</argument>
@@ -57,7 +57,7 @@
                             <argument name="index" xsi:type="string">date_from</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="date_to">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.design.grid.columnSet.date_to" as="date_to">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Date To</argument>
                             <argument name="align" xsi:type="string">left</argument>

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_system_store_grid_block.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_system_store_grid_block.xml
@@ -18,7 +18,7 @@
                     <arguments>
                         <argument name="id" xsi:type="string">storeGrid</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="website_title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.store.grid.columnSet.website_title" as="website_title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Web Site</argument>
                             <argument name="align" xsi:type="string">left</argument>
@@ -27,7 +27,7 @@
                             <argument name="renderer" xsi:type="string">Magento\Backend\Block\System\Store\Grid\Render\Website</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="group_title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.store.grid.columnSet.group_title" as="group_title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store</argument>
                             <argument name="align" xsi:type="string">left</argument>
@@ -36,7 +36,7 @@
                             <argument name="renderer" xsi:type="string">Magento\Backend\Block\System\Store\Grid\Render\Group</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="store_title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.store.grid.columnSet.store_title" as="store_title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store View</argument>
                             <argument name="align" xsi:type="string">left</argument>

--- a/app/code/Magento/Backup/view/adminhtml/layout/backup_index_block.xml
+++ b/app/code/Magento/Backup/view/adminhtml/layout/backup_index_block.xml
@@ -33,7 +33,7 @@
                     <arguments>
                         <argument name="id" xsi:type="string">backupsGrid</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="time">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.product.set.grid.columnSet.time" as="time">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Time</argument>
                             <argument name="index" xsi:type="string">date_object</argument>
@@ -42,7 +42,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="display_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.product.set.grid.columnSet.display_name" as="display_name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Name</argument>
                             <argument name="index" xsi:type="string">display_name</argument>
@@ -51,7 +51,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="size">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.product.set.grid.columnSet.size" as="size">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Size(bytes)</argument>
                             <argument name="index" xsi:type="string">size</argument>
@@ -60,7 +60,7 @@
                             <argument name="sortable" xsi:type="string">1</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="type">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.product.set.grid.columnSet.type" as="type">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Type</argument>
                             <argument name="index" xsi:type="string">type</argument>
@@ -68,7 +68,7 @@
                             <argument name="options" xsi:type="options" model="Magento\Backup\Model\Grid\Options"/>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="download">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.product.set.grid.columnSet.download" as="download">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Download</argument>
                             <argument name="index" xsi:type="string">type</argument>
@@ -78,7 +78,7 @@
                             <argument name="renderer" xsi:type="string">Magento\Backup\Block\Adminhtml\Grid\Column\Renderer\Download</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backup\Block\Adminhtml\Grid\Column\Rollback" as="action">
+                    <block class="Magento\Backup\Block\Adminhtml\Grid\Column\Rollback" name="adminhtml.catalog.product.set.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>
                             <argument name="index" xsi:type="string">type</argument>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_order_shipment_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_order_shipment_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/shipment/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="order_items.bundle" as="bundle" template="Magento_Bundle::sales/shipment/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/catalog_product_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/catalog_product_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Framework\View\Element\Template" template="Magento_Bundle::product/stock/disabler.phtml"/>
+           <block class="Magento\Framework\View\Element\Template" name="js.bundle_stock_disabler" template="Magento_Bundle::product/stock/disabler.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/creditmemo/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="order_items.bundle" as="bundle" template="Magento_Bundle::sales/creditmemo/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/creditmemo/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="order_items.bundle" as="bundle" template="Magento_Bundle::sales/creditmemo/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/creditmemo/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="creditmemo_items.bundle" as="bundle" template="Magento_Bundle::sales/creditmemo/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/invoice/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="order_items.bundle" as="bundle" template="Magento_Bundle::sales/invoice/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/invoice/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="order_items.bundle" as="bundle" template="Magento_Bundle::sales/invoice/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="invoice_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/invoice/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" name="invoice_items.bundle" as="bundle" template="Magento_Bundle::sales/invoice/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer" name="order_items.bundle" as="bundle" template="Magento_Bundle::sales/order/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\Bundle\Block\Checkout\Cart\Item\Renderer" as="bundle" template="Magento_Checkout::cart/item/default.phtml">
+            <block class="Magento\Bundle\Block\Checkout\Cart\Item\Renderer" name="checkout.cart.item.renderers.bundle" as="bundle" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.bundle.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.bundle.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.bundle.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
@@ -9,11 +9,11 @@
     <container name="root">
         <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset" name="product.composite.fieldset">
             <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options" name="product.composite.fieldset.options" template="Magento_Catalog::catalog/product/composite/fieldset/options.phtml">
-                <block class="Magento\Catalog\Block\Product\View\Options\Type\DefaultType" as="default" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/default.phtml"/>
-                <block class="Magento\Catalog\Block\Product\View\Options\Type\Text" as="text" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/text.phtml"/>
-                <block class="Magento\Catalog\Block\Product\View\Options\Type\File" as="file" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/file.phtml"/>
-                <block class="Magento\Catalog\Block\Product\View\Options\Type\Select" as="select" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/select.phtml"/>
-                <block class="Magento\Catalog\Block\Product\View\Options\Type\Date" as="date" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/date.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View\Options\Type\DefaultType" name="product.composite.fieldset.options.default" as="default" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/default.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View\Options\Type\Text" name="product.composite.fieldset.options.text" as="text" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/text.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View\Options\Type\File" name="product.composite.fieldset.options.file" as="file" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/file.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View\Options\Type\Select" name="product.composite.fieldset.options.select" as="select" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/select.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View\Options\Type\Date" name="product.composite.fieldset.options.date" as="date" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/date.phtml"/>
                 <block class="Magento\Framework\View\Element\Template" name="product.composite.fieldset.options.js" as="options_js" template="Magento_Catalog::catalog/product/composite/fieldset/options/js.phtml"/>
             </block>
             <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty" name="product.composite.fieldset.qty" template="Magento_Catalog::catalog/product/composite/fieldset/qty.phtml"/>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_attribute_edit.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_attribute_edit.xml
@@ -10,12 +10,12 @@
         <referenceContainer name="left">
             <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tabs" name="attribute_edit_tabs">
                 <container label="Main" name="main">
-                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Main" as="base"/>
-                    <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options" as="advanced"/>
-                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Advanced" as="options"/>
+                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Main" name="main.base" as="base"/>
+                    <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options" name="main.advanced" as="advanced"/>
+                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Advanced" name="main.options" as="options"/>
                 </container>
-                <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels" as="labels"/>
-                <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Front" as="front"/>
+                <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels" name="attribute_edit_tabs.labels" as="labels"/>
+                <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Front" name="attribute_edit_tabs.front" as="front"/>
             </block>
         </referenceContainer>
         <referenceContainer name="content">

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_attribute_edit_popup.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_attribute_edit_popup.xml
@@ -13,11 +13,11 @@
         <referenceContainer name="content">
             <block template="Magento_Catalog::catalog/product/attribute/form.phtml" class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit" name="attribute_edit_content">
                 <container name="form" label="Form">
-                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Main" as="main"/>
-                    <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options" as="advanced-options"/>
-                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Advanced" as="options"/>
-                    <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels" as="labels"/>
-                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Front" as="front-options"/>
+                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Main" name="form.main" as="main"/>
+                    <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options" name="form.advanced_options" as="advanced-options"/>
+                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Advanced" name="form.options" as="options"/>
+                    <block class="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels" name="form.labels" as="labels"/>
+                    <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Front" name="form.front_options" as="front-options"/>
                 </container>
             </block>
             <block class="Magento\Backend\Block\Template" name="attribute_edit_js" template="Magento_Catalog::catalog/product/attribute/js.phtml"/>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_set_block.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_set_block.xml
@@ -26,7 +26,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="set_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.product.set.grid.columnSet.set_name" as="set_name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Set</argument>
                             <argument name="align" xsi:type="string">left</argument>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
@@ -19,7 +19,7 @@
                 <block class="Magento\Catalog\Block\Product\ListProduct" name="category.products.list" as="product_list" template="Magento_Catalog::product/list.phtml">
                     <container name="category.product.list.additional" as="additional" />
                     <block class="Magento\Framework\View\Element\RendererList" name="category.product.type.details.renderers" as="details.renderers">
-                        <block class="Magento\Framework\View\Element\Template" as="default"/>
+                        <block class="Magento\Framework\View\Element\Template" name="category.product.type.details.renderers.default" as="default"/>
                     </block>
                     <block class="Magento\Catalog\Block\Product\ProductList\Item\Container" name="category.product.addto" as="addto">
                         <block class="Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare"

--- a/app/code/Magento/Catalog/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="virtual" template="Magento_Checkout::cart/item/default.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" name="checkout.cart.item.renderers.virtual" as="virtual" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.virtual.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.virtual.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.virtual.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.simple.extra">
-            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" template="Magento_CatalogInventory::stockqty/default.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" name="product.info.simple.extra.catalog_inventory_stockqty_default" template="Magento_CatalogInventory::stockqty/default.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_virtual.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_virtual.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.virtual.extra">
-            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" template="Magento_CatalogInventory::stockqty/default.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" name="product.info.virtual.extra.catalog_inventory_stockqty_default" template="Magento_CatalogInventory::stockqty/default.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/CatalogRule/view/adminhtml/layout/catalog_rule_promo_catalog_block.xml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/layout/catalog_rule_promo_catalog_block.xml
@@ -25,7 +25,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="rule_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="promo.catalog.grid.columnSet.rule_id" as="rule_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">rule_id</argument>
@@ -34,14 +34,14 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="promo.catalog.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Rule</argument>
                             <argument name="index" xsi:type="string">name</argument>
                             <argument name="type" xsi:type="string">text</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="from_date">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="promo.catalog.grid.columnSet.from_date" as="from_date">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Start</argument>
                             <argument name="type" xsi:type="string">date</argument>
@@ -51,7 +51,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="to_date">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="promo.catalog.grid.columnSet.to_date" as="to_date">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">End</argument>
                             <argument name="type" xsi:type="string">date</argument>
@@ -62,7 +62,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="is_active">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="promo.catalog.grid.columnSet.is_active" as="is_active">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="index" xsi:type="string">is_active</argument>
@@ -79,7 +79,7 @@
                             </argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="rule_website">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="promo.catalog.grid.columnSet.rule_website" as="rule_website">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Web Site</argument>
                             <argument name="index" xsi:type="string">website_ids</argument>

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -23,7 +23,7 @@
                         <argument name="name" xsi:type="string">product_list_toolbar</argument>
                     </action>
                     <block class="Magento\Framework\View\Element\RendererList" name="category.product.type.details.renderers" as="details.renderers">
-                        <block class="Magento\Framework\View\Element\Template" as="default"/>
+                        <block class="Magento\Framework\View\Element\Template" name="category.product.type.details.renderers.default" as="default"/>
                     </block>
                     <block class="Magento\Catalog\Block\Product\ProductList\Item\Container" name="catalogsearch.product.addto" as="addto">
                         <block class="Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare"

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
@@ -24,7 +24,7 @@
                         <argument name="name" xsi:type="string">product_list_toolbar</argument>
                     </action>
                     <block class="Magento\Framework\View\Element\RendererList" name="category.product.type.details.renderers" as="details.renderers">
-                        <block class="Magento\Framework\View\Element\Template" as="default"/>
+                        <block class="Magento\Framework\View\Element\Template" name="category.product.type.details.renderers.default" as="default"/>
                     </block>
                     <block class="Magento\Catalog\Block\Product\ProductList\Item\Container" name="catalogsearch.product.addto" as="addto">
                         <block class="Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare"

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_review_item_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_review_item_renderers.xml
@@ -9,7 +9,7 @@
     <update handle="checkout_item_price_renderers"/>
     <body>
         <referenceBlock name="checkout.onepage.review.item.renderers">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="Magento_Checkout::onepage/review/item.phtml"/>
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" name="checkout.onepage.review.item.renderers.default" as="default" template="Magento_Checkout::onepage/review/item.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Config/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/Config/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Backend\Block\Template" template="Magento_Config::system/config/js.phtml"/>
-            <block class="Magento\Backend\Block\Template" template="Magento_Backend::system/shipping/applicable_country.phtml"/>
+            <block class="Magento\Backend\Block\Template" name="js.system_config_js" template="Magento_Config::system/config/js.phtml"/>
+            <block class="Magento\Backend\Block\Template" name="js.system_shipping_applicable_country" template="Magento_Backend::system/shipping/applicable_country.phtml"/>
         </referenceContainer>
         <referenceContainer name="page.main.actions">
             <block class="Magento\Backend\Block\Store\Switcher" name="adminhtml.system.config.switcher" template="Magento_Backend::store/switcher.phtml">

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_addattribute.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_addattribute.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\ConfigurableProduct\Block\Adminhtml\Product\Attribute\NewAttribute\Product\Created" template="Magento_ConfigurableProduct::catalog/product/attribute/new/created.phtml" as="product.attribute.created" />
+        <block class="Magento\ConfigurableProduct\Block\Adminhtml\Product\Attribute\NewAttribute\Product\Created" template="Magento_ConfigurableProduct::catalog/product/attribute/new/created.phtml" name="root.configurable_product_attribute_created" as="product.attribute.created" />
     </container>
 </layout>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_new.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_new.xml
@@ -11,8 +11,8 @@
     </head>
     <body>
         <referenceContainer name="js">
-            <block class="Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector" template="Magento_ConfigurableProduct::product/configurable/affected-attribute-set-selector/js.phtml"/>
-            <block class="Magento\Framework\View\Element\Template" template="Magento_ConfigurableProduct::product/configurable/stock/disabler.phtml"/>
+            <block class="Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector" name="js.configurable_product_affected_attribute_set_selector" template="Magento_ConfigurableProduct::product/configurable/affected-attribute-set-selector/js.phtml"/>
+            <block class="Magento\Framework\View\Element\Template" name="js.configurable_product_stock_disabler" template="Magento_ConfigurableProduct::product/configurable/stock/disabler.phtml"/>
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\Template" name="affected-attribute-set-selector" template="Magento_ConfigurableProduct::product/configurable/affected-attribute-set-selector/form.phtml">

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_wizard.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_wizard.xml
@@ -7,7 +7,7 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_layout.xsd">
     <container name="root">
-        <block class="Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix" template="Magento_ConfigurableProduct::catalog/product/edit/super/wizard-ajax.phtml" as="wizard">
+        <block class="Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix" template="Magento_ConfigurableProduct::catalog/product/edit/super/wizard-ajax.phtml" name="root.wizard" as="wizard">
             <arguments>
                 <argument name="config" xsi:type="array">
                     <item name="collapsible" xsi:type="boolean">false</item>

--- a/app/code/Magento/ConfigurableProduct/view/frontend/layout/catalog_product_view_type_configurable.xml
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/layout/catalog_product_view_type_configurable.xml
@@ -14,7 +14,7 @@
         <referenceContainer name="product.info.type">
             <block class="Magento\ConfigurableProduct\Block\Product\View\Type\Configurable" name="product.info.configurable" as="product_type_data" template="Magento_Catalog::product/view/type/default.phtml"/>
             <container name="product.info.configurable.extra" after="product.info.configurable" as="product_type_data_extra" label="Product Extra Info">
-                <block class="Magento\ConfigurableProduct\Block\Stockqty\Type\Configurable" template="Magento_CatalogInventory::stockqty/composite.phtml"/>
+                <block class="Magento\ConfigurableProduct\Block\Stockqty\Type\Configurable" name="product.info.configurable.extra.catalog_inventory_stockqty_composite" template="Magento_CatalogInventory::stockqty/composite.phtml"/>
             </container>
         </referenceContainer>
         <referenceBlock name="product.info.options.wrapper">

--- a/app/code/Magento/ConfigurableProduct/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable" as="configurable" template="Magento_Checkout::cart/item/default.phtml">
+            <block class="Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable" name="checkout.cart.item.renderers.configurable" as="configurable" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.configurable.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.configurable.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.configurable.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/ConfigurableProduct/view/frontend/layout/checkout_onepage_review_item_renderers.xml
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/layout/checkout_onepage_review_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.onepage.review.item.renderers">
-            <block class="Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable" as="configurable" template="Magento_Checkout::onepage/review/item.phtml" cacheable="false"/>
+            <block class="Magento\ConfigurableProduct\Block\Cart\Item\Renderer\Configurable" name="checkout.onepage.review.item.renderers.configurable" as="configurable" template="Magento_Checkout::onepage/review/item.phtml" cacheable="false"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Customer/view/adminhtml/layout/customer_group_index.xml
+++ b/app/code/Magento/Customer/view/adminhtml/layout/customer_group_index.xml
@@ -26,7 +26,7 @@
                                 </item>
                             </argument>
                         </arguments>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="time">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.group.grid.columnSet.time" as="time">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">ID</argument>
                                 <argument name="id" xsi:type="string">id</argument>
@@ -35,13 +35,13 @@
                                 <argument name="header_css_class" xsi:type="string">col-id</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="type">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.group.grid.columnSet.type" as="type">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Group</argument>
                                 <argument name="index" xsi:type="string">code</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="class_name">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.group.grid.columnSet.class_name" as="class_name">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Tax Class</argument>
                                 <argument name="index" xsi:type="string">tax_class_name</argument>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -9,7 +9,7 @@
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="sidebar.main">
-            <block class="Magento\Framework\View\Element\Template" template="Magento_Theme::html/collapsible.phtml" before="-">
+            <block class="Magento\Framework\View\Element\Template" name="sidebar.main.account_nav" template="Magento_Theme::html/collapsible.phtml" before="-">
                 <arguments>
                     <argument name="block_css" xsi:type="string">account-nav</argument>
                 </arguments>

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\Downloadable\Block\Checkout\Cart\Item\Renderer" as="downloadable" template="Magento_Checkout::cart/item/default.phtml">
+            <block class="Magento\Downloadable\Block\Checkout\Cart\Item\Renderer" name="checkout.cart.item.renderers.downloadable" as="downloadable" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.downloadable.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.downloadable.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.downloadable.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/Email/view/adminhtml/layout/adminhtml_email_template_grid_block.xml
+++ b/app/code/Magento/Email/view/adminhtml/layout/adminhtml_email_template_grid_block.xml
@@ -28,7 +28,7 @@
                         </argument>
                         <argument name="empty_text" xsi:type="string" translate="true">No Templates Found</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="template_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.template_id" as="template_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">template_id</argument>
@@ -36,13 +36,13 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="code">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.code" as="code">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Template</argument>
                             <argument name="index" xsi:type="string">template_code</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="added_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.added_at" as="added_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Added</argument>
                             <argument name="index" xsi:type="string">added_at</argument>
@@ -52,7 +52,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="modified_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.modified_at" as="modified_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Updated</argument>
                             <argument name="index" xsi:type="string">modified_at</argument>
@@ -62,13 +62,13 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="subject">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.subject" as="subject">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Subject</argument>
                             <argument name="index" xsi:type="string">template_subject</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="type">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.type" as="type">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Template Type</argument>
                             <argument name="index" xsi:type="string">template_type</argument>
@@ -76,7 +76,7 @@
                             <argument name="renderer" xsi:type="string">Magento\Email\Block\Adminhtml\Template\Grid\Renderer\Type</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.email.template.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>
                             <argument name="index" xsi:type="string">template_id</argument>

--- a/app/code/Magento/GroupedProduct/view/adminhtml/layout/catalog_product_new.xml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/layout/catalog_product_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Framework\View\Element\Template" template="Magento_GroupedProduct::product/stock/disabler.phtml"/>
+            <block class="Magento\Framework\View\Element\Template" name="js.grouped_product_stock_disabler" template="Magento_GroupedProduct::product/stock/disabler.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/adminhtml/layout/groupedproduct_popup_grid.xml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/layout/groupedproduct_popup_grid.xml
@@ -24,7 +24,7 @@
                     <arguments>
                         <argument name="id" xsi:type="string">grouped_grid_popup</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="entity_ids">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="catalog.product.edit.tab.super.group.popup.columnSet.entity_ids" as="entity_ids">
                         <arguments>
                             <argument name="type" xsi:type="string">skip-list</argument>
                             <argument name="renderer" xsi:type="string">Magento\Backend\Block\Widget\Grid\Column\Renderer\Checkbox</argument>
@@ -32,13 +32,13 @@
                             <argument name="index" xsi:type="string">entity_id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="entity_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="catalog.product.edit.tab.super.group.popup.columnSet.entity_id" as="entity_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">entity_id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="catalog.product.edit.tab.super.group.popup.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Name</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -47,7 +47,7 @@
                             <argument name="escape" xsi:type="string">1</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sku">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="catalog.product.edit.tab.super.group.popup.columnSet.sku" as="sku">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">SKU</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -55,7 +55,7 @@
                             <argument name="escape" xsi:type="string">1</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="price">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="catalog.product.edit.tab.super.group.popup.columnSet.price" as="price">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Price</argument>
                             <argument name="type" xsi:type="string">currency</argument>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/sales_guest_invoice.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/sales_guest_invoice.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" as="grouped" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Order\Item\Renderer\Grouped" name="sales.order.invoice.renderers.grouped" as="grouped" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_history_grid_block.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_history_grid_block.xml
@@ -16,7 +16,7 @@
                     <argument name="default_dir" xsi:type="string">desc</argument>
                 </arguments>
                 <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="import.history.grid.columnSet">
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="history_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.history_id" as="history_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="sortable" xsi:type="string">true</argument>
@@ -25,7 +25,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="started_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.started_at" as="started_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Start Date&amp;Time</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -33,7 +33,7 @@
                             <argument name="gmtoffset" xsi:type="boolean">true</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="username">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.username" as="username">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">User</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -43,7 +43,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="imported_file">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.imported_file" as="imported_file">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Imported File</argument>
                             <argument name="index" xsi:type="string">type</argument>
@@ -54,7 +54,7 @@
                             <argument name="renderer" xsi:type="string">Magento\ImportExport\Block\Adminhtml\Grid\Column\Renderer\Download</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="error_file">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.error_file" as="error_file">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Error File</argument>
                             <argument name="index" xsi:type="string">type</argument>
@@ -66,7 +66,7 @@
                         </arguments>
                     </block>
 
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="execution_time">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.execution_time" as="execution_time">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Execution Time</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -74,7 +74,7 @@
                             <argument name="filter" xsi:type="string">0</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="summary">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="import.history.grid.columnSet.summary" as="summary">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Summary</argument>
                             <argument name="type" xsi:type="string">text</argument>

--- a/app/code/Magento/Indexer/view/adminhtml/layout/indexer_indexer_list_grid.xml
+++ b/app/code/Magento/Indexer/view/adminhtml/layout/indexer_indexer_list_grid.xml
@@ -38,7 +38,7 @@
                         <argument name="id" xsi:type="string">indexer_grid</argument>
                         <argument name="filter_visibility" xsi:type="string">0</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="indexer_title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.indexer.grid.columnSet.indexer_title" as="indexer_title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Indexer</argument>
                             <argument name="width" xsi:type="string">180</argument>
@@ -49,7 +49,7 @@
                             <argument name="translate" xsi:type="boolean">true</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="indexer_description">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.indexer.grid.columnSet.indexer_description" as="indexer_description">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Description</argument>
                             <argument name="index" xsi:type="string">description</argument>
@@ -58,7 +58,7 @@
                             <argument name="translate" xsi:type="boolean">true</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="indexer_mode">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.indexer.grid.columnSet.indexer_mode" as="indexer_mode">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Mode</argument>
                             <argument name="index" xsi:type="string">is_scheduled</argument>
@@ -67,7 +67,7 @@
                             <argument name="column_css_class" xsi:type="string">indexer-mode</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="indexer_status">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.indexer.grid.columnSet.indexer_status" as="indexer_status">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="index" xsi:type="string">status</argument>
@@ -76,7 +76,7 @@
                             <argument name="column_css_class" xsi:type="string">indexer-status</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="indexer_updated">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.indexer.grid.columnSet.indexer_updated" as="indexer_updated">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Updated</argument>
                             <argument name="index" xsi:type="string">updated</argument>

--- a/app/code/Magento/Integration/view/adminhtml/layout/adminhtml_integration_grid_block.xml
+++ b/app/code/Magento/Integration/view/adminhtml/layout/adminhtml_integration_grid_block.xml
@@ -28,7 +28,7 @@
                         </argument>
                         <argument name="empty_text" xsi:type="string" translate="true">We couldn't find any records.</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="integration.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Name</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -38,7 +38,7 @@
                             <argument name="escape" xsi:type="string">1</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="status">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="integration.grid.columnSet.status" as="status">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="type" xsi:type="string">options</argument>
@@ -47,7 +47,7 @@
                             <argument name="id" xsi:type="string">status</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="activate">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="integration.grid.columnSet.activate" as="activate">
                         <arguments>
                             <argument name="renderer" xsi:type="string">Magento\Integration\Block\Adminhtml\Widget\Grid\Column\Renderer\Link\Activate</argument>
                             <argument name="index" xsi:type="string">activate</argument>
@@ -56,7 +56,7 @@
                             <argument name="filter" xsi:type="string">0</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="edit">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="integration.grid.columnSet.edit" as="edit">
                         <arguments>
                             <argument name="renderer" xsi:type="string">Magento\Integration\Block\Adminhtml\Widget\Grid\Column\Renderer\Button\Edit</argument>
                             <argument name="index" xsi:type="string">edit</argument>
@@ -65,7 +65,7 @@
                             <argument name="filter" xsi:type="string">0</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="delete">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="integration.grid.columnSet.delete" as="delete">
                         <arguments>
                             <argument name="renderer" xsi:type="string">Magento\Integration\Block\Adminhtml\Widget\Grid\Column\Renderer\Button\Delete</argument>
                             <argument name="class" xsi:type="string">action delete</argument>

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_problem_block.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_problem_block.xml
@@ -21,7 +21,7 @@
                         <argument name="id" xsi:type="string">problemGrid</argument>
                         <argument name="empty_text" xsi:type="string" translate="true">We found no problems.</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="checkbox">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.checkbox" as="checkbox">
                         <arguments>
                             <argument name="sortable" xsi:type="string">0</argument>
                             <argument name="filter" xsi:type="string">Magento\Newsletter\Block\Adminhtml\Problem\Grid\Filter\Checkbox</argument>
@@ -30,7 +30,7 @@
                             <argument name="column_css_class" xsi:type="string">col-select</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="problem_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.problem_id" as="problem_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">problem_id</argument>
@@ -38,7 +38,7 @@
                             <argument name="column_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="subscriber">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.subscriber" as="subscriber">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Subscriber</argument>
                             <argument name="format" xsi:type="string">#$subscriber_id $customer_name ($subscriber_email)</argument>
@@ -47,7 +47,7 @@
                             <argument name="column_css_class" xsi:type="string">col-subscriber col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="queue_start">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.queue_start" as="queue_start">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Queue Start Date</argument>
                             <argument name="index" xsi:type="string">queue_start_at</argument>
@@ -57,7 +57,7 @@
                             <argument name="column_css_class" xsi:type="string">col-start col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="queue">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.queue" as="queue">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Queue Subject</argument>
                             <argument name="index" xsi:type="string">template_subject</argument>
@@ -65,7 +65,7 @@
                             <argument name="column_css_class" xsi:type="string">col-subject</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="problem_code">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.problem_code" as="problem_code">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Error Code</argument>
                             <argument name="index" xsi:type="string">problem_error_code</argument>
@@ -74,7 +74,7 @@
                             <argument name="column_css_class" xsi:type="string">col-error-code</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="problem_text">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.problem.grid.columnSet.problem_text" as="problem_text">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Error Text</argument>
                             <argument name="index" xsi:type="string">problem_error_text</argument>

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_queue_grid_block.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_queue_grid_block.xml
@@ -26,7 +26,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="queue_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.queue_id" as="queue_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">queue_id</argument>
@@ -34,7 +34,7 @@
                             <argument name="column_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="start_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.start_at" as="start_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Queue Start</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -45,7 +45,7 @@
                             <argument name="column_css_class" xsi:type="string">col-start</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="finish_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.finish_at" as="finish_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Queue End</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -56,7 +56,7 @@
                             <argument name="column_css_class" xsi:type="string">col-finish</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="newsletter_subject">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.newsletter_subject" as="newsletter_subject">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Subject</argument>
                             <argument name="index" xsi:type="string">newsletter_subject</argument>
@@ -64,7 +64,7 @@
                             <argument name="column_css_class" xsi:type="string">col-subject</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="status">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.status" as="status">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="index" xsi:type="string">queue_status</argument>
@@ -74,7 +74,7 @@
                             <argument name="column_css_class" xsi:type="string">col-status</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="subscribers_sent">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.subscribers_sent" as="subscribers_sent">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Processed</argument>
                             <argument name="type" xsi:type="string">number</argument>
@@ -83,7 +83,7 @@
                             <argument name="column_css_class" xsi:type="string">col-processed</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="subscribers_total">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.subscribers_total" as="subscribers_total">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Recipients</argument>
                             <argument name="type" xsi:type="string">number</argument>
@@ -92,7 +92,7 @@
                             <argument name="column_css_class" xsi:type="string">col-recipients</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newsletter.queue.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>
                             <argument name="filter" xsi:type="string">0</argument>

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_subscriber_block.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_subscriber_block.xml
@@ -51,7 +51,7 @@
                     <arguments>
                         <argument name="id" xsi:type="string">problemGrid</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="subscriber_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.subscriber.grid.columnSet.subscriber_id" as="subscriber_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">subscriber_id</argument>
@@ -59,7 +59,7 @@
                             <argument name="column_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="email">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.subscriber.grid.columnSet.email" as="email">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Email</argument>
                             <argument name="index" xsi:type="string">subscriber_email</argument>
@@ -67,7 +67,7 @@
                             <argument name="column_css_class" xsi:type="string">ccol-email</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="type">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.subscriber.grid.columnSet.type" as="type">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Type</argument>
                             <argument name="index" xsi:type="string">type</argument>
@@ -86,7 +86,7 @@
                             <argument name="column_css_class" xsi:type="string">col-type</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="firstname">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.subscriber.grid.columnSet.firstname" as="firstname">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Customer First Name</argument>
                             <argument name="index" xsi:type="string">firstname</argument>
@@ -95,7 +95,7 @@
                             <argument name="column_css_class" xsi:type="string">col-first-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="lastname">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.subscriber.grid.columnSet.lastname" as="lastname">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Customer Last Name</argument>
                             <argument name="index" xsi:type="string">lastname</argument>
@@ -104,7 +104,7 @@
                             <argument name="column_css_class" xsi:type="string">col-last-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="status">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.newslettrer.subscriber.grid.columnSet.status" as="status">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="index" xsi:type="string">subscriber_status</argument>
@@ -131,7 +131,7 @@
                             <argument name="column_css_class" xsi:type="string">col-status</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="website">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.newslettrer.subscriber.grid.columnSet.website" as="website">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Web Site</argument>
                             <argument name="index" xsi:type="string">website_id</argument>
@@ -141,7 +141,7 @@
                             <argument name="column_css_class" xsi:type="string">col-website</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="group">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.newslettrer.subscriber.grid.columnSet.group" as="group">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store</argument>
                             <argument name="index" xsi:type="string">group_id</argument>
@@ -151,7 +151,7 @@
                             <argument name="column_css_class" xsi:type="string">col-store</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.newslettrer.subscriber.grid.columnSet.store" as="store">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store View</argument>
                             <argument name="index" xsi:type="string">store_id</argument>

--- a/app/code/Magento/PageCache/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/PageCache/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="js">
-            <block class="Magento\PageCache\Block\System\Config\Form\Field\Export" template="Magento_PageCache::page_cache_validation.phtml"/>
+            <block class="Magento\PageCache\Block\System\Config\Form\Field\Export" name="js.page_cache_validation" template="Magento_PageCache::page_cache_validation.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_block.xml
+++ b/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_block.xml
@@ -27,7 +27,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="report_date">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.report_date" as="report_date">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Report Date</argument>
                             <argument name="index" xsi:type="string">report_date</argument>
@@ -36,7 +36,7 @@
                             <argument name="column_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="account_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.account_id" as="account_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Merchant Account</argument>
                             <argument name="index" xsi:type="string">account_id</argument>
@@ -44,7 +44,7 @@
                             <argument name="column_css_class" xsi:type="string">col-merchant</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="transaction_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.transaction_id" as="transaction_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Transaction ID</argument>
                             <argument name="index" xsi:type="string">transaction_id</argument>
@@ -52,7 +52,7 @@
                             <argument name="column_css_class" xsi:type="string">col-transaction</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="invoice_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.invoice_id" as="invoice_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Invoice ID</argument>
                             <argument name="index" xsi:type="string">invoice_id</argument>
@@ -60,7 +60,7 @@
                             <argument name="column_css_class" xsi:type="string">col-invoice</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="paypal_reference_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.paypal_reference_id" as="paypal_reference_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">PayPal Reference ID</argument>
                             <argument name="index" xsi:type="string">paypal_reference_id</argument>
@@ -68,7 +68,7 @@
                             <argument name="column_css_class" xsi:type="string">col-reference</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="transaction_event_code">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.transaction_event_code" as="transaction_event_code">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Event</argument>
                             <argument name="index" xsi:type="string">transaction_event_code</argument>
@@ -78,7 +78,7 @@
                             <argument name="column_css_class" xsi:type="string">ol-event</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="transaction_initiation_date">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.transaction_initiation_date" as="transaction_initiation_date">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Start Date</argument>
                             <argument name="index" xsi:type="string">transaction_initiation_date</argument>
@@ -87,7 +87,7 @@
                             <argument name="column_css_class" xsi:type="string">col-initiation</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="transaction_completion_date">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.transaction_completion_date" as="transaction_completion_date">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Finish Date</argument>
                             <argument name="index" xsi:type="string">transaction_completion_date</argument>
@@ -96,7 +96,7 @@
                             <argument name="column_css_class" xsi:type="string">col-completion</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="gross_transaction_amount">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.gross_transaction_amount" as="gross_transaction_amount">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Gross Amount</argument>
                             <argument name="index" xsi:type="string">gross_transaction_amount</argument>
@@ -106,7 +106,7 @@
                             <argument name="column_css_class" xsi:type="string">col-amount</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="fee_amount">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="paypal.report.grid.columnSet.fee_amount" as="fee_amount">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Fee Amount</argument>
                             <argument name="index" xsi:type="string">fee_amount</argument>

--- a/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -11,7 +11,7 @@
     </head>
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Paypal\Block\Adminhtml\System\Config\ResolutionRules" template="Magento_Paypal::system/config/rules.phtml"/>
+            <block class="Magento\Paypal\Block\Adminhtml\System\Config\ResolutionRules" name="js.rules" template="Magento_Paypal::system/config/rules.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_customer_accounts_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_customer_accounts_grid.xml
@@ -31,7 +31,7 @@
                 <argument name="id" xsi:type="string">gridAccounts</argument>
                 <argument name="count_totals" xsi:type="string">1</argument>
             </arguments>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="accounts">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.accounts" as="accounts">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">New Accounts</argument>
                     <argument name="index" xsi:type="string">accounts</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_customer_orders_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_customer_orders_grid.xml
@@ -30,7 +30,7 @@
             <arguments>
                 <argument name="count_totals" xsi:type="string">1</argument>
             </arguments>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.name" as="name">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">Customer</argument>
                     <argument name="sortable" xsi:type="string">0</argument>
@@ -41,7 +41,7 @@
                     <argument name="header_css_class" xsi:type="string">col-name</argument>
                 </arguments>
             </block>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="orders_count">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.orders_count" as="orders_count">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">Orders</argument>
                     <argument name="sortable" xsi:type="string">0</argument>
@@ -53,7 +53,7 @@
                     <argument name="header_css_class" xsi:type="string">col-qty</argument>
                 </arguments>
             </block>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="orders_avg_amount">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.orders_avg_amount" as="orders_avg_amount">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">Average</argument>
                     <argument name="sortable" xsi:type="string">0</argument>
@@ -65,7 +65,7 @@
                     <argument name="header_css_class" xsi:type="string">col-average</argument>
                 </arguments>
             </block>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="orders_sum_amount">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.orders_sum_amount" as="orders_sum_amount">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">Total</argument>
                     <argument name="sortable" xsi:type="string">0</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_grid.xml
@@ -46,7 +46,7 @@
                         <argument name="empty_text" xsi:type="string" translate="true">We can't find records for this period.</argument>
                         <argument name="empty_cell_label" xsi:type="string" translate="true">We can't find records for this period.</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="period">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.period" as="period">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Interval</argument>
                             <argument name="sortable" xsi:type="string">0</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_lowstock_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_lowstock_grid.xml
@@ -29,7 +29,7 @@
                     </arguments>
                 </block>
                 <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="adminhtml.block.report.product.lowstock.grid.columnSet">
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.product.lowstock.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Product</argument>
                             <argument name="sortable" xsi:type="string">0</argument>
@@ -38,7 +38,7 @@
                             <argument name="column_css_class" xsi:type="string">col-product</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sku">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.product.lowstock.grid.columnSet.sku" as="sku">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">SKU</argument>
                             <argument name="sortable" xsi:type="string">0</argument>
@@ -47,7 +47,7 @@
                             <argument name="column_css_class" xsi:type="string">col-sku</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="qty">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.product.lowstock.grid.columnSet.qty" as="qty">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Stock Quantity</argument>
                             <argument name="filter" xsi:type="string">Magento\Backend\Block\Widget\Grid\Column\Filter\Range</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_sold_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_sold_grid.xml
@@ -31,7 +31,7 @@
                 <argument name="id" xsi:type="string">report_product_sold</argument>
                 <argument name="count_totals" xsi:type="string">1</argument>
             </arguments>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.name" as="name">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">Product</argument>
                     <argument name="type" xsi:type="string">text</argument>
@@ -41,7 +41,7 @@
                     <argument name="header_css_class" xsi:type="string">col-product</argument>
                 </arguments>
             </block>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="sku">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.sku" as="sku">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">SKU</argument>
                     <argument name="type" xsi:type="string">text</argument>
@@ -51,7 +51,7 @@
                     <argument name="header_css_class" xsi:type="string">col-sku</argument>
                 </arguments>
             </block>
-            <block class="Magento\Backend\Block\Widget\Grid\Column" as="ordered_qty">
+            <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.grid.columnSet.ordered_qty" as="ordered_qty">
                 <arguments>
                     <argument name="header" xsi:type="string" translate="true">Ordered Quantity</argument>
                     <argument name="total" xsi:type="string">sum</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_review_customer_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_review_customer_grid.xml
@@ -40,7 +40,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="customer_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.customer.grid.columnSet.customer_name" as="customer_name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Customer</argument>
                             <argument name="index" xsi:type="string">customer_name</argument>
@@ -51,7 +51,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="review_cnt">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.customer.grid.columnSet.review_cnt" as="review_cnt">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Reviews</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -60,7 +60,7 @@
                             <argument name="header_css_class" xsi:type="string">col-qty</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.customer.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>
                             <argument name="filter" xsi:type="string">0</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_review_product_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_review_product_grid.xml
@@ -40,7 +40,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="entity_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.entity_id" as="entity_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">entity_id</argument>
@@ -50,7 +50,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Product</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -59,7 +59,7 @@
                             <argument name="header_css_class" xsi:type="string">col-product</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="review_cnt">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.review_cnt" as="review_cnt">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Reviews</argument>
                             <argument name="id" xsi:type="string">review_cnt</argument>
@@ -68,7 +68,7 @@
                             <argument name="header_css_class" xsi:type="string">col-qty</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="avg_rating">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.avg_rating" as="avg_rating">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Average</argument>
                             <argument name="id" xsi:type="string">avg_rating</argument>
@@ -77,7 +77,7 @@
                             <argument name="header_css_class" xsi:type="string">col-rating</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="avg_rating_approved">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.avg_rating_approved" as="avg_rating_approved">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Average (Approved)</argument>
                             <argument name="id" xsi:type="string">avg_rating_approved</argument>
@@ -86,7 +86,7 @@
                             <argument name="header_css_class" xsi:type="string">col-avg-rating</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="created_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.created_at" as="created_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Last Review</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -96,7 +96,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.report.review.product.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>
                             <argument name="align" xsi:type="string">center</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_statistics_index.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_statistics_index.xml
@@ -42,7 +42,7 @@
                             <argument name="filter_visibility" xsi:type="string">0</argument>
                             <argument name="id" xsi:type="string">gridRefreshStatistics</argument>
                         </arguments>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="report">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.reportrefresh.statistics.columnSet.report" as="report">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Report</argument>
                                 <argument name="type" xsi:type="string">string</argument>
@@ -53,7 +53,7 @@
                                 <argument name="header_css_class" xsi:type="string">col-report</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="comment">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.reportrefresh.statistics.columnSet.comment" as="comment">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Description</argument>
                                 <argument name="type" xsi:type="string">string</argument>
@@ -64,7 +64,7 @@
                                 <argument name="header_css_class" xsi:type="string">col-description</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="updated_at">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.reportrefresh.statistics.columnSet.updated_at" as="updated_at">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Updated</argument>
                                 <argument name="type" xsi:type="string">datetime</argument>

--- a/app/code/Magento/Review/view/adminhtml/layout/rating_block.xml
+++ b/app/code/Magento/Review/view/adminhtml/layout/rating_block.xml
@@ -25,7 +25,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="rating_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.rating.grid.columnSet.rating_id" as="rating_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">rating_id</argument>
@@ -33,19 +33,19 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="rating_code">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.rating.grid.columnSet.rating_code" as="rating_code">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Rating</argument>
                             <argument name="index" xsi:type="string">rating_code</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="position">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.rating.grid.columnSet.position" as="position">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Sort Order</argument>
                             <argument name="index" xsi:type="string">position</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="is_active">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.rating.grid.columnSet.is_active" as="is_active">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Is Active</argument>
                             <argument name="index" xsi:type="string">is_active</argument>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_customer_block.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_customer_block.xml
@@ -27,26 +27,26 @@
                             <item name="generatorClass" xsi:type="string">Magento\Backend\Model\Widget\Grid\Row\UrlGeneratorId</item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="entity_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.entity_id" as="entity_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">entity_id</argument>
                             <argument name="align" xsi:type="string">right</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Name</argument>
                             <argument name="index" xsi:type="string">name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="email">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.email" as="email">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Email</argument>
                             <argument name="index" xsi:type="string">email</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="Telephone">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.telephone" as="Telephone">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Phone</argument>
                             <argument name="index" xsi:type="string">billing_telephone</argument>
@@ -54,26 +54,26 @@
                             <argument name="header_css_class" xsi:type="string">col-phone</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="billing_postcode">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.billing_postcode" as="billing_postcode">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ZIP/Post Code</argument>
                             <argument name="index" xsi:type="string">billing_postcode</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="billing_country_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.billing_country_id" as="billing_country_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Country</argument>
                             <argument name="index" xsi:type="string">billing_country_id</argument>
                             <argument name="type" xsi:type="string">country</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="billing_regione">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.billing_regione" as="billing_regione">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">State/Province</argument>
                             <argument name="index" xsi:type="string">billing_regione</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="store_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.store_name" as="store_name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Signed-up Point</argument>
                             <argument name="index" xsi:type="string">store_name</argument>
@@ -81,7 +81,7 @@
                         </arguments>
                     </block>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="website_name">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.website_name" as="website_name">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Website</argument>
                         <argument name="index" xsi:type="string">website_name</argument>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_index.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_index.xml
@@ -21,7 +21,7 @@
         </referenceBlock>
         <referenceContainer name="after.body.start">
             <block class="Magento\Backend\Block\Template" name="optional_zip_countries" as="optional_zip_countries" template="Magento_Directory::js/optional_zip_countries.phtml"/>
-            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Configure" template="Magento_Catalog::catalog/product/composite/configure.phtml"/>
+            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Configure" name="after.body.start.product_composite_configure" template="Magento_Catalog::catalog/product/composite/configure.phtml"/>
         </referenceContainer>
         <referenceContainer name="js">
             <block class="Magento\Backend\Block\Template" template="Magento_Sales::order/create/js.phtml" name="create"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_grid_block.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_grid_block.xml
@@ -30,7 +30,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="increment_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_creditmemo.grid.columnSet.increment_id" as="increment_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Credit Memo</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -40,7 +40,7 @@
                             <argument name="column_css_class" xsi:type="string">col-memo</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="billing_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_creditmemo.grid.columnSet.billing_name" as="billing_name">
                         <arguments>
                             <argument name="id" xsi:type="string">billing_name</argument>
                             <argument name="header" xsi:type="string" translate="true">Bill-to Name</argument>
@@ -49,7 +49,7 @@
                             <argument name="column_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="created_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_creditmemo.grid.columnSet.created_at" as="created_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Created</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -59,7 +59,7 @@
                             <argument name="column_css_class" xsi:type="string">col-period</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="state">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_creditmemo.grid.columnSet.state" as="state">
                         <arguments>
                             <argument name="id" xsi:type="string">state</argument>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
@@ -70,7 +70,7 @@
                             <argument name="column_css_class" xsi:type="string">col-status</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="base_grand_total">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_creditmemo.grid.columnSet.base_grand_total" as="base_grand_total">
                         <arguments>
                             <argument name="id" xsi:type="string">base_grand_total</argument>
                             <argument name="header" xsi:type="string" translate="true">Refunded</argument>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -18,7 +18,7 @@
                     </block>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items" name="order_items" template="Magento_Sales::order/creditmemo/create/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/create/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="order_items.default" as="default" template="Magento_Sales::order/creditmemo/create/items/renderer/default.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -9,7 +9,7 @@
     <update handle="sales_order_item_price"/>
     <body>
         <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items" name="order_items" template="Magento_Sales::order/creditmemo/create/items.phtml">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/create/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="order_items.default" as="default" template="Magento_Sales::order/creditmemo/create/items/renderer/default.phtml"/>
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
             <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -17,7 +17,7 @@
                     </block>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Items" name="creditmemo_items" template="Magento_Sales::order/creditmemo/view/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/view/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="creditmemo_items.default" as="default" template="Magento_Sales::order/creditmemo/view/items/renderer/default.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_grid_block.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_grid_block.xml
@@ -30,7 +30,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="increment_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_invoice.grid.columnSet.increment_id" as="increment_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Invoice</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -40,7 +40,7 @@
                             <argument name="column_css_class" xsi:type="string">col-invoice-number</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="billing_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_invoice.grid.columnSet.billing_name" as="billing_name">
                         <arguments>
                             <argument name="id" xsi:type="string">billing_name</argument>
                             <argument name="header" xsi:type="string" translate="true">Bill-to Name</argument>
@@ -49,7 +49,7 @@
                             <argument name="column_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="created_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_invoice.grid.columnSet.created_at" as="created_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Invoice Date</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -59,7 +59,7 @@
                             <argument name="column_css_class" xsi:type="string">col-period</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="state">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_invoice.grid.columnSet.state" as="state">
                         <arguments>
                             <argument name="id" xsi:type="string">state</argument>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
@@ -70,7 +70,7 @@
                             <argument name="column_css_class" xsi:type="string">col-status</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="grand_total">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_invoice.grid.columnSet.grand_total" as="grand_total">
                         <arguments>
                             <argument name="id" xsi:type="string">grand_total</argument>
                             <argument name="header" xsi:type="string" translate="true">Amount</argument>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -21,7 +21,7 @@
                     </block>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items" name="order_items" template="Magento_Sales::order/invoice/create/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/create/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="order_items.default" as="default" template="Magento_Sales::order/invoice/create/items/renderer/default.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -9,7 +9,7 @@
     <update handle="sales_order_item_price"/>
     <body>
         <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items" name="order_items" template="Magento_Sales::order/invoice/create/items.phtml">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/create/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="order_items.default" as="default" template="Magento_Sales::order/invoice/create/items/renderer/default.phtml"/>
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
             <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -18,7 +18,7 @@
                     </block>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View\Items" name="invoice_items" template="Magento_Sales::order/invoice/view/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/view/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" name="invoice_items.default" as="default" template="Magento_Sales::order/invoice/view/items/renderer/default.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_shipment_grid_block.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_shipment_grid_block.xml
@@ -30,7 +30,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="real_shipment_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_shipment.grid.columnSet.real_shipment_id" as="real_shipment_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Shipment</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -40,7 +40,7 @@
                             <argument name="column_css_class" xsi:type="string">col-memo</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="shipping_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_shipment.grid.columnSet.shipping_name" as="shipping_name">
                         <arguments>
                             <argument name="id" xsi:type="string">shipping_name</argument>
                             <argument name="header" xsi:type="string" translate="true">Ship-to Name</argument>
@@ -49,7 +49,7 @@
                             <argument name="column_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="created_at">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_shipment.grid.columnSet.created_at" as="created_at">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Ship Date</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -59,7 +59,7 @@
                             <argument name="column_css_class" xsi:type="string">col-period</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="total_qty">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales.order_shipment.grid.columnSet.total_qty" as="total_qty">
                         <arguments>
                             <argument name="id" xsi:type="string">total_qty</argument>
                             <argument name="header" xsi:type="string" translate="true">Total Quantity</argument>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_status_index.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_status_index.xml
@@ -27,13 +27,13 @@
                             </argument>
                             <argument name="filter_visibility" xsi:type="string">1</argument>
                         </arguments>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="label">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales_order_status.grid.columnSet.label" as="label">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Status</argument>
                                 <argument name="index" xsi:type="string">label</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="status">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales_order_status.grid.columnSet.status" as="status">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Status Code</argument>
                                 <argument name="index" xsi:type="string">status</argument>
@@ -42,7 +42,7 @@
                                 <argument name="width" xsi:type="string">200</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="is_default">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales_order_status.grid.columnSet.is_default" as="is_default">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Default Status</argument>
                                 <argument name="index" xsi:type="string">is_default</argument>
@@ -62,7 +62,7 @@
                                 </argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="visible_on_front">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="sales_order_status.grid.columnSet.visible_on_front" as="visible_on_front">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Visible On Storefront</argument>
                                 <argument name="index" xsi:type="string">visible_on_front</argument>
@@ -82,14 +82,14 @@
                                 </argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Sales\Block\Status\Grid\Column\State" as="state">
+                        <block class="Magento\Sales\Block\Status\Grid\Column\State" name="sales_order_status.grid.columnSet.state" as="state">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">State Code and Title</argument>
                                 <argument name="index" xsi:type="string">state</argument>
                                 <argument name="type" xsi:type="string">text</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Sales\Block\Status\Grid\Column\Unassign" as="unassign">
+                        <block class="Magento\Sales\Block\Status\Grid\Column\Unassign" name="sales_order_status.grid.columnSet.unassign" as="unassign">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Action</argument>
                                 <argument name="index" xsi:type="string">unassign</argument>

--- a/app/code/Magento/SalesRule/view/adminhtml/layout/sales_rule_promo_quote_index.xml
+++ b/app/code/Magento/SalesRule/view/adminhtml/layout/sales_rule_promo_quote_index.xml
@@ -26,7 +26,7 @@
                                 </item>
                             </argument>
                         </arguments>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="rule_id">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.rule_id" as="rule_id">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">ID</argument>
                                 <argument name="index" xsi:type="string">rule_id</argument>
@@ -34,19 +34,19 @@
                                 <argument name="header_css_class" xsi:type="string">col-id</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.name" as="name">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Rule</argument>
                                 <argument name="index" xsi:type="string">name</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="coupon_code">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.coupon_code" as="coupon_code">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Coupon Code</argument>
                                 <argument name="index" xsi:type="string">code</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="from_date">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.from_date" as="from_date">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Start</argument>
                                 <argument name="type" xsi:type="string">date</argument>
@@ -56,7 +56,7 @@
                                 <argument name="header_css_class" xsi:type="string">col-date</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="to_date">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.to_date" as="to_date">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">End</argument>
                                 <argument name="type" xsi:type="string">date</argument>
@@ -67,7 +67,7 @@
                                 <argument name="header_css_class" xsi:type="string">col-date</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="is_active">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.is_active" as="is_active">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Status</argument>
                                 <argument name="index" xsi:type="string">is_active</argument>
@@ -84,7 +84,7 @@
                                 </argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="rule_website">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.promo.quote.grid.columnSet.rule_website" as="rule_website">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Web Site</argument>
                                 <argument name="index" xsi:type="string">website_ids</argument>
@@ -93,7 +93,7 @@
                                 <argument name="options" xsi:type="options" model="Magento\Config\Model\Config\Source\Website\OptionHash"/>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="sort_order">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.promo.quote.grid.columnSet.sort_order" as="sort_order">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Priority</argument>
                                 <argument name="index" xsi:type="string">sort_order</argument>

--- a/app/code/Magento/Search/view/adminhtml/layout/adminhtml_dashboard_index.xml
+++ b/app/code/Magento/Search/view/adminhtml/layout/adminhtml_dashboard_index.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="dashboard">
-          <block class="Magento\Search\Block\Adminhtml\Dashboard\Last" as="lastSearches" />
-          <block class="Magento\Search\Block\Adminhtml\Dashboard\Top" as="topSearches" />
+          <block class="Magento\Search\Block\Adminhtml\Dashboard\Last" name="dashboard.lastSearches" as="lastSearches" />
+          <block class="Magento\Search\Block\Adminhtml\Dashboard\Top" name="dashboard.topSearches" as="topSearches" />
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Search/view/adminhtml/layout/search_term_block.xml
+++ b/app/code/Magento/Search/view/adminhtml/layout/search_term_block.xml
@@ -38,7 +38,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="query_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.query_id" as="query_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="filter" xsi:type="string">0</argument>
@@ -48,7 +48,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="query_text">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.query_text" as="query_text">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Search Query</argument>
                             <argument name="index" xsi:type="string">query_text</argument>
@@ -56,7 +56,7 @@
                             <argument name="header_css_class" xsi:type="string">col-query</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.report.search.grid.columnSet.store_id" as="store_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store</argument>
                             <argument name="index" xsi:type="string">store_id</argument>
@@ -68,7 +68,7 @@
                             <argument name="header_css_class" xsi:type="string">col-store</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="num_results">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.num_results" as="num_results">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Results</argument>
                             <argument name="type" xsi:type="string">number</argument>
@@ -77,7 +77,7 @@
                             <argument name="header_css_class" xsi:type="string">col-results</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="popularity">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.popularity" as="popularity">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Hits</argument>
                             <argument name="type" xsi:type="string">number</argument>

--- a/app/code/Magento/Search/view/adminhtml/layout/search_term_grid_block.xml
+++ b/app/code/Magento/Search/view/adminhtml/layout/search_term_grid_block.xml
@@ -39,13 +39,13 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="search_query">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.search.grid.columnSet.search_query" as="search_query">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Search Query</argument>
                             <argument name="index" xsi:type="string">query_text</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.catalog.search.grid.columnSet.store_id" as="store_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store</argument>
                             <argument name="type" xsi:type="string">store</argument>
@@ -55,27 +55,27 @@
                             <argument name="sortable" xsi:type="string">0</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="num_results">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.search.grid.columnSet.num_results" as="num_results">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Results</argument>
                             <argument name="index" xsi:type="string">num_results</argument>
                             <argument name="type" xsi:type="string">number</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="popularity">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.search.grid.columnSet.popularity" as="popularity">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Uses</argument>
                             <argument name="index" xsi:type="string">popularity</argument>
                             <argument name="type" xsi:type="string">number</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="redirect">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.search.grid.columnSet.redirect" as="redirect">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Redirect URL</argument>
                             <argument name="index" xsi:type="string">redirect</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="display_in_terms">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.search.grid.columnSet.display_in_terms" as="display_in_terms">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Suggested Terms</argument>
                             <argument name="sortable" xsi:type="string">1</argument>
@@ -93,7 +93,7 @@
                             </argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.catalog.search.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="type" xsi:type="string">action</argument>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>

--- a/app/code/Magento/Search/view/adminhtml/layout/search_term_report_block.xml
+++ b/app/code/Magento/Search/view/adminhtml/layout/search_term_report_block.xml
@@ -41,7 +41,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="query_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.query_id" as="query_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="filter" xsi:type="string">0</argument>
@@ -51,7 +51,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="query_text">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.query_text" as="query_text">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Search Query</argument>
                             <argument name="index" xsi:type="string">query_text</argument>
@@ -59,7 +59,7 @@
                             <argument name="header_css_class" xsi:type="string">col-query</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.report.search.grid.columnSet.store_id" as="store_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store</argument>
                             <argument name="index" xsi:type="string">store_id</argument>
@@ -71,7 +71,7 @@
                             <argument name="header_css_class" xsi:type="string">col-store</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="num_results">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.num_results" as="num_results">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Results</argument>
                             <argument name="type" xsi:type="string">number</argument>
@@ -80,7 +80,7 @@
                             <argument name="header_css_class" xsi:type="string">col-results</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="popularity">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.report.search.grid.columnSet.popularity" as="popularity">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Hits</argument>
                             <argument name="type" xsi:type="string">number</argument>

--- a/app/code/Magento/Sitemap/view/adminhtml/layout/adminhtml_sitemap_index_grid_block.xml
+++ b/app/code/Magento/Sitemap/view/adminhtml/layout/adminhtml_sitemap_index_grid_block.xml
@@ -24,7 +24,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sitemap_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.sitemap.container.grid.columnSet.sitemap_id" as="sitemap_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">sitemap_id</argument>
@@ -32,25 +32,25 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sitemap_filename">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.sitemap.container.grid.columnSet.sitemap_filename" as="sitemap_filename">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Filename</argument>
                             <argument name="index" xsi:type="string">sitemap_filename</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sitemap_path">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.sitemap.container.grid.columnSet.sitemap_path" as="sitemap_path">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Path</argument>
                             <argument name="index" xsi:type="string">sitemap_path</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="link">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.sitemap.container.grid.columnSet.link" as="link">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Link for Google</argument>
                             <argument name="renderer" xsi:type="string">Magento\Sitemap\Block\Adminhtml\Grid\Renderer\Link</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sitemap_time">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.sitemap.container.grid.columnSet.sitemap_time" as="sitemap_time">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Last Generated</argument>
                             <argument name="index" xsi:type="string">sitemap_time</argument>
@@ -59,7 +59,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.sitemap.container.grid.columnSet.store_id" as="store_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Store View</argument>
                             <argument name="type" xsi:type="string">store</argument>
@@ -68,7 +68,7 @@
                             <argument name="store_view" xsi:type="string">true</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.sitemap.container.grid.columnSet.action" as="action">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Action</argument>
                             <argument name="filter" xsi:type="string">0</argument>

--- a/app/code/Magento/Swatches/view/adminhtml/layout/catalog_product_attribute_edit.xml
+++ b/app/code/Magento/Swatches/view/adminhtml/layout/catalog_product_attribute_edit.xml
@@ -12,8 +12,8 @@
     </head>
     <body>
         <referenceContainer name="main">
-            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual" before="advanced" as="swatches_visual"/>
-            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text" before="advanced" as="swatches_text"/>
+            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual" before="advanced" name="main.swatches_visual" as="swatches_visual"/>
+            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text" before="advanced" name="main.swatches_text" as="swatches_text"/>
         </referenceContainer>
         <referenceBlock name="attribute_edit_js">
             <action method="setTemplate">

--- a/app/code/Magento/Swatches/view/adminhtml/layout/catalog_product_attribute_edit_popup.xml
+++ b/app/code/Magento/Swatches/view/adminhtml/layout/catalog_product_attribute_edit_popup.xml
@@ -12,8 +12,8 @@
     </head>
     <body>
         <referenceContainer name="form">
-            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual" before="advanced-options" as="swatches_visual"/>
-            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text" before="advanced-options" as="swatches_text"/>
+            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual" before="advanced-options" name="form.swatches_visual" as="swatches_visual"/>
+            <block class="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text" before="advanced-options" name="form.swatches_text" as="swatches_text"/>
         </referenceContainer>
         <referenceBlock name="attribute_edit_js">
             <action method="setTemplate">

--- a/app/code/Magento/Swatches/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Swatches/view/frontend/layout/catalog_category_view.xml
@@ -11,7 +11,7 @@
     </head>
     <body>
         <referenceBlock name="category.product.type.details.renderers">
-            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list" />
+            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" name="category.product.type.details.renderers.configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list" />
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Swatches/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/Swatches/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -11,7 +11,7 @@
     </head>
     <body>
         <referenceBlock name="category.product.type.details.renderers">
-            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list" />
+            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" name="category.product.type.details.renderers.configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list" />
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Swatches/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/Swatches/view/frontend/layout/catalogsearch_result_index.xml
@@ -11,7 +11,7 @@
     </head>
     <body>
         <referenceBlock name="category.product.type.details.renderers">
-            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list"/>
+            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" name="category.product.type.details.renderers.configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Tax/view/adminhtml/layout/tax_rule_block.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/tax_rule_block.xml
@@ -25,7 +25,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="code">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.code" as="code">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Name</argument>
                             <argument name="index" xsi:type="string">code</argument>
@@ -35,7 +35,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="customer_tax_classes">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.customer_tax_classes" as="customer_tax_classes">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Customer Tax Class</argument>
                             <argument name="sortable" xsi:type="string">0</argument>
@@ -46,7 +46,7 @@
                             <argument name="options" xsi:type="options" model="Magento\Tax\Model\TaxClass\Source\Customer"/>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="product_tax_classes">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.product_tax_classes" as="product_tax_classes">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Product Tax Class</argument>
                             <argument name="sortable" xsi:type="string">0</argument>
@@ -57,7 +57,7 @@
                             <argument name="options" xsi:type="options" model="Magento\Tax\Model\TaxClass\Source\Product"/>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="tax_rates_codes">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.tax_rates_codes" as="tax_rates_codes">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Tax Rate</argument>
                             <argument name="sortable" xsi:type="string">0</argument>
@@ -69,21 +69,21 @@
                             <argument name="renderer" xsi:type="string">Magento\Tax\Block\Grid\Renderer\Codes</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="priority">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.priority" as="priority">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Priority</argument>
                             <argument name="index" xsi:type="string">priority</argument>
                             <argument name="type" xsi:type="string">text</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="calculate_subtotal">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.calculate_subtotal" as="calculate_subtotal">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Subtotal Only</argument>
                             <argument name="index" xsi:type="string">calculate_subtotal</argument>
                             <argument name="type" xsi:type="string">text</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="position">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.tax.rule.columnSet.position" as="position">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Sort Order</argument>
                             <argument name="index" xsi:type="string">position</argument>

--- a/app/code/Magento/Tax/view/adminhtml/layout/tax_rule_edit.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/tax_rule_edit.xml
@@ -12,7 +12,7 @@
     </head>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Tax\Block\Adminhtml\Rule\Edit"/>
+            <block class="Magento\Tax\Block\Adminhtml\Rule\Edit" name="content.tax_rule_edit"/>
             <block class="Magento\Tax\Block\Adminhtml\Rule\Edit\Form" name="tax-rule-edit" template="Magento_Tax::rule/edit.phtml"/>
             <block class="Magento\Tax\Block\Adminhtml\Rate\Form" name="tax-rate-form" template="Magento_Tax::rule/rate/form.phtml"/>
         </referenceContainer>

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_block.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_block.xml
@@ -28,7 +28,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="theme_title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="theme.grid.columnSet.theme_title" as="theme_title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Theme Title</argument>
                             <argument name="index" xsi:type="string">theme_title</argument>
@@ -36,7 +36,7 @@
                             <argument name="column_css_class" xsi:type="string">theme-title</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="parent_theme_title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="theme.grid.columnSet.parent_theme_title" as="parent_theme_title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Parent Theme</argument>
                             <argument name="index" xsi:type="string">parent_theme_title</argument>
@@ -44,7 +44,7 @@
                             <argument name="column_css_class" xsi:type="string">parent-theme-title</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="theme_path">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="theme.grid.columnSet.theme_path" as="theme_path">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Theme Path</argument>
                             <argument name="index" xsi:type="string">theme_path</argument>

--- a/app/code/Magento/Ups/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/Ups/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Ups\Block\Backend\System\CarrierConfig" template="Magento_Ups::system/shipping/carrier_config.phtml"/>
+            <block class="Magento\Ups\Block\Backend\System\CarrierConfig" name="js.ups_carrier_config" template="Magento_Ups::system/shipping/carrier_config.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
@@ -24,7 +24,7 @@
                                 </item>
                             </argument>
                         </arguments>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="url_rewrite_id">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.url_rewrite.grid.columnSet.url_rewrite_id" as="url_rewrite_id">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">ID</argument>
                                 <argument name="type" xsi:type="string">text</argument>
@@ -34,7 +34,7 @@
                                 <argument name="header_css_class" xsi:type="string">col-id</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="adminhtml.url_rewrite.grid.columnSet.store_id" as="store_id">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Store View</argument>
                                 <argument name="type" xsi:type="string">store</argument>
@@ -43,7 +43,7 @@
                                 <argument name="store_view" xsi:type="string">true</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="request_path">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.url_rewrite.grid.columnSet.request_path" as="request_path">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Request Path</argument>
                                 <argument name="type" xsi:type="string">text</argument>
@@ -51,7 +51,7 @@
                                 <argument name="index" xsi:type="string">request_path</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="target_path">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.url_rewrite.grid.columnSet.target_path" as="target_path">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Target Path</argument>
                                 <argument name="type" xsi:type="string">text</argument>
@@ -59,7 +59,7 @@
                                 <argument name="index" xsi:type="string">target_path</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="redirect_type">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.url_rewrite.grid.columnSet.redirect_type" as="redirect_type">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Redirect Type</argument>
                                 <argument name="type" xsi:type="string">options</argument>
@@ -68,7 +68,7 @@
                                 <argument name="options" xsi:type="options" model="Magento\UrlRewrite\Model\OptionProvider"/>
                             </arguments>
                         </block>
-                        <block class="Magento\Backend\Block\Widget\Grid\Column" as="actions">
+                        <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.url_rewrite.grid.columnSet.actions" as="actions">
                             <arguments>
                                 <argument name="header" xsi:type="string" translate="true">Action</argument>
                                 <argument name="sortable" xsi:type="string">0</argument>

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_locks_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_locks_block.xml
@@ -33,11 +33,11 @@
                         </argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet">
+                <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" name="adminhtml.block.locks.grid.columnSet" as="grid.columnSet">
                     <arguments>
                         <argument name="id" xsi:type="string">lockedAdminsGrid</argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="user_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.locks.grid.columnSet.user_id" as="user_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="type" xsi:type="string">number</argument>
@@ -48,7 +48,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="username">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.locks.grid.columnSet.username" as="username">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Username</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -58,7 +58,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="last_login">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.locks.grid.columnSet.last_login" as="last_login">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Last login</argument>
                             <argument name="type" xsi:type="string">datetime</argument>
@@ -69,7 +69,7 @@
                             <argument name="header_css_class" xsi:type="string">col-date</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="failures_num">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.locks.grid.columnSet.failures_num" as="failures_num">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Failures</argument>
                             <argument name="filter" xsi:type="string">0</argument>
@@ -77,7 +77,7 @@
                             <argument name="index" xsi:type="string">failures_num</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="lock_expires">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.block.locks.grid.columnSet.lock_expires" as="lock_expires">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Unlocked</argument>
                             <argument name="type" xsi:type="string">datetime</argument>

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
@@ -28,7 +28,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="user_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.user_id" as="user_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="sortable" xsi:type="string">true</argument>
@@ -37,7 +37,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="username">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.username" as="username">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">User Name</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -47,7 +47,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="firstname">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.firstname" as="firstname">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">First Name</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -57,7 +57,7 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="lastname">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.lastname" as="lastname">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Last Name</argument>
                             <argument name="type" xsi:type="string">text</argument>
@@ -67,21 +67,21 @@
                             <argument name="header_css_class" xsi:type="string">col-name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="email">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.email" as="email">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Email</argument>
                             <argument name="type" xsi:type="string">text</argument>
                             <argument name="index" xsi:type="string">email</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="role_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.role_name" as="role_name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Role</argument>
                             <argument name="index" xsi:type="string">role_name</argument>
                             <argument name="filter_index" xsi:type="string">detail_role.role_name</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="is_active">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.is_active" as="is_active">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Status</argument>
                             <argument name="type" xsi:type="string">options</argument>

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_grid_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_grid_block.xml
@@ -30,7 +30,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="role_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.role.grid.columnSet.role_id" as="role_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">ID</argument>
                             <argument name="index" xsi:type="string">role_id</argument>
@@ -38,7 +38,7 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="role_name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.role.grid.columnSet.role_name" as="role_name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Role</argument>
                             <argument name="type" xsi:type="string">text</argument>

--- a/app/code/Magento/Variable/view/adminhtml/layout/adminhtml_system_variable_grid_block.xml
+++ b/app/code/Magento/Variable/view/adminhtml/layout/adminhtml_system_variable_grid_block.xml
@@ -24,7 +24,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="variable_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.variable.grid.columnSet.variable_id" as="variable_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Variable ID</argument>
                             <argument name="index" xsi:type="string">variable_id</argument>
@@ -32,13 +32,13 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="code">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.variable.grid.columnSet.code" as="code">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Variable Code</argument>
                             <argument name="index" xsi:type="string">code</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="name">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.system.variable.grid.columnSet.name" as="name">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Name</argument>
                             <argument name="index" xsi:type="string">name</argument>

--- a/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_block.xml
+++ b/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_block.xml
@@ -25,7 +25,7 @@
                             </item>
                         </argument>
                     </arguments>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="instance_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.widget.instance.grid.columnSet.instance_id" as="instance_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Widget ID</argument>
                             <argument name="index" xsi:type="string">instance_id</argument>
@@ -33,13 +33,13 @@
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="title">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.widget.instance.grid.columnSet.title" as="title">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Widget</argument>
                             <argument name="index" xsi:type="string">title</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="type">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.widget.instance.grid.columnSet.type" as="type">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Type</argument>
                             <argument name="index" xsi:type="string">instance_type</argument>
@@ -47,7 +47,7 @@
                             <argument name="options" xsi:type="options" model="Magento\Widget\Model\ResourceModel\Widget\Instance\Options\Types"/>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="theme_id">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.widget.instance.grid.columnSet.theme_id" as="theme_id">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Design Theme</argument>
                             <argument name="index" xsi:type="string">theme_id</argument>
@@ -56,7 +56,7 @@
                             <argument name="with_empty" xsi:type="string">1</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="sort_order">
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.widget.instance.grid.columnSet.sort_order" as="sort_order">
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Sort Order</argument>
                             <argument name="index" xsi:type="string">sort_order</argument>

--- a/app/code/Magento/Wishlist/view/adminhtml/layout/customer_index_wishlist.xml
+++ b/app/code/Magento/Wishlist/view/adminhtml/layout/customer_index_wishlist.xml
@@ -30,7 +30,7 @@
                     </argument>
                     <argument name="empty_text" xsi:type="string" translate="true">No Items Found</argument>
                 </arguments>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="product_name">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="customer.wishlist.edit.tab.columnSet.product_name" as="product_name">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Product Name</argument>
                         <argument name="id" xsi:type="string">product_name</argument>
@@ -41,7 +41,7 @@
                         <argument name="header_css_class" xsi:type="string">col-name</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="description">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="customer.wishlist.edit.tab.columnSet.description" as="description">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">User Description</argument>
                         <argument name="index" xsi:type="string">description</argument>
@@ -49,7 +49,7 @@
                         <argument name="renderer" xsi:type="string">Magento\Customer\Block\Adminhtml\Edit\Tab\Wishlist\Grid\Renderer\Description</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="qty">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="customer.wishlist.edit.tab.columnSet.qty" as="qty">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Quantity</argument>
                         <argument name="index" xsi:type="string">qty</argument>
@@ -57,14 +57,14 @@
                         <argument name="id" xsi:type="string">qty</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store">
+                <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" name="customer.wishlist.edit.tab.columnSet.store" as="store">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Add Locale</argument>
                         <argument name="index" xsi:type="string">store_id</argument>
                         <argument name="type" xsi:type="string">store</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="added_at">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="customer.wishlist.edit.tab.columnSet.added_at" as="added_at">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Add Date</argument>
                         <argument name="index" xsi:type="string">added_at</argument>
@@ -73,7 +73,7 @@
                         <argument name="id" xsi:type="string">added_at</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="days">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="customer.wishlist.edit.tab.columnSet.days" as="days">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Days in Wish List</argument>
                         <argument name="index" xsi:type="string">days_in_wishlist</argument>
@@ -81,7 +81,7 @@
                         <argument name="id" xsi:type="string">days</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                <block class="Magento\Backend\Block\Widget\Grid\Column" name="customer.wishlist.edit.tab.columnSet.action" as="action">
                     <arguments>
                         <argument name="header" xsi:type="string" translate="true">Action</argument>
                         <argument name="index" xsi:type="string">wishlist_item_id</argument>
@@ -104,7 +104,7 @@
                     </arguments>
                 </block>
             </block>
-            <block class="Magento\Framework\View\Element\Template" as="grid.js">
+            <block class="Magento\Framework\View\Element\Template" name="customer.wishlist.edit.tab.grid_js" as="grid.js">
                 <arguments>
                     <argument name="js_object_name" xsi:type="string">wishlistGridJsObject</argument>
                     <argument name="template" xsi:type="string">Magento_Wishlist::customer/edit/tab/wishlist.phtml</argument>

--- a/app/code/Magento/Wishlist/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/catalog_category_view.xml
@@ -21,7 +21,7 @@
                        template="Magento_Wishlist::catalog/product/list/addto/wishlist.phtml"/>
             </referenceBlock>
             <referenceContainer name="category.product.list.additional">
-                <block class="Magento\Wishlist\Block\AddToWishlist" template="Magento_Wishlist::addto.phtml" />
+                <block class="Magento\Wishlist\Block\AddToWishlist" name="category.product.list.additional.wishlist_addto" template="Magento_Wishlist::addto.phtml" />
             </referenceContainer>
         </referenceContainer>
     </body>

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/BlockNamesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/BlockNamesTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Test block names exists
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Test\Integrity\Layout;
+
+class BlockNamesTest extends \PHPUnit\Framework\TestCase
+{
+    public function testBlocksHasName()
+    {
+        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker(
+        /**
+         * Test validate that blocks without name doesn't exist in layout file
+         *
+         * @param string $layoutFile
+         */
+            function ($layoutFile) {
+                $dom = new \DOMDocument();
+                $dom->load($layoutFile);
+                $xpath = new \DOMXpath($dom);
+                $count = $xpath->query('//block[not(@name)]')->length;
+
+                if ($count) {
+                    $this->fail('Following file contains ' . $count . ' blocks without name. ' .
+                        'File Path:' . "\n" . $layoutFile);
+                }
+            },
+            \Magento\Framework\App\Utility\Files::init()->getLayoutFiles()
+        );
+    }
+}


### PR DESCRIPTION
### Description
This change covers an issue when block doesn't contain name attribute in layout file.
As was discussed in https://github.com/magento/magento2/pull/10354#issuecomment-318606882 - need to covert missing block names issue with static test.

### Fixed Issues (if relevant)
1. N/A

### Related issues
1. https://github.com/magento/magento2/pull/10352: Add missing block name to allow block customisation
2. https://github.com/magento/magento2/pull/10354: Add missing block name to allow block customisation
3. https://github.com/magento/magento2/pull/10936: #10824 add name for order items grid default renderer block 

### Manual testing scenarios
1. N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
- [x] All new or changed code is covered with unit/integration tests (if applicable)
 
For now I didn't fixed all places, but we can see list of them in failed test. Will create backport PRs to 2.2, 2.1 if it's needed