### PR TITLE
Fix for #9566: Show the correct label in the admin

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -206,7 +206,6 @@ class Config
             return $this->stateStatuses[$key];
         }
         $statuses = [];
-        $area = $this->state->getAreaCode();
 
         if (!is_array($state)) {
             $state = [$state];
@@ -218,7 +217,7 @@ class Config
                 foreach ($collection as $item) {
                     $status = $item->getData('status');
                     if ($addLabels) {
-                        $statuses[$status] = $area == 'adminhtml' ? $item->getLabel() : $item->getStoreLabel();
+                        $statuses[$status] = $this->getStatusLabel($status);
                     } else {
                         $statuses[] = $status;
                     }

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -122,8 +122,14 @@ class Config
      */
     public function getStatusLabel($code)
     {
-        $code = $this->maskStatusForArea($this->state->getAreaCode(), $code);
+        $area = $this->state->getAreaCode();
+        $code = $this->maskStatusForArea($area, $code);
         $status = $this->orderStatusFactory->create()->load($code);
+
+        if ($area == 'adminhtml') {
+            return $status->getLabel();
+        }
+
         return $status->getStoreLabel();
     }
 

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -206,6 +206,7 @@ class Config
             return $this->stateStatuses[$key];
         }
         $statuses = [];
+        $area = $this->state->getAreaCode();
 
         if (!is_array($state)) {
             $state = [$state];
@@ -217,7 +218,7 @@ class Config
                 foreach ($collection as $item) {
                     $status = $item->getData('status');
                     if ($addLabels) {
-                        $statuses[$status] = $item->getStoreLabel();
+                        $statuses[$status] = $area == 'adminhtml' ? $item->getLabel() : $item->getStoreLabel();
                     } else {
                         $statuses[] = $status;
                     }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ConfigTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ConfigTest.php
@@ -24,9 +24,9 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     protected $orderStatusCollectionFactoryMock;
 
     /**
-     * @var \Magento\Sales\Model\Order\Config|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Sales\Model\Order\StatusFactory|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $orderStatusFactoryMock;
+    protected $statusFactoryMock;
 
     /**
      * @var \Magento\Sales\Model\Order\Status
@@ -46,7 +46,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->orderStatusModel = $objectManager->getObject(\Magento\Sales\Model\Order\Status::class, [
             'storeManager' => $this->storeManagerMock,
         ]);
-        $this->orderStatusFactoryMock = $this->getMockBuilder(\Magento\Sales\Model\Order\StatusFactory::class)
+        $this->statusFactoryMock = $this->getMockBuilder(\Magento\Sales\Model\Order\StatusFactory::class)
             ->setMethods(['load', 'create'])
             ->getMock();
         $this->orderStatusCollectionFactoryMock = $this->createPartialMock(
@@ -57,7 +57,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->getObject(
                 \Magento\Sales\Model\Order\Config::class,
                 [
-                    'orderStatusFactory' => $this->orderStatusFactoryMock,
+                    'orderStatusFactory' => $this->statusFactoryMock,
                     'orderStatusCollectionFactory' => $this->orderStatusCollectionFactoryMock
                 ]
             );
@@ -170,10 +170,10 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->method('joinStates')
             ->will($this->returnValue($collectionData));
 
-        $this->orderStatusFactoryMock->method('create')
+        $this->statusFactoryMock->method('create')
             ->willReturnSelf();
 
-        $this->orderStatusFactoryMock->method('load')
+        $this->statusFactoryMock->method('load')
             ->willReturn($this->orderStatusModel);
 
         $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ConfigTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ConfigTest.php
@@ -23,18 +23,41 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
      */
     protected $orderStatusCollectionFactoryMock;
 
+    /**
+     * @var \Magento\Sales\Model\Order\Config|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $orderStatusFactoryMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order\Status
+     */
+    protected $orderStatusModel;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $storeManagerMock;
+
     protected function setUp()
     {
-        $orderStatusFactory = $this->createMock(\Magento\Sales\Model\Order\StatusFactory::class);
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
+        $this->orderStatusModel = $objectManager->getObject(\Magento\Sales\Model\Order\Status::class, [
+            'storeManager' => $this->storeManagerMock,
+        ]);
+        $this->orderStatusFactoryMock = $this->getMockBuilder(\Magento\Sales\Model\Order\StatusFactory::class)
+            ->setMethods(['load', 'create'])
+            ->getMock();
         $this->orderStatusCollectionFactoryMock = $this->createPartialMock(
             \Magento\Sales\Model\ResourceModel\Order\Status\CollectionFactory::class,
             ['create']
         );
-        $this->salesConfig = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))
+        $this->salesConfig = $objectManager
             ->getObject(
                 \Magento\Sales\Model\Order\Config::class,
                 [
-                    'orderStatusFactory' => $orderStatusFactory,
+                    'orderStatusFactory' => $this->orderStatusFactoryMock,
                     'orderStatusCollectionFactory' => $this->orderStatusCollectionFactoryMock
                 ]
             );
@@ -146,6 +169,22 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $collectionMock->expects($this->once())
             ->method('joinStates')
             ->will($this->returnValue($collectionData));
+
+        $this->orderStatusFactoryMock->method('create')
+            ->willReturnSelf();
+
+        $this->orderStatusFactoryMock->method('load')
+            ->willReturn($this->orderStatusModel);
+
+        $storeMock = $this->createMock(\Magento\Store\Api\Data\StoreInterface::class);
+        $storeMock->method('getId')
+            ->willReturn(1);
+
+        $this->storeManagerMock->method('getStore')
+            ->with($this->anything())
+            ->willReturn($storeMock);
+
+        $this->orderStatusModel->setData('store_labels', [1 => 'Pending label']);
 
         $result = $this->salesConfig->getStateStatuses($state, $joinLabels);
         $this->assertSame($expectedResult, $result);

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
@@ -5,7 +5,7 @@
  */
 
 // @codingStandardsIgnoreFile
-
+/** @var \Magento\Sales\Block\Adminhtml\Order\View\History $block */
 ?>
 <div id="order_history_block" class="edit-order-comments">
     <?php if ($block->canAddComment()):?>

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/StatusTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/StatusTest.php
@@ -12,12 +12,30 @@ namespace Magento\Sales\Model\Order;
  */
 class StatusTest extends \PHPUnit\Framework\TestCase
 {
+    public function theCorrectLabelIsUsedDependingOnTheAreaProvider()
+    {
+        return [
+            'backend label' => [
+                'adminhtml',
+                'Example',
+            ],
+            'store view label' => [
+                'frontend',
+                'Store view example',
+            ],
+        ];
+    }
+
     /**
      * In the backend the regular label must be showed.
      *
+     * @param $area
+     * @param $result
+     *
      * @magentoDataFixture Magento/Sales/_files/order_status.php
+     * @dataProvider theCorrectLabelIsUsedDependingOnTheAreaProvider
      */
-    public function testTheLabelIsUsedInTheBackend()
+    public function testTheCorrectLabelIsUsedDependingOnTheArea($area, $result)
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         $objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('adminhtml');
@@ -27,22 +45,5 @@ class StatusTest extends \PHPUnit\Framework\TestCase
         $order->loadByIncrementId('100000001');
 
         $this->assertEquals('Example', $order->getStatusLabel());
-    }
-
-    /**
-     * In the frontend the store view specific label must be showed.
-     *
-     * @magentoDataFixture Magento/Sales/_files/order_status.php
-     */
-    public function testTheStoreViewLabelIsUsedInTheFrontend()
-    {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('frontend');
-
-        /** @var \Magento\Sales\Model\Order $order */
-        $order = $objectManager->create(\Magento\Sales\Model\Order::class);
-        $order->loadByIncrementId('100000001');
-
-        $this->assertEquals('Store view example', $order->getStatusLabel());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/StatusTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/StatusTest.php
@@ -38,12 +38,12 @@ class StatusTest extends \PHPUnit\Framework\TestCase
     public function testTheCorrectLabelIsUsedDependingOnTheArea($area, $result)
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('adminhtml');
+        $objectManager->get(\Magento\Framework\App\State::class)->setAreaCode($area);
 
         /** @var \Magento\Sales\Model\Order $order */
         $order = $objectManager->create(\Magento\Sales\Model\Order::class);
         $order->loadByIncrementId('100000001');
 
-        $this->assertEquals('Example', $order->getStatusLabel());
+        $this->assertEquals($result, $order->getStatusLabel());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/StatusTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/StatusTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Sales\Model\Order;
+
+/**
+ * Class ShipmentTest
+ * @package Magento\Sales\Model\Order
+ */
+class StatusTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * In the backend the regular label must be showed.
+     *
+     * @magentoDataFixture Magento/Sales/_files/order_status.php
+     */
+    public function testTheLabelIsUsedInTheBackend()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('adminhtml');
+
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $objectManager->create(\Magento\Sales\Model\Order::class);
+        $order->loadByIncrementId('100000001');
+
+        $this->assertEquals('Example', $order->getStatusLabel());
+    }
+
+    /**
+     * In the frontend the store view specific label must be showed.
+     *
+     * @magentoDataFixture Magento/Sales/_files/order_status.php
+     */
+    public function testTheStoreViewLabelIsUsedInTheFrontend()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('frontend');
+
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $objectManager->create(\Magento\Sales\Model\Order::class);
+        $order->loadByIncrementId('100000001');
+
+        $this->assertEquals('Store view example', $order->getStatusLabel());
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_status.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_status.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+require __DIR__ . '/order.php';
+
+$orderStatus = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+    \Magento\Sales\Model\Order\Status::class
+);
+
+$data = [
+    'status' => 'example',
+    'label' => 'Example',
+    'store_labels' => [
+        1 => 'Store view example',
+    ]
+];
+
+$orderStatus->setData($data)->setStatus('example');
+$orderStatus->save();
+
+$order->setStatus('example');
+$order->save();


### PR DESCRIPTION
### Description
When creating an order status it is possible to set different labels for the different store views. This label was used in the backend as well, this fix makes sure the general status label is used in the backend.

### Fixed Issues
1. magento/magento2#9566: Status label is wrong in admin

### Manual testing scenarios
1. Create order
2. Open edit order page in admin and note "Order Status"
3. Go to Admin: Stores>Settings>Order Status and edit row with status that has order
4. Change label for Default Store View = "Processing on store view"
5. Refresh order edit form

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
