### PR TITLE
Can't close mobile search bar

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -88,7 +88,7 @@ define([
                 }
 
                 setTimeout($.proxy(function () {
-                    if (this.autoComplete.is(':hidden')) {
+                    if (this.autoComplete.css('display', 'none')) {
                         this.setActiveState(false);
                     } else {
                         this.element.trigger('focus');

--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -286,16 +286,17 @@ define([
                 $.getJSON(this.options.url, {
                     q: value
                 }, $.proxy(function (data) {
-                    $.each(data, function (index, element) {
-                        var html;
-                        element.index = index;
-                        html = template({
-                            data: element
-                        });
-                        dropdown.append(html);
-                    });
+                    if (data.length) {
+                        $.each(data, function (index, element) {
+                            var html;
 
-                    if (dropdown.has('li').length) {
+                            element.index = index;
+                            html = template({
+                                data: element
+                            });
+                            dropdown.append(html);
+                        });
+
                         this.responseList.indexList = this.autoComplete.html(dropdown)
                             .css(clonePosition)
                             .show()
@@ -322,7 +323,8 @@ define([
                                 this.element.attr('aria-activedescendant', $(e.target).attr('id'));
                             }.bind(this))
                             .on('mouseout', function (e) {
-                                if (!this._getLastElement() && this._getLastElement().hasClass(this.options.selectClass)) {
+                                if (!this._getLastElement() &&
+                                    this._getLastElement().hasClass(this.options.selectClass)) {
                                     $(e.target).removeClass(this.options.selectClass);
                                     this._resetResponseList(false);
                                 }

--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -88,7 +88,7 @@ define([
                 }
 
                 setTimeout($.proxy(function () {
-                    if (this.autoComplete.css('display', 'none')) {
+                    if (this.autoComplete.is(':hidden')) {
                         this.setActiveState(false);
                     } else {
                         this.element.trigger('focus');
@@ -288,44 +288,46 @@ define([
                 }, $.proxy(function (data) {
                     $.each(data, function (index, element) {
                         var html;
-
                         element.index = index;
                         html = template({
                             data: element
                         });
                         dropdown.append(html);
                     });
-                    this.responseList.indexList = this.autoComplete.html(dropdown)
-                        .css(clonePosition)
-                        .show()
-                        .find(this.options.responseFieldElements + ':visible');
 
-                    this._resetResponseList(false);
-                    this.element.removeAttr('aria-activedescendant');
+                    if (dropdown.has('li').length) {
+                        this.responseList.indexList = this.autoComplete.html(dropdown)
+                            .css(clonePosition)
+                            .show()
+                            .find(this.options.responseFieldElements + ':visible');
 
-                    if (this.responseList.indexList.length) {
-                        this._updateAriaHasPopup(true);
-                    } else {
-                        this._updateAriaHasPopup(false);
+                        this._resetResponseList(false);
+                        this.element.removeAttr('aria-activedescendant');
+
+                        if (this.responseList.indexList.length) {
+                            this._updateAriaHasPopup(true);
+                        } else {
+                            this._updateAriaHasPopup(false);
+                        }
+
+                        this.responseList.indexList
+                            .on('click', function (e) {
+                                this.responseList.selected = $(e.currentTarget);
+                                this.searchForm.trigger('submit');
+                            }.bind(this))
+                            .on('mouseenter mouseleave', function (e) {
+                                this.responseList.indexList.removeClass(this.options.selectClass);
+                                $(e.target).addClass(this.options.selectClass);
+                                this.responseList.selected = $(e.target);
+                                this.element.attr('aria-activedescendant', $(e.target).attr('id'));
+                            }.bind(this))
+                            .on('mouseout', function (e) {
+                                if (!this._getLastElement() && this._getLastElement().hasClass(this.options.selectClass)) {
+                                    $(e.target).removeClass(this.options.selectClass);
+                                    this._resetResponseList(false);
+                                }
+                            }.bind(this));
                     }
-
-                    this.responseList.indexList
-                        .on('click', function (e) {
-                            this.responseList.selected = $(e.currentTarget);
-                            this.searchForm.trigger('submit');
-                        }.bind(this))
-                        .on('mouseenter mouseleave', function (e) {
-                            this.responseList.indexList.removeClass(this.options.selectClass);
-                            $(e.target).addClass(this.options.selectClass);
-                            this.responseList.selected = $(e.target);
-                            this.element.attr('aria-activedescendant', $(e.target).attr('id'));
-                        }.bind(this))
-                        .on('mouseout', function (e) {
-                            if (!this._getLastElement() && this._getLastElement().hasClass(this.options.selectClass)) {
-                                $(e.target).removeClass(this.options.selectClass);
-                                this._resetResponseList(false);
-                            }
-                        }.bind(this));
                 }, this));
             } else {
                 this._resetResponseList(true);


### PR DESCRIPTION
### Description
Can't close mobile search bar when using Luma Theme

### Fixed Issues (if relevant)
1. magento/magento2/issues/11231: Can't close mobile search bar once typed

### Steps to reproduce
1. Load the homepage on a mobile device
2. Tap on the search icon to access the search input
3. Start typing (but do not submit)
4. Now tap on the search icon again to close the search bar

### Manual testing scenarios

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
