### PR TITLE
Refactor ConfigGenerator to replace/set crypt key instead of append

### DIFF
--- a/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
+++ b/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
@@ -36,7 +36,7 @@ class ConfigDataFactory
      * @param string $fileKey
      * @return ConfigData
      */
-    public function create(string $fileKey) : ConfigData
+    public function create($fileKey)
     {
         return $this->objectManager->create(ConfigData::class, ['fileKey' => $fileKey]);
     }

--- a/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
+++ b/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
@@ -18,7 +18,7 @@ class ConfigDataFactory
      * @param string $fileKey
      * @return ConfigData
      */
-    public function create(string $fileKey)
+    public function create(string $fileKey) : ConfigData
     {
         return new ConfigData($fileKey);
     }

--- a/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
+++ b/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
@@ -6,12 +6,30 @@
 
 namespace Magento\Framework\Config\Data;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\ObjectManagerInterface;
+
 /**
  * Factory for ConfigData
  * @api
  */
 class ConfigDataFactory
 {
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * Factory constructor
+     *
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
     /**
      * Returns a new instance of ConfigData on every call.
      *
@@ -20,6 +38,6 @@ class ConfigDataFactory
      */
     public function create(string $fileKey) : ConfigData
     {
-        return new ConfigData($fileKey);
+        return $this->objectManager->create(ConfigData::class, ['fileKey' => $fileKey]);
     }
 }

--- a/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
+++ b/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Config\Data;
+
+/**
+ * Factory for ConfigData
+ * @api
+ */
+class ConfigDataFactory
+{
+    /**
+     * Returns a new instance of ConfigData on every call.
+     *
+     * @param string $fileKey
+     * @return ConfigData
+     */
+    public function create(string $fileKey)
+    {
+        return new ConfigData($fileKey);
+    }
+}

--- a/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
+++ b/lib/internal/Magento/Framework/Config/Data/ConfigDataFactory.php
@@ -11,7 +11,6 @@ use Magento\Framework\ObjectManagerInterface;
 
 /**
  * Factory for ConfigData
- * @api
  */
 class ConfigDataFactory
 {

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -82,9 +82,13 @@ class ConfigGenerator
 
         $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
 
-        $key = $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY]
-            ?? $currentKey
-            ?? $this->cryptKeyGenerator->generate();
+        // Use given key if set, else use current
+        $key = $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY] ?? $currentKey;
+
+        // If there is no key given or currently set, generate a new one
+        $key = $key ?? $this->cryptKeyGenerator->generate();
+
+        // Chaining of ".. ?? .." is not used to keep it simpler to understand
 
         $configData->set(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY, $key);
 

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -232,21 +232,34 @@ class ConfigGenerator
     public function createCacheHostsConfig(array $data)
     {
         $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
+
         if (isset($data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS])) {
-            $hostData = explode(',', $data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS]);
-            $hosts = [];
-            foreach ($hostData as $data) {
-                $dataArray = explode(':', trim($data));
-                $host = [];
-                $host['host'] = $dataArray[0];
-                if (isset($dataArray[1])) {
-                    $host['port'] = $dataArray[1];
-                }
-                $hosts[] = $host;
-            }
+            $hosts = explode(',', $data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS]);
+            $hosts = array_map([$this, 'mapHostData'], $hosts);
             $configData->set(ConfigOptionsListConstants::CONFIG_PATH_CACHE_HOSTS, $hosts);
         }
+
         $configData->setOverrideWhenSave(true);
         return $configData;
