### PR TITLE
Defaulting missing alt-text for a product to use the product name.

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -116,7 +116,7 @@ class Gallery extends \Magento\Catalog\Block\Product\View\AbstractView
                 'thumb' => $image->getData('small_image_url'),
                 'img' => $image->getData('medium_image_url'),
                 'full' => $image->getData('large_image_url'),
-                'caption' => $image->getLabel(),
+                'caption' => ($image->getLabel() ?: $this->getProduct()->getName()),
                 'position' => $image->getPosition(),
                 'isMain' => $this->isMainImage($image),
                 'type' => str_replace('external-', '', $image->getMediaType()),

--- a/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
@@ -473,6 +473,7 @@ class CreateHandler implements ExtensionInterface
             );
         }
     }
+
     /**
      * @param \Magento\Catalog\Model\Product $product
      * @param $mediaAttrCode

--- a/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
@@ -167,8 +167,11 @@ class CreateHandler implements ExtensionInterface
             if (empty($attrData) && empty($clearImages) && empty($newImages) && empty($existImages)) {
                 continue;
             }
+            $resetLabel = false;
             if (in_array($attrData, $clearImages)) {
                 $product->setData($mediaAttrCode, 'no_selection');
+                $product->setData($mediaAttrCode . '_label', null);
+                $resetLabel = true;
             }
 
             if (in_array($attrData, array_keys($newImages))) {
@@ -179,10 +182,28 @@ class CreateHandler implements ExtensionInterface
             if (in_array($attrData, array_keys($existImages)) && isset($existImages[$attrData]['label'])) {
                 $product->setData($mediaAttrCode . '_label', $existImages[$attrData]['label']);
             }
+
+            if ($attrData === 'no_selection' && !empty($product->getData($mediaAttrCode . '_label'))) {
+                $product->setData($mediaAttrCode . '_label', null);
+                $resetLabel = true;
+            }
             if (!empty($product->getData($mediaAttrCode))) {
                 $product->addAttributeUpdate(
                     $mediaAttrCode,
                     $product->getData($mediaAttrCode),
+                    $product->getStoreId()
+                );
+            }
+            if (
+                in_array($mediaAttrCode, ['image', 'small_image', 'thumbnail'])
+                && (
+                    !empty($product->getData($mediaAttrCode . '_label'))
+                    || $resetLabel === true
+                )
+            ) {
+                $product->addAttributeUpdate(
+                    $mediaAttrCode  . '_label',
+                    $product->getData($mediaAttrCode . '_label'),
                     $product->getStoreId()
                 );
             }

--- a/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
@@ -167,45 +167,13 @@ class CreateHandler implements ExtensionInterface
             if (empty($attrData) && empty($clearImages) && empty($newImages) && empty($existImages)) {
                 continue;
             }
-            $resetLabel = false;
-            if (in_array($attrData, $clearImages)) {
-                $product->setData($mediaAttrCode, 'no_selection');
-                $product->setData($mediaAttrCode . '_label', null);
-                $resetLabel = true;
-            }
-
-            if (in_array($attrData, array_keys($newImages))) {
-                $product->setData($mediaAttrCode, $newImages[$attrData]['new_file']);
-                $product->setData($mediaAttrCode . '_label', $newImages[$attrData]['label']);
-            }
-
-            if (in_array($attrData, array_keys($existImages)) && isset($existImages[$attrData]['label'])) {
-                $product->setData($mediaAttrCode . '_label', $existImages[$attrData]['label']);
-            }
-
-            if ($attrData === 'no_selection' && !empty($product->getData($mediaAttrCode . '_label'))) {
-                $product->setData($mediaAttrCode . '_label', null);
-                $resetLabel = true;
-            }
-            if (!empty($product->getData($mediaAttrCode))) {
-                $product->addAttributeUpdate(
-                    $mediaAttrCode,
-                    $product->getData($mediaAttrCode),
-                    $product->getStoreId()
-                );
-            }
-            if (in_array($mediaAttrCode, ['image', 'small_image', 'thumbnail']) &&
-                (
-                    !empty($product->getData($mediaAttrCode . '_label'))
-                    || $resetLabel === true
-                )
-            ) {
-                $product->addAttributeUpdate(
-                    $mediaAttrCode  . '_label',
-                    $product->getData($mediaAttrCode . '_label'),
-                    $product->getStoreId()
-                );
-            }
+            $this->processMediaAttribute(
+                $product,
+                $mediaAttrCode,
+                $clearImages,
+                $newImages,
+                $existImages
+            );
         }
 
         $product->setData($attrCode, $value);
@@ -467,5 +435,69 @@ class CreateHandler implements ExtensionInterface
             $this->mediaAttributeCodes = $this->mediaConfig->getMediaAttributeCodes();
         }
         return $this->mediaAttributeCodes;
+    }
+
+    /**
+     * @param \Magento\Catalog\Model\Product $product
+     * @param $attrData
+     * @param array $clearImages
+     * @param $mediaAttrCode
+     * @param array $newImages
+     * @param array $existImages
+     */
+    /**
+     * @param \Magento\Catalog\Model\Product $product
+     * @param $mediaAttrCode
+     * @param array $clearImages
+     * @param array $newImages
+     * @param array $existImages
+     */
+    private function processMediaAttribute(
+        \Magento\Catalog\Model\Product $product,
+        $mediaAttrCode,
+        array $clearImages,
+        array $newImages,
+        array $existImages
+    ) {
+        $resetLabel = false;
+        $attrData = $product->getData($mediaAttrCode);
+        if (in_array($attrData, $clearImages)) {
+            $product->setData($mediaAttrCode, 'no_selection');
+            $product->setData($mediaAttrCode . '_label', null);
+            $resetLabel = true;
+        }
+
+        if (in_array($attrData, array_keys($newImages))) {
+            $product->setData($mediaAttrCode, $newImages[$attrData]['new_file']);
+            $product->setData($mediaAttrCode . '_label', $newImages[$attrData]['label']);
+        }
+
+        if (in_array($attrData, array_keys($existImages)) && isset($existImages[$attrData]['label'])) {
+            $product->setData($mediaAttrCode . '_label', $existImages[$attrData]['label']);
+        }
+
+        if ($attrData === 'no_selection' && !empty($product->getData($mediaAttrCode . '_label'))) {
+            $product->setData($mediaAttrCode . '_label', null);
+            $resetLabel = true;
+        }
+        if (in_array($mediaAttrCode, ['image', 'small_image', 'thumbnail']) &&
+            (
+                !empty($product->getData($mediaAttrCode . '_label'))
+                || $resetLabel === true
+            )
+        ) {
+            $product->addAttributeUpdate(
+                $mediaAttrCode . '_label',
+                $product->getData($mediaAttrCode . '_label'),
+                $product->getStoreId()
+            );
+        }
+        if (!empty($product->getData($mediaAttrCode))) {
+            $product->addAttributeUpdate(
+                $mediaAttrCode,
+                $product->getData($mediaAttrCode),
+                $product->getStoreId()
+            );
+        }
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
@@ -194,9 +194,8 @@ class CreateHandler implements ExtensionInterface
                     $product->getStoreId()
                 );
             }
