### PR TITLE
Fix #1779: CarrierInterface additional requirement

### DIFF
--- a/app/code/Magento/Shipping/Model/Carrier/CarrierInterface.php
+++ b/app/code/Magento/Shipping/Model/Carrier/CarrierInterface.php
@@ -9,7 +9,7 @@ namespace Magento\Shipping\Model\Carrier;
  * Interface \Magento\Shipping\Model\Carrier\CarrierInterface
  *
  */
-interface CarrierInterface
+interface CarrierInterface extends AbstractCarrierInterface
 {
     /**
      * Check if carrier has shipping tracking option available


### PR DESCRIPTION
Fix for issue #1779:
- A carrier model needs to implement the CarrierInterface.
- In the \Magento\Shipping\Model\Shipping class there are several references to functions not in the CarrierInterface.
- A carrier model needs to extend the AbstractCarrier model in order to function
- I changed the CarrierInterface to extend de AbstractCarrierInterface, so that when you create a carrier which does not extend the AbstractCarrier model you are still forced to implement all methods of the AbstractCarrierInterface.
