### PR TITLE
delete url rewrites for all products of an attribute set when said at…

### DIFF
--- a/app/code/Magento/Catalog/Observer/DeleteUrlKeys.php
+++ b/app/code/Magento/Catalog/Observer/DeleteUrlKeys.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Observer;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ *  Delete the url key of a product on product deletion
+ */
+class DeleteUrlKeys implements ObserverInterface
+{
+    /** @var ResourceConnection $resourceConnection */
+    private $resourceConnection;
+
+    public function __construct(
+        ResourceConnection $resourceConnection
+        )
+    {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Delete the product url key
+     *
+     * @param \Magento\Framework\Event\Observer $observer
+     * @return $this
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $ids = $observer->getEvent()->getProducts();
+        $connection = $this->resourceConnection->getConnection();
+
+        try
+        {
+            $connection->delete('url_rewrite', ['entity_type = ?' => 'product', 'entity_id IN (?)' => $ids]);
+        }
+        catch (\Exception $exception)
+        {
+            throw new CouldNotDeleteException(__(
+                'Could not delete the url rewrite(s): %1',
+                $exception->getMessage()
+            ));
+        }
+
+        return $this;
+    }
+}

--- a/app/code/Magento/Catalog/etc/adminhtml/events.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/events.xml
@@ -9,4 +9,7 @@
     <event name="cms_wysiwyg_images_static_urls_allowed">
         <observer name="catalog_wysiwyg" instance="Magento\Catalog\Observer\CatalogCheckIsUsingStaticUrlsAllowedObserver" />
     </event>
+    <event name="attribute_set_delete_after">
+        <observer name="delete_url_keys" instance="Magento\Catalog\Observer\DeleteUrlKeys" />
+    </event>
 </config>


### PR DESCRIPTION
…tribute set is deleted

### Description
This PR adds an observer and dispatches an event when an attribute set is deleted. The observer then deletes any url rewrites for products that belonged to the deleted attribute set.

### Fixed Issues (if relevant)
1. magento/magento2#10764: Delete Attribute Set is not Deleting product url key in url rewrite

### Manual testing scenarios
1. Create an attribute set
2. Create a product from the newly created attribute set and insure that a url key is specified
3. Delete the attribute set
4. Create a new product from the default attribute set and apply the same url key
5. Hopefully you won't get an error when you save the product
