### PR TITLE
Fixes #11163 missing data key code-entity in CMS page edit form

### DIFF
--- a/app/code/Magento/GoogleOptimizer/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/GoogleOptimizer/view/adminhtml/ui_component/cms_page_form.xml
@@ -13,7 +13,12 @@
         </settings>
         <container name="google_experiment_container" sortOrder="250">
             <htmlContent name="html_content">
-                <block name="googleOptimizerBlockAdminhtmlFormCmsPage" class="Magento\GoogleOptimizer\Block\Adminhtml\Form\CmsPage" />
+                <block name="googleOptimizerBlockAdminhtmlFormCmsPage" class="Magento\GoogleOptimizer\Block\Adminhtml\Form\CmsPage">
+                    <arguments>
+                        <argument name="code-entity" xsi:type="string">Magento\GoogleOptimizer\Block\Adminhtml\Cms\Page\EntityCmsPage</argument>
+                        <argument name="form-name" xsi:type="string">cms_page_form</argument>
+                    </arguments>
+                </block>
             </htmlContent>
         </container>
     </fieldset>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This fixes Data key is missing: code-entity Magento 2.2 fatal error while opening admin content pages CMS editor.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11163: Magento 2.2.0 Pages showing error: Data key is missing: code-entity

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Stores -> Settings -> Configuration -> Sales -> Google API -> Google Analytics
2. Set following values: Enable - yes, Account Number - (any), Enable Content Experiments - yes
3. Try to edit Content ->  Elements -> Pages -> (any page edit) 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
