### PR TITLE
Issue #9877: Backport of: getCacheTags for price issue #10930

### DIFF
--- a/app/code/Magento/Catalog/Block/Category/Plugin/PriceBoxTags.php
+++ b/app/code/Magento/Catalog/Block/Category/Plugin/PriceBoxTags.php
@@ -102,8 +102,8 @@ class PriceBoxTags
 
         if (!empty($billingAddress) || !empty($shippingAddress)) {
             $rateRequest = $this->getTaxCalculation()->getRateRequest(
-                $billingAddress,
                 $shippingAddress,
+                $billingAddress,
                 $customerTaxClassId,
                 $this->scopeResolver->getScope()->getId(),
                 $this->customerSession->getCustomerId()

--- a/app/code/Magento/Catalog/Test/Unit/Block/Category/Plugin/PriceBoxTagsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Category/Plugin/PriceBoxTagsTest.php
@@ -119,8 +119,8 @@ class PriceBoxTagsTest extends \PHPUnit\Framework\TestCase
         $this->session->expects($this->once())->method('getCustomerId')->willReturn($customerId);
         $rateRequest = $this->getMockBuilder(\Magento\Framework\DataObject::class)->getMock();
         $this->taxCalculation->expects($this->once())->method('getRateRequest')->with(
-            new \Magento\Framework\DataObject($billingAddress),
             new \Magento\Framework\DataObject($shippingAddress),
+            new \Magento\Framework\DataObject($billingAddress),
             $customerTaxClassId,
             $scopeId,
             $customerId


### PR DESCRIPTION
Backport of https://github.com/magento/magento2/pull/10930

### Description
Backport of https://github.com/magento/magento2/pull/10930

### Fixed Issues (if relevant)
1. magento/magento2#9877: getCacheTags for price issue
2. Change the method argument getRateRequest with actual method
3. Change the test case

### Manual testing scenarios
n/a

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
