### PR TITLE
Issue #6924: Unmask exception message during product import

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import.php
+++ b/app/code/Magento/ImportExport/Model/Import.php
@@ -567,7 +567,6 @@ class Import extends \Magento\ImportExport\Model\AbstractModel
                 ProcessingError::ERROR_LEVEL_CRITICAL,
                 null,
                 null,
-                null,
                 $e->getMessage()
             );
         }


### PR DESCRIPTION
### Description
Probably a typo. Exception message was passed as a exception description argument instead of exception message. Artefact of optional parameters.

### Fixed Issues (if relevant)
1. magento/magento2#6924: Magento 2.1.0 - "General system exception happened" on Import .csv

### Manual testing scenarios
1. Import product CSV with broken encoding

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)