### PR TITLE
Replace module dependency sort algorithm

### DIFF
--- a/lib/internal/Magento/Framework/Module/ModuleList/Sorter.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Sorter.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Module\ModuleList;
+
+/**
+ * Topological module dependency sorter.
+ */
+class Sorter
+{
+    /**
+     * @var array
+     */
+    private $origList = [];
+
+    /**
+     * @var array
+     */
+    private $elements = [];
+
+    /**
+     * @var array
+     */
+    private $sortedModules = [];
+
+    /**
+     * @param array $origList
+     * @return array
+     */
+    public function sort(array $origList)
+    {
+        $this->origList = $origList;
+
+        foreach ($origList as $moduleName => $moduleInformation) {
+            $this->elements[$moduleName] = $moduleInformation;
+            $this->elements[$moduleName]['isProcessed'] = false;
+        }
+
+        $this->sortedModules = [];
+
+        foreach ($this->elements as $element) {
+            $this->processElement($element, []);
+        }
+
+        return $this->sortedModules;
+    }
+
+    /**
+     * @param array $element
+     * @param array $parentElements
+     * @throws \Exception
+     */
+    private function processElement($element, $parentElements = [])
+    {
+        if (isset($parentElements[$element['name']])) {
+            $relatedName = implode('', array_slice(array_keys($parentElements), -1, 1));
+
+            throw new \Exception(
+                "Circular sequence reference from '{$relatedName}' to '{$element['name']}'."
+            );
+        }
+
+        if (!$element['isProcessed']) {
+            $parentElements[$element['name']] = true;
+
+            $element['isProcessed'] = true;
+
+            foreach ($element['sequence'] as $sequence) {
+                if (isset($this->elements[$sequence])) {
+                    $this->processElement($this->elements[$sequence], $parentElements);
+                }
+            }
+
+            unset($element['isProcessed']);
+            $this->sortedModules[$element['name']] = $element;
+        }
+    }
+}

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/LoaderTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/LoaderTest.php
@@ -7,6 +7,7 @@
 namespace Magento\Framework\Module\Test\Unit\ModuleList;
 
 use \Magento\Framework\Module\ModuleList\Loader;
+use Magento\Framework\Module\ModuleList\Sorter;
 
 class LoaderTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/SorterTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/SorterTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Module\Test\Unit\ModuleList;
+
+use Magento\Framework\Module\ModuleList\Sorter;
+use PHPUnit\Framework\TestCase;
+
+class SorterTest extends TestCase
+{
+    /**
+     * @var Sorter
+     */
+    private $sut;
+
+    protected function setUp()
+    {
+        $this->sut = new Sorter();
+    }
+
+    /**
+     *
+     */
+    public function testOrderSequence()
+    {
+        $moduleList = [
+            'a' => ['name' => 'a', 'setup_version' => '2.0.0', 'sequence' => []],    // a is on its own
+            'b' => ['name' => 'b', 'setup_version' => '1.0.0', 'sequence' => ['d']], // b is after d
+            'c' => ['name' => 'c', 'setup_version' => '1.0.0', 'sequence' => ['e']], // c is after e
+            'd' => ['name' => 'd', 'setup_version' => '1.0.0', 'sequence' => ['c']], // d is after c
+            'e' => ['name' => 'e', 'setup_version' => '100.0.0', 'sequence' => ['a']], // e is after a
+        ];
+
+        $expected = [
+            'a' => ['name' => 'a', 'setup_version' => '2.0.0', 'sequence' => []],
+            'e' => ['name' => 'e', 'setup_version' => '100.0.0', 'sequence' => ['a']],
+            'c' => ['name' => 'c', 'setup_version' => '1.0.0', 'sequence' => ['e']],
+            'd' => ['name' => 'd', 'setup_version' => '1.0.0', 'sequence' => ['c']],
+            'b' => ['name' => 'b', 'setup_version' => '1.0.0', 'sequence' => ['d']]
+        ];
+
+        $this->assertEquals($expected, $this->sut->sort($moduleList));
+    }
+}


### PR DESCRIPTION
The new algorithm replaces the old bubble sort with a new topological
sort. This eliminates 53.000 is_array and 35.000 array_unique calls.

### Description
The sort logic is moved into a new Sorter class. In the main class a bunch of code
could be removed. The new logic is much more simple than the old one.

### Manual testing scenarios
Add a new module dependency.
Circular reference check can be tested by adding a circular reference in modules.xml files.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
