### PR TITLE
Can't close mobile search bar

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -88,7 +88,7 @@ define([
                 }
 
                 setTimeout($.proxy(function () {
-                    if (this.autoComplete.is(':hidden')) {
+                    if (this.autoComplete.css('display','none')) {
                         this.setActiveState(false);
                     } else {
                         this.element.trigger('focus');


### PR DESCRIPTION
### Description
Can't close mobile search bar when using Luma Theme

### Fixed Issues (if relevant)
1. magento/magento2/issues/11231: Can't close mobile search bar once typed

### Steps to reproduce
1. Load the homepage on a mobile device
2. Tap on the search icon to access the search input
3. Start typing (but do not submit)
4. Now tap on the search icon again to close the search bar

### Manual testing scenarios

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
