### PR TITLE
A solution for Product Repeat Issue after filter on category listing page.

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
@@ -193,7 +193,10 @@ class Toolbar extends \Magento\Framework\View\Element\Template
         }
         if ($this->getCurrentOrder()) {
             if (($this->getCurrentOrder()) == 'position') {
-                $this->_collection->addAttributeToSort($this->getCurrentOrder(), $this->getCurrentDirection())->addAttributeToSort('entity_id', $this->getCurrentDirection());
+                $this->_collection->addAttributeToSort(
+                    $this->getCurrentOrder(),
+                    $this->getCurrentDirection()
+                )->addAttributeToSort('entity_id', $this->getCurrentDirection());
             } else {
                 $this->_collection->setOrder($this->getCurrentOrder(), $this->getCurrentDirection());
             }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
A solution for Product Repeat Issue after filter on category listing page.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
I have traced the issues and finally, I have found the problem. This issues magento/magento2#11139 is occurring just because of product position. When some products position are same on collection at that time we have faced this issue. For more detail about this issues please check magento/magento2#11139
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11139: Product Repeat Isuue after filter on category listing page.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Please check magento/magento2#11139

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
