### PR TITLE
Fix #10477 Check cart rule subselect conditions against quote item children too

### DIFF
--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -145,8 +145,22 @@ class Subselect extends \Magento\SalesRule\Model\Rule\Condition\Product\Combine
         $attr = $this->getAttribute();
         $total = 0;
         foreach ($model->getQuote()->getAllVisibleItems() as $item) {
-            if (parent::validate($item)) {
-                $total += $item->getData($attr);
+            $hasValidChild = false;
+            $useChildrenTotal = ($item->getProductType() == \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE);
+            $childrenAttrTotal = 0;
+            $children = $item->getChildren();
+            if (!empty($children)) {
+                foreach ($children as $child) {
+                    if (parent::validate($child)) {
+                        $hasValidChild = true;
+                        if ($useChildrenTotal) {
+                            $childrenAttrTotal += $child->getData($attr);
+                        }
+                    }
+                }
+            }
+            if ($hasValidChild || parent::validate($item)) {
+                $total += (($hasValidChild && $useChildrenTotal) ? $childrenAttrTotal : $item->getData($attr));
             }
         }
         return $this->validateAttribute($total);


### PR DESCRIPTION
### Description
The cart price rule subselect condition only checked the visible quote items and this proved to be a problem in the case of configurable and bundle products.
The quote item children are now checked against the validation too, and an item will be considered valid and added to the subselect total if either it, or at least one of it's children is validated.

In the case of bundle products, the children items data will be used and added to the subselect total, when the match is on a child item.

In the case of configurable products, the parent item data will be used in the subselect total, just like for all the other product types.

### Fixed Issues (if relevant)
1. magento/magento2#10477: Cart price rule has failed if use dropdown attribute

### Manual testing scenarios
1. Create a cart price rule with a products subselection condition.
2. The subselection conditions should include checking attribute values that are only set on simple products associated to configurable or bundle products.
3. Add to cart the configurable and bundle products and make sure the associated simple products meet the conditions of the subselection.
4. The cart rule should be applied.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
