### PR TITLE
Add cron expression check when setting cron expression into cron schedule model

### DIFF
--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -32,6 +32,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @param string $scheduleId
      * @param string $newStatus
      * @param string $currentStatus
+     *
      * @return bool
      */
     public function trySetJobStatusAtomic($scheduleId, $newStatus, $currentStatus)
@@ -59,6 +60,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @param string $scheduleId
      * @param string $newStatus
      * @param string $currentStatus
+     *
      * @return bool
      * @since 100.2.0
      */
@@ -75,7 +77,8 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             )
             ->where('current.schedule_id = ?', $scheduleId)
             ->where('current.status = ?', $currentStatus)
-            ->where('existing.schedule_id IS NULL');
+            ->where('existing.schedule_id IS NULL')
+        ;
 
         $update = $connection->updateFromSelect($selectIfUnlocked, ['current' => $this->getTable('cron_schedule')]);
         $result = $connection->query($update)->rowCount();

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\MatcherInterface;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\ParserInterface;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\ValidatorInterface;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression encapsulation class
+ *
+ * @api
+ */
+class Expression implements ExpressionInterface
+{
+    /**
+     * @var ValidatorInterface
+     */
+    private $expressionValidator;
+
+    /**
+     * @var ParserInterface
+     */
+    private $expressionParser;
+
+    /**
+     * @var MatcherInterface
+     */
+    private $expressionMatcher;
+
+    /**
+     * @var string
+     */
+    private $cronExpr;
+
+    /**
+     * @var PartInterface[]
+     */
+    private $parts;
+
+    /**
+     * @var bool
+     */
+    private $isValid;
+
+    /**
+     * @param ValidatorInterface $expressionValidator
+     * @param ParserInterface    $expressionParser
+     * @param MatcherInterface   $expressionMatcher
+     */
+    public function __construct(
+        ValidatorInterface $expressionValidator,
+        ParserInterface $expressionParser,
+        MatcherInterface $expressionMatcher
+    ) {
+        $this->expressionValidator = $expressionValidator;
+        $this->expressionParser = $expressionParser;
+        $this->expressionMatcher = $expressionMatcher;
+    }
+
+    /**
+     * Set cron expression
+     *
+     * @param string $cronExpr
+     *
+     * @throws CronException
+     * @return void
+     */
+    public function setCronExpr($cronExpr)
+    {
+        $this->reset();
+        $this->cronExpr = $cronExpr;
+
+        if (empty($this->getParts()) || !$this->validate()) {
+            throw new CronException(__('Invalid cron expression: %1', $cronExpr));
+        }
+    }
+
+    /**
+     * Get cron expression
+     *
+     * @return string
+     */
+    public function getCronExpr()
+    {
+        return isset($this->cronExpr) ? (string)$this->cronExpr : '';
+    }
+
+    /**
+     * Get cron expression is valid
+     *
+     * @return bool
+     */
+    public function validate()
+    {
+        if (!isset($this->isValid)) {
+            $this->isValid = $this->expressionValidator->validate($this);
+        }
+        return $this->isValid;
+    }
+
+    /**
+     * Get cron expression parts array
+     *
+     * @return bool|PartInterface[]
+     */
+    public function getParts()
+    {
+        if (!isset($this->parts)) {
+            $this->parts = $this->expressionParser->parse($this);
+        }
+        return $this->parts;
+    }
+
+    /**
+     * Match cron expression against timestamp
+     *
+     * @param int $timestamp
+     *
+     * @return bool
+     */
+    public function match($timestamp)
+    {
+        return $this->expressionMatcher->match($this, $timestamp);
+    }
+
+    /**
+     * Reset expression inner data
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->cronExpr = null;
+        $this->parts = null;
+        $this->isValid = null;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getCronExpr();
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Matcher.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Matcher.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface;
+
+/**
+ * Cron expression matcher
+ *
+ * @api
+ */
+class Matcher implements MatcherInterface
+{
+    /**
+     * @var MatcherFactory
+     */
+    private $matcherFactory;
+
+    /**
+     * Matcher constructor.
+     *
+     * @param MatcherFactory $matcherFactory
+     */
+    public function __construct(
+        MatcherFactory $matcherFactory
+    ) {
+        $this->matcherFactory = $matcherFactory;
+    }
+
+    /**
+     * Perform match of cron expression against timestamp
+     *
+     * @param ExpressionInterface $expression
+     * @param int                 $timestamp
+     *
+     * @return bool
+     */
+    public function match(ExpressionInterface $expression, $timestamp)
+    {
+        if (empty($expression->getParts()) || !$expression->validate()) {
+            return false;
+        }
+
+        $parts = $expression->getParts();
+
+        /** @var PartInterface $part */
+        foreach ($parts as $part) {
+            $number = $this->matcherFactory->create($part->getPartMatcher())->getNumber($timestamp);
+            if (!$part->match($number)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/MatcherInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/MatcherInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface;
+
+/**
+ * Cron expression matcher interface
+ *
+ * @api
+ */
+interface MatcherInterface
+{
+    /**
+     * Perform match of cron expression against timestamp
+     *
+     * @param ExpressionInterface $expression
+     * @param int                 $timestamp
+     *
+     * @return bool
+     */
+    public function match(ExpressionInterface $expression, $timestamp);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Parser.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Parser.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface;
+
+/**
+ * Schedule cron expression parser
+ *
+ * @api
+ */
+class Parser implements ParserInterface
+{
+    /**
+     * @var PartFactory
+     */
+    private $partFactory;
+
+    /**
+     * @param PartFactory $partFactory
+     */
+    public function __construct(
+        PartFactory $partFactory
+    ) {
+        $this->partFactory = $partFactory;
+    }
+
+    /**
+     * Perform parsing of cron expression
+     *
+     * @param ExpressionInterface $expression
+     *
+     * @return bool|PartInterface[]
+     */
+    public function parse(ExpressionInterface $expression)
+    {
+        if (!strlen($expression->getCronExpr())) {
+            return false;
+        }
+
+        $stringParts = preg_split('#\s+#', $expression->getCronExpr(), null, PREG_SPLIT_NO_EMPTY);
+
+        $parts = [];
+        foreach ($stringParts as $partIndex => $partValue) {
+            $parts[] = $this->partFactory->create($partIndex, $partValue);
+        }
+
+        return $parts;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/ParserInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/ParserInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface;
+
+/**
+ * Cron expression parser interface
+ *
+ * @api
+ */
+interface ParserInterface
+{
+    /**
+     * Perform parsing of cron expression
+     *
+     * @param ExpressionInterface $expression
+     *
+     * @return bool|PartInterface[]
+     */
+    public function parse(ExpressionInterface $expression);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherInterface as ExpressionPartMatcherInterface;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorInterface as ExpressionPartValidatorInterface;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part encapsulation class
+ *
+ * @api
+ */
+class Part implements PartInterface
+{
+    /**
+     * @var ExpressionPartValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @var ExpressionPartMatcherInterface
+     */
+    private $matcher;
+
+    /**
+     * @var string
+     */
+    private $partValue;
+
+    /**
+     * @var bool
+     */
+    private $isValid;
+
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::GENERIC_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::GENERIC_MATCHER;
+
+    /**
+     * @return string[]
+     */
+    public function getValidatorHandlers()
+    {
+        return $this->validatorHandlers;
+    }
+
+    /**
+     * Numeric parser for expression part
+     *
+     * @return string
+     */
+    public function getNumericParser()
+    {
+        return $this->numericParser;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPartMatcher()
+    {
+        return $this->partMatcher;
+    }
+
+    /**
+     * Part constructor.
+     *
+     * @param ExpressionPartValidatorInterface $validator
+     * @param ExpressionPartMatcherInterface   $matcher
+     * @param string[]                         $validatorHandlers
+     * @param string                           $numericParser
+     * @param string                           $partMatcher
+     */
+    public function __construct(
+        ExpressionPartValidatorInterface $validator,
+        ExpressionPartMatcherInterface $matcher,
+        $validatorHandlers = null,
+        $numericParser = null,
+        $partMatcher = null
+    ) {
+        $this->validator = $validator;
+        $this->matcher = $matcher;
+
+        $this->validatorHandlers = isset($validatorHandlers) ? $validatorHandlers : $this->validatorHandlers;
+        $this->numericParser = isset($numericParser) ? $numericParser : $this->numericParser;
+        $this->partMatcher = isset($partMatcher) ? $partMatcher : $this->partMatcher;
+    }
+
+    /**
+     * Set part value
+     *
+     * @param string $partValue
+     *
+     * @throws CronException
+     * @return void
+     */
+    public function setPartValue($partValue)
+    {
+        $this->reset();
+        $this->partValue = $partValue;
+    }
+
+    /**
+     * Get cron expression part string value
+     *
+     * @return string
+     */
+    public function getPartValue()
+    {
+        return isset($this->partValue) ? (string)$this->partValue : '';
+    }
+
+    /**
+     * Get cron expression part is valid
+     *
+     * @return bool
+     */
+    public function validate()
+    {
+        if (!isset($this->isValid)) {
+            $this->isValid = $this->validator->validate($this);
+        }
+        return $this->isValid;
+    }
+
+    /**
+     * Get cron expression part matches number
+     *
+     * @param int $number
+     *
+     * @return bool
+     */
+    public function match($number)
+    {
+        return $this->matcher->match($this, $number);
+    }
+
+    /**
+     * Reset part inner data
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->partValue = null;
+        $this->isValid = null;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getPartValue();
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Generic.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Generic.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class Generic extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::QUESTION_MARK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::QUESTION_MARK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::GENERIC_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::GENERIC_MATCHER;
+
+    /**
+     * Generic constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Hours.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Hours.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class Hours extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::HOURS_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::HOURS_MATCHER;
+
+    /**
+     * Hours constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Minutes.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Minutes.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class Minutes extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::MINUTES_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::MINUTES_MATCHER;
+
+    /**
+     * Minutes constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Month.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Month.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class Month extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::MONTH_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::MONTH_MATCHER;
+
+    /**
+     * Month constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/MonthDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/MonthDay.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class MonthDay extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::QUESTION_MARK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::QUESTION_MARK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::LAST_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::NEAREST_WEEKDAY_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::MONTHDAY_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::MONTHDAY_MATCHER;
+
+    /**
+     * MonthDay constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/WeekDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/WeekDay.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class WeekDay extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::QUESTION_MARK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::QUESTION_MARK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::LAST_WEEKDAY_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::HASH_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::WEEKDAY_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::WEEKDAY_MATCHER;
+
+    /**
+     * WeekDay constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Year.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Index/Year.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part index class
+ *
+ * @api
+ */
+class Year extends Part implements PartInterface
+{
+    /**
+     * @var string[]
+     */
+    private $validatorHandlers = [
+        ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::ASTERISK_MODULUS_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::RANGE_VALIDATION_HANDLER,
+        ValidatorHandlerFactory::REGULAR_VALIDATION_HANDLER,
+    ];
+
+    /**
+     * @var string
+     */
+    private $numericParser = NumericParserFactory::YEAR_NUMERIC;
+
+    /**
+     * @var string
+     */
+    private $partMatcher = MatcherFactory::YEAR_MATCHER;
+
+    /**
+     * Year constructor.
+     *
+     * @param ExpressionPartValidator $validator
+     * @param ExpressionPartMatcher   $matcher
+     */
+    public function __construct(
+        ExpressionPartValidator $validator,
+        ExpressionPartMatcher $matcher
+    ) {
+        parent::__construct(
+            $validator,
+            $matcher,
+            $this->validatorHandlers,
+            $this->numericParser,
+            $this->partMatcher
+        );
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class Matcher implements MatcherInterface
+{
+    /**
+     * @var ParserInterface
+     */
+    private $parser;
+
+    /**
+     * @var MatcherFactory
+     */
+    private $matcherFactory;
+
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * @var ValidatorHandlerFactory
+     */
+    private $validatorHandlerFactory;
+
+    /**
+     * Matcher constructor.
+     *
+     * @param ParserInterface         $parser
+     * @param MatcherFactory          $matcherFactory
+     * @param NumericParserFactory    $numericFactory
+     * @param ValidatorHandlerFactory $validatorHandlerFactory
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    public function __construct(
+        ParserInterface $parser,
+        MatcherFactory $matcherFactory,
+        NumericParserFactory $numericFactory,
+        ValidatorHandlerFactory $validatorHandlerFactory
+    ) {
+        $this->parser = $parser;
+        $this->matcherFactory = $matcherFactory;
+        $this->numericFactory = $numericFactory;
+        $this->validatorHandlerFactory = $validatorHandlerFactory;
+    }
+
+    /**
+     * Perform match of cron expression part against timestamp
+     *
+     * @param PartInterface $part
+     * @param int           $number
+     *
+     * @return bool
+     */
+    public function match(PartInterface $part, $number)
+    {
+        if (!$part->validate()) {
+            return false;
+        }
+
+        $match = false;
+        foreach ($this->parser->parse($part->getPartValue(), ParserFactory::LIST_PARSER) as $subPartValue) {
+            if ($this->matchCronExpressionPart($part, $subPartValue, $number)) {
+                $match = true;
+                break;
+            }
+        }
+
+        return $match;
+    }
+
+    /**
+     * @param PartInterface $part
+     * @param string        $cronExpr
+     * @param int           $num
+     *
+     * @return bool
+     */
+    private function matchCronExpressionPart(PartInterface $part, $cronExpr, $num)
+    {
+        // handle ALL match
+        if ($this->handleAllMatch($part, $cronExpr)) {
+            return true;
+        }
+
+        // handle modulus
+        list($cronExpr, $mod) = $this->handleModulus($cronExpr);
+        // handle all match by modulus
+        list($fromValue, $toValue) = $this->handleAllMatchByModulus($part, $cronExpr);
+
+        // handle range
+        $rangeParts = $this->parser->parse($cronExpr, ParserFactory::RANGE_PARSER);
+        if (!isset($fromValue) && count($rangeParts) > 1) {
+            $fromValue = $this->numericFactory->create($part->getNumericParser())->getNumber($rangeParts[0]);
+            $toValue = $this->numericFactory->create($part->getNumericParser())->getNumber($rangeParts[1]);
+        }
+
+        // handle regular token
+        if (!isset($fromValue)) {
+            $fromValue = $this->numericFactory->create($part->getNumericParser())->getNumber($cronExpr);
+            $toValue = $fromValue;
+        }
+
+        return $num >= $fromValue && $num <= $toValue && $num % $mod === 0;
+    }
+
+    /**
+     * @param PartInterface $part
+     * @param               $cronExpr
+     *
+     * @return bool
+     */
+    private function handleAllMatch(PartInterface $part, $cronExpr)
+    {
+        if ($this->validatorHandlerFactory->create(ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER)
+                ->handle($part, $cronExpr) === true
+        ) {
+            return true;
+        }
+
+        if ($this->validatorHandlerFactory->create(ValidatorHandlerFactory::QUESTION_MARK_VALIDATION_HANDLER)
+                ->handle($part, $cronExpr) === true
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $cronExpr
+     *
+     * @return array
+     */
+    private function handleModulus($cronExpr)
+    {
+        $mod = 1;
+        $modulusParts = $this->parser->parse($cronExpr, ParserFactory::MODULUS_PARSER);
+        if (count($modulusParts) > 1) {
+            $cronExpr = $modulusParts[0];
+            $mod = $modulusParts[1];
+        }
+
+        return [$cronExpr, $mod];
+    }
+
+    /**
+     * @param PartInterface $part
+     * @param               $cronExpr
+     *
+     * @return array
+     */
+    private function handleAllMatchByModulus(PartInterface $part, $cronExpr)
+    {
+        $fromValue = null;
+        $toValue = null;
+
+        if ($this->validatorHandlerFactory->create(ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER)
+                ->handle($part, $cronExpr) === true
+        ) {
+            $fromValue = $this->numericFactory->create($part->getNumericParser())->getRangeMin();
+            $toValue = $this->numericFactory->create($part->getNumericParser())->getRangeMax();
+        }
+
+        return [$fromValue, $toValue];
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Generic.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Generic.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class Generic implements MatcherInterface
+{
+    /**
+     * @var string
+     */
+    private $dateExpr;
+
+    /**
+     * Generic constructor.
+     *
+     * @param string $dateExpr
+     */
+    public function __construct(
+        $dateExpr
+    ) {
+        $this->dateExpr = $dateExpr;
+    }
+
+    /**
+     * Get number from timestamp
+     *
+     * @param int|string $timestamp
+     *
+     * @return int
+     */
+    public function getNumber($timestamp)
+    {
+        return (int)strftime($this->dateExpr, $timestamp);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Hours.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Hours.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class Hours extends Generic
+{
+    /**
+     * @var string
+     */
+    private $dateExpr = '%H';
+
+    /**
+     * Hours constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->dateExpr);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/MatcherInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/MatcherInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher interface
+ *
+ * @api
+ */
+interface MatcherInterface
+{
+    /**
+     * Get number from timestamp
+     *
+     * @param int|string $timestamp
+     *
+     * @return int
+     */
+    public function getNumber($timestamp);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Minutes.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Minutes.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class Minutes extends Generic
+{
+    /**
+     * @var string
+     */
+    private $dateExpr = '%M';
+
+    /**
+     * Minutes constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->dateExpr);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Month.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Month.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class Month extends Generic
+{
+    /**
+     * @var string
+     */
+    private $dateExpr = '%m';
+
+    /**
+     * Month constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->dateExpr);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/MonthDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/MonthDay.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class MonthDay extends Generic
+{
+    /**
+     * @var string
+     */
+    private $dateExpr = '%d';
+
+    /**
+     * MonthDay constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->dateExpr);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/WeekDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/WeekDay.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class WeekDay extends Generic implements MatcherInterface
+{
+    /**
+     * @var string
+     */
+    private $dateExpr = '%w';
+
+    /**
+     * WeekDay constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->dateExpr);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Year.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Matcher/Year.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class Year extends Generic
+{
+    /**
+     * @var string
+     */
+    private $dateExpr = '%Y';
+
+    /**
+     * Year constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->dateExpr);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/MatcherFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/MatcherFactory.php
@@ -54,12 +54,13 @@ class MatcherFactory
             throw new CronException(__('Invalid cron expression part matcher type: %1', $matcherType));
         }
 
-        $matcher = ObjectManager::getInstance(
-        )->get('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher\\' . $matcherType);
+        $matcher = ObjectManager::getInstance()
+            ->get('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher\\' . $matcherType);
 
         if (!$matcher instanceof PartMatcherInterface) {
-            $exceptionMessage = 'Invalid cron expression part matcher type: %1 is not an instance of ';
-            throw new CronException(__($exceptionMessage . PartMatcherInterface::class, $matcherType));
+            $exceptionMessage = 'Invalid cron expression part matcher type: %1 is not an instance of '
+                . PartMatcherInterface::class;
+            throw new CronException(__($exceptionMessage, $matcherType));
         }
 
         return $matcher;

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/MatcherFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/MatcherFactory.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher\MatcherInterface as PartMatcherInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part matcher
+ *
+ * @api
+ */
+class MatcherFactory
+{
+    const GENERIC_MATCHER = 'Generic';
+    const MINUTES_MATCHER = 'Minutes';
+    const HOURS_MATCHER = 'Hours';
+    const MONTHDAY_MATCHER = 'MonthDay';
+    const MONTH_MATCHER = 'Month';
+    const WEEKDAY_MATCHER = 'WeekDay';
+    const YEAR_MATCHER = 'Year';
+
+    /**
+     * @return array
+     */
+    public function getAvailableMatchers()
+    {
+        return [
+            self::GENERIC_MATCHER,
+            self::MINUTES_MATCHER,
+            self::HOURS_MATCHER,
+            self::MONTHDAY_MATCHER,
+            self::MONTH_MATCHER,
+            self::WEEKDAY_MATCHER,
+            self::YEAR_MATCHER,
+        ];
+    }
+
+    /**
+     * Get the matcher specified by matcher type
+     *
+     * @param string $matcherType
+     *
+     * @throws CronException
+     * @return PartMatcherInterface
+     */
+    public function create($matcherType)
+    {
+        if (!in_array($matcherType, $this->getAvailableMatchers())) {
+            throw new CronException(__('Invalid cron expression part matcher type: %1', $matcherType));
+        }
+
+        $matcher = ObjectManager::getInstance(
+        )->get('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher\\' . $matcherType);
+
+        if (!$matcher instanceof PartMatcherInterface) {
+            $exceptionMessage = 'Invalid cron expression part matcher type: %1 is not an instance of ';
+            throw new CronException(__($exceptionMessage . PartMatcherInterface::class, $matcherType));
+        }
+
+        return $matcher;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/MatcherInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/MatcherInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part matcher interface
+ *
+ * @api
+ */
+interface MatcherInterface
+{
+    /**
+     * Perform match of cron expression part against number
+     *
+     * @param PartInterface $part
+     * @param int           $number
+     *
+     * @return bool
+     */
+    public function match(PartInterface $part, $number);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Generic.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Generic.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class Generic implements NumericInterface
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 0;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = PHP_INT_MAX;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [
+        'jan' => 1,
+        'feb' => 2,
+        'mar' => 3,
+        'apr' => 4,
+        'may' => 5,
+        'jun' => 6,
+        'jul' => 7,
+        'aug' => 8,
+        'sep' => 9,
+        'oct' => 10,
+        'nov' => 11,
+        'dec' => 12,
+        'sun' => 0,
+        'mon' => 1,
+        'tue' => 2,
+        'wed' => 3,
+        'thu' => 4,
+        'fri' => 5,
+        'sat' => 6,
+    ];
+
+    /**
+     * Generic constructor.
+     *
+     * @param int   $rangeMin
+     * @param int   $rangeMax
+     * @param array $valuesMap
+     */
+    public function __construct(
+        $rangeMin,
+        $rangeMax,
+        $valuesMap
+    ) {
+        $this->rangeMin = isset($rangeMin) ? $rangeMin : $this->rangeMin;
+        $this->rangeMax = isset($rangeMax) ? $rangeMax : $this->rangeMax;
+        $this->valuesMap = isset($valuesMap) ? $valuesMap : $this->valuesMap;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRangeMin()
+    {
+        return $this->rangeMin;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRangeMax()
+    {
+        return $this->rangeMax;
+    }
+
+    /**
+     * Get cron expression part number from value
+     *
+     * @param int|string $value
+     *
+     * @return int|bool
+     */
+    public function getNumber($value)
+    {
+        if (is_string($value)) {
+            $numberKey = strtolower(substr($value, 0, 3));
+            if (isset($this->valuesMap[$numberKey])) {
+                $value = $this->valuesMap[$numberKey];
+            }
+        }
+
+        if (!preg_match('/^\d+$/', $value) || $value > $this->getRangeMax() || $value < $this->getRangeMin()) {
+            return false;
+        }
+
+        return (int)$value;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Hours.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Hours.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class Hours extends Generic
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 0;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = 23;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [];
+
+    /**
+     * Hours constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->rangeMin, $this->rangeMax, $this->valuesMap);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Minutes.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Minutes.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class Minutes extends Generic
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 0;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = 59;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [];
+
+    /**
+     * Minutes constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->rangeMin, $this->rangeMax, $this->valuesMap);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Month.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Month.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class Month extends Generic
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 1;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = 12;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [
+        'jan' => 1,
+        'feb' => 2,
+        'mar' => 3,
+        'apr' => 4,
+        'may' => 5,
+        'jun' => 6,
+        'jul' => 7,
+        'aug' => 8,
+        'sep' => 9,
+        'oct' => 10,
+        'nov' => 11,
+        'dec' => 12,
+    ];
+
+    /**
+     * Month constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->rangeMin, $this->rangeMax, $this->valuesMap);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/MonthDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/MonthDay.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class MonthDay extends Generic
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 1;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = 31;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [];
+
+    /**
+     * MonthDay constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->rangeMin, $this->rangeMax, $this->valuesMap);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/NumericInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/NumericInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric interface
+ *
+ * @api
+ */
+interface NumericInterface
+{
+    /**
+     * @return int
+     */
+    public function getRangeMin();
+
+    /**
+     * @return int
+     */
+    public function getRangeMax();
+
+    /**
+     * Get cron expression part number from value
+     *
+     * @param int|string $value
+     *
+     * @return int|bool
+     */
+    public function getNumber($value);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/WeekDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/WeekDay.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class WeekDay extends Generic implements NumericInterface
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 0;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = 6;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [
+        'sun' => 0,
+        'mon' => 1,
+        'tue' => 2,
+        'wed' => 3,
+        'thu' => 4,
+        'fri' => 5,
+        'sat' => 6,
+    ];
+
+    /**
+     * WeekDay constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->rangeMin, $this->rangeMax, $this->valuesMap);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Year.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParser/Year.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class Year extends Generic
+{
+    /**
+     * @var int
+     */
+    private $rangeMin = 1970;
+
+    /**
+     * @var int
+     */
+    private $rangeMax = 2099;
+
+    /**
+     * @var array
+     */
+    private $valuesMap = [];
+
+    /**
+     * Year constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct($this->rangeMin, $this->rangeMax, $this->valuesMap);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParserFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParserFactory.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser\NumericInterface as PartNumericInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part numeric
+ *
+ * @api
+ */
+class NumericParserFactory
+{
+    const GENERIC_NUMERIC = 'Generic';
+    const MINUTES_NUMERIC = 'Minutes';
+    const HOURS_NUMERIC = 'Hours';
+    const MONTHDAY_NUMERIC = 'MonthDay';
+    const MONTH_NUMERIC = 'Month';
+    const WEEKDAY_NUMERIC = 'WeekDay';
+    const YEAR_NUMERIC = 'Year';
+
+    /**
+     * @return array
+     */
+    public function getAvailableNumerics()
+    {
+        return [
+            self::GENERIC_NUMERIC,
+            self::MINUTES_NUMERIC,
+            self::HOURS_NUMERIC,
+            self::MONTHDAY_NUMERIC,
+            self::MONTH_NUMERIC,
+            self::WEEKDAY_NUMERIC,
+            self::YEAR_NUMERIC,
+        ];
+    }
+
+    /**
+     * Get the numeric specified by numeric type
+     *
+     * @param string $numericType
+     *
+     * @throws CronException
+     * @return PartNumericInterface
+     */
+    public function create($numericType)
+    {
+        if (!in_array($numericType, $this->getAvailableNumerics())) {
+            throw new CronException(__('Invalid cron expression part numeric type: %1', $numericType));
+        }
+
+        $numeric = ObjectManager::getInstance()
+            ->get('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser\\' . $numericType);
+
+        if (!$numeric instanceof PartNumericInterface) {
+            $exceptionMessage = 'Invalid cron expression part numeric type: %1 is not an instance of ';
+            throw new CronException(__($exceptionMessage . PartNumericInterface::class, $numericType));
+        }
+
+        return $numeric;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParserFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/NumericParserFactory.php
@@ -58,8 +58,9 @@ class NumericParserFactory
             ->get('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser\\' . $numericType);
 
         if (!$numeric instanceof PartNumericInterface) {
-            $exceptionMessage = 'Invalid cron expression part numeric type: %1 is not an instance of ';
-            throw new CronException(__($exceptionMessage . PartNumericInterface::class, $numericType));
+            $exceptionMessage = 'Invalid cron expression part numeric type: %1 is not an instance of '
+                . PartNumericInterface::class;
+            throw new CronException(__($exceptionMessage, $numericType));
         }
 
         return $numeric;

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+/**
+ * Cron expression part parser
+ *
+ * @api
+ */
+class Parser implements ParserInterface
+{
+    /**
+     * @var ParserFactory
+     */
+    private $parserFactory;
+
+    /**
+     * Parser constructor.
+     *
+     * @param ParserFactory $parserFactory
+     */
+    public function __construct(
+        ParserFactory $parserFactory
+    ) {
+        $this->parserFactory = $parserFactory;
+    }
+
+    /**
+     * Perform parse of cron expression part
+     *
+     * @param string $partValue
+     * @param string $parserType
+     *
+     * @return bool|array
+     */
+    public function parse($partValue, $parserType)
+    {
+        return $this->parserFactory->create($parserType)->parse($partValue);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/AbstractParser.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/AbstractParser.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser;
+
+/**
+ * Cron expression part parser class
+ *
+ * @api
+ */
+abstract class AbstractParser implements ParserInterface
+{
+    /**
+     * @var string
+     */
+    private $explodeChar;
+
+    public function __construct(
+        $explodeChar
+    ) {
+        $this->explodeChar = $explodeChar;
+    }
+
+    /**
+     * Perform parse of cron expression part
+     *
+     * @param string $partValue
+     *
+     * @return bool|array
+     */
+    public function parse($partValue)
+    {
+        $partValue = trim($partValue, $this->explodeChar . ' ');
+        return !strlen($partValue) ? [] : explode($this->explodeChar, $partValue);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/ListParser.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/ListParser.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser;
+
+/**
+ * Cron expression part parser class
+ *
+ * @api
+ */
+class ListParser extends AbstractParser
+{
+    const EXPLODE_CHAR = ',';
+
+    /**
+     * ListParser constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(self::EXPLODE_CHAR);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/ModulusParser.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/ModulusParser.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser;
+
+/**
+ * Cron expression part parser class
+ *
+ * @api
+ */
+class ModulusParser extends AbstractParser
+{
+    const EXPLODE_CHAR = '/';
+
+    /**
+     * ModulusParser constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(self::EXPLODE_CHAR);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/ParserInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/ParserInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser;
+
+/**
+ * Cron expression part parser interface
+ *
+ * @api
+ */
+interface ParserInterface
+{
+    /**
+     * Perform parse of cron expression part
+     *
+     * @param string $partValue
+     *
+     * @return bool|array
+     */
+    public function parse($partValue);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/RangeParser.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Parser/RangeParser.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser;
+
+/**
+ * Cron expression part parser class
+ *
+ * @api
+ */
+class RangeParser extends AbstractParser
+{
+    const EXPLODE_CHAR = '-';
+
+    /**
+     * RangeParser constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(self::EXPLODE_CHAR);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ParserFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ParserFactory.php
@@ -51,8 +51,9 @@ class ParserFactory
         );
 
         if (!$parser instanceof PartParserInterface) {
-            $exceptionMessage = 'Invalid cron expression part parser type: %1 is not an instance of ';
-            throw new CronException(__($exceptionMessage . PartParserInterface::class, $parserType));
+            $exceptionMessage = 'Invalid cron expression part parser type: %1 is not an instance of '
+                . PartParserInterface::class;
+            throw new CronException(__($exceptionMessage, $parserType));
         }
 
         return $parser;

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ParserFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ParserFactory.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser\ParserInterface as PartParserInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part parser
+ *
+ * @api
+ */
+class ParserFactory
+{
+    const LIST_PARSER = 'List';
+    const MODULUS_PARSER = 'Modulus';
+    const RANGE_PARSER = 'Range';
+
+    /**
+     * @return array
+     */
+    public function getAvailableParsers()
+    {
+        return [
+            self::LIST_PARSER,
+            self::MODULUS_PARSER,
+            self::RANGE_PARSER,
+        ];
+    }
+
+    /**
+     * Get the parser specified by parser type
+     *
+     * @param string $parserType
+     *
+     * @throws CronException
+     * @return PartParserInterface
+     */
+    public function create($parserType)
+    {
+        if (!in_array($parserType, $this->getAvailableParsers())) {
+            throw new CronException(__('Invalid cron expression part parser type: %1', $parserType));
+        }
+
+        $parser = ObjectManager::getInstance()->get(
+            'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser\\' . $parserType . 'Parser'
+        );
+
+        if (!$parser instanceof PartParserInterface) {
+            $exceptionMessage = 'Invalid cron expression part parser type: %1 is not an instance of ';
+            throw new CronException(__($exceptionMessage . PartParserInterface::class, $parserType));
+        }
+
+        return $parser;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ParserInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ParserInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+/**
+ * Cron expression part parser interface
+ *
+ * @api
+ */
+interface ParserInterface
+{
+    /**
+     * Perform parse of cron expression part
+     *
+     * @param string $partValue
+     * @param string $parserType
+     *
+     * @return bool|array
+     */
+    public function parse($partValue, $parserType);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Validator.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/Validator.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part validator
+ *
+ * @api
+ */
+class Validator implements ValidatorInterface
+{
+    /**
+     * @var ParserInterface
+     */
+    private $parser;
+
+    /**
+     * @var ValidatorHandlerFactory
+     */
+    private $validatorHandlerFactory;
+
+    /**
+     * Validator constructor.
+     *
+     * @param ParserInterface         $parser
+     * @param ValidatorHandlerFactory $validatorHandlerFactory
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    public function __construct(
+        ParserInterface $parser,
+        ValidatorHandlerFactory $validatorHandlerFactory
+    ) {
+        $this->parser = $parser;
+        $this->validatorHandlerFactory = $validatorHandlerFactory;
+    }
+
+    /**
+     * @param PartInterface $part
+     *
+     * @return bool
+     */
+    public function validate(PartInterface $part)
+    {
+        $check = false;
+        foreach ($this->parser->parse($part->getPartValue(), ParserFactory::LIST_PARSER) as $subPartValue) {
+            foreach ($part->getValidatorHandlers() as $validatorHandler) {
+                $subPartValue = $this->validatorHandlerFactory->create($validatorHandler)->handle($part, $subPartValue);
+                if (is_bool($subPartValue)) {
+                    $check = $subPartValue;
+                    break;
+                }
+            }
+
+            if (!$check) {
+                break;
+            }
+        }
+
+        return $check;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Asterisk.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Asterisk.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class Asterisk implements ValidatorHandlerInterface
+{
+    const MATCH_CHAR = '*';
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        return trim($subPartValue) === self::MATCH_CHAR ?: $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/AsteriskModulus.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/AsteriskModulus.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class AsteriskModulus implements ValidatorHandlerInterface
+{
+    /**
+     * @var ValidatorHandlerFactory
+     */
+    private $validatorHandlerFactory;
+
+    /**
+     * AsteriskModulus constructor.
+     *
+     * @param ValidatorHandlerFactory $validatorHandlerFactory
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    public function __construct(
+        ValidatorHandlerFactory $validatorHandlerFactory
+    ) {
+        $this->validatorHandlerFactory = $validatorHandlerFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        return $this->validatorHandlerFactory
+            ->create(ValidatorHandlerFactory::ASTERISK_VALIDATION_HANDLER)
+            ->handle($part, $subPartValue);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Hash.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Hash.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class Hash implements ValidatorHandlerInterface
+{
+    const MATCH_CHAR = '#';
+
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * Validator constructor.
+     *
+     * @param NumericParserFactory $numericFactory
+     */
+    public function __construct(
+        NumericParserFactory $numericFactory
+    ) {
+        $this->numericFactory = $numericFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        $numeric = $this->numericFactory->create($part->getNumericParser());
+        $regexp = '/^[' . $numeric->getRangeMin() . '-' . $numeric->getRangeMax() . ']' . self::MATCH_CHAR . '[1-5]$/';
+        return (bool)preg_match($regexp, $subPartValue) ?: $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Last.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Last.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class Last implements ValidatorHandlerInterface
+{
+    const MATCH_CHAR = 'L';
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        return trim($subPartValue) === self::MATCH_CHAR ?: $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/LastWeekDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/LastWeekDay.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class LastWeekDay implements ValidatorHandlerInterface
+{
+    const MATCH_CHAR = 'L';
+
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * Validator constructor.
+     *
+     * @param NumericParserFactory $numericFactory
+     */
+    public function __construct(
+        NumericParserFactory $numericFactory
+    ) {
+        $this->numericFactory = $numericFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        $numeric = $this->numericFactory->create($part->getNumericParser());
+        $regexp = '/^[' . $numeric->getRangeMin() . '-' . $numeric->getRangeMax() . ']' . self::MATCH_CHAR . '$/';
+        return (bool)preg_match($regexp, $subPartValue) ?: $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Modulus.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Modulus.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ParserInterface;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class Modulus implements ValidatorHandlerInterface
+{
+    /**
+     * @var ParserInterface
+     */
+    private $parser;
+
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * Modulus constructor.
+     *
+     * @param ParserInterface      $parser
+     * @param NumericParserFactory $numericFactory
+     */
+    public function __construct(
+        ParserInterface $parser,
+        NumericParserFactory $numericFactory
+    ) {
+        $this->parser = $parser;
+        $this->numericFactory = $numericFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        $subPartValues = $this->parser->parse($subPartValue, ParserFactory::MODULUS_PARSER);
+
+        if (count($subPartValues) > 1) {
+            if (count($subPartValues) !== 2) {
+                return false;
+            }
+
+            if (!is_numeric($subPartValues[1])) {
+                return false;
+            }
+
+            return $subPartValues[0];
+        }
+
+        return $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/NearestWeekDay.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/NearestWeekDay.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class NearestWeekDay implements ValidatorHandlerInterface
+{
+    const MATCH_CHAR = 'W';
+
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * Validator constructor.
+     *
+     * @param NumericParserFactory $numericFactory
+     */
+    public function __construct(
+        NumericParserFactory $numericFactory
+    ) {
+        $this->numericFactory = $numericFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        $numeric = $this->numericFactory->create($part->getNumericParser());
+        $regexp = '/^(' . implode('|', range($numeric->getRangeMin(), $numeric->getRangeMax())) . ')'
+            . self::MATCH_CHAR . '$/';
+        return (bool) preg_match($regexp, $subPartValue) ?: $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/QuestionMark.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/QuestionMark.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class QuestionMark implements ValidatorHandlerInterface
+{
+    const MATCH_CHAR = '?';
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        return trim($subPartValue) === self::MATCH_CHAR ?: $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/QuestionMarkModulus.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/QuestionMarkModulus.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class QuestionMarkModulus implements ValidatorHandlerInterface
+{
+    /**
+     * @var ValidatorHandlerFactory
+     */
+    private $validatorHandlerFactory;
+
+    /**
+     * QuestionMarkModulus constructor.
+     *
+     * @param ValidatorHandlerFactory $validatorHandlerFactory
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    public function __construct(
+        ValidatorHandlerFactory $validatorHandlerFactory
+    ) {
+        $this->validatorHandlerFactory = $validatorHandlerFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        return $this->validatorHandlerFactory
+            ->create(ValidatorHandlerFactory::QUESTION_MARK_VALIDATION_HANDLER)
+            ->handle($part, $subPartValue);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Range.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Range.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ParserInterface;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class Range implements ValidatorHandlerInterface
+{
+    /**
+     * @var ParserInterface
+     */
+    private $parser;
+
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * Range constructor.
+     *
+     * @param ParserInterface      $parser
+     * @param NumericParserFactory $numericFactory
+     */
+    public function __construct(
+        ParserInterface $parser,
+        NumericParserFactory $numericFactory
+    ) {
+        $this->parser = $parser;
+        $this->numericFactory = $numericFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        $subPartValues = $this->parser->parse($subPartValue, ParserFactory::RANGE_PARSER);
+
+        if (count($subPartValues) > 1) {
+            if (count($subPartValues) !== 2) {
+                return false;
+            }
+
+            $numeric = $this->numericFactory->create($part->getNumericParser());
+
+            $fromValue = $numeric->getNumber($subPartValues[0]);
+            $toValue = $numeric->getNumber($subPartValues[1]);
+
+            return $fromValue !== false && $toValue !== false && $fromValue <= $toValue;
+        }
+
+        return $subPartValue;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Regular.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/Regular.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler class
+ *
+ * @api
+ */
+class Regular implements ValidatorHandlerInterface
+{
+    /**
+     * @var NumericParserFactory
+     */
+    private $numericFactory;
+
+    /**
+     * Validator constructor.
+     *
+     * @param NumericParserFactory $numericFactory
+     */
+    public function __construct(
+        NumericParserFactory $numericFactory
+    ) {
+        $this->numericFactory = $numericFactory;
+    }
+
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue)
+    {
+        return $this->numericFactory->create($part->getNumericParser())->getNumber($subPartValue) !== false;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/ValidatorHandlerInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandler/ValidatorHandlerInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression sub part validator handler interface
+ *
+ * @api
+ */
+interface ValidatorHandlerInterface
+{
+    /**
+     * Handle cron expression sub part
+     *
+     * Returns
+     * - If valid:
+     *   - original/modified $subPartValue, to continue processing other handles
+     *   - true, to stop executing next handles
+     * - If not valid
+     *   - false, to stop executing next handles
+     *
+     * @param PartInterface $part
+     * @param string        $subPartValue
+     *
+     * @return string|bool
+     */
+    public function handle(PartInterface $part, $subPartValue);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandlerFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandlerFactory.php
@@ -71,8 +71,9 @@ class ValidatorHandlerFactory
             );
 
         if (!$validatorHandler instanceof ValidatorHandlerInterface) {
-            $exceptionMessage = 'Invalid cron expression part validator handler type: %1 is not an instance of ';
-            throw new CronException(__($exceptionMessage . ValidatorHandlerInterface::class, $validatorHandlerType));
+            $exceptionMessage = 'Invalid cron expression part validator handler type: %1 is not an instance of '
+                . ValidatorHandlerInterface::class;
+            throw new CronException(__($exceptionMessage, $validatorHandlerType));
         }
 
         return $validatorHandler;

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandlerFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorHandlerFactory.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler\ValidatorHandlerInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part validatorHandler factory
+ *
+ * @api
+ */
+class ValidatorHandlerFactory
+{
+    const ASTERISK_VALIDATION_HANDLER = 'Asterisk';
+    const QUESTION_MARK_VALIDATION_HANDLER = 'QuestionMark';
+    const MODULUS_VALIDATION_HANDLER = 'Modulus';
+    const ASTERISK_MODULUS_VALIDATION_HANDLER = 'AsteriskModulus';
+    const QUESTION_MARK_MODULUS_VALIDATION_HANDLER = 'QuestionMarkModulus';
+    const RANGE_VALIDATION_HANDLER = 'Range';
+    const REGULAR_VALIDATION_HANDLER = 'Regular';
+    const LAST_VALIDATION_HANDLER = 'Last';
+    const LAST_WEEKDAY_VALIDATION_HANDLER = 'LastWeekDay';
+    const HASH_VALIDATION_HANDLER = 'Hash';
+    const NEAREST_WEEKDAY_VALIDATION_HANDLER = 'NearestWeekDay';
+
+    /**
+     * @return array
+     */
+    public function getAvailableValidatorHandlers()
+    {
+        return [
+            self::ASTERISK_VALIDATION_HANDLER,
+            self::QUESTION_MARK_VALIDATION_HANDLER,
+            self::MODULUS_VALIDATION_HANDLER,
+            self::ASTERISK_MODULUS_VALIDATION_HANDLER,
+            self::QUESTION_MARK_MODULUS_VALIDATION_HANDLER,
+            self::RANGE_VALIDATION_HANDLER,
+            self::REGULAR_VALIDATION_HANDLER,
+            self::LAST_VALIDATION_HANDLER,
+            self::LAST_WEEKDAY_VALIDATION_HANDLER,
+            self::HASH_VALIDATION_HANDLER,
+            self::NEAREST_WEEKDAY_VALIDATION_HANDLER,
+        ];
+    }
+
+    /**
+     * Get the validatorHandler specified by validatorHandler type
+     *
+     * @param string $validatorHandlerType
+     *
+     * @throws CronException
+     * @return ValidatorHandlerInterface
+     */
+    public function create($validatorHandlerType)
+    {
+        if (!in_array($validatorHandlerType, $this->getAvailableValidatorHandlers())) {
+            throw new CronException(
+                __('Invalid cron expression part validator handler type: %1', $validatorHandlerType)
+            );
+        }
+
+        $validatorHandler = ObjectManager::getInstance()
+            ->get(
+                'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler\\'
+                . $validatorHandlerType
+            );
+
+        if (!$validatorHandler instanceof ValidatorHandlerInterface) {
+            $exceptionMessage = 'Invalid cron expression part validator handler type: %1 is not an instance of ';
+            throw new CronException(__($exceptionMessage . ValidatorHandlerInterface::class, $validatorHandlerType));
+        }
+
+        return $validatorHandler;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Part/ValidatorInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+
+/**
+ * Cron expression part validator interface
+ *
+ * @api
+ */
+interface ValidatorInterface
+{
+    /**
+     * Perform validation of cron expression part
+     *
+     * @param PartInterface $part
+     *
+     * @return bool
+     */
+    public function validate(PartInterface $part);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/PartFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/PartFactory.php
@@ -63,8 +63,9 @@ class PartFactory
             ->create('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index\\' . $indexType);
 
         if (!$part instanceof PartInterface) {
-            $exceptionMessage = 'Invalid cron expression part index: %1 is not an instance of ';
-            throw new CronException(__($exceptionMessage . PartInterface::class, $indexType));
+            $exceptionMessage = 'Invalid cron expression part index: %1 is not an instance of '
+                . PartInterface::class;
+            throw new CronException(__($exceptionMessage, $indexType));
         }
 
         $part->setPartValue($partValue);

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/PartFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/PartFactory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part factory
+ *
+ * @api
+ */
+class PartFactory
+{
+    const GENERIC_PART = 'Generic';
+
+    /**
+     * Get available indexes, and its mapping with index part classes for factories
+     *
+     * @return array
+     */
+    public function getPartAvailableIndexes()
+    {
+        return [
+            0 => 'Minutes',
+            1 => 'Hours',
+            2 => 'MonthDay',
+            3 => 'Month',
+            4 => 'WeekDay',
+            5 => 'Year',
+        ];
+    }
+
+    /**
+     * Create an expression part object
+     *
+     * @param int|string $partIndex
+     * @param string     $partValue
+     *
+     * @throws CronException
+     * @return PartInterface
+     */
+    public function create($partIndex, $partValue)
+    {
+        $availableIndexes = $this->getPartAvailableIndexes();
+        if (array_key_exists($partIndex, $availableIndexes)) {
+            $indexType = $availableIndexes[$partIndex];
+        }
+
+        if (!isset($indexType) && $partIndex == self::GENERIC_PART) {
+            $indexType = $partIndex;
+        }
+
+        if (!isset($indexType)) {
+            throw new CronException(__('Invalid cron expression part index: %1', $partIndex));
+        }
+
+        /** @var Part $part */
+        $part = ObjectManager::getInstance()
+            ->create('Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index\\' . $indexType);
+
+        if (!$part instanceof PartInterface) {
+            $exceptionMessage = 'Invalid cron expression part index: %1 is not an instance of ';
+            throw new CronException(__($exceptionMessage . PartInterface::class, $indexType));
+        }
+
+        $part->setPartValue($partValue);
+
+        return $part;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/PartInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/PartInterface.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression part encapsulation interface
+ *
+ * @api
+ */
+interface PartInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getValidatorHandlers();
+
+    /**
+     * Numeric parser for expression part
+     *
+     * @return string
+     */
+    public function getNumericParser();
+
+    /**
+     * @return string
+     */
+    public function getPartMatcher();
+
+    /**
+     * Set part value
+     *
+     * @param string $partValue
+     *
+     * @throws CronException
+     * @return void
+     */
+    public function setPartValue($partValue);
+
+    /**
+     * Get cron expression part string value
+     *
+     * @return string
+     */
+    public function getPartValue();
+
+    /**
+     * Get cron expression part is valid
+     *
+     * @return bool
+     */
+    public function validate();
+
+    /**
+     * Reset part inner data
+     *
+     * @return void
+     */
+    public function reset();
+
+    /**
+     * Get cron expression part matches number
+     *
+     * @param int $number
+     *
+     * @return bool
+     */
+    public function match($number);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Validator.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/Validator.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface;
+
+/**
+ * Schedule cron expression validator
+ *
+ * @api
+ */
+class Validator implements ValidatorInterface
+{
+    const MIN_PARTS_NUMBER = 5;
+    const MAX_PARTS_NUMBER = 6;
+
+    /**
+     * Perform validation of cron expression
+     *
+     * @param ExpressionInterface $expression
+     *
+     * @return bool
+     */
+    public function validate(ExpressionInterface $expression)
+    {
+        $parts = $expression->getParts();
+
+        if (empty($parts)) {
+            return false;
+        }
+
+        if (count($parts) < self::MIN_PARTS_NUMBER || count($parts) > self::MAX_PARTS_NUMBER) {
+            return false;
+        }
+
+        /** @var PartInterface $part */
+        foreach ($parts as $part) {
+            if (!$part instanceof PartInterface || !$part->validate()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/ValidatorInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/Expression/ValidatorInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface;
+
+/**
+ * Cron expression validator interface
+ *
+ * @api
+ */
+interface ValidatorInterface
+{
+    /**
+     * Perform validation of cron expression
+     *
+     * @param ExpressionInterface $expression
+     *
+     * @return bool
+     */
+    public function validate(ExpressionInterface $expression);
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/ExpressionFactory.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/ExpressionFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule;
+
+use Magento\Framework\App\ObjectManager;
+
+/**
+ * Cron expression factory
+ *
+ * @api
+ */
+class ExpressionFactory
+{
+    /**
+     * Create an expression object
+     *
+     * @return ExpressionInterface
+     */
+    public function create()
+    {
+        /** @var ExpressionInterface $expression */
+        return ObjectManager::getInstance()->create(ExpressionInterface::class);
+    }
+}

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule/ExpressionInterface.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule/ExpressionInterface.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model\ResourceModel\Schedule;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface;
+use Magento\Framework\Exception\CronException;
+
+/**
+ * Cron expression encapsulation interface
+ *
+ * @api
+ */
+interface ExpressionInterface
+{
+    /**
+     * Set cron expression
+     *
+     * @param string $cronExpr
+     *
+     * @throws CronException
+     * @return void
+     */
+    public function setCronExpr($cronExpr);
+
+    /**
+     * Get cron expression
+     *
+     * @return string
+     */
+    public function getCronExpr();
+
+    /**
+     * Get cron expression is valid
+     *
+     * @return bool
+     */
+    public function validate();
+
+    /**
+     * Get cron expression parts array
+     *
+     * @return bool|PartInterface[]
+     */
+    public function getParts();
+
+    /**
+     * Match cron expression against timestamp
+     *
+     * @param int $timestamp
+     *
+     * @return bool
+     */
+    public function match($timestamp);
+
+    /**
+     * Reset object
+     *
+     * @return void
+     */
+    public function reset();
+}

--- a/app/code/Magento/Cron/Test/Unit/Console/Command/CronInstallCommandTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Console/Command/CronInstallCommandTest.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\Cron\Test\Unit\Console\Command;
 
-use Symfony\Component\Console\Tester\CommandTester;
 use Magento\Cron\Console\Command\CronInstallCommand;
+use Magento\Framework\Console\Cli;
 use Magento\Framework\Crontab\CrontabManagerInterface;
 use Magento\Framework\Crontab\TasksProviderInterface;
-use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class CronInstallCommandTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Cron/Test/Unit/Console/Command/CronRemoveCommandTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Console/Command/CronRemoveCommandTest.php
@@ -5,12 +5,12 @@
  */
 namespace Magento\Cron\Test\Unit\Console\Command;
 
-use Symfony\Component\Console\Tester\CommandTester;
 use Magento\Cron\Console\Command\CronRemoveCommand;
-use Magento\Framework\Crontab\CrontabManagerInterface;
 use Magento\Framework\Console\Cli;
+use Magento\Framework\Crontab\CrontabManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class CronRemoveCommandTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Cron/Test/Unit/Model/AbstractSchedule.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/AbstractSchedule.php
@@ -1,0 +1,551 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Test\Unit\Model;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher as ExpressionMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser as ExpressionParser;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part as ExpressionPart;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherFactory as ExpressionPartMatcherFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParserFactory as ExpressionPartNumericFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser as ExpressionPartParser;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ParserFactory as ExpressionPartParserFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandlerFactory
+    as ExpressionPartValidatorHandlerFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\PartFactory as ExpressionPartFactory;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator as ExpressionValidator;
+use Magento\Cron\Model\ResourceModel\Schedule\ExpressionFactory;
+
+/**
+ * Class \Magento\Cron\Test\Unit\Model\AbstractScheduleTest
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class AbstractSchedule extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $helper;
+
+    /**
+     * @var string
+     */
+    private $scheduledtAt = '2011-12-13 14:15:16';
+
+    /**
+     * @return \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    public function getHelper()
+    {
+        return $this->helper;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScheduledtAt()
+    {
+        return $this->scheduledtAt;
+    }
+
+    /**
+     * @return false|int
+     */
+    public function getScheduledAtTimestamp()
+    {
+        return strtotime($this->getScheduledtAt());
+    }
+
+    protected function setUp()
+    {
+        $this->helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+    }
+
+    /******************* Expression level **********************/
+    /**
+     * @param string $cronExpr
+     *
+     * @return Expression
+     */
+    protected function getExpressionObject($cronExpr = '')
+    {
+        $expressionValidator = $this->getExpressionValidatorObject();
+        $expressionParser = $this->getExpressionParserObject($cronExpr);
+        $expressionMatcher = $this->getExpressionMatcherObject();
+
+        $expression = $this->getMockBuilder(Expression::class)
+            ->setMethods(['getCronExpr'])
+            ->setConstructorArgs(
+                [
+                    'expressionValidator' => $expressionValidator,
+                    'expressionParser' => $expressionParser,
+                    'expressionMatcher' => $expressionMatcher,
+                ]
+            )
+            ->getMock()
+        ;
+
+        $expression->expects($this->any())->method('getCronExpr')->will($this->returnValue($cronExpr));
+
+        return $expression;
+    }
+
+    /**
+     * @param string $cronExpr
+     *
+     * @return ExpressionFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getExpressionFactoryObject($cronExpr = '')
+    {
+        /** @var ExpressionFactory|\PHPUnit_Framework_MockObject_MockObject $expressionFactory */
+        $expressionFactory = $this->getMockBuilder(ExpressionFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $expression = $this->getExpressionObject($cronExpr);
+        $expressionFactory->expects($this->any())->method('create')->willReturn($expression);
+
+        return $expressionFactory;
+    }
+
+    /**
+     * @return ExpressionValidator
+     */
+    protected function getExpressionValidatorObject()
+    {
+        /** @var ExpressionValidator $expressionValidator */
+        $expressionValidator = $this->helper->getObject(ExpressionValidator::class);
+        return $expressionValidator;
+    }
+
+    /**
+     * @param string $cronExpr
+     *
+     * @return ExpressionParser
+     */
+    protected function getExpressionParserObject($cronExpr = '')
+    {
+        /** @var ExpressionParser $expressionParser */
+        $expressionParser = $this->helper->getObject(
+            ExpressionParser::class,
+            [
+                'partFactory' => $this->getExpressionPartFactoryObject($cronExpr)
+            ]
+        );
+        return $expressionParser;
+    }
+
+    /**
+     * @return ExpressionMatcher
+     */
+    protected function getExpressionMatcherObject()
+    {
+        /** @var ExpressionMatcher $expressionMatcher */
+        $expressionMatcher = $this->helper->getObject(
+            ExpressionMatcher::class,
+            [
+                'matcherFactory' => $this->getExpressionPartMatcherFactoryObject()
+            ]
+        );
+        return $expressionMatcher;
+    }
+
+    /**
+     * @param int    $indexType
+     * @param string $partValue
+     *
+     * @return ExpressionPart
+     */
+    protected function getExpressionPartObject($indexType, $partValue)
+    {
+        $validator = $this->getExpressionPartValidatorObject();
+        $parser = $this->getExpressionPartParserObject();
+        $matcher = $this->getExpressionPartMatcherObject();
+
+        /** @var ExpressionPart $expressionPart */
+        $expressionPart = $this->helper->getObject(
+            'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Index\\' . $indexType,
+            [
+                'validator' => $validator,
+                'parser' => $parser,
+                'matcher' => $matcher,
+            ]
+        );
+
+        $expressionPart->setPartValue($partValue);
+
+        return $expressionPart;
+    }
+
+    /**
+     * @param string $cronExpr
+     *
+     * @return ExpressionPartFactory
+     */
+    protected function getExpressionPartFactoryObject($cronExpr = '')
+    {
+        /** @var ExpressionPartFactory|\PHPUnit_Framework_MockObject_MockObject $partFactory */
+        $partFactory = $this->getMockBuilder(ExpressionPartFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $returnValueMap = [];
+        $returnValueMap[] = [
+            PartFactory::GENERIC_PART,
+            $cronExpr,
+            $this->getExpressionPartObject(PartFactory::GENERIC_PART, $cronExpr)
+        ];
+
+        $availableValidators = $partFactory->getPartAvailableIndexes();
+        $cronExprParts = preg_split('#\s+#', $cronExpr, null, PREG_SPLIT_NO_EMPTY);
+        foreach ($cronExprParts as $partIndex => $partValue) {
+            $returnValueMap[] = [
+                PartFactory::GENERIC_PART,
+                $partValue,
+                $this->getExpressionPartObject(PartFactory::GENERIC_PART, $partValue)
+            ];
+            if (isset($availableValidators[$partIndex])) {
+                $returnValueMap[] = [
+                    $partIndex,
+                    $partValue,
+                    $this->getExpressionPartObject($availableValidators[$partIndex], $partValue)
+                ];
+            }
+        }
+
+        $partFactory->expects($this->any())->method('create')->willReturnMap($returnValueMap);
+
+        return $partFactory;
+    }
+
+    /******************* Expression part level **********************/
+    /**
+     * @return ExpressionPartValidator
+     */
+    protected function getExpressionPartValidatorObject()
+    {
+        /** @var ExpressionPartValidator $expressionValidator */
+        $partValidator = $this->helper->getObject(
+            ExpressionPartValidator::class,
+            [
+                'parser' => $this->getExpressionPartParserObject(),
+                'validatorHandlerFactory' => $this->getExpressionPartValidatorHandlerFactoryObject(),
+            ]
+        );
+        return $partValidator;
+    }
+
+    /**
+     * @return ExpressionPartParser
+     */
+    protected function getExpressionPartParserObject()
+    {
+        /** @var ExpressionPartParser $expressionParser */
+        $partParser = $this->helper->getObject(
+            ExpressionPartParser::class,
+            [
+                'parserFactory' => $this->getExpressionPartParserFactoryObject(),
+            ]
+        );
+        return $partParser;
+    }
+
+    /**
+     * @return ExpressionPartMatcher
+     */
+    protected function getExpressionPartMatcherObject()
+    {
+        /** @var ExpressionPartMatcher $partMatcher */
+        $partMatcher = $this->helper->getObject(
+            ExpressionPartMatcher::class,
+            [
+                'parser' => $this->getExpressionPartParserObject(),
+                'matcherFactory' => $this->getExpressionPartMatcherFactoryObject(),
+                'numericFactory' => $this->getExpressionPartNumericFactoryObject(),
+                'validatorHandlerFactory' => $this->getExpressionPartValidatorHandlerFactoryObject(),
+            ]
+        );
+        return $partMatcher;
+    }
+
+    /**
+     * @return ExpressionPartParserFactory
+     */
+    protected function getExpressionPartParserFactoryObject()
+    {
+        /** @var ExpressionPartParserFactory|\PHPUnit_Framework_MockObject_MockObject $parseFactory */
+        $parseFactory = $this->getMockBuilder(ExpressionPartParserFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $returnValueMap = [];
+        $availableParsers = $parseFactory->getAvailableParsers();
+        foreach ($availableParsers as $parserType) {
+            $returnValueMap[] = [
+                $parserType,
+                $this->helper->getObject(
+                    'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser\\'
+                    . $parserType . 'Parser'
+                )
+            ];
+        }
+
+        $parseFactory->expects($this->any())->method('create')->willReturnMap($returnValueMap);
+
+        return $parseFactory;
+    }
+
+    /**
+     * @return ExpressionPartMatcherFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getExpressionPartMatcherFactoryObject()
+    {
+        /** @var ExpressionPartMatcherFactory|\PHPUnit_Framework_MockObject_MockObject $matcherFactory */
+        $matcherFactory = $this->getMockBuilder(ExpressionPartMatcherFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $returnValueMap = [];
+        $availableMatchers = $matcherFactory->getAvailableMatchers();
+        foreach ($availableMatchers as $matcherType) {
+            $returnValueMap[] = [
+                $matcherType,
+                $this->helper->getObject(
+                    'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher\\' . $matcherType
+                )
+            ];
+        }
+
+        $matcherFactory->expects($this->any())->method('create')->willReturnMap($returnValueMap);
+
+        return $matcherFactory;
+    }
+
+    /**
+     * @return ExpressionPartValidatorHandlerFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    protected function getExpressionPartValidatorHandlerFactoryObject()
+    {
+        /** @var ExpressionPartValidatorHandlerFactory|\PHPUnit_Framework_MockObject_MockObject
+         * $validatorHandlerFactory */
+        $validatorHandlerFactory = $this->getMockBuilder(ExpressionPartValidatorHandlerFactory::class)
+            ->setMethods(['create'])->disableOriginalConstructor()->getMock()
+        ;
+
+        $returnValueMap = [];
+        $availableValidatorHandlers = $validatorHandlerFactory->getAvailableValidatorHandlers();
+        foreach ($availableValidatorHandlers as $validatorHandlerType) {
+            $returnValueMap[] = [
+                $validatorHandlerType,
+                $this->helper->getObject(
+                    'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorHandler\\'
+                    . $validatorHandlerType,
+                    [
+                        'validatorHandlerFactory' => $validatorHandlerFactory,
+                        'parser' => $this->getExpressionPartParserObject(),
+                        'numericFactory' => $this->getExpressionPartNumericFactoryObject(),
+                    ]
+                )
+            ];
+        }
+
+        $validatorHandlerFactory->expects($this->any())->method('create')->willReturnMap($returnValueMap);
+
+        return $validatorHandlerFactory;
+    }
+
+    /**
+     * @return ExpressionPartNumericFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getExpressionPartNumericFactoryObject()
+    {
+        /** @var ExpressionPartNumericFactory|\PHPUnit_Framework_MockObject_MockObject $numericFactory */
+        $numericFactory = $this->getMockBuilder(ExpressionPartNumericFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $returnValueMap = [];
+        $availableNumerics = $numericFactory->getAvailableNumerics();
+        foreach ($availableNumerics as $numericType) {
+            $returnValueMap[] = [
+                $numericType,
+                $this->helper->getObject(
+                    'Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\NumericParser\\' . $numericType
+                )
+            ];
+        }
+
+        $numericFactory->expects($this->any())->method('create')->willReturnMap($returnValueMap);
+
+        return $numericFactory;
+    }
+
+    /**
+     * @return array
+     */
+    public function booleanDataProvider()
+    {
+        return [
+            [true],
+            [false]
+        ];
+    }
+
+    /**
+     * Data provider
+     *
+     * List of valid expressions for cron expression
+     *
+     * @return array
+     */
+    public function validCronExprDataProvider()
+    {
+        $data = [];
+        foreach ($this->fullCronExprDataProvider() as $cronExprData) {
+            if ($cronExprData[2] === true) {
+                $data[] = $cronExprData;
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Data provider
+     *
+     * List of invalid expressions for cron expression
+     *
+     * @return array
+     */
+    public function invalidCronExprDataProvider()
+    {
+        $data = [];
+        foreach ($this->fullCronExprDataProvider() as $cronExprData) {
+            if ($cronExprData[2] === false) {
+                $data[] = $cronExprData;
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Data provider
+     *
+     * List of valid and invalid expressions for cron expression
+     * Array components: string cron expression, parsed array, expected validity, expected match against timestamp
+     *
+     * @return array
+     */
+    public function fullCronExprDataProvider()
+    {
+        return [
+            ['* * * * *', ['*', '*', '*', '*', '*'], true, true],
+            ['* * * * * *', ['*', '*', '*', '*', '*', '*'], true, true],
+            ['1 2 3 4', ['1', '2', '3', '4'], false, false],
+            ['58 6 6 10 4 2017', ['58', '6', '6', '10', '4', '2017'], true, false],
+            [
+                '58/2 6/3 6/4 10/8 4/2 2017/10',
+                ['58/2', '6/3', '6/4', '10/8', '4/2', '2017/10'],
+                true,
+                false
+            ],
+            [
+                '18-39/2 6-16/3 6-16/4 10-12/8 4-5/2 2017-2020',
+                ['18-39/2', '6-16/3', '6-16/4', '10-12/8', '4-5/2', '2017-2020'],
+                true,
+                false
+            ],
+            [
+                '18-39 6-16 6-16 10-12 4-5 2017-2020',
+                ['18-39', '6-16', '6-16', '10-12', '4-5', '2017-2020'],
+                true,
+                false
+            ],
+            ['* * ? * *', ['*', '*', '?', '*', '*'], true, true],
+            ['* * L * *', ['*', '*', 'L', '*', '*'], true, false],
+            ['* * * * ?', ['*', '*', '*', '*', '?'], true, true],
+            ['* * * * L', ['*', '*', '*', '*', 'L'], false, false],
+            ['* * * * 5L', ['*', '*', '*', '*', '5L'], true, false],
+            ['* * 5W * *', ['*', '*', '5W', '*', '*'], true, false],
+            ['* * * * #', ['*', '*', '*', '*', '#'], false, false],
+            ['* * * * 5#', ['*', '*', '*', '*', '5#'], false, false],
+            ['* * * * #3', ['*', '*', '*', '*', '#3'], false, false],
+            ['* * * * 5#3', ['*', '*', '*', '*', '5#3'], true, false],
+
+            ['', false, false, false],
+            [null, false, false, false],
+            [false, false, false, false],
+            ['0', ['0'], false, false],
+            ['* * * *', ['*', '*', '*', '*'], false, false],
+            ['* * * * * * *', ['*', '*', '*', '*', '*', '*', '*'], false, false],
+            ['1 2 3 4', ['1', '2', '3', '4'], false, false],
+            ['1 2 3 4 5 6 7', ['1', '2', '3', '4', '5', '6', '7'], false, false],
+            ['a b c d e', ['a', 'b', 'c', 'd', 'e'], false, false],
+            [', * * * *', [',', '*', '*', '*', '*'], false, false],
+            ['* , * * *', ['*', ',', '*', '*', '*'], false, false],
+            ['* * , * *', ['*', '*', ',', '*', '*'], false, false],
+            ['* * * , *', ['*', '*', '*', ',', '*'], false, false],
+            ['* * * * ,', ['*', '*', '*', '*', ','], false, false],
+            ['* * * * * ,', ['*', '*', '*', '*', '*', ','], false, false],
+            ['68 6 6 10 * 2017', ['68', '6', '6', '10', '*', '2017'], false, false],
+            ['58 36 6 10 * 2017', ['58', '36', '6', '10', '*', '2017'], false, false],
+            ['58 6 36 10 * 2017', ['58', '6', '36', '10', '*', '2017'], false, false],
+            ['58 6 6 16 * 2017', ['58', '6', '6', '16', '*', '2017'], false, false],
+            ['58 6 6 10 8 2017', ['58', '6', '6', '10', '8', '2017'], false, false],
+            ['58 6 6 10 * 2117', ['58', '6', '6', '10', '*', '2117'], false, false],
+            ['58 6 6 0 * 2017', ['58', '6', '6', '0', '*', '2017'], false, false],
+            ['58 6 6 10 * 1917', ['58', '6', '6', '10', '*', '1917'], false, false],
+            ['58/60 6/3 6/4 10/8 4/2 2017/10', ['58/60', '6/3', '6/4', '10/8', '4/2', '2017/10'], true, false],
+            ['58/2 6/30 6/4 10/8 4/2 2017/10', ['58/2', '6/30', '6/4', '10/8', '4/2', '2017/10'], true, false],
+            ['58/2 6/3 6/40 10/8 4/2 2017/10', ['58/2', '6/3', '6/40', '10/8', '4/2', '2017/10'], true, false],
+            ['58/2 6/3 6/4 10/80 4/2 2017/10', ['58/2', '6/3', '6/4', '10/80', '4/2', '2017/10'], true, false],
+            ['58/2 6/3 6/4 10/8 4/20 2017/10', ['58/2', '6/3', '6/4', '10/8', '4/20', '2017/10'], true, false],
+            [
+                '39-18/2 16-6/3 16-6/4 12-10/8 5-4/2 2020-2017',
+                ['39-18/2', '16-6/3', '16-6/4', '12-10/8', '5-4/2', '2020-2017'],
+                false,
+                false
+            ],
+            ['* * * ? *', ['*', '*', '*', '?', '*'], false, false],
+            ['* * * L *', ['*', '*', '*', 'L', '*'], false, false],
+            ['* * * W *', ['*', '*', '*', 'W', '*'], false, false],
+            ['* * * C *', ['*', '*', '*', 'C', '*'], false, false],
+            ['* * 5L * *', ['*', '*', '5L', '*', '*'], false, false],
+            ['* * W * *', ['*', '*', 'W', '*', '*'], false, false],
+            ['* * * * L5', ['*', '*', '*', '*', 'L5'], false, false],
+            ['* * * * a#', ['*', '*', '*', '*', 'a#'], false, false],
+            ['* * * * #a', ['*', '*', '*', '*', '#a'], false, false],
+            ['* * * * a#a', ['*', '*', '*', '*', 'a#a'], false, false],
+            ['15 * * * *', ['15', '*', '*', '*', '*'], true, true],
+            ['* 14 * * *', ['*', '14', '*', '*', '*'], true, true],
+            ['* * 13 * *', ['*', '*', '13', '*', '*'], true, true],
+            ['* * * 12 *', ['*', '*', '*', '12', '*'], true, true],
+            ['*/15 * * * *', ['*/15', '*', '*', '*', '*'], true, true],
+            ['*/4 * * * *', ['*/4', '*', '*', '*', '*'], true, false],
+            ['15/15 * * * *', ['15/15', '*', '*', '*', '*'], true, true],
+            ['30/15 * * * *', ['30/15', '*', '*', '*', '*'], true, false],
+            ['* 30,*/7 * * *', ['*', '30,*/7', '*', '*', '*'], false, false],
+            ['* */7,30 * * *', ['*', '*/7/,30', '*', '*', '*'], false, false],
+            ['* * 15,*/13 * *', ['*', '*', '15,*/13', '*', '*'], true, true],
+            ['* * * */6 *', ['*', '*', '*', '*/6', '*'], true, true],
+            ['* * * * Monday', ['*', '*', '*', '*', 'Monday'], true, false],
+            ['* * * * Tuesday', ['*', '*', '*', '*', 'Tuesday'], true, true],
+        ];
+    }
+}

--- a/app/code/Magento/Cron/Test/Unit/Model/CronJobException.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/CronJobException.php
@@ -6,7 +6,7 @@
 
 /**
  * Class CronJobException used to check that cron handles execution exception
- * Please see \Magento\Cron\Test\Unit\Model\ObserverTest
+ * @see \Magento\Cron\Test\Unit\Observer\ProcessCronQueueObserverTest::dispatchExceptionInCallbackDataProvider
  */
 namespace Magento\Cron\Test\Unit\Model;
 

--- a/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/MatcherTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/MatcherTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Test\Unit\Model\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher as ExpressionMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser as ExpressionParser;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator as ExpressionValidator;
+use Magento\Cron\Test\Unit\Model\AbstractSchedule;
+
+/**
+ * Class \Magento\Cron\Test\Unit\Model\Schedule\Expression\MatcherTest
+ */
+class MatcherTest extends AbstractSchedule
+{
+    /**
+     * @var Expression|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expression;
+
+    /**
+     * @var ExpressionValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionValidator;
+
+    /**
+     * @var ExpressionParser|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionParser;
+
+    /**
+     * @var ExpressionMatcher|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionMatcher;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->expressionValidator = $this->getMockBuilder(ExpressionValidator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->expressionParser = $this->getMockBuilder(ExpressionParser::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->expressionMatcher = $this->getMockBuilder(ExpressionMatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var Expression|\PHPUnit_Framework_MockObject_MockObject $expression */
+        $this->expression = $this->getMockBuilder(Expression::class)
+            ->setMethods(['getCronExpr'])
+            ->setConstructorArgs(
+                [
+                    'expressionValidator' => $this->expressionValidator,
+                    'expressionParser' => $this->expressionParser,
+                    'expressionMatcher' => $this->expressionMatcher,
+                ]
+            )
+            ->getMock();
+    }
+
+    /**
+     * @param string $cronExpr
+     * @param array $cronExprArr
+     * @param bool $expectedValid
+     * @param bool $expectedMatch
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher::match
+     * @dataProvider fullCronExprDataProvider
+     */
+    public function testMatch($cronExpr, $cronExprArr, $expectedValid, $expectedMatch)
+    {
+        $expressionMatcher = $this->getExpressionMatcherObject();
+        $this->expression->expects($this->any())->method('getCronExpr')->will($this->returnValue($cronExpr));
+
+        $exprPartFactory = $this->getExpressionPartFactoryObject($cronExpr);
+
+        $parts = [];
+        if (is_array($cronExprArr)) {
+            foreach ($cronExprArr as $partIndex => $partValue) {
+                $parts[] = $exprPartFactory->create($partIndex, $partValue);
+            }
+        }
+
+        $this->expressionValidator->expects($this->any())->method('validate')->will($this->returnValue($expectedValid));
+        $this->expressionParser->expects($this->once())->method('parse')->willReturn($parts);
+
+        $this->assertEquals(
+            $expectedMatch,
+            $expressionMatcher->match($this->expression, $this->getScheduledAtTimestamp())
+        );
+    }
+
+    /**
+     * Data provider
+     *
+     * @return array
+     */
+    public function matcherMatchDataProvider()
+    {
+        $data = [];
+        foreach ($this->fullCronExprDataProvider() as $cronExprData) {
+            $data[] = [$cronExprData[0], $cronExprData[1], $cronExprData[3]];
+        }
+        return $data;
+    }
+}

--- a/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/ParserTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/ParserTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Test\Unit\Model\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher as ExpressionMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser as ExpressionParser;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator as ExpressionValidator;
+use Magento\Cron\Test\Unit\Model\AbstractSchedule;
+
+/**
+ * Class \Magento\Cron\Test\Unit\Model\Schedule\Expression\ParserTest
+ */
+class ParserTest extends AbstractSchedule
+{
+    /**
+     * @var Expression|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expression;
+
+    /**
+     * @var ExpressionValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionValidator;
+
+    /**
+     * @var ExpressionParser|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionParser;
+
+    /**
+     * @var ExpressionMatcher|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionMatcher;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->expressionValidator = $this->getMockBuilder(ExpressionValidator::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->expressionParser = $this->getMockBuilder(ExpressionParser::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->expressionMatcher = $this->getMockBuilder(ExpressionMatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        /** @var Expression|\PHPUnit_Framework_MockObject_MockObject $expression */
+        $this->expression = $this->getMockBuilder(Expression::class)
+            ->setMethods(['getCronExpr'])
+            ->setConstructorArgs(
+                [
+                    'expressionValidator' => $this->expressionValidator,
+                    'expressionParser' => $this->expressionParser,
+                    'expressionMatcher' => $this->expressionMatcher,
+                ]
+            )
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param string $cronExpr
+     * @param array $cronExprArr
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser::parse
+     * @dataProvider fullCronExprDataProvider
+     */
+    public function testParse($cronExpr, $cronExprArr)
+    {
+        $expressionParser = $this->getExpressionParserObject();
+        $this->expression->expects($this->any())->method('getCronExpr')->will($this->returnValue($cronExpr));
+
+        $this->assertEquals(count($cronExprArr), count($expressionParser->parse($this->expression)));
+    }
+}

--- a/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/PartTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/PartTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Test\Unit\Model\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher as ExpressionPartMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator as ExpressionPartValidator;
+use Magento\Cron\Test\Unit\Model\AbstractSchedule;
+
+/**
+ * Class \Magento\Cron\Test\Unit\Model\Schedule\ExpressionTest
+ */
+class PartTest extends AbstractSchedule
+{
+    /**
+     * @var Part|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $part;
+
+    /**
+     * @var ExpressionPartValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $partValidator;
+
+    /**
+     * @var ExpressionPartMatcher|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $partMatcher;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->partValidator = $this->getMockBuilder(ExpressionPartValidator::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->partMatcher = $this->getMockBuilder(ExpressionPartMatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        /** @var Part|\PHPUnit_Framework_MockObject_MockObject $expression */
+        $this->part = $this->getMockBuilder(Part::class)
+            ->setMethods()
+            ->setConstructorArgs(
+                [
+                    'validator' => $this->partValidator,
+                    'matcher' => $this->partMatcher,
+                ]
+            )
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param string $partValue
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Part::setPartValue
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Part::getPartValue
+     * @dataProvider setPartValueDataProvider
+     */
+    public function testSetPartValue($partValue)
+    {
+        $this->part->setPartValue($partValue);
+
+        $this->assertEquals((string)$partValue, $this->part->getPartValue());
+        // Test __toString()
+        $this->assertEquals((string)$partValue, $this->part);
+    }
+
+    /**
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Part::validate
+     * @dataProvider booleanDataProvider
+     * @param $booleanValue
+     */
+    public function testValidate($booleanValue)
+    {
+        $this->partValidator->expects($this->once())->method('validate')->will($this->returnValue($booleanValue));
+
+        $this->assertEquals($booleanValue, $this->part->validate());
+        // Assert part validator validate method is not called again
+        $this->part->validate();
+    }
+
+    /**
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Part::match
+     * @dataProvider booleanDataProvider
+     * @param $booleanValue
+     */
+    public function testMatch($booleanValue)
+    {
+        $this->partMatcher->expects($this->once())->method('match')->will($this->returnValue($booleanValue));
+
+        $this->assertEquals($booleanValue, $this->part->match($this->getScheduledAtTimestamp()));
+    }
+
+    /**
+     * @param string $partValue
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Part::reset
+     * @dataProvider setPartValueDataProvider
+     */
+    public function testReset($partValue)
+    {
+        $this->partValidator->expects($this->any())->method('validate')->will($this->returnValue(true));
+
+        $this->part->setPartValue($partValue);
+        $this->part->reset();
+
+        $this->assertEquals('', $this->part->getPartValue());
+    }
+
+    /**
+     * @return array
+     */
+    public function setPartValueDataProvider()
+    {
+        $letters = range('A', 'Z');
+        $numbers = range(0, 9);
+        $symbols = ['*', '?', '/', '#'];
+
+        return array_chunk(array_merge($letters, $numbers, $symbols), 1);
+    }
+}

--- a/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/ValidatorTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/Schedule/Expression/ValidatorTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Test\Unit\Model\Schedule\Expression;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher as ExpressionMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser as ExpressionParser;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator as ExpressionValidator;
+use Magento\Cron\Test\Unit\Model\AbstractSchedule;
+
+/**
+ * Class \Magento\Cron\Test\Unit\Model\Schedule\Expression\ValidatorTest
+ */
+class ValidatorTest extends AbstractSchedule
+{
+    /**
+     * @var Expression|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expression;
+
+    /**
+     * @var ExpressionValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionValidator;
+
+    /**
+     * @var ExpressionParser|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionParser;
+
+    /**
+     * @var ExpressionMatcher|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionMatcher;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->expressionValidator = $this->getMockBuilder(ExpressionValidator::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->expressionParser = $this->getMockBuilder(ExpressionParser::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->expressionMatcher = $this->getMockBuilder(ExpressionMatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        /** @var Expression|\PHPUnit_Framework_MockObject_MockObject $expression */
+        $this->expression = $this->getMockBuilder(Expression::class)
+            ->setMethods(['getCronExpr'])
+            ->setConstructorArgs(
+                [
+                    'expressionValidator' => $this->expressionValidator,
+                    'expressionParser' => $this->expressionParser,
+                    'expressionMatcher' => $this->expressionMatcher,
+                ]
+            )
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param string $cronExpr
+     * @param array $cronExprArr
+     * @param array $expectedIsValid
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator::validate
+     * @dataProvider validatorValidateDataProvider
+     */
+    public function testValidate($cronExpr, $cronExprArr, $expectedIsValid)
+    {
+        $exprPartFactory = $this->getExpressionPartFactoryObject($cronExpr);
+
+        $parts = [];
+        if (is_array($cronExprArr)) {
+            foreach ($cronExprArr as $partIndex => $partValue) {
+                $parts[] = $exprPartFactory->create($partIndex, $partValue);
+            }
+        }
+
+        $this->expressionParser->expects($this->once())->method('parse')->willReturn($parts);
+        $this->expression->expects($this->any())->method('getCronExpr')->will($this->returnValue($cronExpr));
+
+        $expressionValidator = $this->getHelper()->getObject(ExpressionValidator::class);
+        $result = $expressionValidator->validate($this->expression);
+
+        $this->assertEquals($expectedIsValid, $result);
+    }
+
+    /**
+     * Data provider
+     *
+     * @return array
+     */
+    public function validatorValidateDataProvider()
+    {
+        $data = [];
+        foreach ($this->fullCronExprDataProvider() as $cronExprData) {
+            $data[] = [$cronExprData[0], $cronExprData[1], $cronExprData[2]];
+        }
+        return $data;
+    }
+}

--- a/app/code/Magento/Cron/Test/Unit/Model/Schedule/ExpressionTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/Schedule/ExpressionTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Test\Unit\Model\Schedule;
+
+use Magento\Cron\Model\ResourceModel\Schedule\Expression;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher as ExpressionMatcher;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser as ExpressionParser;
+use Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator as ExpressionValidator;
+use Magento\Cron\Test\Unit\Model\AbstractSchedule;
+
+/**
+ * Class \Magento\Cron\Test\Unit\Model\Schedule\ExpressionTest
+ */
+class ExpressionTest extends AbstractSchedule
+{
+    /**
+     * @var Expression|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expression;
+
+    /**
+     * @var ExpressionValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionValidator;
+
+    /**
+     * @var ExpressionParser|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionParser;
+
+    /**
+     * @var ExpressionMatcher|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expressionMatcher;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->expressionValidator = $this->getMockBuilder(ExpressionValidator::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->expressionParser = $this->getMockBuilder(ExpressionParser::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->expressionMatcher = $this->getMockBuilder(ExpressionMatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        /** @var Expression|\PHPUnit_Framework_MockObject_MockObject $expression */
+        $this->expression = $this->getMockBuilder(Expression::class)
+            ->setMethods()
+            ->setConstructorArgs(
+                [
+                    'expressionValidator' => $this->expressionValidator,
+                    'expressionParser' => $this->expressionParser,
+                    'expressionMatcher' => $this->expressionMatcher,
+                ]
+            )
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param string $cronExpr
+     * @param $cronExprArr
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::setCronExpr
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::getCronExpr
+     * @dataProvider validCronExprDataProvider
+     */
+    public function testSetCronExpr($cronExpr, $cronExprArr)
+    {
+        $this->expressionParser->expects($this->once())->method('parse')->will($this->returnValue($cronExprArr));
+        $this->expressionValidator->expects($this->once())->method('validate')->will($this->returnValue(true));
+
+        $this->expression->setCronExpr($cronExpr);
+
+        $this->assertEquals((string)$cronExpr, $this->expression->getCronExpr());
+        // Test __toString()
+        $this->assertEquals((string)$cronExpr, $this->expression);
+    }
+
+    /**
+     * @param string $cronExpr
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::setCronExpr
+     * @expectedException \Magento\Framework\Exception\CronException
+     * @dataProvider invalidCronExprDataProvider
+     */
+    public function testSetCronExprExceptionGetParts($cronExpr)
+    {
+        $this->expressionParser->expects($this->once())->method('parse')->will($this->returnValue([]));
+        $this->expressionValidator->expects($this->never())->method('validate')->will($this->returnValue(false));
+
+        $this->expression->setCronExpr($cronExpr);
+    }
+
+    /**
+     * @param string $cronExpr
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::setCronExpr
+     * @expectedException \Magento\Framework\Exception\CronException
+     * @dataProvider invalidCronExprDataProvider
+     */
+    public function testSetCronExprExceptionValidate($cronExpr)
+    {
+        $this->expressionParser->expects($this->once())->method('parse')->will($this->returnValue(true));
+        $this->expressionValidator->expects($this->once())->method('validate')->will($this->returnValue(false));
+
+        $this->expression->setCronExpr($cronExpr);
+    }
+
+    /**
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::getParts
+     * @dataProvider fullCronExprDataProvider
+     * @param $cronExpr
+     * @param $cronExprArr
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function testGetParts($cronExpr, $cronExprArr)
+    {
+        $this->expressionParser->expects($this->once())->method('parse')->will($this->returnValue($cronExprArr));
+
+        $this->assertEquals($cronExprArr, $this->expression->getParts());
+        // Assert expression parser parse method is not called again
+        $this->expression->getParts();
+    }
+
+    /**
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::validate
+     * @dataProvider booleanDataProvider
+     * @param $booleanValue
+     */
+    public function testValidate($booleanValue)
+    {
+        $this->expressionValidator->expects($this->once())->method('validate')->will($this->returnValue($booleanValue));
+
+        $this->assertEquals($booleanValue, $this->expression->validate());
+        // Assert expression validator validate method is not called again
+        $this->expression->validate();
+    }
+
+    /**
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::match
+     * @dataProvider booleanDataProvider
+     * @param $booleanValue
+     */
+    public function testMatch($booleanValue)
+    {
+        $this->expressionMatcher->expects($this->once())->method('match')->will($this->returnValue($booleanValue));
+
+        $this->assertEquals($booleanValue, $this->expression->match($this->getScheduledAtTimestamp()));
+    }
+
+    /**
+     * @param string $cronExpr
+     * @covers       \Magento\Cron\Model\ResourceModel\Schedule\Expression::reset
+     * @dataProvider validCronExprDataProvider
+     */
+    public function testReset($cronExpr)
+    {
+        $this->expressionParser->expects($this->any())->method('parse')->will($this->returnValue(true));
+        $this->expressionValidator->expects($this->any())->method('validate')->will($this->returnValue(true));
+
+        $this->expression->setCronExpr($cronExpr);
+        $this->expression->reset();
+
+        $this->assertEquals('', $this->expression->getCronExpr());
+    }
+}

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -690,7 +690,16 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
         $schedule = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->setMethods(
-            ['getJobCode', 'save', 'getScheduledAt', 'unsScheduleId', 'trySchedule', 'getCollection', 'getResource']
+            [
+                'getJobCode',
+                'save',
+                'getScheduledAt',
+                'unsScheduleId',
+                'trySchedule',
+                'getCollection',
+                'getResource',
+                'setCronExpr'
+            ]
         )->disableOriginalConstructor()->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn('job_code1');
         $schedule->expects($this->once())->method('getScheduledAt')->willReturn('* * * * *');
@@ -699,6 +708,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
         $schedule->expects($this->any())->method('getCollection')->willReturn($this->_collection);
         $schedule->expects($this->atLeastOnce())->method('save')->willReturnSelf();
         $schedule->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $schedule->expects($this->any())->method('setCronExpr')->willReturnSelf();
 
         $this->_collection->addItem(new \Magento\Framework\DataObject());
         $this->_collection->addItem($schedule);
@@ -817,7 +827,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(10));
         $this->_scopeConfig->expects($this->at(1))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/schedule_lifetime'))
-            ->will($this->returnValue(2*24*60));
+            ->will($this->returnValue(2 * 24 * 60));
         $this->_scopeConfig->expects($this->at(2))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/history_success_lifetime'))
             ->will($this->returnValue(0));

--- a/app/code/Magento/Cron/etc/di.xml
+++ b/app/code/Magento/Cron/etc/di.xml
@@ -10,6 +10,14 @@
     <preference for="Magento\Framework\Shell\CommandRendererInterface" type="Magento\Framework\Shell\CommandRenderer" />
     <preference for="Magento\Framework\Crontab\CrontabManagerInterface" type="Magento\Framework\Crontab\CrontabManager" />
     <preference for="Magento\Framework\Crontab\TasksProviderInterface" type="Magento\Framework\Crontab\TasksProvider" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\ExpressionInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\PartInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\MatcherInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Matcher" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\ParserInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Parser" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\ValidatorInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Validator" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ParserInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Parser" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\MatcherInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Matcher" />
+    <preference for="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\ValidatorInterface" type="Magento\Cron\Model\ResourceModel\Schedule\Expression\Part\Validator" />
     <type name="Magento\Config\Model\Config\Structure\Converter">
         <plugin name="cron_backend_config_structure_converter_plugin" type="Magento\Cron\Model\Backend\Config\Structure\Converter" />
     </type>


### PR DESCRIPTION
Related with closed [PR#9917](https://github.com/magento/magento2/pull/9917)
Reviewed considering @okorshenko [comments](https://github.com/magento/magento2/pull/9917#issuecomment-308881495)
Add cron expression check when setting cron expression into cron schedule model. 

### Description
\Magento\Cron\Model\Schedule::setCronExpr() method only checks if cron expression has between 5 and 6 components. \Magento\Cron\Model\Schedule::trySchedule() allows to check a cron expression against a timestamp value, but there is no way to check if a cron expression is valid by itself, without a timestamp.

\Magento\Cron\Model\ResourceModel\Schedule\ExpressionValidator.php class has been added to add missing functionality, and now it's used by default at \Magento\Cron\Model\Schedule::setCronExpr() method, and when trying to try schedule.

Adapted unit tests to new check when setting cron expression into schedule model.
Added unit tests for new ExpressionValidator.php class.

### Fixed Issues
- Expressions like '2-1 * * * *' were accepted as valid expressions before. New method check does not allow to set a from-to value with the $from value higher than $to value.

### Manual testing scenarios
`php vendor/phpunit/phpunit/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Cron/Test/Unit/`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X]  All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)