+    }
+
+    /**
+     * Splits host data to host and port and returns them as an assoc. array.
+     *
+     * @param string $hostData
+     *
+     * @return array
+     */
+    private function mapHostData($hostData)
+    {
+        list($host, $port) = explode(':', trim($hostData));
+
+        $tmp = ['host' => $host];
+
+        if ($port !== null) {
+            $tmp['port'] = $port;
+        }
+
+        return $tmp;
     }
 }

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -26,17 +26,17 @@ class ConfigGenerator
      * @var array
      */
     private static $paramMap = [
-        ConfigOptionsListConstants::INPUT_KEY_DB_HOST => ConfigOptionsListConstants::KEY_HOST,
-        ConfigOptionsListConstants::INPUT_KEY_DB_NAME => ConfigOptionsListConstants::KEY_NAME,
-        ConfigOptionsListConstants::INPUT_KEY_DB_USER => ConfigOptionsListConstants::KEY_USER,
-        ConfigOptionsListConstants::INPUT_KEY_DB_PASSWORD => ConfigOptionsListConstants::KEY_PASSWORD,
-        ConfigOptionsListConstants::INPUT_KEY_DB_PREFIX => ConfigOptionsListConstants::KEY_PREFIX,
-        ConfigOptionsListConstants::INPUT_KEY_DB_MODEL => ConfigOptionsListConstants::KEY_MODEL,
-        ConfigOptionsListConstants::INPUT_KEY_DB_ENGINE => ConfigOptionsListConstants::KEY_ENGINE,
+        ConfigOptionsListConstants::INPUT_KEY_DB_HOST            => ConfigOptionsListConstants::KEY_HOST,
+        ConfigOptionsListConstants::INPUT_KEY_DB_NAME            => ConfigOptionsListConstants::KEY_NAME,
+        ConfigOptionsListConstants::INPUT_KEY_DB_USER            => ConfigOptionsListConstants::KEY_USER,
+        ConfigOptionsListConstants::INPUT_KEY_DB_PASSWORD        => ConfigOptionsListConstants::KEY_PASSWORD,
+        ConfigOptionsListConstants::INPUT_KEY_DB_PREFIX          => ConfigOptionsListConstants::KEY_PREFIX,
+        ConfigOptionsListConstants::INPUT_KEY_DB_MODEL           => ConfigOptionsListConstants::KEY_MODEL,
+        ConfigOptionsListConstants::INPUT_KEY_DB_ENGINE          => ConfigOptionsListConstants::KEY_ENGINE,
         ConfigOptionsListConstants::INPUT_KEY_DB_INIT_STATEMENTS => ConfigOptionsListConstants::KEY_INIT_STATEMENTS,
-        ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY => ConfigOptionsListConstants::KEY_ENCRYPTION_KEY,
-        ConfigOptionsListConstants::INPUT_KEY_SESSION_SAVE => ConfigOptionsListConstants::KEY_SAVE,
-        ConfigOptionsListConstants::INPUT_KEY_RESOURCE => ConfigOptionsListConstants::KEY_RESOURCE,
+        ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY     => ConfigOptionsListConstants::KEY_ENCRYPTION_KEY,
+        ConfigOptionsListConstants::INPUT_KEY_SESSION_SAVE       => ConfigOptionsListConstants::KEY_SAVE,
+        ConfigOptionsListConstants::INPUT_KEY_RESOURCE           => ConfigOptionsListConstants::KEY_RESOURCE,
     ];
 
     /**

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -264,5 +264,4 @@ class ConfigGenerator
         $configData->setOverrideWhenSave(true);
         return $configData;
     }
-
 }

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -69,7 +69,7 @@ class ConfigGenerator
     ) {
         $this->random = $random;
         $this->deploymentConfig = $deploymentConfig;
-        $this->configDataFactory = $deploymentConfig ?? ObjectManager::getInstance()->get(ConfigDataFactory::class);
+        $this->configDataFactory = $configDataFactory ?? ObjectManager::getInstance()->get(ConfigDataFactory::class);
     }
 
     /**
@@ -82,21 +82,24 @@ class ConfigGenerator
         $currentKey = $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY);
 
         $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
-        if (isset($data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY])) {
-            $configData->set(
-                ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY,
-                $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY]
-            );
-        } else {
-            if ($currentKey === null) {
-                $configData->set(
-                    ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY,
-                    md5($this->random->getRandomString(ConfigOptionsListConstants::STORE_KEY_RANDOM_STRING_SIZE))
-                );
-            }
-        }
+
+        $key = $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY]
+            ?? $currentKey
+            ?? $this->generateCryptKey();
+
+        $configData->set(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY, $key);
 
         return $configData;
+    }
+
+    /**
+     * Generates a new crypt key.
+     *
+     * @return string
+     */
+    private function generateCryptKey()
+    {
+        return md5($this->random->getRandomString(ConfigOptionsListConstants::STORE_KEY_RANDOM_STRING_SIZE));
     }
 
     /**

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -256,6 +256,8 @@ class ConfigGenerator
      * @param string $hostData
      *
      * @return array
+     *
+     * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
      */
     private function mapHostData(string $hostData) : array
     {

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -53,7 +53,7 @@ class ConfigGenerator
     /**
      * @var ConfigDataFactory
      */
-    protected $configDataFactory;
+    private $configDataFactory;
 
     /**
      * Constructor

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -242,7 +242,22 @@ class ConfigGenerator
 
         if (isset($data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS])) {
             $hosts = explode(',', $data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS]);
-            $hosts = array_map([$this, 'mapHostData'], $hosts);
+
+            $hosts = array_map(
+                function ($hostData) {
+                    $hostDataParts = explode(':', trim($hostData));
+
+                    $tmp = ['host' => $hostDataParts[0]];
+
+                    if (isset($hostDataParts[1])) {
+                        $tmp['port'] = $hostDataParts[1];
+                    }
+
+                    return $tmp;
+                },
+                $hosts
+            );
+
             $configData->set(ConfigOptionsListConstants::CONFIG_PATH_CACHE_HOSTS, $hosts);
         }
 
@@ -250,25 +265,4 @@ class ConfigGenerator
         return $configData;
     }
 
-    /**
-     * Splits host data to host and port and returns them as an assoc. array.
-     *
-     * @param string $hostData
-     *
-     * @return array
-     *
-     * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
-     */
-    private function mapHostData(string $hostData) : array
-    {
-        $hostDataParts = explode(':', trim($hostData));
-
-        $tmp = ['host' => $hostDataParts[0]];
-
-        if (isset($hostDataParts[1])) {
-            $tmp['port'] = $hostDataParts[1];
-        }
-
-        return $tmp;
-    }
 }

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -6,13 +6,14 @@
 
 namespace Magento\Setup\Model;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\Data\ConfigData;
