### PR TITLE
Disable secret key validation on admin noroute to fix redirect loop

### DIFF
--- a/app/code/Magento/Backend/Controller/Adminhtml/Noroute/Index.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Noroute/Index.php
@@ -9,6 +9,13 @@ namespace Magento\Backend\Controller\Adminhtml\Noroute;
 class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Array of actions which can be processed without secret key validation
+     *
+     * @var string[]
+     */
+    protected $_publicActions = ['index'];
+
+    /**
      * @var \Magento\Framework\View\Result\PageFactory
      */
     protected $resultPageFactory;


### PR DESCRIPTION
Similar to 2f422ad42e5476a476ff095e3377baad9c616927 but using the framework.

Fixes issue #10611 for the `2.2-develop` branch.

Doesn't address the route cause, but only fixes the symptom as per https://github.com/magento/magento2/pull/10921#discussion_r141584859

If preferred I can rebase this branch to do a cherry-pick of 2f422ad42e5476a476ff095e3377baad9c616927, but I figured it better to use the framework to achieve this feature.

## Steps to reproduce

1. Create a user role with no resources assigned to it.
2. Create an admin user with that role.
3. Log in with that user.
4. Should see an "Access denied" screen rather than a redirect loop.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
