### PR TITLE
New Relic: Disables Module Deployments, Creates new Deploy Marker Command

### DIFF
--- a/app/code/Magento/NewRelicReporting/Command/DeployMarker.php
+++ b/app/code/Magento/NewRelicReporting/Command/DeployMarker.php
@@ -1,0 +1,54 @@
+<?php
+namespace Magento\NewRelicReporting\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+use Magento\NewRelicReporting\Model\Apm\DeploymentsFactory;
+use Magento\NewRelicReporting\Model\ServiceShellUser;
+
+class DeployMarker extends Command
+{    
+    protected $deploymentsFactory;
+    protected $serviceShellUser;
+    public function __construct(
+        DeploymentsFactory $deploymentsFactory,
+        ServiceShellUser $serviceShellUser,        
+        $name = null
+    )
+    {
+        $this->deploymentsFactory = $deploymentsFactory;
+        $this->serviceShellUser = $serviceShellUser;
+        parent::__construct($name);
+    }
+        
+    protected function configure()
+    {
+        $this->setName("newrelic:create:deploy-marker");
+        $this->setDescription("Check the deploy queue for entries and create an appropriate deploy marker.")
+              ->addArgument(
+                'message',
+                InputArgument::REQUIRED,
+                'Deploy Message?')
+              ->addArgument(
+                'changelog',
+                InputArgument::REQUIRED,
+                'Change Log?')
+              ->addArgument(
+                'user',
+                InputArgument::OPTIONAL,
+                'Deployment User');
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->deploymentsFactory->create()->setDeployment(
+            $input->getArgument('message'),
+            $input->getArgument('changelog'),
+            $this->serviceShellUser->get($input->getArgument('user'))
+        );    
+    }
+} 

--- a/app/code/Magento/NewRelicReporting/Model/Cron/ReportNewRelicCron.php
+++ b/app/code/Magento/NewRelicReporting/Model/Cron/ReportNewRelicCron.php
@@ -175,7 +175,6 @@ class ReportNewRelicCron
     public function report()
     {
         if ($this->config->isNewRelicEnabled()) {
-            $this->reportModules();
             $this->reportCounts();
         }
 

--- a/app/code/Magento/NewRelicReporting/Model/ServiceShellUser.php
+++ b/app/code/Magento/NewRelicReporting/Model/ServiceShellUser.php
@@ -1,0 +1,21 @@
+<?php
+namespace Magento\NewRelicReporting\Model;
+class ServiceShellUser
+{
+    const DEFAULT_USER='cron';
+    public function get($userFromArgument=false)
+    {
+        if($userFromArgument)
+        {
+            return $userFromArgument;
+        }
+        
+        $user = `echo \$USER`;
+        if($user)
+        {
+            return $user;
+        }
+        
+        return self::DEFAULT_USER;
+    }
+}

--- a/app/code/Magento/NewRelicReporting/etc/di.xml
+++ b/app/code/Magento/NewRelicReporting/etc/di.xml
@@ -27,4 +27,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="magento_new_relic_reporting_command_deploy_marker" xsi:type="object">Magento\NewRelicReporting\Command\DeployMarker</item>
+            </argument>
+        </arguments>
+    </type>    
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The "report module enable/disable changes as deployment markers" functionality in the `Magento_NewRelicReporting` module is broken.  Irrespective of actual module enabling/disabling, if New Relic's cron is enabled Magento will send a New Relic Deployment markers for **every** enabled module once per cron period.  This is for an hourly cron and an average of 100 modules in a module system, this is approximatly 2,400 event per individual Magento cron server, per day.  This is flooding New Relic's systems with -- let's call it a lot -- of traffic.  New Relic is taking steps to drop these deployment requests, but they're still a burden on the system.  Also, this creates an almost unusable deployment feature in the New Relic UI.  Finally, this creates slow running cron and needless network traffic for individual Magento systems.

This pull requests

1. Disabled the REST API calls to the New Relic API for module deployments
2. Offers a new newrelic:create:deployment command as an alternative for users to create their own deployment markers.

### Fixed Issues (if relevant)
Unknown/Not Relevant

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Configure New Relic in `Stores -> Configuration -> New Relic Reporting`
2. Run New Relic cron job
3. In New Relic UI, navigate to `Events -> Deployments` -- ensure there's no flood of deployment events
4. Run the `$ bin/magento newrelic:create:deploy-marker "A Message" "A Changelog" username command
5. In New Relic UI, navigate to `Events -> Deployments` 
6. Ensure the deployment created by the `newrelic:create:deploy-marker` command shows up

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)