-            if (
-                in_array($mediaAttrCode, ['image', 'small_image', 'thumbnail'])
-                && (
+            if (in_array($mediaAttrCode, ['image', 'small_image', 'thumbnail']) &&
+                (
                     !empty($product->getData($mediaAttrCode . '_label'))
                     || $resetLabel === true
                 )

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
@@ -77,6 +77,83 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->registry);
     }
 
+    public function testGetGalleryImagesJsonWithLabel(){
+        $this->prepareGetGalleryImagesJsonMocks();
+        $json = $this->model->getGalleryImagesJson();
+        $decodedJson = json_decode($json, true);
+        $this->assertEquals('product_page_image_small_url', $decodedJson[0]['thumb']);
+        $this->assertEquals('product_page_image_medium_url', $decodedJson[0]['img']);
+        $this->assertEquals('product_page_image_large_url', $decodedJson[0]['full']);
+        $this->assertEquals('test_label', $decodedJson[0]['caption']);
+        $this->assertEquals('2', $decodedJson[0]['position']);
+        $this->assertEquals(false, $decodedJson[0]['isMain']);
+        $this->assertEquals('test_media_type', $decodedJson[0]['type']);
+        $this->assertEquals('test_video_url', $decodedJson[0]['videoUrl']);
+    }
+
+    public function testGetGalleryImagesJsonWithoutLabel(){
+        $this->prepareGetGalleryImagesJsonMocks(false);
+        $json = $this->model->getGalleryImagesJson();
+        $decodedJson = json_decode($json, true);
+        $this->assertEquals('test_product_name', $decodedJson[0]['caption']);
+
+    }
+
+    private function prepareGetGalleryImagesJsonMocks($hasLabel = true){
+        $storeMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $productTypeMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Type\AbstractType::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $productTypeMock->expects($this->any())
+            ->method('getStoreFilter')
+            ->with($productMock)
+            ->willReturn($storeMock);
+
+        $productMock->expects($this->any())
+            ->method('getTypeInstance')
+            ->willReturn($productTypeMock);
+        $productMock->expects($this->any())
+            ->method('getMediaGalleryImages')
+            ->willReturn($this->getImagesCollectionWithPopulatedDataObject($hasLabel));
+        $productMock->expects($this->any())
+            ->method('getName')
+            ->willReturn('test_product_name');
+
+        $this->registry->expects($this->any())
+            ->method('registry')
+            ->with('product')
+            ->willReturn($productMock);
+
+        $this->imageHelper->expects($this->any())
+            ->method('init')
+            ->willReturnMap([
+                [$productMock, 'product_page_image_small', [], $this->imageHelper],
+                [$productMock, 'product_page_image_medium_no_frame', [], $this->imageHelper],
+                [$productMock, 'product_page_image_large_no_frame', [], $this->imageHelper],
+            ])
+            ->willReturnSelf();
+        $this->imageHelper->expects($this->any())
+            ->method('setImageFile')
+            ->with('test_file')
+            ->willReturnSelf();
+        $this->imageHelper->expects($this->at(2))
+            ->method('getUrl')
+            ->willReturn('product_page_image_small_url');
+        $this->imageHelper->expects($this->at(5))
+            ->method('getUrl')
+            ->willReturn('product_page_image_medium_url');
+        $this->imageHelper->expects($this->at(8))
+            ->method('getUrl')
+            ->willReturn('product_page_image_large_url');
+    }
+
     public function testGetGalleryImages()
     {
         $storeMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
@@ -145,6 +222,32 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
         $items = [
             new \Magento\Framework\DataObject([
                 'file' => 'test_file'
+            ]),
+        ];
+
+        $collectionMock->expects($this->any())
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator($items));
+
+        return $collectionMock;
+    }
+
+    /**
+     * @return \Magento\Framework\Data\Collection
+     */
+    private function getImagesCollectionWithPopulatedDataObject($hasLabel)
+    {
+        $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $items = [
+            new \Magento\Framework\DataObject([
+                'file' => 'test_file',
+                'label' => ($hasLabel ? 'test_label' : ''),
+                'position' => '2',
+                'media_type' => 'external-test_media_type',
+                "video_url" => 'test_video_url'
             ]),
         ];
 

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
@@ -98,7 +98,6 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
         $json = $this->model->getGalleryImagesJson();
         $decodedJson = json_decode($json, true);
         $this->assertEquals('test_product_name', $decodedJson[0]['caption']);
-
     }
 
     private function prepareGetGalleryImagesJsonMocks($hasLabel = true)

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
@@ -77,7 +77,8 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->registry);
     }
 
