### PR TITLE
Database backup doesn't include triggers #9036

### DIFF
--- a/app/code/Magento/Backup/Model/Db.php
+++ b/app/code/Magento/Backup/Model/Db.php
@@ -173,6 +173,7 @@ class Db implements \Magento\Framework\Backup\Db\BackupDbInterface
             }
         }
         $backup->write($this->getResource()->getTableForeignKeysSql());
+        $backup->write($this->getResource()->getTableTriggersSql());
         $backup->write($this->getResource()->getFooter());
 
         $this->getResource()->commitTransaction();

--- a/app/code/Magento/Backup/Model/ResourceModel/Db.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Db.php
@@ -136,7 +136,6 @@ class Db
             $triggerScript = $this->getTableTriggersSql($tableName, $addDropIfExists);
         }
         return $triggerScript;
-
     }
 
     /**

--- a/app/code/Magento/Backup/Model/ResourceModel/Db.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Db.php
@@ -115,6 +115,31 @@ class Db
     }
 
     /**
+     * Return triggers fro table(s)
+     *
+     * @param string|null $tableName
+     * @param bool $addDropIfExists
+     * @return string
+     */
+    public function getTableTriggersSql($tableName = null, $addDropIfExists = true)
+    {
+        $triggerScript = '';
+        if (!$tableName) {
+            $tables = $this->getTables();
+            foreach ($tables as $table) {
+                $tableTriggerScript = $this->_resourceHelper->getTableTriggersSql($table, $addDropIfExists);
+                if (!empty($tableTriggerScript)) {
+                    $triggerScript .= "\n" . $tableTriggerScript;
+                }
+            }
+        } else {
+            $triggerScript = $this->getTableTriggersSql($tableName, $addDropIfExists);
+        }
+        return $triggerScript;
+
+    }
+
+    /**
      * Retrieve table status
      *
      * @param string $tableName

--- a/app/code/Magento/Backup/Model/ResourceModel/Helper.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Helper.php
@@ -372,6 +372,5 @@ class Helper extends \Magento\Framework\DB\Helper
         }
 
         return $script;
-
     }
 }

--- a/app/code/Magento/Backup/Model/ResourceModel/Helper.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Helper.php
@@ -337,4 +337,41 @@ class Helper extends \Magento\Framework\DB\Helper
     {
         $this->getConnection()->query('SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ');
     }
+
+    /**
+     * Get create script for triggers
+     *
+     * @param string $tableName
+     * @param boolean $addDropIfExists
+     * @param boolean $stripDefiner
+     * @return string
+     */
+    public function getTableTriggersSql($tableName, $addDropIfExists = false, $stripDefiner = true)
+    {
+        $script = "--\n-- Triggers structure for table `{$tableName}`\n--\n";
+        $triggers = $this->getConnection()->query('SHOW TRIGGERS LIKE \''. $tableName . '\'')->fetchAll();
+
+        if (!$triggers) {
+            return '';
+        }
+        foreach ($triggers as $trigger) {
+            if ($addDropIfExists) {
+                $script .= 'DROP TRIGGER IF EXISTS ' . $trigger['Trigger'] . ";\n";
+            }
+            $script .= "delimiter ;;\n";
+
+            $triggerData = $this->getConnection()->query('SHOW CREATE TRIGGER '. $trigger['Trigger'])->fetch();
+            if ($stripDefiner) {
+                $cleanedScript = preg_replace('/DEFINER=[^\s]*/', '', $triggerData['SQL Original Statement']);
+                $script .= $cleanedScript . "\n";
+            } else {
+                $script .= $triggerData['SQL Original Statement'] . "\n";
+            }
+            $script .= ";;\n";
+            $script .= "delimiter ;\n";
+        }
+
+        return $script;
+
+    }
 }


### PR DESCRIPTION
ADDED getTableTriggersSql() and now it returns valid SQL with drop & create queries for triggers

### Fixed Issues (if relevant)
1. magento/magento2#9036