### PR TITLE
Fix the correct removal of the images and the removal of all images in the catalog

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
@@ -33,8 +33,10 @@ class UpdateHandler extends \Magento\Catalog\Model\Product\Gallery\CreateHandler
             if (!empty($image['removed'])) {
                 if (!empty($image['value_id']) && !isset($picturesInOtherStores[$image['file']])) {
                     $recordsToDelete[] = $image['value_id'];
-                    // only delete physical files if they are not used by any other products
-                    if (!$this->resourceModel->countImageUses($image['file']) > 1) {
+                    $catalogPath = $this->mediaConfig->getBaseMediaPath();
+                    $isFile = $this->mediaDirectory->isFile($catalogPath . $image['file']);
+                    // only delete physical files if they are not used by any other products and if this file exists
+                    if (!($this->resourceModel->countImageUses($image['file']) > 1) && $isFile) {
                         $filesToDelete[] = ltrim($image['file'], '/');
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fix the correct removal of the images and the removal of all images in the catalog
### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you want remove image from admin panel, this file is not removed correctly.
If the path of the image saved in the table **catalog_product_entity_media_gallery** is empty, this remove all the catalog.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
For the first case.
1. Upload image from admin panel
2. Save product
3. Remove this image
4. Save product
The file is not removed in pub/media/catalog/product/....

For the second case.
1. Upload image from admin panel
2. Save product
3. Go to the DB to the table **catalog_product_entity_media_gallery** and remove the value of this image
3. Remove this image from admin panel
4. Save product
All the files are removed in pub/media/catalog/product/....
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
