### PR TITLE
Save region correctly to save sales address from admin [backport]

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -6,7 +6,29 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\Redirect;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Sales\Controller\Adminhtml\Order;
+use Magento\Sales\Model\Order\Address;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Registry;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\Translate\InlineInterface;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\View\Result\LayoutFactory;
+use Magento\Framework\Controller\Result\RawFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\App\ObjectManager;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class AddressSave extends Order
 {
     /**
      * Authorization level of a basic admin session
@@ -16,16 +38,69 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 
     /**
+     * @var RegionFactory
+     */
+    private $regionFactory;
+    /**
+     * @param Context $context
+     * @param Registry $coreRegistry
+     * @param FileFactory $fileFactory
+     * @param InlineInterface $translateInline
+     * @param PageFactory $resultPageFactory
+     * @param JsonFactory $resultJsonFactory
+     * @param LayoutFactory $resultLayoutFactory
+     * @param RawFactory $resultRawFactory
+     * @param OrderManagementInterface $orderManagement
+     * @param OrderRepositoryInterface $orderRepository
+     * @param LoggerInterface $logger
+     * @param RegionFactory|null $regionFactory
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        Context $context,
+        Registry $coreRegistry,
+        FileFactory $fileFactory,
+        InlineInterface $translateInline,
+        PageFactory $resultPageFactory,
+        JsonFactory $resultJsonFactory,
+        LayoutFactory $resultLayoutFactory,
+        RawFactory $resultRawFactory,
+        OrderManagementInterface $orderManagement,
+        OrderRepositoryInterface $orderRepository,
+        LoggerInterface $logger,
+        RegionFactory $regionFactory = null
+    ) {
+        $this->regionFactory = $regionFactory ?: ObjectManager::getInstance()->get(RegionFactory::class);
+        parent::__construct(
+            $context,
+            $coreRegistry,
+            $fileFactory,
+            $translateInline,
+            $resultPageFactory,
+            $resultJsonFactory,
+            $resultLayoutFactory,
+            $resultRawFactory,
+            $orderManagement,
+            $orderRepository,
+            $logger
+        );
+    }
+
+    /**
      * Save order address
      *
-     * @return \Magento\Backend\Model\View\Result\Redirect
+     * @return Redirect
      */
     public function execute()
     {
         $addressId = $this->getRequest()->getParam('address_id');
-        /** @var $address \Magento\Sales\Api\Data\OrderAddressInterface|\Magento\Sales\Model\Order\Address */
-        $address = $this->_objectManager->create('Magento\Sales\Api\Data\OrderAddressInterface')->load($addressId);
+        /** @var $address OrderAddressInterface|Address */
+        $address = $this->_objectManager->create(
+            OrderAddressInterface::class
+        )->load($addressId);
         $data = $this->getRequest()->getPostValue();
+        $data = $this->updateRegionData($data);
         $resultRedirect = $this->resultRedirectFactory->create();
         if ($data && $address->getId()) {
             $address->addData($data);
@@ -39,7 +114,7 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
                 );
                 $this->messageManager->addSuccess(__('You updated the order address.'));
                 return $resultRedirect->setPath('sales/*/view', ['order_id' => $address->getParentId()]);
-            } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            } catch (LocalizedException $e) {
                 $this->messageManager->addError($e->getMessage());
             } catch (\Exception $e) {
                 $this->messageManager->addException($e, __('We can\'t update the order address right now.'));
@@ -48,5 +123,21 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
         } else {
             return $resultRedirect->setPath('sales/*/');
         }
+    }
+
+    /**
+     * Update region data
+     *
+     * @param array $attributeValues
+     * @return array
+     */
+    private function updateRegionData($attributeValues)
+    {
+        if (!empty($attributeValues['region_id'])) {
+            $newRegion = $this->regionFactory->create()->load($attributeValues['region_id']);
+            $attributeValues['region_code'] = $newRegion->getCode();
+            $attributeValues['region'] = $newRegion->getDefaultName();
+        }
+        return $attributeValues;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Save region correctly to save sales address from admin
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10441: State/Province Not displayed after edit Billing Address on Sales Orders - Backend Admin.

### Steps to reproduce
1. Go to the backend -> Sales -> Orders -> View any order.
2. Select the section -> Information -> Address Information
3. Edit Billing Address, for example the street address.
4. Save Order Address.

**Note:** The same issue happen with the Shipping Address.
### Manual testing scenarios

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
