### PR TITLE
Disabeling js merge,bundle,minify does not work in admin

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/default.xml
@@ -69,7 +69,7 @@
             </container>
         </referenceContainer>
         <referenceContainer name="after.body.start">
-            <block class="Magento\RequireJs\Block\Html\Head\Config" name="requirejs-config"/>
+            <block class="Magento\RequireJs\Block\Adminhtml\Html\Head\Config" name="requirejs-config"/>
             <block class="Magento\Translation\Block\Html\Head\Config" name="translate-config"/>
             <block class="Magento\Translation\Block\Js" name="translate" template="Magento_Translation::translate.phtml"/>
             <block class="Magento\Framework\View\Element\Js\Components" name="head.components" as="components" template="Magento_Backend::page/js/components.phtml"/>

--- a/app/code/Magento/RequireJs/Block/Adminhtml/Html/Head/Config.php
+++ b/app/code/Magento/RequireJs/Block/Adminhtml/Html/Head/Config.php
@@ -8,7 +8,12 @@ namespace Magento\RequireJs\Block\Adminhtml\Html\Head;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\RequireJs\Config as RequireJsConfig;
+use Magento\Framework\View\Asset\ConfigInterface as ViewAssetConfigInterface;
 use Magento\Framework\View\Asset\Minification;
+use Magento\Framework\View\Element\AbstractBlock;
+use Magento\Framework\View\Element\Context as ViewElementContext;
+use Magento\Framework\View\Page\Config as ViewPageConfig;
+use Magento\RequireJs\Model\FileManager as RequireJsFileManager;
 
 /**
  * Block responsible for including RequireJs config on backend pages
@@ -16,20 +21,20 @@ use Magento\Framework\View\Asset\Minification;
  * @api
  * @since 100.0.2
  */
