### PR TITLE
ADDED $sortByPostion flag to getChildren()

### DIFF
--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -780,12 +780,14 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
     /**
      * Retrieve children ids comma separated
      *
+     * @param boolean $recursive
+     * @param boolean $isActive
      * @param boolean $sortByPosition
      * @return string
      */
-    public function getChildren($sortByPosition = false)
+    public function getChildren($recursive = true, $isActive = true, $sortByPosition = false)
     {
-        return implode(',', $this->getResource()->getChildren($this, false, true, $sortByPosition));
+        return implode(',', $this->getResource()->getChildren($this, $recursive, $isActive, $sortByPosition));
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -785,7 +785,7 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
      * @param boolean $sortByPosition
      * @return string
      */
-    public function getChildren($recursive = true, $isActive = true, $sortByPosition = false)
+    public function getChildren($recursive = false, $isActive = true, $sortByPosition = false)
     {
         return implode(',', $this->getResource()->getChildren($this, $recursive, $isActive, $sortByPosition));
     }

--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -780,11 +780,12 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
     /**
      * Retrieve children ids comma separated
      *
+     * @param boolean $sortByPosition
      * @return string
      */
-    public function getChildren()
+    public function getChildren($sortByPosition = false)
     {
-        return implode(',', $this->getResource()->getChildren($this, false));
+        return implode(',', $this->getResource()->getChildren($this, false, true, $sortByPosition));
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Flat.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Flat.php
@@ -602,9 +602,10 @@ class Flat extends \Magento\Indexer\Model\ResourceModel\AbstractResource
      * @param \Magento\Catalog\Model\Category $category
      * @param bool $recursive
      * @param bool $isActive
+     * @param bool $sortByPosition
      * @return array
      */
-    public function getChildren($category, $recursive = true, $isActive = true)
+    public function getChildren($category, $recursive = true, $isActive = true, $sortByPosition = false)
     {
         $select = $this->getConnection()->select()->from(
             $this->getMainStoreTable($category->getStoreId()),
@@ -618,6 +619,9 @@ class Flat extends \Magento\Indexer\Model\ResourceModel\AbstractResource
         }
         if ($isActive) {
             $select->where('is_active = ?', '1');
+        }
+        if ($sortByPosition) {
+            $select->order('position ASC');
         }
         $_categories = $this->getConnection()->fetchAll($select);
         $categoriesIds = [];

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -128,6 +128,12 @@ class CategoryTreeTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array_diff([4, 13], explode(',', $this->_model->getChildren())), []);
     }
 
+    public function testGetChildrenSorted()
+    {
+        $this->_model->load(2);
+        $this->assertEquals(array_diff([3, 4, 5], explode(',', $this->_model->getChildren(true))), []);
+    }
+
     public function testGetPathInStore()
     {
         $this->_model->load(5);

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -131,7 +131,9 @@ class CategoryTreeTest extends \PHPUnit\Framework\TestCase
     public function testGetChildrenSorted()
     {
         $this->_model->load(2);
-        $this->assertEquals(array_diff([3, 4, 5], explode(',', $this->_model->getChildren(true))), []);
+        $unsorted = explode(',', $this->_model->getChildren());
+        usort($unsorted);
+        $this->assertEquals(array_diff($unsorted, explode(',', $this->_model->getChildren(true, true, true))), []);
     }
 
     public function testGetPathInStore()

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -132,7 +132,7 @@ class CategoryTreeTest extends \PHPUnit\Framework\TestCase
     {
         $this->_model->load(2);
         $unsorted = explode(',', $this->_model->getChildren());
-        usort($unsorted);
+        sort($unsorted);
         $this->assertEquals(array_diff($unsorted, explode(',', $this->_model->getChildren(true, true, true))), []);
     }
 


### PR DESCRIPTION
Method "getChildren" sort ordering (SQUASHTOBERFEST)

### Description
ADDED $sortByPostion flag to getChildren()

### Fixed Issues (if relevant)
1. magento/magento2#11310
