### PR TITLE
_extend.less before _responsive.less compiled css specificity

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/styles-l.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-l.less
@@ -24,6 +24,12 @@
 //@magento_import 'source/_widgets.less'; // Theme widgets
 
 //
+//  Extend for minor customisation
+//  ---------------------------------------------
+
+//@magento_import 'source/_extend.less';
+
+//
 //  Media queries collector
 //  ---------------------------------------------
 
@@ -37,9 +43,3 @@
 //  ---------------------------------------------
 
 @import 'source/_theme.less';
-
-//
-//  Extend for minor customisation
-//  ---------------------------------------------
-
-//@magento_import 'source/_extend.less';

--- a/app/design/frontend/Magento/blank/web/css/styles-m.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-m.less
@@ -25,6 +25,12 @@
 //@magento_import 'source/_widgets.less'; // Theme widgets
 
 //
+//  Extend for minor customisation
+//  ---------------------------------------------
+
+//@magento_import 'source/_extend.less';
+
+//
 //  Media queries collector
 //  ---------------------------------------------
 
@@ -37,9 +43,3 @@
 //  ---------------------------------------------
 
 @import 'source/_theme.less';
-
-//
-//  Extend for minor customisation
-//  ---------------------------------------------
-
-//@magento_import 'source/_extend.less';


### PR DESCRIPTION
resolve #11098

Within `_extend.less` the media queries styles compiled in styles-m.css and styles-l.css appeared before non media queries style, so they had lesser specificity and they were overridden by others styles not in the media queries.

### Description
Inside styles-m.less and styles-l.less moved `//@magento_import 'source/_extend.less';` before `@import 'source/lib/_responsive.less';`

### Fixed Issues
1. magento/magento2#11098: Mobile media query inside _extend.less, wrong order in styles-m.css and styles-l.css

### Manual testing scenarios
When using media queries inside `_extend.less`:
```
// normal
.logo {
    border-bottom: 4px solid #cccccc; // should be overwritten with media queries styles
}
& when (@media-common = true) {
    .logo {
        border: 1px solid #cccccc; // should be overwritten with media queries styles
        .lib-css(background, @link__color);
    }
}
// mobile media query
.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
    .logo {
        border: 1px solid #ff00ff;
    }
}
// tablet media query
.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
    .logo {
        border: 1px solid #ff0000;
    }
}
```
Styles specificity order: compiled styles-m.css and styles-l.css "// normal" before media queries styles.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
