### PR TITLE
Fix isTemplate to not return true for string containing ${{

### DIFF
--- a/lib/web/mage/utils/template.js
+++ b/lib/web/mage/utils/template.js
@@ -76,7 +76,11 @@ define([
      * @returns {Boolean}
      */
     function isTemplate(value) {
-        return typeof value === 'string' && ~value.indexOf(opener);
+        return typeof value === 'string' &&
+            value.indexOf(opener) !== -1 &&
+            // the below pattern almost always indicates an accident which should not cause template evaluation
+            // refuse to evaluate
+            value.indexOf('${{') === -1;
     }
 
     /**


### PR DESCRIPTION
Changed `isTemplate` in [template.js](https://github.com/magento/magento2/blob/develop/lib/web/mage/utils/template.js#L78)
Now it returns `false` if value contains `${{`

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10501 Dollar sign before config path or custom variables in cms page content makes listing crash

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. create a cms page o static block with `${{config path="web/unsecure/base_url"}}` as content
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
