### PR TITLE
Add db-prefix from env conf when command admin:user:create is executed

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -1010,6 +1010,7 @@ class Installer
     public function installAdminUser($data)
     {
         $this->assertDbConfigExists();
+        $data += ['db-prefix' => $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DB_PREFIX)];
         $setup = $this->setupFactory->create($this->context->getResources());
         $adminAccount = $this->adminAccountFactory->create($setup->getConnection(), (array)$data);
         $adminAccount->save();


### PR DESCRIPTION
Read config env.php to get db-prefix when command `admin:user:create` is executed

### Description
If you don't read `db-prefix` in env.php you don't have this information in this function: `Magento\Setup\Model\AdminAccount::getTableName` that is called in first instance in`\Magento\Setup\Model\Installer::installAdminUser`.

### Fixed Issues (if relevant)
1. magento/magento2#11176: IConfigured table prefix is not recognized in CLI admin:user:create

### Manual testing scenarios
1. Install fresh Magento with db-prefix
2. Create admin user: `php bin/magento admin:user:create --admin-user=user --admin-password=pass123Lolailo --admin-email=mail@mail.com --admin-firstname=fname --admin-lastname=lname`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
