### PR TITLE
Fixed issue #10738: Don't display attribute label if defined as "none" in layout (develop branch)

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -94,7 +94,7 @@
                         <argument name="at_call" xsi:type="string">getShortDescription</argument>
                         <argument name="at_code" xsi:type="string">short_description</argument>
                         <argument name="css_class" xsi:type="string">overview</argument>
-                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
+                        <argument name="at_label" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Overview</argument>
                         <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
                     </arguments>
@@ -135,7 +135,7 @@
                         <argument name="at_call" xsi:type="string">getDescription</argument>
                         <argument name="at_code" xsi:type="string">description</argument>
                         <argument name="css_class" xsi:type="string">description</argument>
-                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
+                        <argument name="at_label" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Details</argument>
                     </arguments>
                 </block>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -22,6 +22,12 @@ $_attributeLabel = $block->getAtLabel();
 $_attributeType = $block->getAtType();
 $_attributeAddAttribute = $block->getAddAttribute();
 
+$renderLabel = true;
+// if defined as 'none' in layout, do not render
+if ($_attributeLabel == 'none') {
+    $renderLabel = false;
+}
+
 if ($_attributeLabel && $_attributeLabel == 'default') {
     $_attributeLabel = $_product->getResource()->getAttribute($_code)->getStoreLabel();
 }
@@ -34,7 +40,7 @@ if ($_attributeType && $_attributeType == 'text') {
 
 <?php if ($_attributeValue): ?>
 <div class="product attribute <?= /* @escapeNotVerified */ $_className ?>">
-    <?php if ($_attributeLabel != __('none')): ?><strong class="type"><?= /* @escapeNotVerified */ $_attributeLabel ?></strong><?php endif; ?>
+    <?php if ($renderLabel): ?><strong class="type"><?= /* @escapeNotVerified */ $_attributeLabel ?></strong><?php endif; ?>
     <div class="value" <?= /* @escapeNotVerified */ $_attributeAddAttribute ?>><?= /* @escapeNotVerified */ $_attributeValue ?></div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
### Description
PR fix issue when attribute label name in `app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml` defined as `none` to hide from rendering, but there is translation for `none` in another locale, which force rendering the label.

Only layout instruction can define "none" as keyword for skip rendering label in `attrubute.phtml` template. If an attribute has label "none" defined in admin attribute settings, it must be generated as defined, and template must not read it as instruction to hide.

### Fixed Issues (if relevant)
1. magento/magento2#10738: Empty attribute label is displayed on product page

### Manual testing scenarios
1. Add new store view with another locale (language)
2. Translate "none" in new local to another language (different from "none")
3. Create new product, with some short description
4. Open product on product details view in English locale
5. Change local 
6. In steps 4 and 5 - no label for "short description" must be rendered

7. Change default store label for "SKU" to "none" in admin attribute settings
8. Open product on product details view in English local - "none" must be displayed instead of SKU. 




3. Change 'description' attribute value

### Contribution checklist
 - [] Pull request has a meaningful description of its purpose
 - [] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
