### PR TITLE
Virtual Theme load: Check for null to actually reach the code that handles this case to t…

### DIFF
--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -799,7 +799,7 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
     protected function _getPhysicalTheme(\Magento\Framework\View\Design\ThemeInterface $theme)
     {
         $result = $theme;
-        while ($result->getId() && !$result->isPhysical()) {
+        while (!is_null($result) && $result->getId() && !$result->isPhysical()) {
             $result = $result->getParentTheme();
         }
         if (!$result) {

--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -799,7 +799,7 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
     protected function _getPhysicalTheme(\Magento\Framework\View\Design\ThemeInterface $theme)
     {
         $result = $theme;
-        while (!is_null($result) && $result->getId() && !$result->isPhysical()) {
+        while ($result !== null && $result->getId() && !$result->isPhysical()) {
             $result = $result->getParentTheme();
         }
         if (!$result) {


### PR DESCRIPTION
Virtual Theme load: Check for null to actually reach the code that handles this case to throw the appropriate exception

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Actually gives the chances for a meaningful Exception when a virtual theme does not a have a physical parent theme. In the previous code this exception was not reachable, since getParentTheme returned null and in the loop it was expected to be a Model/Theme object. 

### Fixed Issues (if relevant)
- No Issues fixed

### Manual testing scenarios
1. Create a virtual theme without a physical parent

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
