### PR TITLE
Fix #10856: Sync billing with shipping address on Admin Order Page

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1170,7 +1170,8 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
      */
     public function getAppliedTaxes()
     {
-        return $this->serializer->unserialize($this->getData('applied_taxes'));
+        $taxes = $this->getData('applied_taxes');
+        return $taxes ? $this->serializer->unserialize($taxes) : [];
     }
 
     /**

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
@@ -9,7 +9,7 @@
 namespace Magento\Quote\Test\Unit\Model\Quote;
 
 use Magento\Directory\Model\Currency;
-use \Magento\Quote\Model\Quote\Address;
+use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\Rate;
 use Magento\Quote\Model\ResourceModel\Quote\Address\Rate\CollectionFactory as RateCollectionFactory;
 use Magento\Quote\Model\ResourceModel\Quote\Address\Rate\Collection as RatesCollection;
@@ -28,6 +28,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\Quote\Model\Quote\Address\RateResult\AbstractResult;
+use Magento\Framework\Serialize\Serializer\Json;
 
 /**
  * Test class for sales quote address model
@@ -117,7 +118,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $this->scopeConfig = $this->createMock(\Magento\Framework\App\Config::class);
-        $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->serializer = new Json();
 
         $this->requestFactory = $this->getMockBuilder(RateRequestFactory::class)
             ->disableOriginalConstructor()
@@ -273,20 +274,17 @@ class AddressTest extends \PHPUnit\Framework\TestCase
     public function testSetAndGetAppliedTaxes()
     {
         $data = ['data'];
-        $result = json_encode($data);
+        self::assertInstanceOf(Address::class, $this->address->setAppliedTaxes($data));
+        self::assertEquals($data, $this->address->getAppliedTaxes());
+    }
 
-        $this->serializer->expects($this->once())
-            ->method('serialize')
-            ->with($data)
-            ->willReturn($result);
-
-        $this->serializer->expects($this->once())
-            ->method('unserialize')
-            ->with($result)
-            ->willReturn($data);
-
-        $this->assertInstanceOf(\Magento\Quote\Model\Quote\Address::class, $this->address->setAppliedTaxes($data));
-        $this->assertEquals($data, $this->address->getAppliedTaxes());
+    /**
+     * Checks a case, when applied taxes are not provided.
+     */
+    public function testGetAppliedTaxesWithEmptyValue()
+    {
+        $this->address->setData('applied_taxes', null);
+        self::assertEquals([], $this->address->getAppliedTaxes());
     }
 
     /**

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1477,6 +1477,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         // but if quote already has the billing address it won't be overridden
         if (empty($billingAddress->getCustomerAddressId())) {
             $quote->removeAddress($quote->getBillingAddress()->getId());
+            $billingAddress->setCustomerAddressId(null);
         }
         $quote->setBillingAddress($billingAddress);
 
@@ -1779,6 +1780,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             $address = $this->getShippingAddress()->setCustomerId($this->getQuote()->getCustomer()->getId());
             $this->setShippingAddress($address);
         }
+        $this->getBillingAddress()->setCustomerId($customer->getId());
         $this->getQuote()->updateCustomerData($this->getQuote()->getCustomer());
 
         $customer = $this->getQuote()->getCustomer();

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -10,6 +10,7 @@ namespace Magento\Sales\Model\AdminOrder;
 
 use Magento\Customer\Api\AddressMetadataInterface;
 use Magento\Customer\Model\Metadata\Form as CustomerForm;
+use Magento\Framework\App\ObjectManager;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Item;
 
@@ -324,7 +325,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         $this->dataObjectHelper = $dataObjectHelper;
         $this->orderManagement = $orderManagement;
         $this->quoteFactory = $quoteFactory;
-        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->serializer = $serializer ?: ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($data);
     }
@@ -1476,8 +1477,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         // not assigned billing address should be saved as new
         // but if quote already has the billing address it won't be overridden
         if (empty($billingAddress->getCustomerAddressId())) {
-            $quote->removeAddress($quote->getBillingAddress()->getId());
             $billingAddress->setCustomerAddressId(null);
+            $quote->getBillingAddress()->setCustomerAddressId(null);
         }
         $quote->setBillingAddress($billingAddress);
 

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -157,6 +157,7 @@ define([
             }
             if(this.addresses[id]){
                 this.fillAddressFields(container, this.addresses[id]);
+
             }
             else{
                 this.fillAddressFields(container, {});
@@ -190,43 +191,52 @@ define([
             }
         },
 
-        changeAddressField : function(event){
-            var field = Event.element(event);
-            var re = /[^\[]*\[([^\]]*)_address\]\[([^\]]*)\](\[(\d)\])?/;
-            var matchRes = field.name.match(re);
+        /**
+         * Triggers on each form's element changes.
+         *
+         * @param {Object} event
+         */
+        changeAddressField: function (event) {
+            var field = Event.element(event),
+                re = /[^\[]*\[([^\]]*)_address\]\[([^\]]*)\](\[(\d)\])?/,
+                matchRes = field.name.match(re),
+                type,
+                name,
+                data;
 
             if (!matchRes) {
                 return;
             }
 
-            var type = matchRes[1];
-            var name = matchRes[2];
-            var data;
+            type = matchRes[1];
+            name = matchRes[2];
 
