### PR TITLE
[Backport 2.2-develop] PHP Livecodetest testCodeStyle() method does not use whitelist files

### DIFF
--- a/dev/tests/static/phpunit-all.xml.dist
+++ b/dev/tests/static/phpunit-all.xml.dist
@@ -19,5 +19,7 @@
     </testsuites>
     <php>
         <ini name="date.timezone" value="America/Los_Angeles"/>
+        <!-- TESTCODESTYLE_IS_FULL_SCAN - specify if full scan should be performed for test code style test -->
+        <const name="TESTCODESTYLE_IS_FULL_SCAN" value="1"/>
     </php>
 </phpunit>

--- a/dev/tests/static/phpunit.xml.dist
+++ b/dev/tests/static/phpunit.xml.dist
@@ -29,6 +29,8 @@
     </testsuites>
     <php>
         <ini name="date.timezone" value="America/Los_Angeles"/>
+        <!-- TESTCODESTYLE_IS_FULL_SCAN - specify if full scan should be performed for test code style test -->
+        <const name="TESTCODESTYLE_IS_FULL_SCAN" value="1"/>
         <!-- TESTS_COMPOSER_PATH - specify the path to composer binary, if a relative reference cannot be resolved -->
         <!--<const name="TESTS_COMPOSER_PATH" value="/usr/local/bin/composer"/>-->
     </php>

--- a/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
@@ -201,11 +201,14 @@ class LiveCodeTest extends \PHPUnit\Framework\TestCase
 
     public function testCodeStyle()
     {
+        $whiteList = defined('TESTCODESTYLE_IS_FULL_SCAN') && TESTCODESTYLE_IS_FULL_SCAN === '1'
+            ? $this->getFullWhitelist() : self::getWhitelist(['php', 'phtml']);
+
         $reportFile = self::$reportDir . '/phpcs_report.txt';
         $codeSniffer = new CodeSniffer('Magento', $reportFile, new Wrapper());
         $this->assertEquals(
             0,
-            $result = $codeSniffer->run($this->getFullWhitelist()),
+            $result = $codeSniffer->run($whiteList),
             "PHP Code Sniffer detected {$result} violation(s): " . PHP_EOL . file_get_contents($reportFile)
         );
     }


### PR DESCRIPTION
### Description
Backport of [PR#11362](https://github.com/magento/magento2/pull/11362)

\Magento\Test\Php\LiveCodeTest::testCodeStyle method does not use whitelist files, as it does \Magento\Test\Php\LiveCodeTest::testCodeMess. Because of that, it takes ages to complete when you only want to test code style for a few modified files.

With proposed changes, it will try to find whitelisted files, and if it does not find any, then full whitelist will be checked. By default the behaviour is the same, as long as you have the ability to limit processed files if you create whitelist files from outside.

### Fixed Issues (if relevant)
Improvement

### Manual testing scenarios
1. Create (manually, via git diff, via get_github_changes.php script) Magento/Test/_files/changed_files_local.txt, with references to real modified files to be tested.
2. Run vendor/bin/phpunit --verbose -c dev/tests/static/phpunit-all.xml.dist.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
