### PR TITLE
Fix : wrong sender for sales emails sent from BO

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
+++ b/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
@@ -48,6 +48,8 @@ class SenderBuilder
      */
     public function send()
     {
+        $this->transportBuilder->setScopeId($this->identityContainer->getStore()->getId());
+
         $this->configureEmailTemplate();
 
         $this->transportBuilder->addTo(

--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -85,6 +85,11 @@ class TransportBuilder
     protected $mailTransportFactory;
 
     /**
+     * @var int|null
+     */
+    protected $scopeId;
+
+    /**
      * @param FactoryInterface $templateFactory
      * @param MessageInterface $message
      * @param SenderResolverInterface $senderResolver
@@ -164,8 +169,20 @@ class TransportBuilder
      */
     public function setFrom($from)
     {
-        $result = $this->_senderResolver->resolve($from);
+        $result = $this->_senderResolver->resolve($from, $this->scopeId);
         $this->message->setFrom($result['email'], $result['name']);
+        return $this;
+    }
+
+    /**
+     * Set scope
+     *
+     * @param int $scopeId
+     * @return $this
+     */
+    public function setScopeId($scopeId)
+    {
+        $this->scopeId = $scopeId;
         return $this;
     }
 
@@ -242,6 +259,7 @@ class TransportBuilder
         $this->templateIdentifier = null;
         $this->templateVars = null;
         $this->templateOptions = null;
+        $this->scopeId = null;
         return $this;
     }
 


### PR DESCRIPTION
Fix for wrong sender when sending sales emails from BO for non-default stores

### Description
The sales emails are always sent from default sender when sent via BO, even if the sender is overriden in configs

### Manual testing scenarios
1. Change sales email sender for non-default store
2. Send "order confirmation" email from BO
