### PR TITLE
Provide a cache.xml entry for compiled_config cache

### DIFF
--- a/app/code/Magento/Store/etc/cache.xml
+++ b/app/code/Magento/Store/etc/cache.xml
@@ -30,4 +30,8 @@
         <label>Database DDL operations</label>
         <description>Results of DDL queries, such as describing tables or indexes</description>
     </type>
+    <type name="compiled_config" translate="label,description" instance="Magento\Framework\App\Interception\Cache\CompiledConfig">
+        <label>Compiled Config</label>
+        <description>Compliation configuration</description>
+    </type>
 </config>

--- a/app/code/Magento/Store/i18n/en_US.csv
+++ b/app/code/Magento/Store/i18n/en_US.csv
@@ -41,3 +41,5 @@ Layouts,Layouts
 "API interfaces reflection data","API interfaces reflection data"
 "Database DDL operations","Database DDL operations"
 "Results of DDL queries, such as describing tables or indexes","Results of DDL queries, such as describing tables or indexes"
+"Compiled Config","Compiled Config"
+"Compliation configuration","Compliation configuration"


### PR DESCRIPTION


<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Provide a cache.xml entry for compiled_config cache.
This seems to be missing as it is the only subclass of `\Magento\Framework\Cache\Frontend\Decorator\TagScope` that does not appear in any `cache.xml` file.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11295: The following requested cache types are not supported: 'compiled_config'.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Run `bin/magento cache:enable compiled_config`
2. See 
``` Changed cache status:
               compiled_config: 0 -> 1
Cleaned cache types:
compiled_config
``` 

instead of 

```
  [InvalidArgumentException]
  The following requested cache types are not supported: 'compiled_config'.
  Supported types: config, layout, block_html, collections, reflection, db_ddl, eav, customer_notification, translate, target_rule, full_page, config_integration, config_integration_api, config_webservice



cache:enable [--bootstrap="..."] [types1] ... [typesN]
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
