### PR TITLE
Fixed incorrect text above billing addresses list

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/list.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/list.html
@@ -5,7 +5,7 @@
  */
 -->
 <div class="field field-select-billing">
-    <label class="label"><span data-bind="i18n: 'My billing and shipping address are the same'"></span></label>
+    <label class="label"><span data-bind="i18n: 'Billing Address'"></span></label>
     <div class="control" data-bind="if: (addressOptions.length > 1)">
         <select class="select" name="billing_address_id" data-bind="
         options: addressOptions,


### PR DESCRIPTION
### Description
This label is not visible at standard checkout, but here are screenshots of how it looks at third-party checkout:

Default Label | Correct Label
-------------------|-----------------
![image](https://user-images.githubusercontent.com/306080/31497294-56515206-af67-11e7-831b-3e10d2b2407b.png) | ![image](https://user-images.githubusercontent.com/306080/31497261-3e875242-af67-11e7-9d65-47b63a58ee1b.png)


### Manual testing scenarios
1. Apply some styles to make label visible at standard checkout:

    ```css
    .checkout-payment-method .field-select-billing > .label {
        clip: auto;
        width: auto;
        height: auto;
    }
    ```

2. Navigate to checkout page as registered customer and proceed to payment method
2. Uncheck "My billing and shipping address are the same" checkbox and you'll see the address list with the incorrect label.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
