### PR TITLE
Delete CallExit function for After plugin logic execution 2.2-develop [BackPort]

### DIFF
--- a/lib/internal/Magento/Framework/App/Response/Http/FileFactory.php
+++ b/lib/internal/Magento/Framework/App/Response/Http/FileFactory.php
@@ -99,19 +99,7 @@ class FileFactory
             if (!empty($content['rm'])) {
                 $dir->delete($file);
             }
-            $this->callExit();
         }
         return $this->_response;
-    }
-
-    /**
-     * Call exit
-     *
-     * @return void
-     * @SuppressWarnings(PHPMD.ExitExpression)
-     */
-    protected function callExit()
-    {
-        exit(0);
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/Http/FileFactoryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/Http/FileFactoryTest.php
@@ -235,7 +235,7 @@ class FileFactoryTest extends \PHPUnit\Framework\TestCase
     private function getModelMock()
     {
         $modelMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http\FileFactory::class)
-            ->setMethods(['callExit'])
+            ->setMethods(null)
             ->setConstructorArgs(
                 [
                     'response' => $this->responseMock,


### PR DESCRIPTION
Delete `CallExit` to allow Around/After plugin  work correctly

### Description
If you call a exit, you break the lifecycle of Magento, Post/Dispatch Events, Profiler, etc

### Fixed Issues
1. #7356

### Manual testing scenarios
Create a plugin that executes code after `\Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\PrintAction::execute()`. e.g:

```
#File: di.xml
<type name="Magento\Sales\Controller\Adminhtml\Invoice\PrintAction">
    <plugin name="after_print_shipment"
            type="VendorModule\Plugin\Magento\Sales\Controller\Adminhtml\Invoice\PrintAction\Plugin"
            sortOrder='10'
    />
</type>
```

```
#File: Plugin.php
function afterExecute($subject, $result) {
    echo 'After Plugin';
    die;
}
```

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

### Related Pull Requests
https://github.com/magento/magento2/pull/11029
