### PR TITLE
Show first day of the week in dob datepicker based on locale [backport]

### DIFF
--- a/app/code/Magento/Customer/Block/Widget/Dob.php
+++ b/app/code/Magento/Customer/Block/Widget/Dob.php
@@ -186,7 +186,8 @@ class Dob extends AbstractWidget
             'max_date' => '-1d',
             'change_month' => 'true',
             'change_year' => 'true',
-            'show_on' => 'both'
+            'show_on' => 'both',
+            'first_day' => $this->getFirstDay()
         ]);
         return $this->dateElement->getHtml();
     }
@@ -286,5 +287,18 @@ class Dob extends AbstractWidget
             }
         }
         return null;
+    }
+
+    /**
+     * Return first day of the week
+     *
+     * @return int
+     */
+    public function getFirstDay()
+    {
+        return (int)$this->_scopeConfig->getValue(
+            'general/locale/firstday',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/lib/internal/Magento/Framework/View/Element/Html/Date.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Date.php
@@ -26,6 +26,7 @@ class Date extends \Magento\Framework\View\Element\Template
         $changeYear = $this->getChangeYear();
         $maxDate = $this->getMaxDate();
         $showOn = $this->getShowOn();
+        $firstDay = $this->getFirstDay();
 
         $html .= '<script type="text/javascript">
             require(["jquery", "mage/calendar"], function($){
@@ -59,6 +60,7 @@ class Date extends \Magento\Framework\View\Element\Template
             ($changeMonth === null ? '' : ', changeMonth: ' . $changeMonth) .
             ($changeYear === null ? '' : ', changeYear: ' . $changeYear) .
             ($showOn ? ', showOn: "' . $showOn . '"' : '') .
+            ($firstDay ? ', firstDay: ' . $firstDay : '') .
             '})
             });
             </script>';


### PR DESCRIPTION
### Description
The frontend datepicker control for the DOB field is not localized: month names, day names and week start date are all using en_US. This pull request fixes this using the first day of the week set in the back office (core_config_data)

Backport for https://github.com/magento/magento2/pull/11057

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6350

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
