### PR TITLE
Fixed #10421: Missing Foreign Key / Cascade process for catalog_category_product_index table

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -94,6 +94,8 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
      */
     public function execute()
     {
+        $this->connection->truncateTable($this->activeTableSwitcher
+            ->getAdditionalTableName($this->getMainTable()));
         $this->reindex();
         $this->activeTableSwitcher->switchTable($this->connection, [$this->getMainTable()]);
         return $this;


### PR DESCRIPTION
Fix for https://github.com/magento/magento2/issues/10421

### Description
Added replica table (catalog_category_product_index_replica) truncate before building catalog_category_product_index

### Fixed Issues (if relevant)
1. magento/magento2#10421: Missing Foreign Key / Cascade process for catalog_category_product_index table

### Manual testing scenarios
See https://github.com/magento/magento2/issues/10421 for steps to reproduce and acceptance creteria

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