-            if(this.isBillingField(field.id)){
-                data = this.serializeData(this.billingAddressContainer)
-            }
-            else{
-                data = this.serializeData(this.shippingAddressContainer)
+            if (this.isBillingField(field.id)) {
+                data = this.serializeData(this.billingAddressContainer);
+            } else {
+                data = this.serializeData(this.shippingAddressContainer);
             }
             data = data.toObject();
 
-            if( (type == 'billing' && this.shippingAsBilling)
-                || (type == 'shipping' && !this.shippingAsBilling) ) {
+            if (type === 'billing' && this.shippingAsBilling || type === 'shipping' && !this.shippingAsBilling) {
                 data['reset_shipping'] = true;
             }
 
-            data['order['+type+'_address][customer_address_id]'] = $('order-'+type+'_address_customer_address_id').value;
+            data['order[' + type + '_address][customer_address_id]'] = null;
+
+            if (name === 'customer_address_id') {
+                data['order[' + type + '_address][customer_address_id]'] =
+                    $('order-' + type + '_address_customer_address_id').value;
+            }
 
             if (data['reset_shipping']) {
                 this.resetShippingMethod(data);
             } else {
                 this.saveData(data);
-                if (name == 'country_id' || name == 'customer_address_id') {
+
+                if (name === 'country_id' || name === 'customer_address_id') {
                     this.loadArea(['shipping_method', 'billing_method', 'totals', 'items'], true, data);
                 }
-                // added for reloading of default sender and default recipient for giftmessages
-                //this.loadArea(['giftmessage'], true, data);
             }
         },
 

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -223,6 +223,7 @@ define([
             }
 
             data['order[' + type + '_address][customer_address_id]'] = null;
+            data['shipping_as_billing'] = jQuery('[name="shipping_same_as_billing"]').is(':checked') ? 1 : 0;
 
             if (name === 'customer_address_id') {
                 data['order[' + type + '_address][customer_address_id]'] =

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreateTest.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Backend\Model\Session\Quote;
+use Magento\Quote\Api\CartRepositoryInterface;
+
 /**
  * @magentoAppArea adminhtml
  * @magentoDbIsolation enabled
@@ -158,7 +162,7 @@ class CreateTest extends \Magento\TestFramework\TestCase\AbstractBackendControll
      */
     public function testGetAclResource($actionName, $reordered, $expectedResult)
     {
-        $this->_objectManager->get(\Magento\Backend\Model\Session\Quote::class)->setReordered($reordered);
+        $this->_objectManager->get(Quote::class)->setReordered($reordered);
         $orderController = $this->_objectManager->get(
             \Magento\Sales\Controller\Adminhtml\Order\Stub\OrderCreateStub::class
         );
@@ -228,5 +232,58 @@ class CreateTest extends \Magento\TestFramework\TestCase\AbstractBackendControll
 
         $this->dispatch('backend/sales/order_create/save');
         $this->assertEquals('403', $this->getResponse()->getHttpResponseCode());
+    }
+
+    /**
+     * Checks a case when shipping is the same as billing and billing address details was changed by request.
+     * Both billing and shipping addresses should be updated.
+     *
+     * @magentoAppArea adminhtml
+     * @magentoDataFixture Magento/Sales/_files/quote_with_customer.php
+     */
+    public function testSyncBetweenQuoteAddresses()
+    {
+        /** @var CustomerRepositoryInterface $customerRepository */
+        $customerRepository = $this->_objectManager->get(CustomerRepositoryInterface::class);
+        $customer = $customerRepository->get('customer@example.com');
+
+        /** @var CartRepositoryInterface $quoteRepository */
+        $quoteRepository = $this->_objectManager->get(CartRepositoryInterface::class);
+        $quote = $quoteRepository->getActiveForCustomer($customer->getId());
+
+        $session = $this->_objectManager->get(Quote::class);
+        $session->setQuoteId($quote->getId());
+
+        $data = [
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'street' => ['Soborna 23'],
+            'city' => 'Kyiv',
+            'country_id' => 'UA',
+            'region' => 'Kyivska',
+            'region_id' => 1
+        ];
+        $this->getRequest()->setPostValue(
+            [
+                'order' => ['billing_address' => $data],
+                'reset_shipping' => 1,
+                'customer_id' => $customer->getId(),
+                'store_id' => 1,
+                'json' => true
+            ]
+        );
+
+        $this->dispatch('backend/sales/order_create/loadBlock/block/shipping_address');
+        self::assertEquals(200, $this->getResponse()->getHttpResponseCode());
+
+        $updatedQuote = $quoteRepository->get($quote->getId());
+
+        $billingAddress = $updatedQuote->getBillingAddress();
+        self::assertEquals($data['region_id'], $billingAddress->getRegionId());
+        self::assertEquals($data['country_id'], $billingAddress->getCountryId());
+
+        $shippingAddress = $updatedQuote->getShippingAddress();
+        self::assertEquals($data['city'], $shippingAddress->getCity());
+        self::assertEquals($data['street'], $shippingAddress->getStreet());
     }
 }


### PR DESCRIPTION
### Fixed Issues
1. magento/magento2#10856: Sync billing with shipping address on Admin Reorder and Admin Customer Create Order page does not work for Existing address selected

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
