### PR TITLE
[Backport 2.1-develop] cron:install and cron:remove commands, support to manage multiple instances in the same crontab, based on installation directory

### DIFF
--- a/app/code/Magento/Cron/Console/Command/CronCommand.php
+++ b/app/code/Magento/Cron/Console/Command/CronCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -94,7 +94,7 @@ class CronCommand extends Command
             }
         }
         /** @var \Magento\Framework\App\Cron $cronObserver */
-        $cronObserver = $objectManager->create('Magento\Framework\App\Cron', ['parameters' => $params]);
+        $cronObserver = $objectManager->create(\Magento\Framework\App\Cron::class, ['parameters' => $params]);
         $cronObserver->launch();
         $output->writeln('<info>' . 'Ran jobs by schedule.' . '</info>');
     }

--- a/app/code/Magento/Cron/Console/Command/CronInstallCommand.php
+++ b/app/code/Magento/Cron/Console/Command/CronInstallCommand.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Console\Command;
+
+use Magento\Framework\Crontab\CrontabManagerInterface;
+use Magento\Framework\Crontab\TasksProviderInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * CronInstallCommand installs Magento cron tasks
+ */
+class CronInstallCommand extends Command
+{
+    /**
+     * @var CrontabManagerInterface
+     */
+    private $crontabManager;
+
+    /**
+     * @var TasksProviderInterface
+     */
+    private $tasksProvider;
+
+    /**
+     * @param CrontabManagerInterface $crontabManager
+     * @param TasksProviderInterface $tasksProvider
+     */
+    public function __construct(
+        CrontabManagerInterface $crontabManager,
+        TasksProviderInterface $tasksProvider
+    ) {
+        $this->crontabManager = $crontabManager;
+        $this->tasksProvider = $tasksProvider;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('cron:install')
+            ->setDescription('Generates and installs crontab for current user')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install tasks');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->crontabManager->getTasks() && !$input->getOption('force')) {
+            $output->writeln('<error>Crontab has already been generated and saved</error>');
+            return Cli::RETURN_FAILURE;
+        }
+
+        try {
+            $this->crontabManager->saveTasks($this->tasksProvider->getTasks());
+        } catch (LocalizedException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return Cli::RETURN_FAILURE;
+        }
+
+        $output->writeln('<info>Crontab has been generated and saved</info>');
+
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/app/code/Magento/Cron/Console/Command/CronRemoveCommand.php
+++ b/app/code/Magento/Cron/Console/Command/CronRemoveCommand.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Console\Command;
+
+use Magento\Framework\Crontab\CrontabManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * CronRemoveCommand removes Magento cron tasks
+ */
+class CronRemoveCommand extends Command
+{
+    /**
+     * @var CrontabManagerInterface
+     */
+    private $crontabManager;
+
+    /**
+     * @param CrontabManagerInterface $crontabManager
+     */
+    public function __construct(CrontabManagerInterface $crontabManager)
+    {
+        $this->crontabManager = $crontabManager;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('cron:remove')
+            ->setDescription('Removes tasks from crontab');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $this->crontabManager->removeTasks();
+        } catch (LocalizedException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return Cli::RETURN_FAILURE;
+        }
+
+        $output->writeln('<info>Magento cron tasks have been removed</info>');
+
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/app/code/Magento/Cron/etc/di.xml
+++ b/app/code/Magento/Cron/etc/di.xml
@@ -8,6 +8,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\Cron\Model\ConfigInterface" type="Magento\Cron\Model\Config" />
     <preference for="Magento\Framework\Shell\CommandRendererInterface" type="Magento\Framework\Shell\CommandRenderer" />
+    <preference for="Magento\Framework\Crontab\CrontabManagerInterface" type="Magento\Framework\Crontab\CrontabManager" />
+    <preference for="Magento\Framework\Crontab\TasksProviderInterface" type="Magento\Framework\Crontab\TasksProvider" />
     <type name="Magento\Cron\Model\Config\Reader\Db">
         <arguments>
             <argument name="defaultReader" xsi:type="object">DefaultScopeReader</argument>
@@ -33,6 +35,8 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="cronCommand" xsi:type="object">Magento\Cron\Console\Command\CronCommand</item>
+                <item name="cronInstall" xsi:type="object">Magento\Cron\Console\Command\CronInstallCommand</item>
+                <item name="cronRemove" xsi:type="object">Magento\Cron\Console\Command\CronRemoveCommand</item>
             </argument>
         </arguments>
     </type>
@@ -40,6 +44,26 @@
         <arguments>
             <argument name="areas" xsi:type="array">
                 <item name="crontab" xsi:type="null" />
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\Crontab\CrontabManagerInterface">
+        <arguments>
+            <argument name="shell" xsi:type="object">Magento\Framework\App\Shell</argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\Crontab\TasksProviderInterface">
+        <arguments>
+            <argument name="tasks" xsi:type="array">
+                <item name="cronMagento" xsi:type="array">
+                    <item name="command" xsi:type="string">{magentoRoot}bin/magento cron:run | grep -v "Ran jobs by schedule" >> {magentoLog}magento.cron.log</item>
+                </item>
+                <item name="cronUpdate" xsi:type="array">
+                    <item name="command" xsi:type="string">{magentoRoot}update/cron.php >> {magentoLog}update.cron.log</item>
+                </item>
+                <item name="cronSetup" xsi:type="array">
+                    <item name="command" xsi:type="string">{magentoRoot}bin/magento setup:cron:run >> {magentoLog}setup.cron.log</item>
+                </item>
             </argument>
         </arguments>
     </type>

--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Crontab;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Phrase;
+use Magento\Framework\ShellInterface;
+
+/**
+ * Manager works with cron tasks
+ */
+class CrontabManager implements CrontabManagerInterface
+{
+    /**
+     * @var ShellInterface
+     */
+    private $shell;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @param ShellInterface $shell
+     * @param Filesystem $filesystem
+     */
+    public function __construct(
+        ShellInterface $shell,
+        Filesystem $filesystem
+    ) {
+        $this->shell = $shell;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @return string
+     */
+    private function getTasksBlockStart()
+    {
+        $tasksBlockStart = self::TASKS_BLOCK_START;
+        if (defined('BP')) {
+            $tasksBlockStart .= ' ' . md5(BP);
+        }
+        return $tasksBlockStart;
+    }
+
+    /**
+     * @return string
+     */
+    private function getTasksBlockEnd()
+    {
+        $tasksBlockEnd = self::TASKS_BLOCK_END;
+        if (defined('BP')) {
+            $tasksBlockEnd .= ' ' . md5(BP);
+        }
+        return $tasksBlockEnd;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTasks()
+    {
+        $this->checkSupportedOs();
+        $content = $this->getCrontabContent();
+        $pattern = '!(' . $this->getTasksBlockStart() . ')(.*?)(' . $this->getTasksBlockEnd() . ')!s';
+
+        if (preg_match($pattern, $content, $matches)) {
+            $tasks = trim($matches[2], PHP_EOL);
+            $tasks = explode(PHP_EOL, $tasks);
+            return $tasks;
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveTasks(array $tasks)
+    {
+        if (!$tasks) {
+            throw new LocalizedException(new Phrase('List of tasks is empty'));
+        }
+
+        $this->checkSupportedOs();
+        $baseDir = $this->filesystem->getDirectoryRead(DirectoryList::ROOT)->getAbsolutePath();
+        $logDir = $this->filesystem->getDirectoryRead(DirectoryList::LOG)->getAbsolutePath();
+
+        foreach ($tasks as $key => $task) {
+            if (empty($task['expression'])) {
+                $tasks[$key]['expression'] = '* * * * *';
+            }
+
+            if (empty($task['command'])) {
+                throw new LocalizedException(new Phrase('Command should not be empty'));
+            }
+
+            $tasks[$key]['command'] = str_replace(
+                ['{magentoRoot}', '{magentoLog}'],
+                [$baseDir, $logDir],
+                $task['command']
+            );
+        }
+
+        $content = $this->getCrontabContent();
+        $content = $this->cleanMagentoSection($content);
+        $content = $this->generateSection($content, $tasks);
+
+        $this->save($content);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws LocalizedException
+     */
+    public function removeTasks()
+    {
+        $this->checkSupportedOs();
+        $content = $this->getCrontabContent();
+        $content = $this->cleanMagentoSection($content);
+        $this->save($content);
+    }
+
+    /**
+     * Generate Magento Tasks Section
+     *
+     * @param string $content
+     * @param array $tasks
+     * @return string
+     */
+    private function generateSection($content, $tasks = [])
+    {
+        if ($tasks) {
+            $content .= $this->getTasksBlockStart() . PHP_EOL;
+            foreach ($tasks as $task) {
+                $content .= $task['expression'] . ' ' . PHP_BINARY . ' ' . $task['command'] . PHP_EOL;
+            }
+            $content .= $this->getTasksBlockEnd() . PHP_EOL;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Clean Magento Tasks Section in crontab content
+     *
+     * @param string $content
+     * @return string
+     */
+    private function cleanMagentoSection($content)
+    {
+        $content = preg_replace(
+            '!' . preg_quote($this->getTasksBlockStart()) . '.*?'
+            . preg_quote($this->getTasksBlockEnd() . PHP_EOL) . '!s',
+            '',
+            $content
+        );
+
+        return $content;
+    }
+
+    /**
+     * Get crontab content without Magento Tasks Section
+     *
+     * In case of some exceptions the empty content is returned
+     *
+     * @return string
+     */
+    private function getCrontabContent()
+    {
+        try {
+            $content = (string)$this->shell->execute('crontab -l');
+        } catch (LocalizedException $e) {
+            return '';
+        }
+
+        return $content;
+    }
+
+    /**
+     * Save crontab
+     *
+     * @param string $content
+     * @return void
+     * @throws LocalizedException
+     */
+    private function save($content)
+    {
+        $content = str_replace(['%', '"'], ['%%', '\"'], $content);
+
+        try {
+            $this->shell->execute('echo "' . $content . '" | crontab -');
+        } catch (LocalizedException $e) {
+            throw new LocalizedException(
+                new Phrase('Error during saving of crontab: %1', [$e->getPrevious()->getMessage()]),
+                $e
+            );
+        }
+    }
+
+    /**
+     * Check that OS is supported
+     *
+     * If OS is not supported then no possibility to work with crontab
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    private function checkSupportedOs()
+    {
+        if (stripos(PHP_OS, 'WIN') === 0) {
+            throw new LocalizedException(
+                new Phrase('Your operating system is not supported to work with this command')
+            );
+        }
+    }
+}

--- a/lib/internal/Magento/Framework/Crontab/CrontabManagerInterface.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManagerInterface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Crontab;
+
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Interface \Magento\Framework\Crontab\CrontabManagerInterface
+ *
+ */
+interface CrontabManagerInterface
+{
+    /**#@+
+     * Constants for wrapping Magento section in crontab
+     */
+    const TASKS_BLOCK_START = '#~ MAGENTO START';
+    const TASKS_BLOCK_END = '#~ MAGENTO END';
+    /**#@-*/
+
+    /**
+     * Get list of Magento Tasks
+     *
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getTasks();
+
+    /**
+     * Save Magento Tasks to crontab
+     *
+     * @param array $tasks
+     * @return void
+     * @throws LocalizedException
+     */
+    public function saveTasks(array $tasks);
+
+    /**
+     * Remove Magento Tasks form crontab
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    public function removeTasks();
+}

--- a/lib/internal/Magento/Framework/Crontab/README.md
+++ b/lib/internal/Magento/Framework/Crontab/README.md
@@ -1,0 +1,12 @@
+Library for working with crontab
+
+The library has the next interfaces:
+* CrontabManagerInterface
+* TasksProviderInterface
+
+*CrontabManagerInterface* provides working with crontab:
+* *getTasks* - get list of Magento cron tasks from crontab
+* *saveTasks* - save Magento cron tasks to crontab
+* *removeTasks* - remove Magento cron tasks from crontab
+
+*TasksProviderInterface* has only one method *getTasks*. This interface provides transportation the list of tasks from DI

--- a/lib/internal/Magento/Framework/Crontab/TasksProvider.php
+++ b/lib/internal/Magento/Framework/Crontab/TasksProvider.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Crontab;
+
+/**
+ * TasksProvider collects list of tasks
+ */
+class TasksProvider implements TasksProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $tasks = [];
+
+    /**
+     * @param array $tasks
+     */
+    public function __construct(array $tasks = [])
+    {
+        $this->tasks = $tasks;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTasks()
+    {
+        return $this->tasks;
+    }
+}

--- a/lib/internal/Magento/Framework/Crontab/TasksProviderInterface.php
+++ b/lib/internal/Magento/Framework/Crontab/TasksProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Crontab;
+
+/**
+ * Interface \Magento\Framework\Crontab\TasksProviderInterface
+ *
+ */
+interface TasksProviderInterface
+{
+    /**
+     * Get list of tasks
+     *
+     * @return array
+     */
+    public function getTasks();
+}

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Crontab\Test\Unit;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Crontab\CrontabManager;
+use Magento\Framework\Crontab\CrontabManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+use Magento\Framework\Filesystem\DriverPool;
+use Magento\Framework\Phrase;
+use Magento\Framework\ShellInterface;
+
+class CrontabManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ShellInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $shellMock;
+
+    /**
+     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $filesystemMock;
+
+    /**
+     * @var CrontabManager
+     */
+    private $crontabManager;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->shellMock = $this->getMockBuilder(ShellInterface::class)
+            ->getMockForAbstractClass();
+        $this->filesystemMock = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalClone()
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->crontabManager = new CrontabManager($this->shellMock, $this->filesystemMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetTasksNoCrontab()
+    {
+        $exception = new \Exception('crontab: no crontab for user');
+        $localizedException = new LocalizedException(new Phrase('Some error'), $exception);
+
+        $this->shellMock->expects($this->once())
+            ->method('execute')
+            ->with('crontab -l', [])
+            ->willThrowException($localizedException);
+
+        $this->assertEquals([], $this->crontabManager->getTasks());
+    }
+
+    /**
+     * @param string $content
+     * @param array $tasks
+     * @return void
+     * @dataProvider getTasksDataProvider
+     */
+    public function testGetTasks($content, $tasks)
+    {
+        $this->shellMock->expects($this->once())
+            ->method('execute')
+            ->with('crontab -l', [])
+            ->willReturn($content);
+
+        $this->assertEquals($tasks, $this->crontabManager->getTasks());
+    }
+
+    /**
+     * @return array
+     */
+    public function getTasksDataProvider()
+    {
+        return [
+            [
+                'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+                'tasks' => ['* * * * * /bin/php /var/www/magento/bin/magento cron:run'],
+            ],
+            [
+                'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
+                    . '* * * * * /bin/php /var/www/magento/bin/magento setup:cron:run' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+                'tasks' => [
+                    '* * * * * /bin/php /var/www/magento/bin/magento cron:run',
+                    '* * * * * /bin/php /var/www/magento/bin/magento setup:cron:run',
+                ],
+            ],
+            [
+                'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL,
+                'tasks' => [],
+            ],
+            [
+                'content' => '',
+                'tasks' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return void
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage Shell error
+     */
+    public function testRemoveTasksWithException()
+    {
+        $exception = new \Exception('Shell error');
+        $localizedException = new LocalizedException(new Phrase('Some error'), $exception);
+
+        $this->shellMock->expects($this->at(0))
+            ->method('execute')
+            ->with('crontab -l', [])
+            ->willReturn('');
+
+        $this->shellMock->expects($this->at(1))
+            ->method('execute')
+            ->with('echo "" | crontab -', [])
+            ->willThrowException($localizedException);
+
+        $this->crontabManager->removeTasks();
+    }
+
+    /**
+     * @param string $contentBefore
+     * @param string $contentAfter
+     * @return void
+     * @dataProvider removeTasksDataProvider
+     */
+    public function testRemoveTasks($contentBefore, $contentAfter)
+    {
+        $this->shellMock->expects($this->at(0))
+            ->method('execute')
+            ->with('crontab -l', [])
+            ->willReturn($contentBefore);
+
+        $this->shellMock->expects($this->at(1))
+            ->method('execute')
+            ->with('echo "' . $contentAfter . '" | crontab -', []);
+
+        $this->crontabManager->removeTasks();
+    }
+
+    /**
+     * @return array
+     */
+    public function removeTasksDataProvider()
+    {
+        return [
+            [
+                'contentBefore' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+                'contentAfter' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+            ],
+            [
+                'contentBefore' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
+                    . '* * * * * /bin/php /var/www/magento/bin/magento setup:cron:run' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+                'contentAfter' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+            ],
+            [
+                'contentBefore' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL,
+                'contentAfter' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+            ],
+            [
+                'contentBefore' => '',
+                'contentAfter' => ''
+            ],
+        ];
+    }
+
+    /**
+     * @return void
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage List of tasks is empty
+     */
+    public function testSaveTasksWithEmptyTasksList()
+    {
+        $baseDirMock = $this->getMockBuilder(ReadInterface::class)
+            ->getMockForAbstractClass();
+        $baseDirMock->expects($this->never())
+            ->method('getAbsolutePath');
+        $logDirMock = $this->getMockBuilder(ReadInterface::class)
+            ->getMockForAbstractClass();
+        $logDirMock->expects($this->never())
+            ->method('getAbsolutePath');
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getDirectoryRead')
+            ->willReturnMap([
+                [DirectoryList::ROOT, DriverPool::FILE, $baseDirMock],
+                [DirectoryList::LOG, DriverPool::FILE, $logDirMock],
+            ]);
+
+        $this->crontabManager->saveTasks([]);
+    }
+
+    /**
+     * @return void
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage Command should not be empty
+     */
+    public function testSaveTasksWithoutCommand()
+    {
+        $baseDirMock = $this->getMockBuilder(ReadInterface::class)
+            ->getMockForAbstractClass();
+        $baseDirMock->expects($this->once())
+            ->method('getAbsolutePath')
+            ->willReturn('/var/www/magento2/');
+        $logDirMock = $this->getMockBuilder(ReadInterface::class)
+            ->getMockForAbstractClass();
+        $logDirMock->expects($this->once())
+            ->method('getAbsolutePath')
+            ->willReturn('/var/www/magento2/var/log/');
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getDirectoryRead')
+            ->willReturnMap([
+                [DirectoryList::ROOT, DriverPool::FILE, $baseDirMock],
+                [DirectoryList::LOG, DriverPool::FILE, $logDirMock],
+            ]);
+
+        $this->crontabManager->saveTasks([
+            'myCron' => ['expression' => '* * * * *']
+        ]);
+    }
+
+    /**
+     * @param array $tasks
+     * @param string $content
+     * @param string $contentToSave
+     * @return void
+     * @dataProvider saveTasksDataProvider
+     */
+    public function testSaveTasks($tasks, $content, $contentToSave)
+    {
+        $baseDirMock = $this->getMockBuilder(ReadInterface::class)
+            ->getMockForAbstractClass();
+        $baseDirMock->expects($this->once())
+            ->method('getAbsolutePath')
+            ->willReturn('/var/www/magento2/');
+        $logDirMock = $this->getMockBuilder(ReadInterface::class)
+            ->getMockForAbstractClass();
+        $logDirMock->expects($this->once())
+            ->method('getAbsolutePath')
+            ->willReturn('/var/www/magento2/var/log/');
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getDirectoryRead')
+            ->willReturnMap([
+                [DirectoryList::ROOT, DriverPool::FILE, $baseDirMock],
+                [DirectoryList::LOG, DriverPool::FILE, $logDirMock],
+            ]);
+
+        $this->shellMock->expects($this->at(0))
+            ->method('execute')
+            ->with('crontab -l', [])
+            ->willReturn($content);
+
+        $this->shellMock->expects($this->at(1))
+            ->method('execute')
+            ->with('echo "' . $contentToSave . '" | crontab -', []);
+
+        $this->crontabManager->saveTasks($tasks);
+    }
+
+    /**
+     * @return array
+     */
+    public function saveTasksDataProvider()
+    {
+        $content = '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+            . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+            . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
+            . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL;
+
+        return [
+            [
+                'tasks' => [
+                    ['expression' => '* * * * *', 'command' => 'run.php']
+                ],
+                'content' => $content,
+                'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * ' . PHP_BINARY . ' run.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+            ],
+            [
+                'tasks' => [
+                    ['expression' => '1 2 3 4 5', 'command' => 'run.php']
+                ],
+                'content' => $content,
+                'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '1 2 3 4 5 ' . PHP_BINARY . ' run.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+            ],
+            [
+                'tasks' => [
+                    ['command' => '{magentoRoot}run.php >> {magentoLog}cron.log']
+                ],
+                'content' => $content,
+                'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php >>'
+                    . ' /var/www/magento2/var/log/cron.log' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+            ],
+            [
+                'tasks' => [
+                    ['command' => '{magentoRoot}run.php % cron:run | grep -v "Ran \'jobs\' by schedule"']
+                ],
+                'content' => $content,
+                'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
+                    . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+            ],
+        ];
+    }
+}

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/TasksProviderTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/TasksProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Crontab\Test\Unit;
+
+use Magento\Framework\Crontab\TasksProvider;
+
+class TasksProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return void
+     */
+    public function testTasksProviderEmpty()
+    {
+        /** @var $tasksProvider $tasksProvider */
+        $tasksProvider = new TasksProvider();
+        $this->assertSame([], $tasksProvider->getTasks());
+    }
+
+    public function testTasksProvider()
+    {
+        $tasks = [
+            'magentoCron' => ['expressin' => '* * * * *', 'command' => 'bin/magento cron:run'],
+            'magentoSetup' => ['command' => 'bin/magento setup:cron:run'],
+        ];
+
+        /** @var $tasksProvider $tasksProvider */
+        $tasksProvider = new TasksProvider($tasks);
+        $this->assertSame($tasks, $tasksProvider->getTasks());
+    }
+}


### PR DESCRIPTION
### Description
Backport of [PR#11359](https://github.com/magento/magento2/pull/11359)

Backported cron:install and cron:remove commands. 

Unable to manage (install/uninstall) cron via bin/magento cron:install / cron:remove with multiple installations against same crontab. Having two (or more) installations in different folders, it's not possible to create different crontab entries for both of them, because of the same prefix and suffix used for both of them (#~ MAGENTO START and #~ MAGENTO END)

### Fixed Issues (if relevant)
No related issue found

### Manual testing scenarios
1. Install Magento 2 in two different folders.
2. Run bin/magento cron:install on both of them
3. The second one fails because the first one already installed a cron entry

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
