### PR TITLE
 Allow custom payment gateway commands

### DIFF
--- a/app/code/Magento/Payment/Model/Method/Adapter.php
+++ b/app/code/Magento/Payment/Model/Method/Adapter.php
@@ -520,7 +520,7 @@ class Adapter implements MethodInterface
     /**
      * @inheritdoc
      */
-    private function executeCommand($commandCode, array $arguments = [])
+    public function executeCommand($commandCode, array $arguments = [])
     {
         if (!$this->canPerformCommand($commandCode)) {
             return null;


### PR DESCRIPTION
In order to create custom payment gateway command - we need to allow to call this method from any other place