### PR TITLE
Fix for #10317 Disable region list when switching to a region optional country.

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -206,7 +206,7 @@ define([
                     regionInput.removeClass('required-entry');
                 }
 
-                regionList.removeClass('required-entry').hide();
+                regionList.removeClass('required-entry').prop('disabled', 'disabled').hide();
                 regionInput.show();
                 label.attr('for', regionInput.attr('id'));
             }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
This is a fix for issue #10317 

### Description
<!--- Provide a description of the changes proposed in the pull request -->

The PR consist only on disabling the region dropdown element after hiding it when switching to a country not using option based regions.

This prevent the previous value being sent when submitting the form.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10317: Region is being overridden when changing from a required-state country to one that is not required

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Log into your Account on the frontend
2. Edit your billing address and save using EUA for country and pick a state (Alaska) , save it.
3. Edit your billing address again, change from EUA to Uruguay, change the region input for Test
4. Save it and you will see Test state showed. Without this fix, it would still have shown Alaska.


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
