### PR TITLE
Remove quantity_and_stock_status attribute from excluded attributes in Catalog Widget

### DIFF
--- a/app/code/Magento/CatalogWidget/etc/di.xml
+++ b/app/code/Magento/CatalogWidget/etc/di.xml
@@ -6,11 +6,5 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\CatalogWidget\Model\Rule\Condition\Combine">
-        <arguments>
-            <argument name="excludedAttributes" xsi:type="array">
-                <item name="0" xsi:type="string">quantity_and_stock_status</item>
-            </argument>
-        </arguments>
-    </type>
+    <type name="Magento\CatalogWidget\Model\Rule\Condition\Combine" />
 </config>


### PR DESCRIPTION
Remove quantity_and_stock_status from excluded attributes in Catalog Widget

### Description
Remove quantity_and_stock_status from excluded attributes in Catalog Widget in di.xml. It allows load quantity field in filter select when load a Catalog Widget in CMS pages or blocks as in 1.9.x

### Fixed Issues (if relevant)

1. magento/magento2#11187: Quantity Condition not shown in Widget

### Manual testing scenarios
1. Create a CMS page or block
2. Add a Product list widget
3. Add a quantity filter
4. Test in front-end

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