+use Magento\Framework\Config\Data\ConfigDataFactory;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Math\Random;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\State;
-use Magento\Framework\App\ObjectManagerFactory;
 
 /**
  * Creates deployment config data based on user input array
@@ -50,15 +51,25 @@ class ConfigGenerator
     protected $deploymentConfig;
 
     /**
+     * @var ConfigDataFactory
+     */
+    protected $configDataFactory;
+
+    /**
      * Constructor
      *
      * @param Random $random
      * @param DeploymentConfig $deploymentConfig
+     * @param ConfigDataFactory $configDataFactory
      */
-    public function __construct(Random $random, DeploymentConfig $deploymentConfig)
-    {
+    public function __construct(
+        Random $random,
+        DeploymentConfig $deploymentConfig,
+        ConfigDataFactory $configDataFactory
+    ) {
         $this->random = $random;
         $this->deploymentConfig = $deploymentConfig;
+        $this->configDataFactory = $configDataFactory;
     }
 
     /**
@@ -70,15 +81,14 @@ class ConfigGenerator
     {
         $currentKey = $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY);
 
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        // TODO: refactor configData to factory in constructor
+        // TODO: test method 'set' with mock
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
         if (isset($data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY])) {
-            if ($currentKey !== null) {
-                $key = $currentKey . "\n" . $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY];
-            } else {
-                $key = $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY];
-            }
-
-            $configData->set(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY, $key);
+            $configData->set(
+                ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY,
+                $data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY]
+            );
         } else {
             if ($currentKey === null) {
                 $configData->set(
@@ -99,7 +109,7 @@ class ConfigGenerator
      */
     public function createSessionConfig(array $data)
     {
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
 
         if (isset($data[ConfigOptionsListConstants::INPUT_KEY_SESSION_SAVE])) {
             $configData->set(
@@ -132,7 +142,7 @@ class ConfigGenerator
      */
     public function createDbConfig(array $data)
     {
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
 
         $optional = [
             ConfigOptionsListConstants::INPUT_KEY_DB_HOST,
@@ -182,7 +192,7 @@ class ConfigGenerator
      */
     public function createResourceConfig()
     {
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
 
         if ($this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_RESOURCE_DEFAULT_SETUP) === null) {
             $configData->set(ConfigOptionsListConstants::CONFIG_PATH_RESOURCE_DEFAULT_SETUP, 'default');
@@ -198,7 +208,7 @@ class ConfigGenerator
      */
     public function createXFrameConfig()
     {
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
         if ($this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT) === null) {
             $configData->set(ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT, 'SAMEORIGIN');
         }
@@ -212,7 +222,7 @@ class ConfigGenerator
      */
     public function createModeConfig()
     {
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
         if ($this->deploymentConfig->get(State::PARAM_MODE) === null) {
             $configData->set(State::PARAM_MODE, State::MODE_DEFAULT);
         }
@@ -227,7 +237,7 @@ class ConfigGenerator
      */
     public function createCacheHostsConfig(array $data)
     {
-        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
         if (isset($data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS])) {
             $hostData = explode(',', $data[ConfigOptionsListConstants::INPUT_KEY_CACHE_HOSTS]);
             $hosts = [];

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -155,25 +155,18 @@ class ConfigGenerator
             );
         }
 
+        $dbConnectionPrefix = ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT . '/';
+
         foreach ($optional as $key) {
             if (isset($data[$key])) {
-                $configData->set(
-                    ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT . '/' . self::$paramMap[$key],
-                    $data[$key]
-                );
+                $configData->set($dbConnectionPrefix . self::$paramMap[$key], $data[$key]);
             }
         }
 
-        $currentStatus = $this->deploymentConfig->get(
-            ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT . '/' . ConfigOptionsListConstants::KEY_ACTIVE
-        );
+        $currentStatus = $this->deploymentConfig->get($dbConnectionPrefix . ConfigOptionsListConstants::KEY_ACTIVE);
 
         if ($currentStatus === null) {
-            $configData->set(
-                ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT
-                . '/' . ConfigOptionsListConstants::KEY_ACTIVE,
-                '1'
-            );
+            $configData->set($dbConnectionPrefix . ConfigOptionsListConstants::KEY_ACTIVE, '1');
         }
 
         return $configData;

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -249,12 +249,12 @@ class ConfigGenerator
      */
     private function mapHostData($hostData)
     {
-        list($host, $port) = explode(':', trim($hostData));
+        $hostDataParts = explode(':', trim($hostData));
 
-        $tmp = ['host' => $host];
+        $tmp = ['host' => $hostDataParts[0]];
 
-        if ($port !== null) {
-            $tmp['port'] = $port;
+        if (isset($hostDataParts[1])) {
+            $tmp['port'] = $hostDataParts[1];
         }
 
         return $tmp;

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -65,11 +65,11 @@ class ConfigGenerator
     public function __construct(
         Random $random,
         DeploymentConfig $deploymentConfig,
-        ConfigDataFactory $configDataFactory
+        ConfigDataFactory $configDataFactory = null
     ) {
         $this->random = $random;
         $this->deploymentConfig = $deploymentConfig;
-        $this->configDataFactory = $configDataFactory;
+        $this->configDataFactory = $deploymentConfig ?? ObjectManager::getInstance()->get(ConfigDataFactory::class);
     }
 
     /**

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -75,6 +75,7 @@ class ConfigGenerator
         ConfigDataFactory $configDataFactory = null,
         CryptKeyGeneratorInterface $cryptKeyGenerator = null
     ) {
+        $this->random = $random;
         $this->deploymentConfig = $deploymentConfig;
         $this->configDataFactory = $configDataFactory ?? ObjectManager::getInstance()->get(ConfigDataFactory::class);
         $this->cryptKeyGenerator = $cryptKeyGenerator ?? ObjectManager::getInstance()->get(CryptKeyGenerator::class);

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -81,8 +81,6 @@ class ConfigGenerator
     {
         $currentKey = $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY);
 
-        // TODO: refactor configData to factory in constructor
-        // TODO: test method 'set' with mock
         $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
         if (isset($data[ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY])) {
             $configData->set(

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -203,9 +203,11 @@ class ConfigGenerator
     public function createXFrameConfig()
     {
         $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
+
         if ($this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT) === null) {
             $configData->set(ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT, 'SAMEORIGIN');
         }
+
         return $configData;
     }
 
@@ -217,9 +219,11 @@ class ConfigGenerator
     public function createModeConfig()
     {
         $configData = $this->configDataFactory->create(ConfigFilePool::APP_ENV);
+
         if ($this->deploymentConfig->get(State::PARAM_MODE) === null) {
             $configData->set(State::PARAM_MODE, State::MODE_DEFAULT);
         }
+
         return $configData;
     }
 

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -257,7 +257,7 @@ class ConfigGenerator
      *
      * @return array
      */
-    private function mapHostData($hostData)
+    private function mapHostData(string $hostData) : array
     {
         $hostDataParts = explode(':', trim($hostData));
 

--- a/setup/src/Magento/Setup/Model/ConfigGenerator.php
+++ b/setup/src/Magento/Setup/Model/ConfigGenerator.php
@@ -13,6 +13,7 @@ use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\State;
+use Magento\Framework\Math\Random;
 
 /**
  * Creates deployment config data based on user input array
@@ -45,6 +46,12 @@ class ConfigGenerator
     protected $deploymentConfig;
 
     /**
+     * @var Random
+     * @deprecated since 100.2.0
+     */
+    protected $random;
+
+    /**
      * @var ConfigDataFactory
      */
     private $configDataFactory;
@@ -57,11 +64,13 @@ class ConfigGenerator
     /**
      * Constructor
      *
+     * @param Random $random Deprecated since 100.2.0
      * @param DeploymentConfig $deploymentConfig
      * @param ConfigDataFactory|null $configDataFactory
      * @param CryptKeyGeneratorInterface|null $cryptKeyGenerator
      */
     public function __construct(
+        Random $random,
         DeploymentConfig $deploymentConfig,
         ConfigDataFactory $configDataFactory = null,
         CryptKeyGeneratorInterface $cryptKeyGenerator = null

--- a/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
@@ -34,7 +34,7 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      *
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function generate()
+    public function generate() : string
     {
         return md5($this->getRandomString());
     }

--- a/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Setup\Model;
 
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Math\Random;
 
@@ -21,9 +20,9 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      */
     private $random;
 
-    public function __construct(Random $random = null)
+    public function __construct(Random $random)
     {
-        $this->random = $random ?? ObjectManager::getInstance()->get(Random::class);
+        $this->random = $random;
     }
 
     /**

--- a/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Setup\Model;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Math\Random;
 
@@ -20,9 +21,9 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      */
     private $random;
 
-    public function __construct(Random $random)
+    public function __construct(Random $random = null)
     {
-        $this->random = $random;
+        $this->random = $random ?? ObjectManager::getInstance()->get(Random::class);
     }
 
     /**

--- a/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
@@ -11,7 +11,6 @@ use Magento\Framework\Math\Random;
 
 /**
  * Generates a crypt
- * @api
  */
 class CryptKeyGenerator implements CryptKeyGeneratorInterface
 {
@@ -39,7 +38,7 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      *
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function generate() : string
+    public function generate()
     {
         return md5($this->getRandomString());
     }
@@ -49,7 +48,7 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      *
      * @return string
      */
-    private function getRandomString() : string
+    private function getRandomString()
     {
         return $this->random->getRandomString(ConfigOptionsListConstants::STORE_KEY_RANDOM_STRING_SIZE);
     }

--- a/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
@@ -20,6 +20,11 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      */
     private $random;
 
+    /**
+     * CryptKeyGenerator constructor.
+     *
+     * @param Random $random
+     */
     public function __construct(Random $random)
     {
         $this->random = $random;
@@ -44,7 +49,7 @@ class CryptKeyGenerator implements CryptKeyGeneratorInterface
      *
      * @return string
      */
-    private function getRandomString()
+    private function getRandomString() : string
     {
         return $this->random->getRandomString(ConfigOptionsListConstants::STORE_KEY_RANDOM_STRING_SIZE);
     }

--- a/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGenerator.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Setup\Model;
+
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\Math\Random;
+
+/**
+ * Generates a crypt
+ * @api
+ */
+class CryptKeyGenerator implements CryptKeyGeneratorInterface
+{
+    /**
+     * @var Random
+     */
+    private $random;
+
+    public function __construct(Random $random)
+    {
+        $this->random = $random;
+    }
+
+    /**
+     * Generates & returns a string to be used as crypt key.
+     *
+     * The key length is not a parameter, but an implementation detail.
+     *
+     * @return string
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function generate()
+    {
+        return md5($this->getRandomString());
+    }
+
+    /**
+     * Returns a random string.
+     *
+     * @return string
+     */
+    private function getRandomString()
+    {
+        return $this->random->getRandomString(ConfigOptionsListConstants::STORE_KEY_RANDOM_STRING_SIZE);
+    }
+}

--- a/setup/src/Magento/Setup/Model/CryptKeyGeneratorInterface.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGeneratorInterface.php
@@ -19,5 +19,5 @@ interface CryptKeyGeneratorInterface
      *
      * @return string
      */
-    public function generate();
+    public function generate() : string;
 }

--- a/setup/src/Magento/Setup/Model/CryptKeyGeneratorInterface.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGeneratorInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Setup\Model;
+
+/**
+ * Interface for crypt key generators.
+ * @api
+ */
+interface CryptKeyGeneratorInterface
+{
+    /**
+     * Generates & returns a string to be used as crypt key.
+     *
+     * The key length is not a parameter, but an implementation detail.
+     *
+     * @return string
+     */
+    public function generate();
+}

--- a/setup/src/Magento/Setup/Model/CryptKeyGeneratorInterface.php
+++ b/setup/src/Magento/Setup/Model/CryptKeyGeneratorInterface.php
@@ -8,7 +8,6 @@ namespace Magento\Setup\Model;
 
 /**
  * Interface for crypt key generators.
- * @api
  */
 interface CryptKeyGeneratorInterface
 {
@@ -19,5 +18,5 @@ interface CryptKeyGeneratorInterface
      *
      * @return string
      */
-    public function generate() : string;
+    public function generate();
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
@@ -29,6 +29,9 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     private $configDataMock;
 
+    /**
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
     public function setUp()
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
@@ -140,6 +140,5 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
             ->with(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY, $key);
 
         $this->model->createCryptConfig($data);
-
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
@@ -5,27 +5,57 @@
  */
 namespace Magento\Setup\Test\Unit\Model;
 
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\State;
+use Magento\Framework\Config\Data\ConfigData;
+use Magento\Framework\Config\Data\ConfigDataFactory;
+use Magento\Setup\Model\ConfigGenerator;
 
 class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var  \Magento\Framework\App\DeploymentConfig | \PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var DeploymentConfig | \PHPUnit_Framework_MockObject_MockObject
+     */
     private $deploymentConfigMock;
 
-    /** @var  \Magento\Setup\Model\ConfigGenerator | \PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var ConfigGenerator | \PHPUnit_Framework_MockObject_MockObject
+     */
     private $model;
+
+    /**
+     * @var ConfigData|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configDataMock;
 
     public function setUp()
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
-        $this->deploymentConfigMock = $this->getMockBuilder(\Magento\Framework\App\DeploymentConfig::class)
+        $this->deploymentConfigMock = $this->getMockBuilder(DeploymentConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->configDataMock = $this->getMockBuilder(ConfigData::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['set'])
+            ->getMock();
+
+        $configDataFactoryMock = $this->getMockBuilder(ConfigDataFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
+        $configDataFactoryMock->method('create')
+            ->willReturn($this->configDataMock);
+
         $this->model = $objectManager->getObject(
-            \Magento\Setup\Model\ConfigGenerator::class,
-            ['deploymentConfig' => $this->deploymentConfigMock]
+            ConfigGenerator::class,
+            [
+                'deploymentConfig'  => $this->deploymentConfigMock,
+                'configDataFactory' => $configDataFactoryMock,
+            ]
         );
     }
 
@@ -35,8 +65,13 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->with(ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT)
             ->willReturn(null);
-        $configData = $this->model->createXFrameConfig();
-        $this->assertSame('SAMEORIGIN', $configData->getData()[ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT]);
+
+        $this->configDataMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(ConfigOptionsListConstants::CONFIG_PATH_X_FRAME_OPT, 'SAMEORIGIN');
+
+        $this->model->createXFrameConfig();
     }
 
     public function testCreateCacheHostsConfig()
@@ -55,8 +90,13 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
                 'port' => '90',
             ],
         ];
-        $configData = $this->model->createCacheHostsConfig($data);
-        $this->assertEquals($expectedData, $configData->getData()[ConfigOptionsListConstants::CONFIG_PATH_CACHE_HOSTS]);
+
+        $this->configDataMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(ConfigOptionsListConstants::CONFIG_PATH_CACHE_HOSTS, $expectedData);
+
+        $this->model->createCacheHostsConfig($data);
     }
 
     public function testCreateModeConfig()
@@ -65,8 +105,13 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->with(State::PARAM_MODE)
             ->willReturn(null);
-        $configData = $this->model->createModeConfig();
-        $this->assertSame(State::MODE_DEFAULT, $configData->getData()[State::PARAM_MODE]);
+
+        $this->configDataMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(State::PARAM_MODE, State::MODE_DEFAULT);
+
+        $this->model->createModeConfig();
     }
 
     public function testCreateModeConfigIfAlreadySet()
@@ -77,5 +122,24 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
             ->willReturn(State::MODE_PRODUCTION);
         $configData = $this->model->createModeConfig();
         $this->assertSame([], $configData->getData());
+    }
+
+    public function testCreateCryptKeyConfig()
+    {
+        $key = 'my-new-key';
+        $data = [ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY => $key];
+
+        $this->deploymentConfigMock
+            ->method('get')
+            ->with(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY)
+            ->willReturn(null);
+
+        $this->configDataMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(ConfigOptionsListConstants::CONFIG_PATH_CRYPT_KEY, $key);
+
+        $this->model->createCryptConfig($data);
+
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigGeneratorTest.php
@@ -29,9 +29,6 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     private $configDataMock;
 
-    /**
-     * @SuppressWarnings(PHPMD.LongVariable)
-     */
     public function setUp()
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);

--- a/setup/src/Magento/Setup/Test/Unit/Model/CryptKeyGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/CryptKeyGeneratorTest.php
@@ -1,0 +1,58 @@
+<?php
+/***
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Setup\Test\Unit\Model;
+
+use Magento\Framework\Math\Random;
+use Magento\Setup\Model\CryptKeyGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testcase for CryptKeyGenerator
+ */
+class CryptKeyGeneratorTest extends TestCase
+{
+    /**
+     * @var Random|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $randomMock;
+
+    /**
+     * @var CryptKeyGenerator
+     */
+    private $cryptKeyGenerator;
+
+    public function setUp()
+    {
+        $this->randomMock = $this->getMockBuilder(Random::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->cryptKeyGenerator = new CryptKeyGenerator($this->randomMock);
+    }
+
+    public function testStringForHashingIsReadFromRandom()
+    {
+        $this->randomMock
+            ->expects($this->once())
+            ->method('getRandomString');
+        
+        $this->cryptKeyGenerator->generate();
+    }
+
+    public function testReturnsMd5OfRandomString()
+    {
+        $expected = 'fdb7594e77f1ad5fbb8e6c917b6012ce'; // == 'magento2'
+
+        $this->randomMock
+            ->method('getRandomString')
+            ->willReturn('magento2');
+
+        $actual = $this->cryptKeyGenerator->generate();
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/setup/src/Magento/Setup/Test/Unit/Model/CryptKeyGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/CryptKeyGeneratorTest.php
@@ -38,7 +38,8 @@ class CryptKeyGeneratorTest extends TestCase
     {
         $this->randomMock
             ->expects($this->once())
-            ->method('getRandomString');
+            ->method('getRandomString')
+            ->willReturn('');
         
         $this->cryptKeyGenerator->generate();
     }

--- a/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
@@ -44,7 +44,12 @@ class ConfigGeneratorTest extends TestCase
         $configDataFactoryMock = (new ObjectManager($this))
             ->getObject(ConfigDataFactory::class, ['objectManager' => $objectManagerMock]);
 
-        $this->configGeneratorObject = new ConfigGenerator($randomMock, $deployConfig, $configDataFactoryMock, $cryptKeyGenerator);
+        $this->configGeneratorObject = new ConfigGenerator(
+            $randomMock,
+            $deployConfig,
+            $configDataFactoryMock,
+            $cryptKeyGenerator
+        );
     }
 
     public function testCreateCryptConfigWithInput()

--- a/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
@@ -31,7 +31,7 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
 
         $cryptKeyGenerator = new CryptKeyGenerator($randomMock);
 
-        $this->configGeneratorObject = new ConfigGenerator($deployConfig, null, $cryptKeyGenerator);
+        $this->configGeneratorObject = new ConfigGenerator($randomMock, $deployConfig, null, $cryptKeyGenerator);
     }
 
     public function testCreateCryptConfigWithInput()

--- a/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
@@ -23,6 +23,9 @@ class ConfigGeneratorTest extends TestCase
      */
     private $configGeneratorObject;
 
+    /**
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
     protected function setUp()
     {
         /** @var DeploymentConfig|\PHPUnit_Framework_MockObject_MockObject $deployConfig */

--- a/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
@@ -6,13 +6,17 @@
 namespace Magento\Setup\Test\Unit\Module;
 
 use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Config\Data\ConfigData;
+use Magento\Framework\Config\Data\ConfigDataFactory;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Math\Random;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Setup\Model\ConfigGenerator;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Setup\Model\CryptKeyGenerator;
+use PHPUnit\Framework\TestCase;
 
-class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
+class ConfigGeneratorTest extends TestCase
 {
     /**
      * @var ConfigGenerator
@@ -31,7 +35,16 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
 
         $cryptKeyGenerator = new CryptKeyGenerator($randomMock);
 
-        $this->configGeneratorObject = new ConfigGenerator($randomMock, $deployConfig, null, $cryptKeyGenerator);
+        $objectManagerMock = $this->getMockBuilder(\Magento\Framework\App\ObjectManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $objectManagerMock->method('create')->willReturn(new ConfigData('app_env'));
+
+        $configDataFactoryMock = (new ObjectManager($this))
+            ->getObject(ConfigDataFactory::class, ['objectManager' => $objectManagerMock]);
+
+        $this->configGeneratorObject = new ConfigGenerator($randomMock, $deployConfig, $configDataFactoryMock, $cryptKeyGenerator);
     }
 
     public function testCreateCryptConfigWithInput()

--- a/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
@@ -23,9 +23,6 @@ class ConfigGeneratorTest extends TestCase
      */
     private $configGeneratorObject;
 
-    /**
-     * @SuppressWarnings(PHPMD.LongVariable)
-     */
     protected function setUp()
     {
         /** @var DeploymentConfig|\PHPUnit_Framework_MockObject_MockObject $deployConfig */

--- a/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/ConfigGeneratorTest.php
@@ -5,9 +5,12 @@
  */
 namespace Magento\Setup\Test\Unit\Module;
 
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Math\Random;
 use Magento\Setup\Model\ConfigGenerator;
 use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Setup\Model\CryptKeyGenerator;
 
 class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
 {
@@ -18,11 +21,17 @@ class ConfigGeneratorTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $random = $this->createMock(\Magento\Framework\Math\Random::class);
-        $random->expects($this->any())->method('getRandomString')->willReturn('key');
-        $deployConfig= $this->createMock(\Magento\Framework\App\DeploymentConfig::class);
+        /** @var DeploymentConfig|\PHPUnit_Framework_MockObject_MockObject $deployConfig */
+        $deployConfig = $this->createMock(DeploymentConfig::class);
         $deployConfig->expects($this->any())->method('isAvailable')->willReturn(false);
-        $this->configGeneratorObject = new ConfigGenerator($random, $deployConfig);
+
+        /** @var Random|\PHPUnit_Framework_MockObject_MockObject $randomMock */
+        $randomMock = $this->createMock(Random::class);
+        $randomMock->expects($this->any())->method('getRandomString')->willReturn('key');
+
+        $cryptKeyGenerator = new CryptKeyGenerator($randomMock);
+
+        $this->configGeneratorObject = new ConfigGenerator($deployConfig, null, $cryptKeyGenerator);
     }
 
     public function testCreateCryptConfigWithInput()


### PR DESCRIPTION
Fix the command "setup:config:set --key=..." to replace existing crypt key instead of append it.

### Description
Originally a call so "bin/magento setup:config:set --key='foobar'" did
not replace the crypt key, but append it with a newline.

This does not only "break" handling of values, encryptwed with the old
key, but also don't allow use of new key, because the new key is
composed of the old one, a newline and the new one.


### Fixed Issues (if relevant)
1. magento/magento2#11089: setup:config:set --key append instead of replace

### Manual testing scenarios
1. Install Magento & get sure, that there is a crypt key defined in env.php
2. Call "bin/magento setup:config:set --key=<new key>"
3. New crypt key in env.php should be your new key, instead of "<old>\n<new>"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
