### PR TITLE
Save region correctly to save sales address from admin [backport]

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -60,16 +60,6 @@ class AddressSave extends Order
         LoggerInterface $logger,
         RegionFactory $regionFactory
     ) {
-        $this->_coreRegistry = $coreRegistry;
-        $this->_fileFactory = $fileFactory;
-        $this->_translateInline = $translateInline;
-        $this->resultPageFactory = $resultPageFactory;
-        $this->resultJsonFactory = $resultJsonFactory;
-        $this->resultLayoutFactory = $resultLayoutFactory;
-        $this->resultRawFactory = $resultRawFactory;
-        $this->orderManagement = $orderManagement;
-        $this->orderRepository = $orderRepository;
-        $this->logger = $logger;
         $this->regionFactory = $regionFactory;
         parent::__construct(
             $context,

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -7,7 +7,15 @@
 
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
+use Magento\Sales\Controller\Adminhtml\Order;
+use Magento\Backend\App\Action;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Directory\Model\RegionFactory;
+use Psr\Log\LoggerInterface;
+use Magento\Framework;
+
+class AddressSave extends Order
 {
     /**
      * Authorization level of a basic admin session
@@ -17,40 +25,40 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 
     /**
-     * @var \Magento\Directory\Model\RegionFactory
+     * @var RegionFactory
      */
     private $regionFactory;
 
     /**
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Framework\App\Response\Http\FileFactory $fileFactory
-     * @param \Magento\Framework\Translate\InlineInterface $translateInline
-     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
-     * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
-     * @param \Magento\Framework\View\Result\LayoutFactory $resultLayoutFactory
-     * @param \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
-     * @param \Magento\Sales\Api\OrderManagementInterface $orderManagement
-     * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository
-     * @param \Psr\Log\LoggerInterface $logger
-     * @param \Magento\Directory\Model\RegionFactory $regionFactory
+     * @param Action\Context $context
+     * @param Framework\Registry $coreRegistry
+     * @param Framework\App\Response\Http\FileFactory $fileFactory
+     * @param Framework\Translate\InlineInterface $translateInline
+     * @param Framework\View\Result\PageFactory $resultPageFactory
+     * @param Framework\Controller\Result\JsonFactory $resultJsonFactory
+     * @param Framework\View\Result\LayoutFactory $resultLayoutFactory
+     * @param Framework\Controller\Result\RawFactory $resultRawFactory
+     * @param OrderManagementInterface $orderManagement
+     * @param OrderRepositoryInterface $orderRepository
+     * @param LoggerInterface $logger
+     * @param RegionFactory $regionFactory
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
      */
     public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Framework\App\Response\Http\FileFactory $fileFactory,
-        \Magento\Framework\Translate\InlineInterface $translateInline,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
-        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
-        \Magento\Framework\View\Result\LayoutFactory $resultLayoutFactory,
-        \Magento\Framework\Controller\Result\RawFactory $resultRawFactory,
-        \Magento\Sales\Api\OrderManagementInterface $orderManagement,
-        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
-        \Psr\Log\LoggerInterface $logger,
-        \Magento\Directory\Model\RegionFactory $regionFactory
+        Action\Context $context,
+        Framework\Registry $coreRegistry,
+        Framework\App\Response\Http\FileFactory $fileFactory,
+        Framework\Translate\InlineInterface $translateInline,
+        Framework\View\Result\PageFactory $resultPageFactory,
+        Framework\Controller\Result\JsonFactory $resultJsonFactory,
+        Framework\View\Result\LayoutFactory $resultLayoutFactory,
+        Framework\Controller\Result\RawFactory $resultRawFactory,
+        OrderManagementInterface $orderManagement,
+        OrderRepositoryInterface $orderRepository,
+        LoggerInterface $logger,
+        RegionFactory $regionFactory
     ) {
         $this->regionFactory = $regionFactory;
         parent::__construct(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -7,7 +7,7 @@
 
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Sales\Controller\Adminhtml\Order;
+use Magento\Sales\Controller\Adminhtml;
 use Magento\Backend\App\Action;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
@@ -15,7 +15,7 @@ use Magento\Directory\Model\RegionFactory;
 use Psr\Log\LoggerInterface;
 use Magento\Framework;
 
-class AddressSave extends Order
+class AddressSave extends Adminhtml\Order
 {
     /**
      * Authorization level of a basic admin session

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -7,7 +7,6 @@
 
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Sales\Controller\Adminhtml;
 use Magento\Backend\App\Action;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
@@ -15,7 +14,7 @@ use Magento\Directory\Model\RegionFactory;
 use Psr\Log\LoggerInterface;
 use Magento\Framework;
 
-class AddressSave extends Adminhtml\Order
+class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
      * Authorization level of a basic admin session

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -133,7 +133,7 @@ class AddressSave extends Order
      * @param array $attributeValues
      * @return array
      */
-    protected function updateRegionData($attributeValues)
+    private function updateRegionData($attributeValues)
     {
         if (!empty($attributeValues['region_id'])) {
             $newRegion = $this->regionFactory->create()->load($attributeValues['region_id']);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -4,9 +4,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
+use Magento\Sales\Controller\Adminhtml\Order;
+use Magento\Backend\App\Action;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Directory\Model\RegionFactory;
+use Psr\Log\LoggerInterface;
+use Magento\Framework;
+
+class AddressSave extends Order
 {
     /**
      * Authorization level of a basic admin session
@@ -14,6 +23,57 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
      * @see _isAllowed()
      */
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
+
+    /**
+     * @var RegionFactory
+     */
+    private $regionFactory;
+
+    /**
+     * @param Action\Context $context
+     * @param Framework\Registry $coreRegistry
+     * @param Framework\App\Response\Http\FileFactory $fileFactory
+     * @param Framework\Translate\InlineInterface $translateInline
+     * @param Framework\View\Result\PageFactory $resultPageFactory
+     * @param Framework\Controller\Result\JsonFactory $resultJsonFactory
+     * @param Framework\View\Result\LayoutFactory $resultLayoutFactory
+     * @param Framework\Controller\Result\RawFactory $resultRawFactory
+     * @param OrderManagementInterface $orderManagement
+     * @param OrderRepositoryInterface $orderRepository
+     * @param LoggerInterface $logger
+     * @param RegionFactory $regionFactory
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+     */
+    public function __construct(
+        Action\Context $context,
+        Framework\Registry $coreRegistry,
+        Framework\App\Response\Http\FileFactory $fileFactory,
+        Framework\Translate\InlineInterface $translateInline,
+        Framework\View\Result\PageFactory $resultPageFactory,
+        Framework\Controller\Result\JsonFactory $resultJsonFactory,
+        Framework\View\Result\LayoutFactory $resultLayoutFactory,
+        Framework\Controller\Result\RawFactory $resultRawFactory,
+        OrderManagementInterface $orderManagement,
+        OrderRepositoryInterface $orderRepository,
+        LoggerInterface $logger,
+        RegionFactory $regionFactory
+    ) {
+        $this->_coreRegistry = $coreRegistry;
+        $this->_fileFactory = $fileFactory;
+        $this->_translateInline = $translateInline;
+        $this->resultPageFactory = $resultPageFactory;
+        $this->resultJsonFactory = $resultJsonFactory;
+        $this->resultLayoutFactory = $resultLayoutFactory;
+        $this->resultRawFactory = $resultRawFactory;
+        $this->orderManagement = $orderManagement;
+        $this->orderRepository = $orderRepository;
+        $this->logger = $logger;
+        $this->regionFactory = $regionFactory;
+        parent::__construct($context, $coreRegistry, $fileFactory, $translateInline, $resultPageFactory,
+            $resultJsonFactory, $resultLayoutFactory, $resultRawFactory, $orderManagement, $orderRepository, $logger);
+    }
 
     /**
      * Save order address
@@ -28,6 +88,7 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
             \Magento\Sales\Api\Data\OrderAddressInterface::class
         )->load($addressId);
         $data = $this->getRequest()->getPostValue();
+        $this->updateRegionData($data);
         $resultRedirect = $this->resultRedirectFactory->create();
         if ($data && $address->getId()) {
             $address->addData($data);
@@ -49,6 +110,22 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
             return $resultRedirect->setPath('sales/*/address', ['address_id' => $address->getId()]);
         } else {
             return $resultRedirect->setPath('sales/*/');
+        }
+    }
+    
+    /**
+     * Update region data
+     *
+     * @param array $attributeValues
+     * @return void
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    protected function updateRegionData(&$attributeValues)
+    {
+        if (!empty($attributeValues['region_id'])) {
+            $newRegion = $this->regionFactory->create()->load($attributeValues['region_id']);
+            $attributeValues['region_code'] = $newRegion->getCode();
+            $attributeValues['region'] = $newRegion->getDefaultName();
         }
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -71,8 +71,19 @@ class AddressSave extends Order
         $this->orderRepository = $orderRepository;
         $this->logger = $logger;
         $this->regionFactory = $regionFactory;
-        parent::__construct($context, $coreRegistry, $fileFactory, $translateInline, $resultPageFactory,
-            $resultJsonFactory, $resultLayoutFactory, $resultRawFactory, $orderManagement, $orderRepository, $logger);
+        parent::__construct(
+            $context,
+            $coreRegistry,
+            $fileFactory,
+            $translateInline,
+            $resultPageFactory,
+            $resultJsonFactory,
+            $resultLayoutFactory,
+            $resultRawFactory,
+            $orderManagement,
+            $orderRepository,
+            $logger
+        );
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -7,13 +7,6 @@
 
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Backend\App\Action;
-use Magento\Sales\Api\OrderManagementInterface;
-use Magento\Sales\Api\OrderRepositoryInterface;
-use Magento\Directory\Model\RegionFactory;
-use Psr\Log\LoggerInterface;
-use Magento\Framework;
-
 class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
@@ -24,40 +17,40 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 
     /**
-     * @var RegionFactory
+     * @var \Magento\Directory\Model\RegionFactory
      */
     private $regionFactory;
 
     /**
-     * @param Action\Context $context
-     * @param Framework\Registry $coreRegistry
-     * @param Framework\App\Response\Http\FileFactory $fileFactory
-     * @param Framework\Translate\InlineInterface $translateInline
-     * @param Framework\View\Result\PageFactory $resultPageFactory
-     * @param Framework\Controller\Result\JsonFactory $resultJsonFactory
-     * @param Framework\View\Result\LayoutFactory $resultLayoutFactory
-     * @param Framework\Controller\Result\RawFactory $resultRawFactory
-     * @param OrderManagementInterface $orderManagement
-     * @param OrderRepositoryInterface $orderRepository
-     * @param LoggerInterface $logger
-     * @param RegionFactory $regionFactory
+     * @param \Magento\Backend\App\Action\Context $context
+     * @param \Magento\Framework\Registry $coreRegistry
+     * @param \Magento\Framework\App\Response\Http\FileFactory $fileFactory
+     * @param \Magento\Framework\Translate\InlineInterface $translateInline
+     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
+     * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
+     * @param \Magento\Framework\View\Result\LayoutFactory $resultLayoutFactory
+     * @param \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
+     * @param \Magento\Sales\Api\OrderManagementInterface $orderManagement
+     * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Magento\Directory\Model\RegionFactory $regionFactory
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
      */
     public function __construct(
-        Action\Context $context,
-        Framework\Registry $coreRegistry,
-        Framework\App\Response\Http\FileFactory $fileFactory,
-        Framework\Translate\InlineInterface $translateInline,
-        Framework\View\Result\PageFactory $resultPageFactory,
-        Framework\Controller\Result\JsonFactory $resultJsonFactory,
-        Framework\View\Result\LayoutFactory $resultLayoutFactory,
-        Framework\Controller\Result\RawFactory $resultRawFactory,
-        OrderManagementInterface $orderManagement,
-        OrderRepositoryInterface $orderRepository,
-        LoggerInterface $logger,
-        RegionFactory $regionFactory
+        \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\Registry $coreRegistry,
+        \Magento\Framework\App\Response\Http\FileFactory $fileFactory,
+        \Magento\Framework\Translate\InlineInterface $translateInline,
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
+        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
+        \Magento\Framework\View\Result\LayoutFactory $resultLayoutFactory,
+        \Magento\Framework\Controller\Result\RawFactory $resultRawFactory,
+        \Magento\Sales\Api\OrderManagementInterface $orderManagement,
+        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
+        \Psr\Log\LoggerInterface $logger,
+        \Magento\Directory\Model\RegionFactory $regionFactory
     ) {
         $this->regionFactory = $regionFactory;
         parent::__construct(


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Related with [PR#11381](https://github.com/magento/magento2/pull/11381)
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Save region correctly to save sales address from admin
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10441: State/Province Not displayed after edit Billing Address on Sales Orders - Backend Admin.

### Steps to reproduce
1. Go to the backend -> Sales -> Orders -> View any order.
2. Select the section -> Information -> Address Information
3. Edit Billing Address, for example the street address.
4. Save Order Address.

**Note:** The same issue happen with the Shipping Address.
### Manual testing scenarios

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
