### PR TITLE
Added minimal price to configurable product upon fetching via API

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -23,7 +23,6 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 use Magento\Framework\Exception\ValidatorException;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -248,10 +247,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             }
 
             $product->load($productId);
-
-            if ($product->getTypeId() == Configurable::TYPE_CODE) {
-                $product->setMinimalPrice($product->getFinalPrice());
-            }
+            $product->setMinimalPrice($product->getFinalPrice());
 
             $this->cacheProduct($cacheKey, $product);
         }
@@ -695,6 +691,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $collection->addAttributeToSelect('*');
         $collection->joinAttribute('status', 'catalog_product/status', 'entity_id', null, 'inner');
         $collection->joinAttribute('visibility', 'catalog_product/visibility', 'entity_id', null, 'inner');
+        $collection->addMinimalPrice();
 
         $this->collectionProcessor->process($searchCriteria, $collection);
 

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -23,6 +23,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 use Magento\Framework\Exception\ValidatorException;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -245,7 +246,13 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             if ($storeId !== null) {
                 $product->setData('store_id', $storeId);
             }
+
             $product->load($productId);
+
+            if ($product->getTypeId() == Configurable::TYPE_CODE) {
+                $product->setMinimalPrice($product->getFinalPrice());
+            }
+
             $this->cacheProduct($cacheKey, $product);
         }
         if (!isset($this->instances[$sku])) {

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -176,6 +176,7 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
                 'load',
                 'setData',
                 'getStoreId',
+                'getPriceModel',
                 'getMediaGalleryEntries'
             ]);
 
@@ -191,6 +192,7 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
                 'getProductLinks',
                 'setProductLinks',
                 'validate',
+                'getPriceModel',
                 'save',
                 'getMediaGalleryEntries',
             ]
@@ -198,6 +200,21 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->initializedProductMock->expects($this->any())
             ->method('hasGalleryAttribute')
             ->willReturn(true);
+
+        $productTypePriceMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Product\Type\Price::class,
+            ['getFinalPrice']
+        );
+
+        $this->productMock->expects($this->any())
+            ->method('getPriceModel')
+            ->willReturn($productTypePriceMock);
+
+        $this->initializedProductMock->expects($this->any())
+            ->method('getPriceModel')
+            ->willReturn($productTypePriceMock);
+
+
         $this->filterBuilderMock = $this->createMock(\Magento\Framework\Api\FilterBuilder::class);
         $this->initializationHelperMock = $this->createMock(\Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper::class);
         $this->collectionFactoryMock = $this->createPartialMock(\Magento\Catalog\Model\ResourceModel\Product\CollectionFactory::class, ['create']);
@@ -311,7 +328,10 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($this->productMock));
         $this->resourceModelMock->expects($this->once())->method('getIdBySku')->with($sku)
             ->will($this->returnValue('test_id'));
-        $this->productMock->expects($this->once())->method('setData')->with('_edit_mode', true);
+        $this->productMock->expects($this->atLeastOnce())->method('setData')->withConsecutive(
+            [$this->equalTo('_edit_mode'), $this->equalTo(true)],
+            [$this->equalTo('minimal_price'), $this->equalTo(null)]
+        );
         $this->productMock->expects($this->once())->method('load')->with('test_id');
         $this->productMock->expects($this->once())->method('getSku')->willReturn($sku);
         $this->assertEquals($this->productMock, $this->model->get($sku, true));
@@ -337,7 +357,10 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
         $storeId = 7;
         $this->productFactoryMock->expects($this->once())->method('create')->willReturn($this->productMock);
         $this->resourceModelMock->expects($this->once())->method('getIdBySku')->with($sku)->willReturn($productId);
-        $this->productMock->expects($this->once())->method('setData')->with('store_id', $storeId);
+        $this->productMock->expects($this->atLeastOnce())->method('setData')->withConsecutive(
+            [$this->equalTo('store_id'), $this->equalTo($storeId)],
+            [$this->equalTo('minimal_price'), $this->equalTo(null)]
+        );
         $this->productMock->expects($this->once())->method('load')->with($productId);
         $this->productMock->expects($this->once())->method('getId')->willReturn($productId);
         $this->productMock->expects($this->once())->method('getSku')->willReturn($sku);

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Price.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Price.php
@@ -46,6 +46,8 @@ class Price extends \Magento\Catalog\Model\Product\Type\Price
                 if (!empty($simpleProduct)) {
                     return $simpleProduct->getPrice();
                 }
+            } elseif ($product->getMinimalPrice() !== null) {
+                return $product->getMinimalPrice();
             }
         }
         return 0;


### PR DESCRIPTION
Description

Upon getting a configurable product via API (/rest/V1/products/:sku) the product does not contain any useful information about the price. The minimal price is useful here in order to avoid additional requests to the API for getting the configurable product price information.

Fixed Issues

magento/magento2#10644: REST API Configurable Product has price
Manual testing scenarios

Create a configurable product accessible on the storefront
Get the product information via API using GET request to the rest/V1/products/:sku
You should get a minimal price among the custom attributes for the configurable product.