### PR TITLE
FIX #11022 in 2.2-develop: Filter Groups of search criteria parameter have not been included for further processing 

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -72,10 +72,15 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
                     ->create(),
             ]
         );
+
         $this->searchCriteriaBuilder->setSortOrders((array)$searchCriteria->getSortOrders());
         $this->searchCriteriaBuilder->setCurrentPage($searchCriteria->getCurrentPage());
         $this->searchCriteriaBuilder->setPageSize($searchCriteria->getPageSize());
-        return $this->attributeSetRepository->getList($this->searchCriteriaBuilder->create());
+
+        $searchResult = $this->attributeSetRepository->getList($this->searchCriteriaBuilder->create());
+        $searchResult->setSearchCriteria($searchCriteria);
+
+        return $searchResult;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -62,7 +62,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
-        $this->searchCriteriaBuilder->setFilterGroups($searchCriteria->getFilterGroups());
+        $this->searchCriteriaBuilder->setFilterGroups((array)$searchCriteria->getFilterGroups());
         $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder

--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -62,6 +62,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
+        $this->searchCriteriaBuilder->setFilterGroups($searchCriteria->getFilterGroups());
         $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
@@ -71,6 +72,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
                     ->create(),
             ]
         );
+        $this->searchCriteriaBuilder->setSortOrders((array)$searchCriteria->getSortOrders());
         $this->searchCriteriaBuilder->setCurrentPage($searchCriteria->getCurrentPage());
         $this->searchCriteriaBuilder->setPageSize($searchCriteria->getPageSize());
         return $this->attributeSetRepository->getList($this->searchCriteriaBuilder->create());

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/AttributeSetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/AttributeSetRepositoryTest.php
@@ -165,19 +165,9 @@ class AttributeSetRepositoryTest extends WebapiAbstract
     {
         $searchCriteria = [
             'searchCriteria' => [
-                'filter_groups' => [
-                    [
-                        'filters' => [
-                            [
-                                'field' => 'entity_type_code',
-                                'value' => 'catalog_product',
-                                'condition_type' => 'eq',
-                            ],
-                        ],
-                    ],
-                ],
+                'filter_groups' => [],
                 'current_page' => 1,
-                'page_size' => 2,
+                'page_size' => 2
             ],
         ];
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The Filter Groups and the Sort Order of the $searchCriteria parameter have not been included in the searchCriteria Object that is finally provided for the eav set repository.

This Pull request sets the filtergroups and sort order in the searchCriteriaBuilder

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11022: GET v1/products/attribute-sets/sets/list inconsistent return result

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create an additional product attribute set
1. call to GET http://URL/rest/v1/products/attribute-sets/sets/list?searchCriteria[filter_groups][0][filters][0][field]=attribute_set_name&searchCriteria[filter_groups][0][filters][0][condition_type]=eq&searchCriteria[filter_groups][0][filters][0][value]=default
2. Result should be only the default attribute set (before it always returned all product attribute sets)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

//cc @dmanners 