### PR TITLE
Reversed order of YES and NO options in Boolean source

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -42,8 +42,8 @@ class Boolean extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     {
         if ($this->_options === null) {
             $this->_options = [
-                ['label' => __('Yes'), 'value' => self::VALUE_YES],
                 ['label' => __('No'), 'value' => self::VALUE_NO],
+                ['label' => __('Yes'), 'value' => self::VALUE_YES],
             ];
         }
         return $this->_options;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Just a tiny change to reverse the appearance order of Yes and No options in Boolean attributes in product edit page

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you have a boolean attribute without any or null value (I.e. because you've imported it from csv and that was a non required attribute not present in csv) and you go to the product edit page you will have all the select with the YES option selected. This happens because if no value is present the selected option is the firs one. So if you save all those attributes are saved with YES value.

Since the attribute value was null during import it is safe to assume that the user meant NO for the value of that attributes, so this PR changes the order in which those values are showed so that with save those attributes are saved with NO as default.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
