### PR TITLE
Cms page/block eventprefix fix issue 9900

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
@@ -19,6 +19,13 @@ class Collection extends AbstractCollection
     protected $_idFieldName = 'block_id';
 
     /**
+     * Event prefix
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'cms_block_collection';
+
+    /**
      * Perform operations after collection load
      *
      * @return $this

--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
@@ -26,6 +26,13 @@ class Collection extends AbstractCollection
     protected $_eventPrefix = 'cms_block_collection';
 
     /**
+     * Event object
+     *
+     * @var string
+     */
+    protected $_eventObject = 'block_collection';
+
+    /**
      * Perform operations after collection load
      *
      * @return $this

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -26,6 +26,13 @@ class Collection extends AbstractCollection
     protected $_previewFlag;
 
     /**
+     * Event prefix
+     *
+     * @var string
+     */
+    //protected $_eventPrefix = 'cms_page_collection';
+
+    /**
      * Define resource model
      *
      * @return void

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -30,7 +30,7 @@ class Collection extends AbstractCollection
      *
      * @var string
      */
-    //protected $_eventPrefix = 'cms_page_collection';
+    protected $_eventPrefix = 'cms_page_collection';
 
     /**
      * Define resource model

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -30,14 +30,14 @@ class Collection extends AbstractCollection
      *
      * @var string
      */
-    protected $_eventPrefix = 'page_collection';
+    protected $_eventPrefix = 'cms_page_collection';
 
     /**
      * Event object
      *
      * @var string
      */
-    protected $_eventObject = 'order_item_collection';
+    protected $_eventObject = 'page_collection';
 
     /**
      * Define resource model

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -30,7 +30,14 @@ class Collection extends AbstractCollection
      *
      * @var string
      */
-    protected $_eventPrefix = 'cms_page_collection';
+    protected $_eventPrefix = 'page_collection';
+
+    /**
+     * Event object
+     *
+     * @var string
+     */
+    protected $_eventObject = 'order_item_collection';
 
     /**
      * Define resource model


### PR DESCRIPTION
Fix issue https://github.com/magento/magento2/issues/9900 by defining `eventPrefix` and `eventObject` against collections.

This issue is fixed in the `develop` branch by https://github.com/magento/magento2/pull/11046

This PR cherry-picks those commits into the `2.2-develop` branch.
```bash
$ git cherry-pick a15f4cc7e77b672b94657620e7e961265160d103 bf0dbee9cc4483f212b9c5643f3e50df7a2214cd d782c711321a10879f4b0d24e6400a45ac04bed8 a87f1cfdc5907eac0185316636ebe99b800a1ac4
[cms-page-eventprefix-fix-issue-9900 08491d33e99] Add EventPrefix to CMS Page/Block Collection
 Author: Oscar Recio <oscar.recio@interactiv4.com>
 Date: Tue Sep 26 11:17:51 2017 +0200
 2 files changed, 14 insertions(+)
[cms-page-eventprefix-fix-issue-9900 bc6180ca862] Add EventPrefix to CMS Page/Block Collection
 Author: Oscar Recio <oscar.recio@interactiv4.com>
 Date: Tue Sep 26 11:29:20 2017 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)
[cms-page-eventprefix-fix-issue-9900 e110196da16] Add EventObject to CMS Page/Block Collection
 Author: Oscar Recio <oscar.recio@interactiv4.com>
 Date: Tue Sep 26 11:52:56 2017 +0200
 2 files changed, 15 insertions(+), 1 deletion(-)
[cms-page-eventprefix-fix-issue-9900 ce93e40ae2d] Add EventObject to CMS Page/Block Collection
 Author: Oscar Recio <oscar.recio@interactiv4.com>
 Date: Tue Sep 26 11:54:08 2017 +0200
 1 file changed, 2 insertions(+), 2 deletions(-)
```

I'll see how this runs against travis, if it passes I'd consider this a success.

#SQUASHTOBERFEST 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
