### PR TITLE
Added template as argument to the store address renderer to allow custom formatting

### DIFF
--- a/app/code/Magento/Store/Model/Address/Renderer.php
+++ b/app/code/Magento/Store/Model/Address/Renderer.php
@@ -15,6 +15,12 @@ use Magento\Framework\DataObject;
  */
 class Renderer
 {
+    const DEFAULT_TEMPLATE = "{{var name}}\n" .
+        "{{var street_line1}}\n" .
+        "{{depend street_line2}}{{var street_line2}}\n{{/depend}}" .
+        "{{depend city}}{{var city}},{{/depend}} {{var region}} {{depend postcode}}{{var postcode}},{{/depend}}\n" .
+        "{{var country}}";
+
     /**
      * @var EventManager
      */
@@ -26,17 +32,25 @@ class Renderer
     protected $filterManager;
 
     /**
+     * @var string
+     */
+    private $template;
+
+    /**
      * Constructor
      *
      * @param EventManager $eventManager
      * @param FilterManager $filterManager
+     * @param string $template
      */
     public function __construct(
         EventManager $eventManager,
-        FilterManager $filterManager
+        FilterManager $filterManager,
+        $template = self::DEFAULT_TEMPLATE
     ) {
         $this->eventManager = $eventManager;
         $this->filterManager = $filterManager;
+        $this->template = $template;
     }
 
     /**
@@ -50,9 +64,7 @@ class Renderer
     {
         $this->eventManager->dispatch('store_address_format', ['type' => $type, 'store_info' => $storeInfo]);
         $address = $this->filterManager->template(
-            "{{var name}}\n{{var street_line1}}\n{{depend street_line2}}{{var street_line2}}\n{{/depend}}" .
-            "{{depend city}}{{var city}},{{/depend}} {{var region}} {{depend postcode}}{{var postcode}},{{/depend}}\n" .
-            "{{var country}}",
+            $this->template,
             ['variables' => $storeInfo->getData()]
         );
 


### PR DESCRIPTION
### Description
See #10850 for the original pull request.

It's not easy to change the format of the store address used in for example the footer of an e-mail template. By adding the template as an argument in the constructor of `Magento\Store\Model\Address\Renderer` you can easily change it using dependency injection.  