### PR TITLE
Review not display for Cross sell product.

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -200,7 +200,7 @@ switch ($type = $block->getType()) {
                         <?= /* @escapeNotVerified */ $block->getProductPrice($_item) ?>
 
                             <?php if ($templateType): ?>
-                                <?= $block->getReviewsSummaryHtml($_item, $templateType) ?>
+                                <?= $block->getReviewsSummaryHtml($_item, $templateType, true) ?>
                             <?php endif; ?>
 
                             <?php if (!$_item->isComposite() && $_item->isSaleable() && $type == 'related'): ?>


### PR DESCRIPTION

**Description**
Product review ratings not display for Cross sell product in cart page. Product with already rating doesnt display ration value in cart page cross sell section. Template file contains code related to review summary.


**Fixed Issues (if relevant)**

I have checked `app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml` contains code related to display review rating in product. when we pass third parameter as true at that time review rating is display fine in crosssell product in cart page.
When we change code from
`<?= $block->getReviewsSummaryHtml($_item, $templateType) ?>`
to 
`<?= $block->getReviewsSummaryHtml($_item, $templateType,true) ?>`
in items.phtml file, review display fine in crosssell prodct at cart page.