### PR TITLE
Fix bug reset message must create an instance of "MessageInterface"

### DIFF
--- a/app/code/Magento/Newsletter/Test/Unit/Model/Queue/TransportBuilderTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/Queue/TransportBuilderTest.php
@@ -26,7 +26,7 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
     protected $templateFactoryMock;
 
     /**
-     * @var \Magento\Framework\Mail\Message | \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Mail\MessageInterface | \PHPUnit_Framework_MockObject_MockObject
      */
     protected $messageMock;
 
@@ -52,7 +52,7 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->templateFactoryMock = $this->createMock(\Magento\Framework\Mail\Template\FactoryInterface::class);
-        $this->messageMock = $this->createMock(\Magento\Framework\Mail\Message::class);
+        $this->messageMock = $this->createMock(\Magento\Framework\Mail\MessageInterface::class);
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
         $this->senderResolverMock = $this->createMock(\Magento\Framework\Mail\Template\SenderResolverInterface::class);
         $this->mailTransportFactoryMock = $this->getMockBuilder(
@@ -159,7 +159,7 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
         )->method(
             'create'
         )->with(
-            $this->equalTo(\Magento\Framework\Mail\Message::class)
+            $this->equalTo(\Magento\Framework\Mail\MessageInterface::class)
         )->will(
             $this->returnValue($transport)
         );

--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -72,7 +72,7 @@ class TransportBuilder
     /**
      * Message
      *
-     * @var \Magento\Framework\Mail\Message
+     * @var \Magento\Framework\Mail\MessageInterface
      */
     protected $message;
 

--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -242,7 +242,7 @@ class TransportBuilder
      */
     protected function reset()
     {
-        $this->message = $this->objectManager->create(\Magento\Framework\Mail\Message::class);
+        $this->message = $this->objectManager->create(MessageInterface::class);
         $this->templateIdentifier = null;
         $this->templateVars = null;
         $this->templateOptions = null;

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
@@ -26,7 +26,7 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
     protected $templateFactoryMock;
 
     /**
-     * @var \Magento\Framework\Mail\Message | \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Mail\MessageInterface | \PHPUnit_Framework_MockObject_MockObject
      */
     protected $messageMock;
 
@@ -52,7 +52,7 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->templateFactoryMock = $this->createMock(\Magento\Framework\Mail\Template\FactoryInterface::class);
-        $this->messageMock = $this->createMock(\Magento\Framework\Mail\Message::class);
+        $this->messageMock = $this->createMock(\Magento\Framework\Mail\MessageInterface::class);
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
         $this->senderResolverMock = $this->createMock(\Magento\Framework\Mail\Template\SenderResolverInterface::class);
         $this->mailTransportFactoryMock = $this->getMockBuilder(
@@ -123,7 +123,7 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
 
         $this->objectManagerMock->expects($this->at(0))
             ->method('create')
-            ->with($this->equalTo(\Magento\Framework\Mail\Message::class))
+            ->with($this->equalTo(\Magento\Framework\Mail\MessageInterface::class))
             ->willReturn($transport);
 
         $this->builder->setTemplateIdentifier('identifier')->setTemplateVars($vars)->setTemplateOptions($options);


### PR DESCRIPTION
On line 245 the object manager should return an instance of `\Magento\Framework\Mail\MessageInterface` same type as original message created on constructor (line 100).
However the objectManager does not use the `MessageInterface`. That causes unexpected results when the message is reseted because `$this->message` does no longer have the type set in the preferences `di.xml` for `\Magento\Framework\Mail\MessageInterface`

### Description
`reset()` method uses different class type for `$message` as the one on the constructor.  

### Fixed Issues (if relevant)

1. If a custom preference is set for `\Magento\Framework\Mail\MessageInterface` and several emails are sent using the same instance of `\Magento\Framework\Mail\Template\TransportBuilder`, only the first email is properly sent. After the first one, following `$messages` no longer match the custom preference type. They are always type of `\Magento\Framework\Mail\Message`.

### Manual testing scenarios

1. Add a preference for `\Magento\Framework\Mail\MessageInterface`

```
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <preference for="Magento\Framework\Mail\MessageInterface" type="Vendor\Package\Mail\CustomMessage"/>
</config>
```

2. Send several messages using same instance of `\Magento\Framework\Mail\Template\TransportBuilder`

```
    $transportBuilder = $objectManager->create(\Magento\Framework\Mail\Template\TransportBuilder::class);
    $transport = $transportBuilder
            ->setTemplateIdentifier('some_email_identifier')
            ->setTemplateOptions(['area' => FrontNameResolver::AREA_CODE, 'store' => Store::DEFAULT_STORE_ID])
            ->setTemplateVars([])
            ->setFrom(['name' => 'integration-tests', 'email' => 'integration-test@custom.mail'])
            ->addTo($recipients);
        
      $useSeveralTimes = [1, 2, 3];
      foreach ($useSeveralTimes as $time) {
           $transport = $transport->getTransport();
           /**
            * Expected: all $message inside $transport to be Vendor\Package\Mail\CustomMessage
            * Actual: only first iteration $message has this type. All others are type Magento\Framework\Mail\Message
            */
      }
```
    
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)