### PR TITLE
Allow setting of http response status code in a Redirection

### DIFF
--- a/lib/internal/Magento/Framework/Controller/Result/Redirect.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Redirect.php
@@ -9,6 +9,8 @@ namespace Magento\Framework\Controller\Result;
 use Magento\Framework\App;
 use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
+use Magento\Framework\App\Response\RedirectInterface;
+use Magento\Framework\UrlInterface;
 
 /**
  * In many cases controller actions may result in a redirect
@@ -18,13 +20,14 @@ use Magento\Framework\Controller\AbstractResult;
  */
 class Redirect extends AbstractResult
 {
+
     /**
-     * @var \Magento\Framework\App\Response\RedirectInterface
+     * @var RedirectInterface
      */
     protected $redirect;
 
     /**
-     * @var \Magento\Framework\UrlInterface
+     * @var UrlInterface
      */
     protected $urlBuilder;
 
@@ -37,11 +40,11 @@ class Redirect extends AbstractResult
      * Constructor
      *
      * @param App\Response\RedirectInterface $redirect
-     * @param \Magento\Framework\UrlInterface $urlBuilder
+     * @param UrlInterface $urlBuilder
      */
     public function __construct(
         App\Response\RedirectInterface $redirect,
-        \Magento\Framework\UrlInterface $urlBuilder
+        UrlInterface $urlBuilder
     ) {
         $this->redirect = $redirect;
         $this->urlBuilder = $urlBuilder;
@@ -70,6 +73,7 @@ class Redirect extends AbstractResult
     }
 
     /**
+     * URL Setter
      * @param string $url
      * @return $this
      */
@@ -97,7 +101,11 @@ class Redirect extends AbstractResult
      */
     protected function render(HttpResponseInterface $response)
     {
-        $response->setRedirect($this->url);
+        if (empty($this->httpResponseCode)) {
+            $response->setRedirect($this->url);
+        } else {
+            $response->setRedirect($this->url, $this->httpResponseCode);
+        }
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectTest.php
@@ -6,10 +6,13 @@
 
 namespace Magento\Framework\Controller\Test\Unit\Result;
 
-use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
+use \PHPUnit\Framework\TestCase;
+use \Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
+use \Magento\Framework\App\Response\RedirectInterface;
 use \Magento\Framework\Controller\Result\Redirect;
+use \Magento\Framework\UrlInterface;
 
-class RedirectTest extends \PHPUnit\Framework\TestCase
+class RedirectTest extends TestCase
 {
     /** @var \Magento\Framework\Controller\Result\Redirect */
     protected $redirect;
@@ -28,9 +31,9 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->redirectInterface = $this->createMock(\Magento\Framework\App\Response\RedirectInterface::class);
-        $this->urlBuilder = $this->createMock(\Magento\Framework\UrlInterface::class);
-        $this->urlInterface = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->redirectInterface = $this->createMock(RedirectInterface::class);
+        $this->urlBuilder = $this->createMock(UrlInterface::class);
+        $this->urlInterface = $this->createMock(UrlInterface::class);
         $this->response = $this->createMock(HttpResponseInterface::class);
         $this->redirect = new Redirect($this->redirectInterface, $this->urlInterface);
     }
@@ -39,7 +42,7 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
     {
         $this->redirectInterface->expects($this->once())->method('getRefererUrl');
         $this->assertInstanceOf(
-            \Magento\Framework\Controller\Result\Redirect::class,
+            Redirect::class,
             $this->redirect->setRefererUrl()
         );
     }
@@ -48,7 +51,7 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
     {
         $this->redirectInterface->expects($this->once())->method('getRedirectUrl');
         $this->assertInstanceOf(
-            \Magento\Framework\Controller\Result\Redirect::class,
+            Redirect::class,
             $this->redirect->setRefererOrBaseUrl()
         );
     }
@@ -56,7 +59,7 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
     public function testSetUrl()
     {
         $url = 'http://test.com';
-        $this->assertInstanceOf(\Magento\Framework\Controller\Result\Redirect::class, $this->redirect->setUrl($url));
+        $this->assertInstanceOf(Redirect::class, $this->redirect->setUrl($url));
     }
 
     public function testSetPath()
@@ -67,17 +70,36 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($params)
         );
         $this->assertInstanceOf(
-            \Magento\Framework\Controller\Result\Redirect::class,
+            Redirect::class,
             $this->redirect->setPath($path, $params)
         );
     }
 
-    public function testRender()
+    public function httpRedirectResponseStatusCodes()
     {
-        $this->response->expects($this->once())->method('setRedirect');
-        $this->assertInstanceOf(
-            \Magento\Framework\Controller\Result\Redirect::class,
-            $this->redirect->renderResult($this->response)
-        );
+        return [
+            [302, null],
+            [302, 302],
+            [303, 303]
+        ];
+    }
+
+    /**
+     * @param int $expectedStatusCode
+     * @param int|null $actualStatusCode
+     * @dataProvider httpRedirectResponseStatusCodes
+     */
+    public function testRender($expectedStatusCode, $actualStatusCode)
+    {
+        $url = 'http://test.com';
+        $this->redirect->setUrl($url);
+        $this->redirect->setHttpResponseCode($actualStatusCode);
+
+        $this->response
+            ->expects($this->once())
+            ->method('setRedirect')
+            ->with($url, $expectedStatusCode);
+
+        $this->redirect->renderResult($this->response);
     }
 }


### PR DESCRIPTION
Extensions currently cannot define http response status code when redirecting. It is always overwritten to 302

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)

1. magento/magento2#9028: You cannot set a 303 redirect response using a result factory


### Manual testing scenarios

1. Perform a 303 redirect from any controller (see code below)
2. Send a request to that controller endpoint
3. Examine the response code

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
