### PR TITLE
allow more attribute sets to be created by increasing id size

### DIFF
--- a/app/code/Magento/Catalog/Setup/InstallSchema.php
+++ b/app/code/Magento/Catalog/Setup/InstallSchema.php
@@ -40,7 +40,7 @@ class InstallSchema implements InstallSchemaInterface
             )
             ->addColumn(
                 'attribute_set_id',
-                \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                 null,
                 ['unsigned' => true, 'nullable' => false, 'default' => '0'],
                 'Attribute Set ID'
@@ -671,7 +671,7 @@ class InstallSchema implements InstallSchemaInterface
             )
             ->addColumn(
                 'attribute_set_id',
-                \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                 null,
                 ['unsigned' => true, 'nullable' => false, 'default' => '0'],
                 'Attriute Set ID'

--- a/app/code/Magento/Eav/Setup/InstallSchema.php
+++ b/app/code/Magento/Eav/Setup/InstallSchema.php
@@ -86,7 +86,7 @@ class InstallSchema implements InstallSchemaInterface
             'Data Sharing Key'
         )->addColumn(
             'default_attribute_set_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['unsigned' => true, 'nullable' => false, 'default' => '0'],
             'Default Attribute Set Id'
@@ -153,7 +153,7 @@ class InstallSchema implements InstallSchemaInterface
             'Entity Type Id'
         )->addColumn(
             'attribute_set_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['unsigned' => true, 'nullable' => false, 'default' => '0'],
             'Attribute Set Id'
@@ -812,7 +812,7 @@ class InstallSchema implements InstallSchemaInterface
             $installer->getTable('eav_attribute_set')
         )->addColumn(
             'attribute_set_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
             'Attribute Set Id'
@@ -863,13 +863,13 @@ class InstallSchema implements InstallSchemaInterface
             $installer->getTable('eav_attribute_group')
         )->addColumn(
             'attribute_group_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
             'Attribute Group Id'
         )->addColumn(
             'attribute_set_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['unsigned' => true, 'nullable' => false, 'default' => '0'],
             'Attribute Set Id'
@@ -944,13 +944,13 @@ class InstallSchema implements InstallSchemaInterface
             'Entity Type Id'
         )->addColumn(
             'attribute_set_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['unsigned' => true, 'nullable' => false, 'default' => '0'],
             'Attribute Set Id'
         )->addColumn(
             'attribute_group_id',
-            \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
             ['unsigned' => true, 'nullable' => false, 'default' => '0'],
             'Attribute Group Id'


### PR DESCRIPTION
### Description
This commit increases the size of the attribute set ids in order to allow more attribute sets.

### Fixed Issues
1. magento/magento2#10470: attribute_group_id in eav_attribute_group. Data Type is to small.

### Manual testing scenarios
I've created a gist containing a php-script that will automatically create 7000 attribute sets, which can be found here: https://gist.github.com/patrikpihlstrom/d31921a6d7aa2c5b674e4b49232868b6
1. Download the files in the gist and place them in your magento root directory
2. Run test.php (you'll get some output describing what is happening)
3. Make sure all of your attribute sets were created