-    public function testGetGalleryImagesJsonWithLabel(){
+    public function testGetGalleryImagesJsonWithLabel()
+    {
         $this->prepareGetGalleryImagesJsonMocks();
         $json = $this->model->getGalleryImagesJson();
         $decodedJson = json_decode($json, true);
@@ -91,7 +92,8 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test_video_url', $decodedJson[0]['videoUrl']);
     }
 
-    public function testGetGalleryImagesJsonWithoutLabel(){
+    public function testGetGalleryImagesJsonWithoutLabel()
+    {
         $this->prepareGetGalleryImagesJsonMocks(false);
         $json = $this->model->getGalleryImagesJson();
         $decodedJson = json_decode($json, true);
@@ -99,7 +101,8 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
 
     }
 
-    private function prepareGetGalleryImagesJsonMocks($hasLabel = true){
+    private function prepareGetGalleryImagesJsonMocks($hasLabel = true)
+    {
         $storeMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The code in app/code/Magento/Catalog/Block/Product/View/Gallery.php's getGalleryImagesJson() function was setting the image's label to $image->getLabel() regardless of whether the image's label was null or empty.  The fix was to test the $image->getLabel() response and if it was empty to use the product's name instead.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9931: Empty image alt-text & missing alt attribute on product detail page


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Manually create a product with images.
2. Intentionally leave the Image Label blank.
3. Navigate to that product's PDP and you should see the alt attribute for the image be populated with the product's name.
4. You should also test images that have Image Labels and ensure that those labels show in the alt attribute

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
