### PR TITLE
[Backport 2.1-develop] Send email to subscribers only when are new

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -447,14 +447,12 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
 
         try {
             $this->save();
-            if ($sendInformationEmail) {
-                if ($isConfirmNeed === true
-                    && $isOwnSubscribes === false
-                ) {
-                    $this->sendConfirmationRequestEmail();
-                } else {
-                    $this->sendConfirmationSuccessEmail();
-                }
+            if ($isConfirmNeed === true
+                && $isOwnSubscribes === false
+            ) {
+                $this->sendConfirmationRequestEmail();
+            } else {
+                $this->sendConfirmationSuccessEmail();
             }
             return $this->getStatus();
         } catch (\Exception $e) {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -445,7 +445,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
 
         try {
             $this->save();
-            if($sendInformationEmail) {
+            if ($sendInformationEmail) {
                 if ($isConfirmNeed === true
                     && $isOwnSubscribes === false
                 ) {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -393,10 +393,12 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
      */
     public function subscribe($email)
     {
+        $sendInformationEmail = false;
         $this->loadByEmail($email);
 
         if (!$this->getId()) {
             $this->setSubscriberConfirmCode($this->randomSequence());
+            $sendInformationEmail = true;
         }
 
         $isConfirmNeed = $this->_scopeConfig->getValue(
@@ -443,12 +445,14 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
 
         try {
             $this->save();
-            if ($isConfirmNeed === true
-                && $isOwnSubscribes === false
-            ) {
-                $this->sendConfirmationRequestEmail();
-            } else {
-                $this->sendConfirmationSuccessEmail();
+            if($sendInformationEmail) {
+                if ($isConfirmNeed === true
+                    && $isOwnSubscribes === false
+                ) {
+                    $this->sendConfirmationRequestEmail();
+                } else {
+                    $this->sendConfirmationSuccessEmail();
+                }
             }
             return $this->getStatus();
         } catch (\Exception $e) {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -393,12 +393,14 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
      */
     public function subscribe($email)
     {
-        $sendInformationEmail = false;
         $this->loadByEmail($email);
+
+        if ($this->getId() && $this->getStatus() == self::STATUS_SUBSCRIBED) {
+            return $this->getStatus();
+        }
 
         if (!$this->getId()) {
             $this->setSubscriberConfirmCode($this->randomSequence());
-            $sendInformationEmail = true;
         }
 
         $isConfirmNeed = $this->_scopeConfig->getValue(


### PR DESCRIPTION
Only send email/confirmation email of subscription to newsletter only when subscriber is new in newsletter

### Description
Check if is necessary send email to a customer that is subscribed to newsletter. If this customer was subscribed previously not necessary send email. 

### Fixed Issues (if relevant)
1. magento/magento2#5439: Newsletter subscription

### Manual testing scenarios
1. Subscribe an email not subscribed previously (e.g: test@test.com)
2. this email will receive a confirmation email of subscription
3. Subscribe the same email (test@test.com)
4. this email NOT will recieve a confirmation email of subscription

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
