### PR TITLE
Add a payload extender to the default shipping-save-processor (Backport to 2.2)

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -12,7 +12,8 @@ define([
     'Magento_Checkout/js/model/payment/method-converter',
     'Magento_Checkout/js/model/error-processor',
     'Magento_Checkout/js/model/full-screen-loader',
-    'Magento_Checkout/js/action/select-billing-address'
+    'Magento_Checkout/js/action/select-billing-address',
+    'Magento_Checkout/js/model/shipping-save-processor/payload-extender'
 ], function (
     ko,
     quote,
@@ -22,7 +23,8 @@ define([
     methodConverter,
     errorProcessor,
     fullScreenLoader,
-    selectBillingAddressAction
+    selectBillingAddressAction,
+    payloadExtender
 ) {
     'use strict';
 
@@ -45,6 +47,8 @@ define([
                     'shipping_carrier_code': quote.shippingMethod()['carrier_code']
                 }
             };
+
+            payloadExtender(payload);
 
             fullScreenLoader.startLoader();
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define(function () {
+    'use strict';
+
+    return function (payload) {
+        payload.addressInformation['extension_attributes'] = {};
+
+        return payload;
+    };
+});


### PR DESCRIPTION
This will allow third party extensions to modify the payload for the
shipping address selection process, with the goal being the easy
addition of extension_attributes with as few extension conflicts as
possible.

By separating this out into it's own model (as opposed to including it
in the result of the processor return), non-default processors will also
be able to utilize it.

Backports https://github.com/magento/magento2/pull/10991 to 2.2
