### PR TITLE
Update attributes mass action in catalog/product grid can not proceed

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Multiselect.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Multiselect.php
@@ -60,7 +60,7 @@ class Multiselect extends AbstractElement
             $html .= '<input type="hidden" id="' . $this->getHtmlId() . '_hidden" name="' . parent::getName() . '" value="" />';
         }
         if (!empty($this->_data['disabled'])) {
-            $html .= '<input type="hidden" id="' . $this->getHtmlId() . '_hidden" name="' . parent::getName() . '_disabled" value="" />';
+            $html .= '<input type="hidden" name="' . parent::getName() . '_disabled" value="" />';
         }
 
         $html .= '<select id="' . $this->getHtmlId() . '" name="' . $this->getName() . '" ' . $this->serialize(

--- a/lib/internal/Magento/Framework/Data/Form/Element/Multiselect.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Multiselect.php
@@ -57,10 +57,10 @@ class Multiselect extends AbstractElement
         $this->addClass('select multiselect admin__control-multiselect');
         $html = '';
         if ($this->getCanBeEmpty()) {
-            $html .= '<input type="hidden" name="' . parent::getName() . '" value="" />';
+            $html .= '<input type="hidden" id="' . $this->getHtmlId() . '_hidden" name="' . parent::getName() . '" value="" />';
         }
         if (!empty($this->_data['disabled'])) {
-            $html .= '<input type="hidden" name="' . parent::getName() . '_disabled" value="" />';
+            $html .= '<input type="hidden" id="' . $this->getHtmlId() . '_hidden" name="' . parent::getName() . '_disabled" value="" />';
         }
 
         $html .= '<select id="' . $this->getHtmlId() . '" name="' . $this->getName() . '" ' . $this->serialize(

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
@@ -41,12 +41,10 @@ class MultiselectTest extends \PHPUnit\Framework\TestCase
     public function testHiddenDisabledFieldPresentInMultiSelect()
     {
         $fieldName = 'fieldName';
-        $fieldId = 'fieldId';
         $this->_model->setDisabled(true);
         $this->_model->setName($fieldName);
-        $this->_model->setId($fieldId);
         $elementHtml = $this->_model->getElementHtml();
-        $this->assertContains('<input type="hidden" id="' . $fieldId . '_hidden" name="' . $fieldName . '_disabled"', $elementHtml);
+        $this->assertContains('<input type="hidden" name="' . $fieldName . '_disabled"', $elementHtml);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
@@ -27,10 +27,12 @@ class MultiselectTest extends \PHPUnit\Framework\TestCase
     public function testHiddenFieldPresentInMultiSelect()
     {
         $fieldName = 'fieldName';
+        $fieldId = 'fieldId';
         $this->_model->setCanBeEmpty(true);
         $this->_model->setName($fieldName);
+        $this->_model->setId($fieldId);
         $elementHtml = $this->_model->getElementHtml();
-        $this->assertContains('<input type="hidden" name="' . $fieldName . '"', $elementHtml);
+        $this->assertContains('<input type="hidden" id="' . $fieldId . '_hidden" name="' . $fieldName . '"', $elementHtml);
     }
 
     /**
@@ -39,10 +41,12 @@ class MultiselectTest extends \PHPUnit\Framework\TestCase
     public function testHiddenDisabledFieldPresentInMultiSelect()
     {
         $fieldName = 'fieldName';
+        $fieldId = 'fieldId';
         $this->_model->setDisabled(true);
         $this->_model->setName($fieldName);
+        $this->_model->setId($fieldId);
         $elementHtml = $this->_model->getElementHtml();
-        $this->assertContains('<input type="hidden" name="' . $fieldName . '_disabled"', $elementHtml);
+        $this->assertContains('<input type="hidden" id="' . $fieldId . '_hidden" name="' . $fieldName . '_disabled"', $elementHtml);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
@@ -32,7 +32,9 @@ class MultiselectTest extends \PHPUnit\Framework\TestCase
         $this->_model->setName($fieldName);
         $this->_model->setId($fieldId);
         $elementHtml = $this->_model->getElementHtml();
-        $this->assertContains('<input type="hidden" id="' . $fieldId . '_hidden" name="' . $fieldName . '"', $elementHtml);
+        $this->assertContains(
+            '<input type="hidden" id="' . $fieldId . '_hidden" name="' . $fieldName . '"', $elementHtml
+        );
     }
 
     /**


### PR DESCRIPTION
### Description
MassAction "update attributes" with required multiselect attribute doesn't work when save

### Fixed Issues
1. https://github.com/magento/magento2/issues/11329 : Unable to proceed massaction "Update attributes" with required multiple select attribute

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
