### PR TITLE
Ability to connect to Redis Sentinel for Cache, PageCache and Session

### DIFF
--- a/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
@@ -101,6 +101,26 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
     const PARAM_BREAK_AFTER             = 'session/redis/break_after';
 
     /**
+     * Configuration path for number of seconds to wait before completely failing to break the lock
+     */
+    const PARAM_FAIL_AFTER             = 'session/redis/fail_after';
+
+    /**
+     * The name of master to reach via Sentinel servers.
+     */
+    const PARAM_SENTINEL_MASTER         = 'session/redis/sentinel_master';
+
+    /**
+     * Configuration path indicating if master status should be verified during connections.
+     */
+    const PARAM_SENTINEL_VERIFY_MASTER  = 'session/redis/sentinel_master_verify';
+
+    /**
+     * Configuration path indicating the number of connect retries for sentinel servers connection.
+     */
+    const PARAM_SENTINEL_CONNECT_RETRIES  = 'session/redis/sentinel_connect_retries';
+
+    /**
      * Cookie lifetime config path
      */
     const XML_PATH_COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
@@ -300,10 +320,52 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Get number of seconds to wait before completely failing to break the lock
+     *
+     * @return int
      */
     public function getFailAfter()
     {
-        return self::DEFAULT_FAIL_AFTER;
+        return $this->deploymentConfig->get(self::PARAM_FAIL_AFTER . '_' . $this->appState->getAreaCode());
+    }
+
+    /**
+     * Get list of redis sentinels
+     *
+     * @return string
+     */
+    public function getSentinelServers()
+    {
+        return $this->getHost();
+    }
+
+    /**
+     * Get sentinel master name
+     *
+     * @return string
+     */
+    public function getSentinelMaster()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_MASTER);
+    }
+
+    /**
+     * Verify master status flag
+     *
+     * @return string
+     */
+    public function getSentinelVerifyMaster()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_VERIFY_MASTER);
+    }
+
+    /**
+     * Connection retries for sentinels
+     *
+     * @return string
+     */
+    public function getSentinelConnectRetries()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_CONNECT_RETRIES);
     }
 }

--- a/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandler/Redis/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandler/Redis/ConfigTest.php
@@ -216,6 +216,20 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->config->getBreakAfter(), $breakAfter);
     }
 
+    public function testFailAfter()
+    {
+        $areaCode = 'frontend';
+        $breakAfter = 5;
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_FAIL_AFTER . '_' . $areaCode)
+            ->willReturn($breakAfter);
+        $this->appStateMock->expects($this->once())
+            ->method('getAreaCode')
+            ->willReturn($areaCode);
+        $this->assertEquals($this->config->getFailAfter(), $breakAfter);
+    }
+
     public function testGetLifetimeAdmin()
     {
         $areaCode = 'adminhtml';
@@ -245,5 +259,45 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             )
             ->willReturn($expectedLifetime);
         $this->assertEquals($this->config->getLifetime(), $expectedLifetime);
+    }
+
+    public function testGetSentinelServers()
+    {
+        $expected = 'tcp://127.0.0.1:26379,tcp://127.0.0.2:26379';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_HOST)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelServers(), $expected);
+    }
+
+    public function testGetSentinelMaster()
+    {
+        $expected = 'redismaster';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_SENTINEL_MASTER)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelMaster(), $expected);
+    }
+
+    public function testGetSentinelVerifyMaster()
+    {
+        $expected = '1';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_SENTINEL_VERIFY_MASTER)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelVerifyMaster(), $expected);
+    }
+
+    public function testGetSentinelConnectRetries()
+    {
+        $expected = '3';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_SENTINEL_CONNECT_RETRIES)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelConnectRetries(), $expected);
     }
 }

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
@@ -31,12 +31,18 @@ class Session implements ConfigOptionsListInterface
     const INPUT_KEY_SESSION_REDIS_MAX_CONCURRENCY = 'session-save-redis-max-concurrency';
     const INPUT_KEY_SESSION_REDIS_BREAK_AFTER_FRONTEND = 'session-save-redis-break-after-frontend';
     const INPUT_KEY_SESSION_REDIS_BREAK_AFTER_ADMINHTML = 'session-save-redis-break-after-adminhtml';
