### PR TITLE
Fix typo in design rule hint message

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/web/template/dynamic-rows/grid.html
+++ b/app/code/Magento/Backend/view/adminhtml/web/template/dynamic-rows/grid.html
@@ -85,7 +85,7 @@
 <div class="messages">
     <div class="message message-notice notice">
         <span
-            translate="'Search strings are either normal strings or regular exceptions (PCRE). They are matched in the same order as entered.'"></span>
+            translate="'Search strings are either normal strings or regular expressions (PCRE). They are matched in the same order as entered.'"></span>
         <br>
         <span
             translate="'Examples'"></span>:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Change text in design rule hint message from "Search strings are either normal strings or regular **exceptions** (PCRE)" to "Search strings are either normal strings or regular **expressions** (PCRE)".

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8958: Hint mistake in english language

### Manual testing scenarios
1. Login to backend
2. Navigate to Content > Configuration
3. Click "Edit" in Global scope.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
