### PR TITLE
Fix for issue #5105 - Error While send Invoice with Grouped Products

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
@@ -31,6 +31,6 @@
     </td>
     <td class="item-qty"><?= /* @escapeNotVerified */  $_item->getQty() * 1 ?></td>
     <td class="item-price">
-        <?= /* @escapeNotVerified */  $block->getItemPrice($_item) ?>
+        <?= /* @escapeNotVerified */  $block->getItemPrice($_item->getOrderItem()) ?>
     </td>
 </tr>


### PR DESCRIPTION
This is a fix for issue #5105.

### Description
When the merchant tried to send the invoice to the customer, it could get an fatal error. This only happend when the order contained grouped products. This was caused by the fact that ``DefaultOrder::getItemPrice`` has an type hint for the OrderItem, but the InvoiceItem was passed. I fixed this by requesting the OrderItem from the InvoiceItem.

### Fixed Issues (if relevant)
1. magento/magento2#5105: Error While send Invoice with Grouped Products

### Manual testing scenarios
1. Install the sample data.
2. Order the **Set of Sprite Yoga Straps**.
3. Create an invoice.
4. Open the invoice and click **Send e-mail**.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
