### PR TITLE
#7582: use setStoreId after custom load method to give storeId precedence

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteRepository.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository.php
@@ -212,7 +212,7 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
         if ($sharedStoreIds) {
             $quote->setSharedStoreIds($sharedStoreIds);
         }
-        $quote->setStoreId($this->storeManager->getStore()->getId())->$loadMethod($identifier);
+        $quote->$loadMethod($identifier)->setStoreId($this->storeManager->getStore()->getId());
         if (!$quote->getId()) {
             throw NoSuchEntityException::singleField($loadField, $identifier);
         }


### PR DESCRIPTION
### Description
I propose to change the order of of custom load method e.g. loadByCustomerId and setStoreId in `Magento/Quote/Model/QuoteRepository::loadQuote` to apply storeId. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#7582: Payment methods in payments title in wrong language

### Manual testing scenarios
1. Have 2 Store Views with different languages e.g. EN and FR
2. Change payment method title for FR
3. Put some products into cart on EN store view
4. Switch to FR store view
5. Go to checkout payment methods
6. Payment method will now be translated because storeId is applied after loading quote

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
