### PR TITLE
Added CLI command to enable and disable the Profiler

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -49,12 +49,13 @@ if (empty($_SERVER['ENABLE_IIS_REWRITES']) || ($_SERVER['ENABLE_IIS_REWRITES'] !
     unset($_SERVER['ORIG_PATH_INFO']);
 }
 
-if (!empty($_SERVER['MAGE_PROFILER'])
+if (
+    (!empty($_SERVER['MAGE_PROFILER']) || file_exists(BP . '/var/profiler.flag'))
     && isset($_SERVER['HTTP_ACCEPT'])
     && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false
 ) {
     \Magento\Framework\Profiler::applyConfig(
-        $_SERVER['MAGE_PROFILER'],
+        (isset($_SERVER['MAGE_PROFILER']) && strlen($_SERVER['MAGE_PROFILER'])) ? $_SERVER['MAGE_PROFILER'] : trim(file_get_contents(BP . '/var/profiler.flag')),
         BP,
         !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest'
     );

--- a/app/code/Magento/Developer/Console/Command/ProfilerDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/ProfilerDisableCommand.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Console\Command;
+
+use Magento\Framework\Filesystem\Io\File;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProfilerDisableCommand extends Command
+{
+    /**
+     * Profiler flag file
+     */
+    const PROFILER_FLAG_FILE = 'var/profiler.flag';
+
+    /**
+     * Command name
+     */
+    const COMMAND_NAME = 'dev:profiler:disable';
+
+    /**
+     * Success message
+     */
+    const SUCCESS_MESSAGE = 'Profiler disabled.';
+
+    /**
+     * @var File
+     */
+    protected $filesystem;
+
+    /**
+     * Initialize dependencies.
+     *
+     * @param File $filesystem
+     * @internal param ConfigInterface $resourceConfig
+     */
+    public function __construct(File $filesystem)
+    {
+        parent::__construct();
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Disable the profiler.');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->filesystem->rm(BP . '/' . self::PROFILER_FLAG_FILE);
+        if (!$this->filesystem->fileExists(BP . '/' . self::PROFILER_FLAG_FILE)) {
+            $output->writeln('<info>'. self::SUCCESS_MESSAGE . '</info>');
+            return;
+        }
+        $output->writeln('<error>Something went wrong while disabling the profiler.</error>');
+    }
+}

--- a/app/code/Magento/Developer/Console/Command/ProfilerEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/ProfilerEnableCommand.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Console\Command;
+
+use Magento\Framework\Filesystem\Io\File;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ProfilerEnableCommand extends Command
+{
+    /**
+     * Profiler flag file
+     */
+    const PROFILER_FLAG_FILE = 'var/profiler.flag';
+
+    /**
+     * Profiler type default setting
+     */
+    const TYPE_DEFAULT = 'html';
+
+    /**
+     * Built in profiler types
+     */
+    const BUILT_IN_TYPES = ['html', 'csvfile'];
+
+    /**
+     * Command name
+     */
+    const COMMAND_NAME = 'dev:profiler:enable';
+
+    /**
+     * Success message
+     */
+    const SUCCESS_MESSAGE = 'Profiler enabled with %s output.';
+
+    /**
+     * @var File
+     */
+    protected $filesystem;
+
+    /**
+     * Initialize dependencies.
+     *
+     * @param File $filesystem
+     * @internal param ConfigInterface $resourceConfig
+     */
+    public function __construct(File $filesystem)
+    {
+        parent::__construct();
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Enable the profiler.')
+            ->addArgument('type', InputArgument::OPTIONAL, 'Profiler type');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $type = $input->getArgument('type');
+        if (!$type) {
+            $type = self::TYPE_DEFAULT;
+        }
+
+        if (!in_array($type, self::BUILT_IN_TYPES)) {
+            $builtInTypes = implode(', ', self::BUILT_IN_TYPES);
+            $output->writeln(
+                '<comment>' . sprintf('Type %s is not one of the built-in output types (%s).', $type) .
+                sprintf('Make sure the necessary class exists.', $type, $builtInTypes) . '</comment>'
+            );
+        }
+
+        $this->filesystem->write(BP . '/' . self::PROFILER_FLAG_FILE, $type);
+        if ($this->filesystem->fileExists(BP . '/' . self::PROFILER_FLAG_FILE)) {
+            $output->write('<info>'. sprintf(self::SUCCESS_MESSAGE, $type) . '</info>');
+            if ($type == 'csvfile') {
+                $output->write(
+                    '<info> ' . sprintf(
+                        'Output will be saved in %s',
+                        \Magento\Framework\Profiler\Driver\Standard\Output\Csvfile::DEFAULT_FILEPATH
+                    )
+                    . '</info>'
+                );
+            }
+            $output->write(PHP_EOL);
+            return;
+        }
+
+        $output->writeln('<error>Something went wrong while enabling the profiler.</error>');
+    }
+}

--- a/app/code/Magento/Developer/etc/di.xml
+++ b/app/code/Magento/Developer/etc/di.xml
@@ -102,6 +102,8 @@
                 <item name="dev_query_log_disable" xsi:type="object">Magento\Developer\Console\Command\QueryLogDisableCommand</item>
                 <item name="dev_template_hints_disable" xsi:type="object">Magento\Developer\Console\Command\TemplateHintsDisableCommand</item>
                 <item name="dev_template_hints_enable" xsi:type="object">Magento\Developer\Console\Command\TemplateHintsEnableCommand</item>
+                <item name="dev_profiler_disable" xsi:type="object">Magento\Developer\Console\Command\ProfilerDisableCommand</item>
+                <item name="dev_profiler_enable" xsi:type="object">Magento\Developer\Console\Command\ProfilerEnableCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Added CLI command to enable and disable the Profiler

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Adjusted `app/bootstrap.php` to have it read out the flagfile `var/profiler.flag` to enable the profiler and added CLI commands to create and remove the file.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9277: Create new CLI command: enable/disable Magento Profiler

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. `php bin/magento dev:profiler:enable`
2. Open up a page
3. Scroll down

Or;
1. `php bin/magento dev:profiler:enable csvfile`
2. Open up a page
3. Open `var/log/profiler.csv`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