+    const INPUT_KEY_SESSION_REDIS_FAIL_AFTER_FRONTEND = 'session-save-redis-fail-after-frontend';
+    const INPUT_KEY_SESSION_REDIS_FAIL_AFTER_ADMINHTML = 'session-save-redis-fail-after-adminhtml';
     const INPUT_KEY_SESSION_REDIS_FIRST_LIFETIME = 'session-save-redis-first-lifetime';
     const INPUT_KEY_SESSION_REDIS_BOT_FIRST_LIFETIME = 'session-save-redis-bot-first-lifetime';
     const INPUT_KEY_SESSION_REDIS_BOT_LIFETIME = 'session-save-redis-bot-lifetime';
     const INPUT_KEY_SESSION_REDIS_DISABLE_LOCKING = 'session-save-redis-disable-locking';
     const INPUT_KEY_SESSION_REDIS_MIN_LIFETIME = 'session-save-redis-min-lifetime';
     const INPUT_KEY_SESSION_REDIS_MAX_LIFETIME = 'session-save-redis-max-lifetime';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER = 'session-save-redis-sentinel-master';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER_VERIFY = 'session-save-redis-sentinel-master-verify';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_LOAD_FROM_SLAVES= 'session-save-redis-sentinel-load-from-slaves';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES= 'session-save-redis-sentinel-connect-retries';
 
     const CONFIG_PATH_SESSION_REDIS = 'session/redis';
     const CONFIG_PATH_SESSION_REDIS_HOST = 'session/redis/host';
@@ -51,12 +57,18 @@ class Session implements ConfigOptionsListInterface
     const CONFIG_PATH_SESSION_REDIS_MAX_CONCURRENCY = 'session/redis/max_concurrency';
     const CONFIG_PATH_SESSION_REDIS_BREAK_AFTER_FRONTEND = 'session/redis/break_after_frontend';
     const CONFIG_PATH_SESSION_REDIS_BREAK_AFTER_ADMINHTML = 'session/redis/break_after_adminhtml';
