### PR TITLE
Magento UI - Cleanup of undefined mixins parameters and usage of "leaking" variables scope

### DIFF
--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -285,6 +285,10 @@
     .lib-icon-text-hide();
 }
 
+._lib-icon-image-url(@_path) when not (@_path = false) {
+    .lib-css(background-image, url(@_path));
+}
+
 ._lib-icon-image(
     @_icon-image,
     @_icon-image-width,
@@ -294,9 +298,7 @@
     @_icon-image-position-x,
     @_icon-image-position-y
 ) {
-    .lib-url-check(@_icon-image);
-
-    .lib-css(background-image, @lib-url-check-output); // @lib-url-check-output is a returned variable of .lib-url-check() mixin
+    ._lib-icon-image-url(@_icon-image);
     .lib-css(background-position-x, @_icon-image-position-x);
     .lib-css(background-position-y, @_icon-image-position-y);
     .lib-css(line-height, @_icon-image-height);

--- a/lib/web/css/source/lib/_pages.less
+++ b/lib/web/css/source/lib/_pages.less
@@ -119,11 +119,15 @@
     ._lib-pager-label-display(  // To hide or to display label
         @_pager-label-display: @_pager-label-display,
         @_pager-font-size: @_pager-font-size,
+        @_pager-font-weight: @_pager-font-weight,
         @_pager-line-height: @_pager-line-height
     );
 
     .items {
-        ._lib-pager-inline-block-spaces-container();
+        ._lib-pager-inline-block-spaces-container(
+            @_pager-reset-spaces,
+            @_pager-item-display
+        );
         .lib-list-reset-styles();
         .lib-css(display, @_pager-item-display);
         .lib-css(font-weight, @_pager-font-weight);
@@ -131,8 +135,10 @@
 
     .item {
         ._lib-pager-inline-block-spaces-item(
-            @_pager-font-size: @_pager-font-size,
-            @_pager-line-height: @_pager-line-height
+            @_pager-reset-spaces,
+            @_pager-item-display,
+            @_pager-font-size,
+            @_pager-line-height
         );
         .lib-css(margin, @_pager-item-margin);
         .lib-css(display, @_pager-item-display);
@@ -204,8 +210,10 @@
         );
         .lib-css(border, @_pager-current-border);
         ._lib-pager-inline-block-spaces-item(
-            @_pager-font-size: @_pager-font-size,
-            @_pager-line-height: @_pager-line-height
+            @_pager-reset-spaces,
+            @_pager-item-display,
+            @_pager-font-size,
+            @_pager-line-height
         );
         .lib-css(color, @_pager-current-color);
         .lib-css(display, @_pager-item-display);
@@ -266,12 +274,13 @@
 
         &.next {
             ._lib-pager-icon (
-                @_pager-icon-use: @_pager-icon-use,
                 @_icon-font-content: @_pager-icon-next-content,
+                @_pager-icon-use: @_pager-icon-use,
                 @_icon-font: @_pager-icon-font,
                 @_icon-font-size: @_pager-icon-font-size,
                 @_icon-font-line-height: @_pager-icon-font-line-height,
                 @_icon-font-color: @_pager-action-color,
+                @_icon-font-color-visited: @_pager-action-color-visited,
                 @_icon-font-color-hover: @_pager-action-color-hover,
                 @_icon-font-color-active: @_pager-action-color-active,
                 @_icon-font-margin: @_pager-icon-font-margin,
@@ -283,12 +292,13 @@
 
         &.previous {
             ._lib-pager-icon (
-                @_pager-icon-use: @_pager-icon-use,
                 @_icon-font-content: @_pager-icon-previous-content,
+                @_pager-icon-use: @_pager-icon-use,
                 @_icon-font: @_pager-icon-font,
                 @_icon-font-size: @_pager-icon-font-size,
                 @_icon-font-line-height: @_pager-icon-font-line-height,
                 @_icon-font-color: @_pager-action-color,
+                @_icon-font-color-visited: @_pager-action-color-visited,
                 @_icon-font-color-hover: @_pager-action-color-hover,
                 @_icon-font-color-active: @_pager-action-color-active,
                 @_icon-font-margin: @_pager-icon-font-margin,
@@ -301,14 +311,19 @@
 }
 
 //  Delete spaces between elements when pager items have display: inline-block
-._lib-pager-inline-block-spaces-container() when (@_pager-reset-spaces = true) and (@_pager-item-display = inline-block) {
+._lib-pager-inline-block-spaces-container(
+    @_pager-reset-spaces,
+    @_pager-item-display
+) when (@_pager-reset-spaces = true) and (@_pager-item-display = inline-block) {
     .lib-inline-block-space-container();
     white-space: nowrap;
 }
 
 ._lib-pager-inline-block-spaces-item(
-    @_pager-font-size: @_pager-font-size,
-    @_pager-line-height: @_pager-line-height
+    @_pager-reset-spaces,
+    @_pager-item-display,
+    @_pager-font-size,
+    @_pager-line-height
 ) when (@_pager-reset-spaces = true) and (@_pager-item-display = inline-block) {
     .lib-inline-block-space-item(
         @_font-size: @_pager-font-size,
@@ -318,10 +333,10 @@
 
 // Display or hide "page" label
 ._lib-pager-label-display(
-    @_pager-label-display: @_pager-label-display,
-    @_pager-font-size: @_pager-font-size,
-    @_pager-font-weight: @_pager-font-weight,
-    @_pager-line-height: @_pager-line-height
+    @_pager-label-display,
+    @_pager-font-size,
+    @_pager-font-weight,
+    @_pager-line-height
 ) when not (@_pager-label-display = none){
     > .label {
         .lib-css(display, @_pager-label-display);
@@ -338,10 +353,10 @@
 }
 
 ._lib-pager-label-display(
-    @_pager-label-display: @_pager-label-display,
-    @_pager-font-size: @_pager-font-size,
-    @_pager-font-weight: @_pager-font-weight,
-    @_pager-line-height: @_pager-line-height
+    @_pager-label-display,
+    @_pager-font-size,
+    @_pager-font-weight,
+    @_pager-line-height
 ) when (@_pager-label-display = none) {
     > .label {
         .lib-visually-hidden();
@@ -349,10 +364,10 @@
 }
 
 ._lib-pager-label-display(
-    @_pager-label-display: @_pager-label-display,
-    @_pager-font-size: @_pager-font-size,
-    @_pager-font-weight: @_pager-font-weight,
-    @_pager-line-height: @_pager-line-height
+    @_pager-label-display,
+    @_pager-font-size,
+    @_pager-font-weight,
+    @_pager-line-height
 ) when (@_pager-label-display = false) {
     > .label {
         .lib-visually-hidden();
@@ -360,19 +375,19 @@
 }
 
 ._lib-pager-icon (
-    @_pager-icon-use: @_pager-icon-use,
+    @_pager-icon-use,
     @_icon-font-content,
-    @_icon-font: @_pager-icon-font,
-    @_icon-font-size: @_pager-icon-font-size,
-    @_icon-font-line-height: @_pager-icon-font-line-height,
-    @_icon-font-color: @_pager-action-color,
-    @_icon-font-color-visited: @_pager-action-color-visited,
-    @_icon-font-color-hover: @_pager-action-color-hover,
-    @_icon-font-color-active: @_pager-action-color-active,
-    @_icon-font-margin: @_pager-icon-font-margin,
-    @_icon-font-vertical-align: @_pager-icon-font-vertical-align,
-    @_icon-font-position: @_pager-icon-font-position,
-    @_icon-font-text-hide: @_pager-icon-font-text-hide
+    @_icon-font,
+    @_icon-font-size,
+    @_icon-font-line-height,
+    @_icon-font-color,
+    @_icon-font-color-visited,
+    @_icon-font-color-hover,
+    @_icon-font-color-active,
+    @_icon-font-margin,
+    @_icon-font-vertical-align,
+    @_icon-font-position,
+    @_icon-font-text-hide
 ) when (@_pager-icon-use = true) and (@_icon-font-position = before) {
     &:visited {
         &:before {
@@ -402,19 +417,19 @@
 }
 
 ._lib-pager-icon (
-    @_pager-icon-use: @_pager-icon-use,
     @_icon-font-content,
-    @_icon-font: @_pager-icon-font,
-    @_icon-font-size: @_pager-icon-font-size,
-    @_icon-font-line-height: @_pager-icon-font-line-height,
-    @_icon-font-color: @_pager-action-color,
-    @_icon-font-color-visited: @_pager-action-color-visited,
-    @_icon-font-color-hover: @_pager-action-color-hover,
-    @_icon-font-color-active: @_pager-action-color-active,
-    @_icon-font-margin: @_pager-icon-font-margin,
-    @_icon-font-vertical-align: @_pager-icon-font-vertical-align,
-    @_icon-font-position: @_pager-icon-font-position,
-    @_icon-font-text-hide: @_pager-icon-font-text-hide
+    @_pager-icon-use,
+    @_icon-font,
+    @_icon-font-size,
+    @_icon-font-line-height,
+    @_icon-font-color,
+    @_icon-font-color-visited,
+    @_icon-font-color-hover,
+    @_icon-font-color-active,
+    @_icon-font-margin,
+    @_icon-font-vertical-align,
+    @_icon-font-position,
+    @_icon-font-text-hide
 ) when (@_pager-icon-use = true) and (@_icon-font-position = after) {
     .lib-icon-font(
         @_icon-font-content: @_icon-font-content,

--- a/lib/web/css/source/lib/_utilities.less
+++ b/lib/web/css/source/lib/_utilities.less
@@ -335,18 +335,6 @@
 }
 
 //
-//  Url existing check
-//  ---------------------------------------------
-
-.lib-url-check(@_path) {
-    @lib-url-check-output: @_path;
-}
-
-.lib-url-check(@_path) when not (@_path = false) {
-    @lib-url-check-output: url(@_path);
-}
-
-//
 //  Arrow
 //  ---------------------------------------------
 


### PR DESCRIPTION
# Backstory
It's not a secret that I don't like LESS, but because of SASS Blank project, I often have to deep dive into Magento UI LESS library code.
Unfortunately, 9 of 10 times I got a punch of weirdness of language "features" mixed with the inconsistency of the implementation right in the face. 
That's why I decided to do something with it and clean up most annoying places.

It may be considered as heavily opinionated changes, but all of this code is 100% safe and didn't change the output CSS, the goal is to make working on this code less painful, especially for porting into languages that care more about scope and execution order, but it also should help people working directly on LESS, because all of the changes can be considered as a good practice in any programing language.

# Technical reason of changes
In LESS variables have kinda weird scope rules, which I'm considering as a leaking scope and the source of confusion i.e. functions (mixins) invoked inside function declaration inherits all variables of the parent function.

An example in a JS-like code to show weirdness of the LESS scoping:
```js
function parent (param) {
  child();
}

function child() {
  return param;
}

parent('red'); // it will return 'red', but should throw an error of undefined variable
```
It's not a common practice in other languages used in FE development and it not clear for developers, so will be nice to avoid it.

The goal is to pass all necessary values to mixin only through parameters or using global variables as default values of parameters.

Same example, but with this new rules applied:

```js
const sample = 'red';

function parent (param = sample) {
  child(param);
}

function child(param) {
  return param;
}

parent(); // it will return 'red'
parent('blue'); // it will return 'blue'
```

# Description of changes
I removed all fallbacks to variables not existing in the global scope, defined all variables used inside mixins as parameters and added all missing parameters to the places where mixins are invoked.
Also mixin that was used just once, was moved and simplified, to reduce usage of weird LESS scoping, where variables defined in mixin are accessible in the place where mixin is invoked.