-class Config extends \Magento\Framework\View\Element\AbstractBlock
+class Config extends AbstractBlock
 {
     /**
      * @var RequireJsConfig
      */
-    private $config;
+    protected $config;
 
     /**
-     * @var \Magento\RequireJs\Model\FileManager
+     * @var RequireJsFileManager
      */
-    private $fileManager;
+    protected $fileManager;
 
     /**
-     * @var \Magento\Framework\View\Page\Config
+     * @var ViewPageConfig
      */
     protected $pageConfig;
 
@@ -39,25 +44,27 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     protected $minification;
 
     /**
-     * @var \Magento\Framework\View\Asset\ConfigInterface
+     * @var ViewAssetConfigInterface
      */
-    private $bundleConfig;
+    protected $bundleConfig;
 
     /**
-     * @param \Magento\Framework\View\Element\Context $context
+     * Config constructor.
+     *
+     * @param ViewElementContext $context
      * @param RequireJsConfig $config
-     * @param \Magento\RequireJs\Model\FileManager $fileManager
-     * @param \Magento\Framework\View\Page\Config $pageConfig
-     * @param \Magento\Framework\View\Asset\ConfigInterface $bundleConfig
+     * @param RequireJsFileManager $fileManager
+     * @param ViewPageConfig $pageConfig
+     * @param ViewAssetConfigInterface $bundleConfig
      * @param Minification $minification
      * @param array $data
      */
     public function __construct(
-        \Magento\Framework\View\Element\Context $context,
+        ViewElementContext $context,
         RequireJsConfig $config,
-        \Magento\RequireJs\Model\FileManager $fileManager,
-        \Magento\Framework\View\Page\Config $pageConfig,
-        \Magento\Framework\View\Asset\ConfigInterface $bundleConfig,
+        RequireJsFileManager $fileManager,
+        ViewPageConfig $pageConfig,
+        ViewAssetConfigInterface $bundleConfig,
         Minification $minification,
         array $data = []
     ) {
@@ -72,7 +79,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     /**
      * Include RequireJs configuration as an asset on the page
      *
-     * @return $this
+     * @inheritdoc
      */
     protected function _prepareLayout()
     {
@@ -112,8 +119,8 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
 
             $bundleAssets = $this->fileManager->createBundleJsPool();
             $staticAsset = $this->fileManager->createStaticJsAsset();
-            /** @var \Magento\Framework\View\Asset\File $bundleAsset */
 
+            /** @var \Magento\Framework\View\Asset\File $bundleAsset */
             if (!empty($bundleAssets) && $staticAsset !== false) {
                 $bundleAssets = array_reverse($bundleAssets);
                 foreach ($bundleAssets as $bundleAsset) {

--- a/app/code/Magento/RequireJs/Block/Adminhtml/Html/Head/Config.php
+++ b/app/code/Magento/RequireJs/Block/Adminhtml/Html/Head/Config.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\RequireJs\Block\Adminhtml\Html\Head;
+
+use Magento\Framework\RequireJs\Config as RequireJsConfig;
+use Magento\Framework\View\Asset\Minification;
+
+/**
+ * Block responsible for including RequireJs config on backend pages
+ *
+ * @api
+ * @since 100.0.2
+ */
+class Config extends \Magento\Framework\View\Element\AbstractBlock
+{
+    /**
+     * @var RequireJsConfig
+     */
+    private $config;
+
+    /**
+     * @var \Magento\RequireJs\Model\FileManager
+     */
+    private $fileManager;
+
+    /**
+     * @var \Magento\Framework\View\Page\Config
+     */
+    protected $pageConfig;
+
+    /**
+     * @var Minification
+     */
+    protected $minification;
+
+    /**
+     * @var \Magento\Framework\View\Asset\ConfigInterface
+     */
+    private $bundleConfig;
+
+    /**
+     * @param \Magento\Framework\View\Element\Context $context
+     * @param RequireJsConfig $config
+     * @param \Magento\RequireJs\Model\FileManager $fileManager
+     * @param \Magento\Framework\View\Page\Config $pageConfig
+     * @param \Magento\Framework\View\Asset\ConfigInterface $bundleConfig
+     * @param Minification $minification
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Context $context,
+        RequireJsConfig $config,
+        \Magento\RequireJs\Model\FileManager $fileManager,
+        \Magento\Framework\View\Page\Config $pageConfig,
+        \Magento\Framework\View\Asset\ConfigInterface $bundleConfig,
+        Minification $minification,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->config = $config;
+        $this->fileManager = $fileManager;
+        $this->pageConfig = $pageConfig;
+        $this->bundleConfig = $bundleConfig;
+        $this->minification = $minification;
+    }
+
+    /**
+     * Include RequireJs configuration as an asset on the page
+     *
+     * @return $this
+     */
+    protected function _prepareLayout()
+    {
+        $after = RequireJsConfig::REQUIRE_JS_FILE_NAME;
+        $assetCollection = $this->pageConfig->getAssetCollection();
+        if ($this->minification->isEnabled('js')) {
+            $minResolver = $this->fileManager->createMinResolverAsset();
+            $assetCollection->insert(
+                $minResolver->getFilePath(),
+                $minResolver,
+                $after
+            );
+            $after = $minResolver->getFilePath();
+        }
+        $requireJsMapConfig = $this->fileManager->createRequireJsMapConfigAsset();
+        if ($requireJsMapConfig) {
+            $urlResolverAsset = $this->fileManager->createUrlResolverAsset();
+            $assetCollection->insert(
+                $urlResolverAsset->getFilePath(),
+                $urlResolverAsset,
+                $after
+            );
+            $after = $urlResolverAsset->getFilePath();
+            $assetCollection->insert(
+                $requireJsMapConfig->getFilePath(),
+                $requireJsMapConfig,
+                $after
+            );
+            $after = $requireJsMapConfig->getFilePath();
+        }
+        if ($this->bundleConfig->isBundlingJsFiles()) {
+            $bundleAssets = $this->fileManager->createBundleJsPool();
+            $staticAsset = $this->fileManager->createStaticJsAsset();
+            /** @var \Magento\Framework\View\Asset\File $bundleAsset */
+            if (!empty($bundleAssets) && $staticAsset !== false) {
+                $bundleAssets = array_reverse($bundleAssets);
+                foreach ($bundleAssets as $bundleAsset) {
+                    $assetCollection->insert(
+                        $bundleAsset->getFilePath(),
+                        $bundleAsset,
+                        $after
+                    );
+                }
+                $assetCollection->insert(
+                    $staticAsset->getFilePath(),
+                    $staticAsset,
+                    reset($bundleAssets)->getFilePath()
+                );
+                $after = $staticAsset->getFilePath();
+            }
+        }
+        $requireJsConfig = $this->fileManager->createRequireJsConfigAsset();
+        $assetCollection->insert(
+            $requireJsConfig->getFilePath(),
+            $requireJsConfig,
+            $after
+        );
+        $requireJsMixinsConfig = $this->fileManager->createRequireJsMixinsAsset();
+        $assetCollection->insert(
+            $requireJsMixinsConfig->getFilePath(),
+            $requireJsMixinsConfig,
+            $after
+        );
+        return parent::_prepareLayout();
+    }
+}

--- a/app/code/Magento/RequireJs/Block/Adminhtml/Html/Head/Config.php
+++ b/app/code/Magento/RequireJs/Block/Adminhtml/Html/Head/Config.php
@@ -6,6 +6,7 @@
 
 namespace Magento\RequireJs\Block\Adminhtml\Html\Head;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\RequireJs\Config as RequireJsConfig;
 use Magento\Framework\View\Asset\Minification;
 
@@ -76,7 +77,9 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     protected function _prepareLayout()
     {
         $after = RequireJsConfig::REQUIRE_JS_FILE_NAME;
+        $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
         $assetCollection = $this->pageConfig->getAssetCollection();
+
         if ($this->minification->isEnabled('js')) {
             $minResolver = $this->fileManager->createMinResolverAsset();
             $assetCollection->insert(
@@ -86,7 +89,9 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
             );
             $after = $minResolver->getFilePath();
         }
+
         $requireJsMapConfig = $this->fileManager->createRequireJsMapConfigAsset();
+
         if ($requireJsMapConfig) {
             $urlResolverAsset = $this->fileManager->createUrlResolverAsset();
             $assetCollection->insert(
@@ -102,10 +107,13 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
             );
             $after = $requireJsMapConfig->getFilePath();
         }
-        if ($this->bundleConfig->isBundlingJsFiles()) {
+
+        if ($this->bundleConfig->isBundlingJsFiles($scopeType)) {
+
             $bundleAssets = $this->fileManager->createBundleJsPool();
             $staticAsset = $this->fileManager->createStaticJsAsset();
             /** @var \Magento\Framework\View\Asset\File $bundleAsset */
+
             if (!empty($bundleAssets) && $staticAsset !== false) {
                 $bundleAssets = array_reverse($bundleAssets);
                 foreach ($bundleAssets as $bundleAsset) {
@@ -123,6 +131,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
                 $after = $staticAsset->getFilePath();
             }
         }
+
         $requireJsConfig = $this->fileManager->createRequireJsConfigAsset();
         $assetCollection->insert(
             $requireJsConfig->getFilePath(),
@@ -135,6 +144,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
             $requireJsMixinsConfig,
             $after
         );
+
         return parent::_prepareLayout();
     }
 }

--- a/app/code/Magento/RequireJs/Block/Html/Head/Config.php
+++ b/app/code/Magento/RequireJs/Block/Html/Head/Config.php
@@ -7,7 +7,13 @@
 namespace Magento\RequireJs\Block\Html\Head;
 
 use Magento\Framework\RequireJs\Config as RequireJsConfig;
+use Magento\Framework\View\Asset\ConfigInterface as ViewAssetConfigInterface;
+use Magento\Framework\View\Asset\File as ViewAssetFile;
 use Magento\Framework\View\Asset\Minification;
+use Magento\Framework\View\Element\AbstractBlock;
+use Magento\Framework\View\Element\Context as ViewElementContext;
+use Magento\Framework\View\Page\Config as PageConfig;
+use Magento\RequireJs\Model\FileManager as RequireJsFileManager;
 
 /**
  * Block responsible for including RequireJs config on the page
@@ -15,20 +21,20 @@ use Magento\Framework\View\Asset\Minification;
  * @api
  * @since 100.0.2
  */
-class Config extends \Magento\Framework\View\Element\AbstractBlock
+class Config extends AbstractBlock
 {
     /**
      * @var RequireJsConfig
      */
-    private $config;
+    protected $config;
 
     /**
-     * @var \Magento\RequireJs\Model\FileManager
+     * @var RequireJsFileManager
      */
-    private $fileManager;
+    protected $fileManager;
 
     /**
-     * @var \Magento\Framework\View\Page\Config
+     * @var PageConfig
      */
     protected $pageConfig;
 
@@ -38,25 +44,27 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     protected $minification;
 
     /**
-     * @var \Magento\Framework\View\Asset\ConfigInterface
+     * @var ViewAssetConfigInterface
      */
-    private $bundleConfig;
+    protected $bundleConfig;
 
     /**
-     * @param \Magento\Framework\View\Element\Context $context
+     * Config constructor.
+     *
+     * @param ViewElementContext $context
      * @param RequireJsConfig $config
-     * @param \Magento\RequireJs\Model\FileManager $fileManager
-     * @param \Magento\Framework\View\Page\Config $pageConfig
-     * @param \Magento\Framework\View\Asset\ConfigInterface $bundleConfig
+     * @param RequireJsFileManager $fileManager
+     * @param PageConfig $pageConfig
+     * @param ViewAssetConfigInterface $bundleConfig
      * @param Minification $minification
      * @param array $data
      */
     public function __construct(
-        \Magento\Framework\View\Element\Context $context,
+        ViewElementContext $context,
         RequireJsConfig $config,
-        \Magento\RequireJs\Model\FileManager $fileManager,
-        \Magento\Framework\View\Page\Config $pageConfig,
-        \Magento\Framework\View\Asset\ConfigInterface $bundleConfig,
+        RequireJsFileManager $fileManager,
+        PageConfig $pageConfig,
+        ViewAssetConfigInterface $bundleConfig,
         Minification $minification,
         array $data = []
     ) {
@@ -71,12 +79,13 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     /**
      * Include RequireJs configuration as an asset on the page
      *
-     * @return $this
+     * @inheritdoc
      */
     protected function _prepareLayout()
     {
         $after = RequireJsConfig::REQUIRE_JS_FILE_NAME;
         $assetCollection = $this->pageConfig->getAssetCollection();
+
         if ($this->minification->isEnabled('js')) {
             $minResolver = $this->fileManager->createMinResolverAsset();
             $assetCollection->insert(
@@ -86,7 +95,9 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
             );
             $after = $minResolver->getFilePath();
         }
+
         $requireJsMapConfig = $this->fileManager->createRequireJsMapConfigAsset();
+
         if ($requireJsMapConfig) {
             $urlResolverAsset = $this->fileManager->createUrlResolverAsset();
             $assetCollection->insert(
@@ -102,10 +113,12 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
             );
             $after = $requireJsMapConfig->getFilePath();
         }
+
         if ($this->bundleConfig->isBundlingJsFiles()) {
             $bundleAssets = $this->fileManager->createBundleJsPool();
             $staticAsset = $this->fileManager->createStaticJsAsset();
-            /** @var \Magento\Framework\View\Asset\File $bundleAsset */
+
+            /** @var ViewAssetFile $bundleAsset */
             if (!empty($bundleAssets) && $staticAsset !== false) {
                 $bundleAssets = array_reverse($bundleAssets);
                 foreach ($bundleAssets as $bundleAsset) {
@@ -123,6 +136,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
                 $after = $staticAsset->getFilePath();
             }
         }
+
         $requireJsConfig = $this->fileManager->createRequireJsConfigAsset();
         $assetCollection->insert(
             $requireJsConfig->getFilePath(),
@@ -135,6 +149,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
             $requireJsMixinsConfig,
             $after
         );
+
         return parent::_prepareLayout();
     }
 }

--- a/app/code/Magento/RequireJs/Test/Unit/Block/Adminhtml/Html/Head/ConfigTest.php
+++ b/app/code/Magento/RequireJs/Test/Unit/Block/Adminhtml/Html/Head/ConfigTest.php
@@ -4,29 +4,43 @@
  * See COPYING.txt for license details.
  */
 
-namespace Magento\RequireJs\Test\Unit\Block\Html\Head;
+namespace Magento\RequireJs\Test\Unit\Block\Adminhtml\Html\Head;
 
-use \Magento\RequireJs\Block\Html\Head\Config;
+use Magento\Framework\RequireJs\Config as RequireJsConfig;
+use Magento\Framework\View\Asset\ConfigInterface as ViewAssetConfigInterface;
+use Magento\Framework\View\Asset\GroupedCollection as ViewAssetGroupedCollection;
+use Magento\Framework\View\Asset\LocalInterface as ViewAssetLocalInterface;
+use Magento\Framework\View\Asset\Minification as ViewAssetMinification;
+use Magento\Framework\View\Element\Context as ViewElementContext;
+use Magento\Framework\View\LayoutInterface as ViewLayoutInterface;
+use Magento\Framework\View\Page\Config as PageConfig;
+use Magento\RequireJs\Block\Adminhtml\Html\Head\Config;
+use Magento\RequireJs\Model\FileManager as RequireJsFileManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
 
-class ConfigTest extends \PHPUnit\Framework\TestCase
+/**
+ * Class ConfigTest
+ */
+class ConfigTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\View\Element\Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewElementContext|PHPUnit_Framework_MockObject_MockObject
      */
-    private $context;
+    protected $context;
 
     /**
-     * @var \Magento\Framework\RequireJs\Config|\PHPUnit_Framework_MockObject_MockObject
+     * @var RequireJsConfig|PHPUnit_Framework_MockObject_MockObject
      */
-    private $config;
+    protected $config;
 
     /**
-     * @var \Magento\RequireJs\Model\FileManager|\PHPUnit_Framework_MockObject_MockObject
+     * @var RequireJsFileManager|PHPUnit_Framework_MockObject_MockObject
      */
-    private $fileManager;
+    protected $fileManager;
 
     /**
-     * @var \Magento\Framework\View\Page\Config|\PHPUnit_Framework_MockObject_MockObject
+     * @var PageConfig|PHPUnit_Framework_MockObject_MockObject
      */
     protected $pageConfig;
 
@@ -36,25 +50,25 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     protected $blockConfig;
 
     /**
-     * @var \Magento\Framework\View\Asset\ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewAssetConfigInterface|PHPUnit_Framework_MockObject_MockObject
      */
     protected $bundleConfig;
 
     /**
-     * @var \Magento\Framework\View\Asset\Minification|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewAssetMinification|PHPUnit_Framework_MockObject_MockObject
      */
-    private $minificationMock;
+    protected $minificationMock;
 
     /**
      * @return void
      */
     protected function setUp()
     {
-        $this->context = $this->createMock(\Magento\Framework\View\Element\Context::class);
-        $this->config = $this->createMock(\Magento\Framework\RequireJs\Config::class);
-        $this->fileManager = $this->createMock(\Magento\RequireJs\Model\FileManager::class);
-        $this->pageConfig = $this->createMock(\Magento\Framework\View\Page\Config::class);
-        $this->bundleConfig = $this->createMock(\Magento\Framework\View\Asset\ConfigInterface::class);
+        $this->context = $this->createMock(ViewElementContext::class);
+        $this->config = $this->createMock(RequireJsConfig::class);
+        $this->fileManager = $this->createMock(RequireJsFileManager::class);
+        $this->pageConfig = $this->createMock(PageConfig::class);
+        $this->bundleConfig = $this->createMock(ViewAssetConfigInterface::class);
     }
 
     /**
@@ -67,16 +81,16 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->method('isBundlingJsFiles')
             ->willReturn(true);
         $filePath = 'require_js_fie_path';
-        $asset = $this->getMockForAbstractClass(\Magento\Framework\View\Asset\LocalInterface::class);
+        $asset = $this->getMockForAbstractClass(ViewAssetLocalInterface::class);
         $asset->expects($this->atLeastOnce())
             ->method('getFilePath')
             ->willReturn($filePath);
-        $requireJsAsset = $this->getMockForAbstractClass(\Magento\Framework\View\Asset\LocalInterface::class);
+        $requireJsAsset = $this->getMockForAbstractClass(ViewAssetLocalInterface::class);
         $requireJsAsset
             ->expects($this->atLeastOnce())
             ->method('getFilePath')
             ->willReturn('/path/to/require/require.js');
-        $minResolverAsset = $this->getMockForAbstractClass(\Magento\Framework\View\Asset\LocalInterface::class);
+        $minResolverAsset = $this->getMockForAbstractClass(ViewAssetLocalInterface::class);
         $minResolverAsset
             ->expects($this->atLeastOnce())
             ->method('getFilePath')
@@ -103,9 +117,9 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->method('createMinResolverAsset')
             ->will($this->returnValue($minResolverAsset));
 
-        $layout = $this->createMock(\Magento\Framework\View\LayoutInterface::class);
+        $layout = $this->createMock(ViewLayoutInterface::class);
 
-        $assetCollection = $this->getMockBuilder(\Magento\Framework\View\Asset\GroupedCollection::class)
+        $assetCollection = $this->getMockBuilder(ViewAssetGroupedCollection::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->pageConfig->expects($this->atLeastOnce())
@@ -117,7 +131,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->method('insert')
             ->willReturn(true);
 
-        $this->minificationMock = $this->getMockBuilder(\Magento\Framework\View\Asset\Minification::class)
+        $this->minificationMock = $this->getMockBuilder(ViewAssetMinification::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->minificationMock
@@ -134,6 +148,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             $this->bundleConfig,
             $this->minificationMock
         );
+
         $object->setLayout($layout);
     }
 }

--- a/app/code/Magento/RequireJs/etc/di.xml
+++ b/app/code/Magento/RequireJs/etc/di.xml
@@ -38,4 +38,14 @@
             <argument name="minifyAdapter" xsi:type="object">jsMinificationAdapter</argument>
         </arguments>
     </type>
+    <virtualType name="defaultScopeMinification" type="Magento\Framework\View\Asset\Minification">
+        <arguments>
+            <argument name="scope" xsi:type="string">default</argument>
+        </arguments>
+    </virtualType>
+    <type name="Magento\RequireJs\Block\Adminhtml\Html\Head\Config">
+        <arguments>
+            <argument name="minification" xsi:type="object">defaultScopeMinification</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Store\App\FrontController\Plugin;
 
+use Magento\Store\Model\Store;
 use \Magento\Store\Model\StoreResolver\ReaderList;
 use \Magento\Store\Model\ScopeInterface;
 
@@ -48,7 +49,7 @@ class DefaultStore
         $scopeCode = null
     ) {
         $this->runMode = $scopeCode ? $runMode : ScopeInterface::SCOPE_WEBSITE;
-        $this->scopeCode = $scopeCode;
+        $this->scopeCode = $scopeCode ? : Store::ADMIN_CODE;
         $this->readerList = $readerList;
         $this->storeManager = $storeManager;
     }
@@ -58,6 +59,7 @@ class DefaultStore
      *
      * @param \Magento\Framework\App\FrontController $subject
      * @param \Magento\Framework\App\RequestInterface $request
+     *
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)

--- a/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Store\App\FrontController\Plugin;
 
+use Magento\Framework\App\FrontController;
+use Magento\Framework\App\RequestInterface as AppRequestInterface;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
-use \Magento\Store\Model\StoreResolver\ReaderList;
-use \Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\StoreResolver\ReaderList;
 
 /**
  * Plugin to set default store for admin area.
@@ -15,7 +19,7 @@ use \Magento\Store\Model\ScopeInterface;
 class DefaultStore
 {
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     protected $storeManager;
 
@@ -37,13 +41,13 @@ class DefaultStore
     /**
      * Initialize dependencies.
      *
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param StoreManagerInterface $storeManager
      * @param ReaderList $readerList
      * @param string $runMode
      * @param null $scopeCode
      */
     public function __construct(
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        StoreManagerInterface $storeManager,
         ReaderList $readerList,
         $runMode = ScopeInterface::SCOPE_STORE,
         $scopeCode = null
@@ -57,16 +61,16 @@ class DefaultStore
     /**
      * Set current store for admin area
      *
-     * @param \Magento\Framework\App\FrontController $subject
-     * @param \Magento\Framework\App\RequestInterface $request
+     * @param FrontController $subject
+     * @param AppRequestInterface $request
      *
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeDispatch(
-        \Magento\Framework\App\FrontController $subject,
-        \Magento\Framework\App\RequestInterface $request
+        FrontController $subject,
+        AppRequestInterface $request
     ) {
         $reader = $this->readerList->getReader($this->runMode);
         $defaultStoreId = $reader->getDefaultStoreId($this->scopeCode);

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -50,7 +50,7 @@
     </type>
     <type name="Magento\Store\Model\Resolver\Website">
         <arguments>
-        <argument name="storeManager" xsi:type="object">Magento\Store\Model\StoreManagerInterface\Proxy</argument>
+            <argument name="storeManager" xsi:type="object">Magento\Store\Model\StoreManagerInterface\Proxy</argument>
         </arguments>
     </type>
     <preference for="Magento\Framework\App\ScopeResolverInterface" type="Magento\Store\Model\Resolver\Store" />

--- a/lib/internal/Magento/Framework/View/Asset/Config.php
+++ b/lib/internal/Magento/Framework/View/Asset/Config.php
@@ -6,14 +6,14 @@
 
 namespace Magento\Framework\View\Asset;
 
-use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\State;
+use Magento\Framework\View\Asset\ConfigInterface as ViewAssetConfigInterface;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * View asset configuration interface
  */
-class Config implements \Magento\Framework\View\Asset\ConfigInterface
+class Config implements ViewAssetConfigInterface
 {
     /**
      * XML path for CSS files merge configuration
@@ -51,52 +51,68 @@ class Config implements \Magento\Framework\View\Asset\ConfigInterface
     /**
      * Check whether merging of CSS files is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isMergeCssFiles()
+    public function isMergeCssFiles($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null)
     {
         return (bool)$this->scopeConfig->isSetFlag(
             self::XML_PATH_MERGE_CSS_FILES,
-            ScopeInterface::SCOPE_STORE
+            $scopeType,
+            $scopeCode
         );
     }
 
     /**
      * Check whether bundling of JavScript files is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isBundlingJsFiles()
+    public function isBundlingJsFiles($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null)
     {
         return (bool)$this->scopeConfig->isSetFlag(
             self::XML_PATH_JS_BUNDLING,
-            ScopeInterface::SCOPE_STORE
+            $scopeType,
+            $scopeCode
         );
     }
 
     /**
      * Check whether merging of JavScript files is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isMergeJsFiles()
+    public function isMergeJsFiles($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null)
     {
         return (bool)$this->scopeConfig->isSetFlag(
             self::XML_PATH_MERGE_JS_FILES,
-            ScopeInterface::SCOPE_STORE
+            $scopeType,
+            $scopeCode
         );
     }
 
     /**
      * Check whether minify of HTML is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isMinifyHtml()
+    public function isMinifyHtml($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null)
     {
         return (bool)$this->scopeConfig->isSetFlag(
             self::XML_PATH_MINIFICATION_HTML,
-            ScopeInterface::SCOPE_STORE
+            $scopeType,
+            $scopeCode
         );
     }
 }

--- a/lib/internal/Magento/Framework/View/Asset/ConfigInterface.php
+++ b/lib/internal/Magento/Framework/View/Asset/ConfigInterface.php
@@ -3,7 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\View\Asset;
+
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * View asset configuration interface
@@ -15,28 +18,40 @@ interface ConfigInterface
     /**
      * Check whether merging of CSS files is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isMergeCssFiles();
+    public function isMergeCssFiles($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null);
 
     /**
      * Check whether merging of JavScript files is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isMergeJsFiles();
+    public function isMergeJsFiles($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null);
 
     /**
      * Check whether bundling of JavScript files is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isBundlingJsFiles();
+    public function isBundlingJsFiles($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null);
 
     /**
      * Check whether minify of HTML is on
      *
+     * @param string $scopeType
+     * @param string|null $scopeCode
+     *
      * @return bool
      */
-    public function isMinifyHtml();
+    public function isMinifyHtml($scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null);
 }

--- a/lib/internal/Magento/Framework/View/Design/FileResolution/Fallback/TemplateFile.php
+++ b/lib/internal/Magento/Framework/View/Design/FileResolution/Fallback/TemplateFile.php
@@ -6,10 +6,14 @@
 
 namespace Magento\Framework\View\Design\FileResolution\Fallback;
 
+use Magento\Framework\App\Area as AppArea;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\View\Asset\ConfigInterface;
+use Magento\Framework\View\Design\Fallback\RulePool as ViewDesignFallbackRulePool;
 use Magento\Framework\View\Design\ThemeInterface;
 use Magento\Framework\View\Template\Html\MinifierInterface;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Provider of template view files
@@ -32,6 +36,8 @@ class TemplateFile extends File
     protected $assetConfig;
 
     /**
+     * TemplateFile constructor.
+     *
      * @param ResolverInterface $resolver
      * @param MinifierInterface $templateMinifier
      * @param State $appState
@@ -46,6 +52,7 @@ class TemplateFile extends File
         $this->appState = $appState;
         $this->templateMinifier = $templateMinifier;
         $this->assetConfig = $assetConfig;
+
         parent::__construct($resolver);
     }
 
@@ -54,7 +61,7 @@ class TemplateFile extends File
      */
     protected function getFallbackType()
     {
-        return \Magento\Framework\View\Design\Fallback\RulePool::TYPE_TEMPLATE_FILE;
+        return ViewDesignFallbackRulePool::TYPE_TEMPLATE_FILE;
     }
 
     /**
@@ -64,13 +71,17 @@ class TemplateFile extends File
      * @param ThemeInterface $themeModel
      * @param string $file
      * @param string|null $module
+     *
      * @return string|bool
      */
     public function getFile($area, ThemeInterface $themeModel, $file, $module = null)
     {
+        $scopeType = (AppArea::AREA_ADMINHTML == $area) ?
+            ScopeConfigInterface::SCOPE_TYPE_DEFAULT :
+            ScopeInterface::SCOPE_STORE;
         $template = parent::getFile($area, $themeModel, $file, $module);
 
-        if ($template && $this->assetConfig->isMinifyHtml()) {
+        if ($template && $this->assetConfig->isMinifyHtml($scopeType)) {
             switch ($this->appState->getMode()) {
                 case State::MODE_PRODUCTION:
                     return $this->templateMinifier->getPathToMinified($template);
@@ -81,6 +92,7 @@ class TemplateFile extends File
                     return $template;
             }
         }
+
         return $template;
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/FileResolution/Fallback/TemplateFileTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/FileResolution/Fallback/TemplateFileTest.php
@@ -11,6 +11,9 @@ use Magento\Framework\View\Design\Fallback\RulePool;
 use Magento\Framework\View\Design\FileResolution\Fallback\TemplateFile;
 use Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface;
 
+/**T
+ * Class TemplateFileTest
+ */
 class TemplateFileTest extends \PHPUnit\Framework\TestCase
 {
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
When disabling the js, and css ,merge, minify and bundling for default scope and keeping them enabled for website and store view scope, the admin still loads minified and bundled js. 

These changes does the following to fix the issue:
- specify scope type in the `Magento\Framework\View\Asset\ConfigInterface` methods
- specify the default store view for adminhtml area in `Magento\Store\App\FrontController\Plugin\DefaultStore` plugin

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10605: Disabeling js merge,bundle,minify does not work in admin

### Manual testing scenarios

#### Steps to reproduce

- Disable js merge, minify, bundling for default scope in system config
- Enable the same in Website scope
- Enable the same in store view scope

#### Expected result

- Admin should load all the js files separately
- Frontend should load bundled files