+    const CONFIG_PATH_SESSION_REDIS_FAIL_AFTER_FRONTEND = 'session/redis/fail_after_frontend';
+    const CONFIG_PATH_SESSION_REDIS_FAIL_AFTER_ADMINHTML = 'session/redis/fail_after_adminhtml';
     const CONFIG_PATH_SESSION_REDIS_FIRST_LIFETIME = 'session/redis/first_lifetime';
     const CONFIG_PATH_SESSION_REDIS_BOT_FIRST_LIFETIME = 'session/redis/bot_first_lifetime';
     const CONFIG_PATH_SESSION_REDIS_BOT_LIFETIME = 'session/redis/bot_lifetime';
     const CONFIG_PATH_SESSION_REDIS_DISABLE_LOCKING = 'session/redis/disable_locking';
     const CONFIG_PATH_SESSION_REDIS_MIN_LIFETIME = 'session/redis/min_lifetime';
     const CONFIG_PATH_SESSION_REDIS_MAX_LIFETIME = 'session/redis/max_lifetime';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER = 'session/redis/sentinel_master';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER_VERIFY = 'session/redis/sentinel_master_verify';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_LOAD_FROM_SLAVES = 'session/redis/load_from_slaves';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_CONNECT_RETRIES = 'session/redis/sentinel_connect_retries';
 
     /**
      * @var array
@@ -75,12 +87,15 @@ class Session implements ConfigOptionsListInterface
         self::INPUT_KEY_SESSION_REDIS_MAX_CONCURRENCY => '6',
         self::INPUT_KEY_SESSION_REDIS_BREAK_AFTER_FRONTEND => '5',
         self::INPUT_KEY_SESSION_REDIS_BREAK_AFTER_ADMINHTML => '30',
+        self::INPUT_KEY_SESSION_REDIS_FAIL_AFTER_FRONTEND => '1',
+        self::INPUT_KEY_SESSION_REDIS_FAIL_AFTER_ADMINHTML => '10',
         self::INPUT_KEY_SESSION_REDIS_FIRST_LIFETIME => '600',
         self::INPUT_KEY_SESSION_REDIS_BOT_FIRST_LIFETIME => '60',
         self::INPUT_KEY_SESSION_REDIS_BOT_LIFETIME => '7200',
         self::INPUT_KEY_SESSION_REDIS_DISABLE_LOCKING => '0',
         self::INPUT_KEY_SESSION_REDIS_MIN_LIFETIME => '60',
-        self::INPUT_KEY_SESSION_REDIS_MAX_LIFETIME => '2592000'
+        self::INPUT_KEY_SESSION_REDIS_MAX_LIFETIME => '2592000',
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES => 3,
     ];
 
     /**
@@ -115,12 +130,20 @@ class Session implements ConfigOptionsListInterface
         self::INPUT_KEY_SESSION_REDIS_MAX_CONCURRENCY => self::CONFIG_PATH_SESSION_REDIS_MAX_CONCURRENCY,
         self::INPUT_KEY_SESSION_REDIS_BREAK_AFTER_FRONTEND => self::CONFIG_PATH_SESSION_REDIS_BREAK_AFTER_FRONTEND,
         self::INPUT_KEY_SESSION_REDIS_BREAK_AFTER_ADMINHTML => self::CONFIG_PATH_SESSION_REDIS_BREAK_AFTER_ADMINHTML,
+        self::INPUT_KEY_SESSION_REDIS_FAIL_AFTER_FRONTEND => self::CONFIG_PATH_SESSION_REDIS_FAIL_AFTER_FRONTEND,
+        self::INPUT_KEY_SESSION_REDIS_FAIL_AFTER_ADMINHTML => self::CONFIG_PATH_SESSION_REDIS_FAIL_AFTER_ADMINHTML,
         self::INPUT_KEY_SESSION_REDIS_FIRST_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_FIRST_LIFETIME,
         self::INPUT_KEY_SESSION_REDIS_BOT_FIRST_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_BOT_FIRST_LIFETIME,
         self::INPUT_KEY_SESSION_REDIS_BOT_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_BOT_LIFETIME,
         self::INPUT_KEY_SESSION_REDIS_DISABLE_LOCKING => self::CONFIG_PATH_SESSION_REDIS_DISABLE_LOCKING,
         self::INPUT_KEY_SESSION_REDIS_MIN_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_MIN_LIFETIME,
         self::INPUT_KEY_SESSION_REDIS_MAX_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_MAX_LIFETIME,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER_VERIFY => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER_VERIFY,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_LOAD_FROM_SLAVES
+            => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_LOAD_FROM_SLAVES,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES
+            => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_CONNECT_RETRIES,
     ];
 
     /**
@@ -211,6 +234,18 @@ class Session implements ConfigOptionsListInterface
                 'Number of seconds to wait before trying to break a lock for Admin session'
             ),
             new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_FAIL_AFTER_FRONTEND,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_FAIL_AFTER_FRONTEND,
+                'Number of seconds to wait before completely failing to break the lock for frontend session'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_FAIL_AFTER_ADMINHTML,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_FAIL_AFTER_ADMINHTML,
+                'Number of seconds to wait before completely failing to break the lock for Admin session'
+            ),
+            new TextConfigOption(
                 self::INPUT_KEY_SESSION_REDIS_FIRST_LIFETIME,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_SESSION_REDIS_FIRST_LIFETIME,
@@ -245,6 +280,31 @@ class Session implements ConfigOptionsListInterface
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_SESSION_REDIS_MAX_LIFETIME,
                 'Redis max session lifetime, in seconds'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER,
+                'Redis sentinel master'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER_VERIFY,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER_VERIFY,
+                'Verify connected server is actually master'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_LOAD_FROM_SLAVES,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_LOAD_FROM_SLAVES,
+                'Using the value \'1\' indicates to only load from slaves and ' .
+                    ' \'2\' to include the master in the random read slave selection'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_CONNECT_RETRIES,
+                'The number of attempts when contacting Redis Sentinel servers.'
             ),
         ];
     }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -39,7 +39,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configOptionsList->getOptions();
-        $this->assertCount(4, $options);
+        $this->assertCount(7, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -56,6 +56,18 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(3, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[3]);
         $this->assertEquals('cache-backend-redis-port', $options[3]->getName());
+
+        $this->assertArrayHasKey(4, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[4]);
+        $this->assertEquals('cache-backend-redis-sentinel-master', $options[4]->getName());
+
+        $this->assertArrayHasKey(5, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[5]);
+        $this->assertEquals('cache-backend-redis-sentinel-master-verify', $options[5]->getName());
+
+        $this->assertArrayHasKey(2, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[6]);
+        $this->assertEquals('cache-backend-redis-sentinel-load-from-slaves', $options[6]->getName());
     }
 
     public function testCreateConfigCacheRedis()
@@ -70,7 +82,10 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                         'backend_options' => [
                             'server' => '',
                             'port' => '',
-                            'database' => ''
+                            'database' => '',
+                            'sentinel_master' => '',
+                            'sentinel_master_verify' => '',
+                            'load_from_slaves' => '',
                         ]
                     ]
                 ]
@@ -92,17 +107,24 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                         'backend_options' => [
                             'server' => 'localhost',
                             'port' => '1234',
-                            'database' => '5'
+                            'database' => '5',
+                            'sentinel_master' => 'redismaster',
+                            'sentinel_master_verify' => '1',
+                            'load_from_slaves' => '2',
                         ]
                     ]
                 ]
             ]
         ];
+
         $options = [
             'cache-backend' => 'redis',
             'cache-backend-redis-server' => 'localhost',
             'cache-backend-redis-port' => '1234',
-            'cache-backend-redis-db' => '5'
+            'cache-backend-redis-db' => '5',
+            'cache-backend-redis-sentinel-master' => 'redismaster',
+            'cache-backend-redis-sentinel-master-verify' => '1',
+            'cache-backend-redis-sentinel-load-from-slaves' => '2',
         ];
 
         $configData = $this->configOptionsList->createConfig($options, $this->deploymentConfigMock);
@@ -118,7 +140,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         ];
         $this->validatorMock->expects($this->once())
             ->method('isValidConnection')
-            ->with(['host'=>'localhost', 'db'=>'', 'port'=>''])
+            ->with(['host'=>'localhost'])
             ->willReturn(true);
 
         $errors = $this->configOptionsList->validate($options, $this->deploymentConfigMock);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -39,7 +39,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configList->getOptions();
-        $this->assertCount(5, $options);
+        $this->assertCount(8, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -60,6 +60,18 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(4, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[4]);
         $this->assertEquals('page-cache-redis-compress-data', $options[4]->getName());
+
+        $this->assertArrayHasKey(4, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[5]);
+        $this->assertEquals('page-cache-redis-sentinel-master', $options[5]->getName());
+
+        $this->assertArrayHasKey(4, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[6]);
+        $this->assertEquals('page-cache-redis-sentinel-master-verify', $options[6]->getName());
+
+        $this->assertArrayHasKey(4, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[7]);
+        $this->assertEquals('page-cache-redis-sentinel-load-from-slaves', $options[7]->getName());
     }
 
     public function testCreateConfigWithRedis()
@@ -75,7 +87,10 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'server'=> '',
                             'port' => '',
                             'database' => '',
-                            'compress_data' => ''
+                            'compress_data' => '',
+                            'sentinel_master' => '',
+                            'sentinel_master_verify' => '',
+                            'load_from_slaves' => '',
                         ]
                     ]
                 ]
@@ -98,7 +113,10 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'server' => 'foo.bar',
                             'port' => '9000',
                             'database' => '6',
-                            'compress_data' => '1'
+                            'compress_data' => '1',
+                            'sentinel_master' => 'redismaster',
+                            'sentinel_master_verify' => '1',
+                            'load_from_slaves' => '2',
                         ]
                     ]
                 ]
@@ -110,7 +128,10 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
             'page-cache-redis-server' => 'foo.bar',
             'page-cache-redis-port' => '9000',
             'page-cache-redis-db' => '6',
-            'page-cache-redis-compress-data' => '1'
+            'page-cache-redis-compress-data' => '1',
+            'page-cache-redis-sentinel-master' => 'redismaster',
+            'page-cache-redis-sentinel-master-verify' => '1',
+            'page-cache-redis-sentinel-load-from-slaves' => '2',
         ];
 
         $configData = $this->configList->createConfig($options, $this->deploymentConfigMock);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/SessionTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/SessionTest.php
@@ -29,10 +29,13 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->deploymentConfigMock = $this->createMock(\Magento\Framework\App\DeploymentConfig::class);
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
     public function testGetOptions()
     {
         $options = $this->configList->getOptions();
-        $this->assertCount(19, $options);
+        $this->assertCount(25, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -88,27 +91,51 @@ class SessionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey(13, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[13]);
-        $this->assertEquals('session-save-redis-first-lifetime', $options[13]->getName());
+        $this->assertEquals('session-save-redis-fail-after-frontend', $options[13]->getName());
 
         $this->assertArrayHasKey(14, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[14]);
-        $this->assertEquals('session-save-redis-bot-first-lifetime', $options[14]->getName());
+        $this->assertEquals('session-save-redis-fail-after-adminhtml', $options[14]->getName());
 
         $this->assertArrayHasKey(15, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[15]);
-        $this->assertEquals('session-save-redis-bot-lifetime', $options[15]->getName());
+        $this->assertEquals('session-save-redis-first-lifetime', $options[15]->getName());
 
         $this->assertArrayHasKey(16, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[16]);
-        $this->assertEquals('session-save-redis-disable-locking', $options[16]->getName());
+        $this->assertEquals('session-save-redis-bot-first-lifetime', $options[16]->getName());
 
         $this->assertArrayHasKey(17, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[17]);
-        $this->assertEquals('session-save-redis-min-lifetime', $options[17]->getName());
+        $this->assertEquals('session-save-redis-bot-lifetime', $options[17]->getName());
 
         $this->assertArrayHasKey(18, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[18]);
-        $this->assertEquals('session-save-redis-max-lifetime', $options[18]->getName());
+        $this->assertEquals('session-save-redis-disable-locking', $options[18]->getName());
+
+        $this->assertArrayHasKey(19, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[19]);
+        $this->assertEquals('session-save-redis-min-lifetime', $options[19]->getName());
+
+        $this->assertArrayHasKey(20, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[20]);
+        $this->assertEquals('session-save-redis-max-lifetime', $options[20]->getName());
+
+        $this->assertArrayHasKey(21, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[21]);
+        $this->assertEquals('session-save-redis-sentinel-master', $options[21]->getName());
+
+        $this->assertArrayHasKey(22, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[22]);
+        $this->assertEquals('session-save-redis-sentinel-master-verify', $options[22]->getName());
+
+        $this->assertArrayHasKey(23, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[23]);
+        $this->assertEquals('session-save-redis-sentinel-load-from-slaves', $options[23]->getName());
+
+        $this->assertArrayHasKey(24, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[24]);
+        $this->assertEquals('session-save-redis-sentinel-connect-retries', $options[24]->getName());
     }
 
     public function testCreateConfig()
@@ -156,7 +183,13 @@ class SessionTest extends \PHPUnit\Framework\TestCase
                     'bot_lifetime' => '',
                     'disable_locking' => '',
                     'min_lifetime' => '',
-                    'max_lifetime' => ''
+                    'max_lifetime' => '',
+                    'fail_after_frontend' => '',
+                    'fail_after_adminhtml' => '',
+                    'sentinel_connect_retries' => '',
+                    'sentinel_master' => '',
+                    'sentinel_master_verify' => '',
+                    'load_from_slaves' => '',
                 ]
 
             ]
@@ -186,6 +219,10 @@ class SessionTest extends \PHPUnit\Framework\TestCase
             'session-save-redis-log-level' => '4',
             'session-save-redis-min-lifetime' => '60',
             'session-save-redis-max-lifetime' => '3600',
+            'session-save-redis-sentinel-master' => 'redismaster',
+            'session-save-redis-sentinel-master-verify' => '1',
+            'session-save-redis-sentinel-load-from-slaves'=> '2',
+            'session-save-redis-sentinel-connect-retries'=> '3',
         ];
 
         $expectedConfigData = [
@@ -209,7 +246,13 @@ class SessionTest extends \PHPUnit\Framework\TestCase
                     'bot_lifetime' => '',
                     'disable_locking' => '',
                     'min_lifetime' => '60',
-                    'max_lifetime' => '3600'
+                    'max_lifetime' => '3600',
+                    'sentinel_master' => 'redismaster',
+                    'sentinel_master_verify' => '1',
+                    'load_from_slaves' => '2',
+                    'fail_after_frontend' => '',
+                    'fail_after_adminhtml' => '',
+                    'sentinel_connect_retries' => 3,
                 ]
             ],
 
@@ -277,12 +320,18 @@ class SessionTest extends \PHPUnit\Framework\TestCase
             ['session-save-redis-max-concurrency', 'max_concurrency', '3'],
             ['session-save-redis-break-after-frontend', 'break_after_frontend', '10'],
             ['session-save-redis-break-after-adminhtml', 'break_after_adminhtml', '20'],
+            ['session-save-redis-fail-after-frontend', 'fail_after_frontend', '1'],
+            ['session-save-redis-fail-after-adminhtml', 'fail_after_adminhtml', '10'],
             ['session-save-redis-first-lifetime', 'first_lifetime', '300'],
             ['session-save-redis-bot-first-lifetime', 'bot_first_lifetime', '30'],
             ['session-save-redis-bot-lifetime', 'bot_lifetime', '3600'],
             ['session-save-redis-disable-locking', 'disable_locking', '1'],
             ['session-save-redis-min-lifetime', 'min_lifetime', '20'],
             ['session-save-redis-max-lifetime', 'max_lifetime', '12000'],
+            ['session-save-redis-sentinel-master', 'sentinel_master', 'redismaster'],
+            ['session-save-redis-sentinel-master-verify', 'sentinel_master_verify', '1'],
+            ['session-save-redis-sentinel-load-from-slaves', 'load_from_slaves', '2'],
+            ['session-save-redis-sentinel-connect-retries', 'sentinel_connect_retries', '1'],
         ];
     }
 

--- a/setup/src/Magento/Setup/Validator/RedisConnectionValidator.php
+++ b/setup/src/Magento/Setup/Validator/RedisConnectionValidator.php
@@ -15,22 +15,49 @@ class RedisConnectionValidator
      * Validate redis connection
      *
      * @param array $redisOptions
+     *
      * @return bool
      */
     public function isValidConnection(array $redisOptions)
     {
         $default = [
-            'host' => '',
-            'port' => '',
-            'db' => '',
-            'password' => null,
-            'timeout' => null,
-            'persistent' => ''
+            'host'                   => '',
+            'port'                   => '',
+            'db'                     => '',
+            'password'               => null,
+            'timeout'                => null,
+            'persistent'             => '',
+            'sentinel_master'        => null,
+            'sentinel_master_verify' => null,
         ];
 
         $config = array_merge($default, $redisOptions);
 
         try {
+            // If Redis is set to use sentinel, try to retrieve master from Sentinel servers, then try connecting to it.
+            if (isset($config['sentinel_master'])) {
+                $sentinelClient = new \Credis_Client(
+                    $config['host'],
+                    $config['port'],
+                    $config['timeout'],
+                    $config['persistent']
+                );
+                $sentinelClient->forceStandalone();
+                $sentinelClient->setMaxConnectRetries(0);
+
+                $sentinel = new \Credis_Sentinel($sentinelClient);
+                $sentinel
+                    ->setClientTimeout($config['timeout'])
+                    ->setClientPersistent($config['persistent']);
+
+                $redisClient = $sentinel->getMasterClient($config['sentinel_master']);
+                $redisClient->setMaxConnectRetries(1);
+                $redisClient->connect();
+
+                return true;
+            }
+
+            // When not using sentinel mode, just process standard check.
             $redisClient = new \Credis_Client(
                 $config['host'],
                 $config['port'],
@@ -39,6 +66,7 @@ class RedisConnectionValidator
                 $config['db'],
                 $config['password']
             );
+
             $redisClient->setMaxConnectRetries(1);
             $redisClient->connect();
         } catch (\CredisException $e) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

This PR provides the support of [Redis Sentinel](https://redis.io/topics/sentinel) for Cache, PageCache, and Session.

Usage of Redis Sentinel is suitable in an HA environment.

This is supported "out of the box" by colinmollenhour modules (credis, php-abstract-session, and it's cache backend). See https://github.com/colinmollenhour/Cm_Cache_Backend_Redis#high-availability-and-load-balancing-support

But Magento is not actually fully compatible with Redis Sentinel usage. This PR intends to add this compatibility.

What has been done : 

- leveraging dependencies to colinmollenhour modules.
- adding the ability to support additional configuration variables related to Redis Sentinel when installing with command line.
- updating unit tests to remain compliant.

New variables added to the `setup:install` in command line : 

	--cache-backend-redis-sentinel-master
	--cache-backend-redis-sentinel-master-verify
	--cache-backend-redis-sentinel-load-from-slaves
	--page-cache-redis-sentinel-master
	--page-cache-redis-sentinel-master-verify
	--page-cache-redis-sentinel-load-from-slaves
	--session-save-redis-sentinel-master
	--session-save-redis-sentinel-master-verify
	--session-save-redis-sentinel-load-from-slaves
	--session-save-redis-sentinel-connect-retries

Basically, there are three parameters that are identical in the 3 cases : 

|Argument | Required ? | Values | Comment |
---------|-----------|-------------|----------|
| --cache-backend-redis-sentinel-master | No | string |the name of the Redis master which is monitored by the sentinel servers. |
| --cache-backend-redis-sentinel-master-verify | No | 0/1 |Verify connected server is actually master as per Sentinel client spec. |
| --cache-backend-redis-sentinel-load-from-slaves | No | 1/2 |A random slave will be chosen for performing reads in order to load balance across multiple Redis instances. Using the value '1' indicates to only load from slaves and '2' to include the master in the random read slave selection. |
| --page-cache-redis-sentinel-master | No | string |the name of the Redis master which is monitored by the sentinel servers. |
| --page-cache-redis-sentinel-master-verify | No | 0/1 |Verify connected server is actually master as per Sentinel client spec. |
| --page-cache-redis-sentinel-load-from-slaves | No | 1/2 |A random slave will be chosen for performing reads in order to load balance across multiple Redis instances. Using the value '1' indicates to only load from slaves and '2' to include the master in the random read slave selection. |
| --session-save-redis-sentinel-master | No | string |the name of the Redis master which is monitored by the sentinel servers. |
| --session-save-redis-sentinel-master-verify | No | 0/1 |Verify connected server is actually master as per Sentinel client spec. |
| --session-save-redis-sentinel-load-from-slaves | No | 1/2 |A random slave will be chosen for performing reads in order to load balance across multiple Redis instances. Using the value '1' indicates to only load from slaves and '2' to include the master in the random read slave selection. |
| --session-save-redis-sentinel-connect-retries | No | string |Number of connect retries when contacting sentinels  |

Please also note that when using Sentinel, you must use the IP/address of your sentinel servers as your Redis Host. Since you are meant to have several sentinels when running such an instance, you can use the list of all your sentinel servers as an input for the "host" or "server" configuration values for Redis (Eg : 'tcp://10.0.3.1:26379,tcp://10.0.3.2:26379,tcp://10.0.3.3:26379') . 

Here is an example of a generated `app/etc/env.php` : 

```
  'session' => 
  array (
    'save' => 'redis',
    'redis' => 
    array (
      'host' => 'tcp://10.0.3.1:26379,tcp://10.0.3.2:26379,tcp://10.0.3.3:26379', // Sentinel servers
      'port' => '26379',
      'password' => '',
      'timeout' => '2.5',
      'persistent_identifier' => '',
      'database' => '0',
      'compression_threshold' => '2048',
      'compression_library' => 'gzip',
      'log_level' => '1',
      'max_concurrency' => '6',
      'break_after_frontend' => '5',
      'break_after_adminhtml' => '30',
      'fail_after_frontend' => '1',
      'fail_after_adminhtml' => '10',
      'first_lifetime' => '600',
      'bot_first_lifetime' => '60',
      'bot_lifetime' => '7200',
      'disable_locking' => '0',
      'min_lifetime' => '60',
      'max_lifetime' => '2592000',
      'sentinel_master' => 'redismaster', // Name of master monitored by Sentinels.
      'sentinel_master_verify' => '1',
      'load_from_slaves' => '2',
      'sentinel_connect_retries' => '3',
    ),
  ),
  'cache' => 
  array (
    'frontend' => 
    array (
      'default' => 
      array (
        'backend' => 'Cm_Cache_Backend_Redis',
        'backend_options' => 
        array (
          'server' => 'tcp://10.0.3.1:26379,tcp://10.0.3.2:26379,tcp://10.0.3.3:26379', // Sentinel servers
          'database' => '1',
          'port' => '26379',
          'sentinel_master' => 'redismaster', // Name of master monitored by Sentinels.
          'sentinel_master_verify' => '1',
          'load_from_slaves' => '2',
        ),
      ),
      'page_cache' => 
      array (
        'backend' => 'Cm_Cache_Backend_Redis',
        'backend_options' => 
        array (
          'server' => 'tcp://10.0.3.1:26379,tcp://10.0.3.2:26379,tcp://10.0.3.3:26379', // Sentinel servers
          'database' => '2',
          'port' => '26379',
          'compress_data' => '0',
          'sentinel_master' => 'redismaster', // Name of master monitored by Sentinels.
          'sentinel_master_verify' => '1',
          'load_from_slaves' => '2',
        ),
      ),
    ),
  ),
```

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ... Install a Redis Sentinel Cluster somewhere (there are some "fast to setup" examples with Docker-Compose)
2. ... Install Magento2 with command line and specify these set of parameters : 

```
	--cache-backend=redis \
        --cache-backend-redis-server=tcp://10.0.3.1 \
        --cache-backend-redis-db=1 \
        --cache-backend-redis-port=26379 \
	--cache-backend-redis-sentinel-master=redismaster \
	--cache-backend-redis-sentinel-master-verify=1 \
	--cache-backend-redis-sentinel-load-from-slaves=2 \
        --page-cache=redis \
        --page-cache-redis-server=tcp://10.0.3.1:26379 \
        --page-cache-redis-db=2 \
        --page-cache-redis-port=26379 \
	--page-cache-redis-sentinel-master=redismaster \
	--page-cache-redis-sentinel-master-verify=1 \
	--page-cache-redis-sentinel-load-from-slaves=2 \
        --session-save=redis \
        --session-save-redis-host=tcp://10.0.3.1:26379 \
        --session-save-redis-db=0 \
	--session-save-redis-port=26379 \
	--session-save-redis-host=tcp://10.0.3.1:26379 \
	--session-save-redis-sentinel-master=redismaster \
	--session-save-redis-sentinel-master-verify=1 \
	--session-save-redis-sentinel-load-from-slaves=2 \
	--session-save-redis-sentinel-connect-retries=3 \
```

3. Check everything is running properly (cache keys are here in Redis, the same for page cache and sessions).


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
