### PR TITLE
Save region correctly to save sales address from admin [backport]

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -4,9 +4,32 @@
  * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\Redirect;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Sales\Controller\Adminhtml\Order;
+use Magento\Sales\Model\Order\Address;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Registry;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\Translate\InlineInterface;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\View\Result\LayoutFactory;
+use Magento\Framework\Controller\Result\RawFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\App\ObjectManager;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class AddressSave extends Order
 {
     /**
      * Authorization level of a basic admin session
@@ -14,18 +37,71 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
      * @see _isAllowed()
      */
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
+    /**
+     * @var RegionFactory
+     */
+    private $regionFactory;
+
+    /**
+     * @param Context $context
+     * @param Registry $coreRegistry
+     * @param FileFactory $fileFactory
+     * @param InlineInterface $translateInline
+     * @param PageFactory $resultPageFactory
+     * @param JsonFactory $resultJsonFactory
+     * @param LayoutFactory $resultLayoutFactory
+     * @param RawFactory $resultRawFactory
+     * @param OrderManagementInterface $orderManagement
+     * @param OrderRepositoryInterface $orderRepository
+     * @param LoggerInterface $logger
+     * @param RegionFactory|null $regionFactory
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        Context $context,
+        Registry $coreRegistry,
+        FileFactory $fileFactory,
+        InlineInterface $translateInline,
+        PageFactory $resultPageFactory,
+        JsonFactory $resultJsonFactory,
+        LayoutFactory $resultLayoutFactory,
+        RawFactory $resultRawFactory,
+        OrderManagementInterface $orderManagement,
+        OrderRepositoryInterface $orderRepository,
+        LoggerInterface $logger,
+        RegionFactory $regionFactory = null
+    ) {
+        $this->regionFactory = $regionFactory ?: ObjectManager::getInstance()->get(RegionFactory::class);
+        parent::__construct(
+            $context,
+            $coreRegistry,
+            $fileFactory,
+            $translateInline,
+            $resultPageFactory,
+            $resultJsonFactory,
+            $resultLayoutFactory,
+            $resultRawFactory,
+            $orderManagement,
+            $orderRepository,
+            $logger
+        );
+    }
 
     /**
      * Save order address
      *
-     * @return \Magento\Backend\Model\View\Result\Redirect
+     * @return Redirect
      */
     public function execute()
     {
         $addressId = $this->getRequest()->getParam('address_id');
-        /** @var $address \Magento\Sales\Api\Data\OrderAddressInterface|\Magento\Sales\Model\Order\Address */
-        $address = $this->_objectManager->create('Magento\Sales\Api\Data\OrderAddressInterface')->load($addressId);
+        /** @var $address OrderAddressInterface|Address */
+        $address = $this->_objectManager->create(
+            OrderAddressInterface::class
+        )->load($addressId);
         $data = $this->getRequest()->getPostValue();
+        $data = $this->updateRegionData($data);
         $resultRedirect = $this->resultRedirectFactory->create();
         if ($data && $address->getId()) {
             $address->addData($data);
@@ -38,15 +114,34 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
                     ]
                 );
                 $this->messageManager->addSuccess(__('You updated the order address.'));
+
                 return $resultRedirect->setPath('sales/*/view', ['order_id' => $address->getParentId()]);
-            } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            } catch (LocalizedException $e) {
                 $this->messageManager->addError($e->getMessage());
             } catch (\Exception $e) {
                 $this->messageManager->addException($e, __('We can\'t update the order address right now.'));
             }
+
             return $resultRedirect->setPath('sales/*/address', ['address_id' => $address->getId()]);
         } else {
             return $resultRedirect->setPath('sales/*/');
         }
+    }
+
+    /**
+     * Update region data
+     *
+     * @param array $attributeValues
+     * @return array
+     */
+    private function updateRegionData($attributeValues)
+    {
+        if (!empty($attributeValues['region_id'])) {
+            $newRegion = $this->regionFactory->create()->load($attributeValues['region_id']);
+            $attributeValues['region_code'] = $newRegion->getCode();
+            $attributeValues['region'] = $newRegion->getDefaultName();
+        }
+
+        return $attributeValues;
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -14,7 +14,7 @@ use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Api\Data\OrderAddressInterface;
 use Magento\Sales\Controller\Adminhtml\Order;
-use Magento\Sales\Model\Order\Address;
+use Magento\Sales\Model\Order\Address as ModelOrderAddress;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\App\Response\Http\FileFactory;
@@ -96,7 +96,7 @@ class AddressSave extends Order
     public function execute()
     {
         $addressId = $this->getRequest()->getParam('address_id');
-        /** @var $address OrderAddressInterface|Address */
+        /** @var $address OrderAddressInterface|ModelOrderAddress */
         $address = $this->_objectManager->create(
             OrderAddressInterface::class
         )->load($addressId);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -37,6 +37,7 @@ class AddressSave extends Order
      * @see _isAllowed()
      */
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
+    
     /**
      * @var RegionFactory
      */


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Related with [PR#11381](https://github.com/magento/magento2/pull/11381)
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Save region correctly to save sales address from admin
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10441: State/Province Not displayed after edit Billing Address on Sales Orders - Backend Admin.

### Steps to reproduce
1. Go to the backend -> Sales -> Orders -> View any order.
2. Select the section -> Information -> Address Information
3. Edit Billing Address, for example the street address.
4. Save Order Address.

**Note:** The same issue happen with the Shipping Address.
### Manual testing scenarios

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
