### PR TITLE
Unable to manage (install/uninstall) cron via bin/magento cron:install / cron:remove with multiple installations against same crontab

### DIFF
--- a/app/code/Magento/Cron/etc/di.xml
+++ b/app/code/Magento/Cron/etc/di.xml
@@ -43,7 +43,7 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Framework\Crontab\CrontabManager">
+    <type name="Magento\Framework\Crontab\CrontabManagerInterface">
         <arguments>
             <argument name="shell" xsi:type="object">Magento\Framework\App\Shell</argument>
         </arguments>

--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -5,11 +5,11 @@
  */
 namespace Magento\Framework\Crontab;
 
-use Magento\Framework\ShellInterface;
-use Magento\Framework\Phrase;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Phrase;
+use Magento\Framework\ShellInterface;
 
 /**
  * Manager works with cron tasks
@@ -39,13 +39,37 @@ class CrontabManager implements CrontabManagerInterface
     }
 
     /**
+     * @return string
+     */
+    private function getTasksBlockStart()
+    {
+        $tasksBlockStart = self::TASKS_BLOCK_START;
+        if (defined('BP')) {
+            $tasksBlockStart .= ' ' . md5(BP);
+        }
+        return $tasksBlockStart;
+    }
+
+    /**
+     * @return string
+     */
+    private function getTasksBlockEnd()
+    {
+        $tasksBlockEnd = self::TASKS_BLOCK_END;
+        if (defined('BP')) {
+            $tasksBlockEnd .= ' ' . md5(BP);
+        }
+        return $tasksBlockEnd;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getTasks()
     {
         $this->checkSupportedOs();
         $content = $this->getCrontabContent();
-        $pattern = '!(' . self::TASKS_BLOCK_START . ')(.*?)(' . self::TASKS_BLOCK_END . ')!s';
+        $pattern = '!(' . $this->getTasksBlockStart() . ')(.*?)(' . $this->getTasksBlockEnd() . ')!s';
 
         if (preg_match($pattern, $content, $matches)) {
             $tasks = trim($matches[2], PHP_EOL);
@@ -61,13 +85,13 @@ class CrontabManager implements CrontabManagerInterface
      */
     public function saveTasks(array $tasks)
     {
-        $this->checkSupportedOs();
-        $baseDir = $this->filesystem->getDirectoryRead(DirectoryList::ROOT)->getAbsolutePath();
-        $logDir = $this->filesystem->getDirectoryRead(DirectoryList::LOG)->getAbsolutePath();
-
         if (!$tasks) {
             throw new LocalizedException(new Phrase('List of tasks is empty'));
         }
+
+        $this->checkSupportedOs();
+        $baseDir = $this->filesystem->getDirectoryRead(DirectoryList::ROOT)->getAbsolutePath();
+        $logDir = $this->filesystem->getDirectoryRead(DirectoryList::LOG)->getAbsolutePath();
 
         foreach ($tasks as $key => $task) {
             if (empty($task['expression'])) {
@@ -114,11 +138,11 @@ class CrontabManager implements CrontabManagerInterface
     private function generateSection($content, $tasks = [])
     {
         if ($tasks) {
-            $content .= self::TASKS_BLOCK_START . PHP_EOL;
+            $content .= $this->getTasksBlockStart() . PHP_EOL;
             foreach ($tasks as $task) {
-                $content .=  $task['expression'] . ' ' . PHP_BINARY . ' '. $task['command'] . PHP_EOL;
+                $content .= $task['expression'] . ' ' . PHP_BINARY . ' ' . $task['command'] . PHP_EOL;
             }
-            $content .= self::TASKS_BLOCK_END . PHP_EOL;
+            $content .= $this->getTasksBlockEnd() . PHP_EOL;
         }
 
         return $content;
@@ -133,7 +157,8 @@ class CrontabManager implements CrontabManagerInterface
     private function cleanMagentoSection($content)
     {
         $content = preg_replace(
-            '!' . preg_quote(self::TASKS_BLOCK_START) . '.*?' . preg_quote(self::TASKS_BLOCK_END . PHP_EOL) . '!s',
+            '!' . preg_quote($this->getTasksBlockStart()) . '.*?'
+            . preg_quote($this->getTasksBlockEnd() . PHP_EOL) . '!s',
             '',
             $content
         );
@@ -192,7 +217,7 @@ class CrontabManager implements CrontabManagerInterface
     {
         if (stripos(PHP_OS, 'WIN') === 0) {
             throw new LocalizedException(
-                new Phrase('Your operation system is not supported to work with this command')
+                new Phrase('Your operating system is not supported to work with this command')
             );
         }
     }

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -87,17 +87,17 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
                 'tasks' => ['* * * * * /bin/php /var/www/magento/bin/magento cron:run'],
             ],
             [
                 'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento setup:cron:run' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
                 'tasks' => [
                     '* * * * * /bin/php /var/www/magento/bin/magento cron:run',
                     '* * * * * /bin/php /var/www/magento/bin/magento setup:cron:run',
@@ -165,17 +165,17 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 'contentBefore' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
                 'contentAfter' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
             ],
             [
                 'contentBefore' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento setup:cron:run' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
                 'contentAfter' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
             ],
             [
@@ -198,14 +198,13 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     {
         $baseDirMock = $this->getMockBuilder(ReadInterface::class)
             ->getMockForAbstractClass();
-        $baseDirMock->expects($this->once())
+        $baseDirMock->expects($this->never())
             ->method('getAbsolutePath')
             ->willReturn('/var/www/magento2/');
         $logDirMock = $this->getMockBuilder(ReadInterface::class)
             ->getMockForAbstractClass();
-        $logDirMock->expects($this->once())
-            ->method('getAbsolutePath')
-            ->willReturn('/var/www/magento2/var/log/');
+        $logDirMock->expects($this->never())
+            ->method('getAbsolutePath');
 
         $this->filesystemMock->expects($this->any())
             ->method('getDirectoryRead')
@@ -292,9 +291,9 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     public function saveTasksDataProvider()
     {
         $content = '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-            . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+            . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
             . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
-            . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL;
+            . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL;
 
         return [
             [
@@ -303,9 +302,9 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
                 ],
                 'content' => $content,
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' run.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
             ],
             [
                 'tasks' => [
@@ -313,9 +312,9 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
                 ],
                 'content' => $content,
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '1 2 3 4 5 ' . PHP_BINARY . ' run.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
             ],
             [
                 'tasks' => [
@@ -323,10 +322,10 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
                 ],
                 'content' => $content,
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php >>'
                     . ' /var/www/magento2/var/log/cron.log' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
             ],
             [
                 'tasks' => [
@@ -334,10 +333,10 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
                 ],
                 'content' => $content,
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_START . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
                     . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
             ],
         ];
     }


### PR DESCRIPTION
### Description
Backport of [PR#11359](https://github.com/magento/magento2/pull/11359)

Unable to manage (install/uninstall) cron via bin/magento cron:install / cron:remove with multiple installations against same crontab. Having two (or more) installations in different folders, it's not possible to create different crontab entries for both of them, because of the same prefix and suffix used for both of them (#~ MAGENTO START and #~ MAGENTO END)

### Fixed Issues (if relevant)
No related issue found

### Manual testing scenarios
1. Install Magento 2 in two different folders.
2. Run bin/magento cron:install on both of them
3. The second one fails because the first one already installed a cron entry

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
