### PR TITLE
Add missing return statements in setters

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Shipment/ItemCreation.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/ItemCreation.php
@@ -43,6 +43,7 @@ class ItemCreation implements ShipmentItemCreationInterface
     public function setOrderItemId($orderItemId)
     {
         $this->orderItemId = $orderItemId;
+        return $this;
     }
 
     /**
@@ -59,6 +60,7 @@ class ItemCreation implements ShipmentItemCreationInterface
     public function setQty($qty)
     {
         $this->qty = $qty;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Description
<!--- Provide a description of the changes proposed in the pull request -->
There were 2 missing return statements in
Magento\Sales\Model\Order\Shipment\ItemCreation setters.

This brakes "fluent interface" suggested in its interface.
https://github.com/magento/magento2/blob/fa2439c5be917b1e84f3a6a8e3802b1aa7e01da7/app/code/Magento/Sales/Api/Data/LineItemInterface.php#L30

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
