### PR TITLE
Magento setup:install interactive shell

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/InstallCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/InstallCommand.php
@@ -13,6 +13,9 @@ use Magento\Setup\Model\InstallerFactory;
 use Magento\Framework\Setup\ConsoleLogger;
 use Symfony\Component\Console\Input\InputOption;
 use Magento\Setup\Model\ConfigModel;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Helper\QuestionHelper;
 
 /**
  * Command to install Magento application
@@ -34,6 +37,16 @@ class InstallCommand extends AbstractSetupCommand
      * Parameter indicating command whether to install Sample Data
      */
     const INPUT_KEY_USE_SAMPLE_DATA = 'use-sample-data';
+
+    /**
+     * Parameter indicating command for interactive setup
+     */
+    const INPUT_KEY_INTERACTIVE_SETUP = 'interactive';
+
+    /**
+     * Parameter indicating command shortcut for interactive setup
+     */
+    const INPUT_KEY_INTERACTIVE_SETUP_SHORTCUT = 'i';
 
     /**
      * Regex for sales_order_increment_prefix validation.
@@ -109,7 +122,13 @@ class InstallCommand extends AbstractSetupCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Use sample data'
-            )
+            ),
+            new InputOption(
+                self::INPUT_KEY_INTERACTIVE_SETUP,
+                self::INPUT_KEY_INTERACTIVE_SETUP_SHORTCUT,
+                InputOption::VALUE_NONE,
+                'Interactive Magento instalation'
+            ),
         ]);
         $this->setName('setup:install')
             ->setDescription('Installs the Magento application')
@@ -139,12 +158,17 @@ class InstallCommand extends AbstractSetupCommand
     {
         $inputOptions = $input->getOptions();
 
-        $configOptionsToValidate = [];
-        foreach ($this->configModel->getAvailableOptions() as $option) {
-            if (array_key_exists($option->getName(), $inputOptions)) {
-                $configOptionsToValidate[$option->getName()] = $inputOptions[$option->getName()];
+        if ($inputOptions['interactive']) {
+            $configOptionsToValidate = $this->interactiveQuestions($input, $output);
+        } else {
+            $configOptionsToValidate = [];
+            foreach ($this->configModel->getAvailableOptions() as $option) {
+                if (array_key_exists($option->getName(), $inputOptions)) {
+                    $configOptionsToValidate[$option->getName()] = $inputOptions[$option->getName()];
+                }
             }
         }
+
         $errors = $this->configModel->validate($configOptionsToValidate);
         $errors = array_merge($errors, $this->adminUser->validate($input));
         $errors = array_merge($errors, $this->validate($input));
@@ -176,5 +200,82 @@ class InstallCommand extends AbstractSetupCommand
                 . ' must be 20 characters or less';
         }
         return $errors;
+    }
+
+    /**
+     * Runs interactive questions
+     *
+     * It will ask users for interactive questionst regarding setup configuration.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return string[] Array of inputs
+     */
+    private function interactiveQuestions(InputInterface $input, OutputInterface $output)
+    {
+        $helper = $this->getHelper('question');
+        $configOptionsToValidate = [];
+        foreach ($this->configModel->getAvailableOptions() as $option) {
+
+            $configOptionsToValidate[$option->getName()] = $this->askQuestion($input, $output, $helper, $option);
+
+            /*$question = new Question($option->getDescription() . '? ', $option->getDefault());
+            $configOptionsToValidate[$option->getName()] = $helper->ask($input, $output, $question);
+            */
+        }
+        return $configOptionsToValidate;
+    }
+
+    /**
+     * Runs interactive questions
+     *
+     * It will ask users for interactive questionst regarding setup configuration.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $helper
+     * @param Magento\Framework\Setup\Option\TextConfigOption|Magento\Framework\Setup\Option\FlagConfigOption\Magento\Framework\Setup\Option\SelectConfigOption $option
+     * @return string[] Array of inputs
+     */
+    private function askQuestion(InputInterface $input, OutputInterface $output, QuestionHelper $helper, $option)
+    {
+        if (get_class($option) === 'Magento\Framework\Setup\Option\SelectConfigOption') {
+            if ($option->isValueRequired()) {
+                $question = new ChoiceQuestion(
+                    $option->getDescription() . '? ',
+                    $option->getSelectOptions(),
+                    $option->getDefault()
+                );
+            } else {
+                $question = new ChoiceQuestion(
+                    $option->getDescription() . ' [optional]? ',
+                    $option->getSelectOptions(),
+                    $option->getDefault()
+                );
+            }
+            $question->setValidator(function ($answer) use ($option) {
+                $option->validate($option->getSelectOptions()[$answer]);
+                return $answer;
+            });
+        } else {
+            if ($option->isValueRequired()) {
+                $question = new Question(
+                    $option->getDescription() . '? ',
+                    $option->getDefault()
+                );
+            } else {
+                $question = new Question(
+                    $option->getDescription() . ' [optional]? ',
+                    $option->getDefault()
+                );
+            }
+            $question->setValidator(function ($answer) use ($option) {
+                $option->validate($answer);
+                return $answer;
+            });
+        }
+
+        $value = $helper->ask($input, $output, $question);
+        return $value;
     }
 }


### PR DESCRIPTION
Run magento setup console command interactively

### Description
I've added -i|--interactive flag to setup:install command.
It is doing validation of parameters and it uses ChoiceQuestions on SelectConfigOption.
Also on the end it dumps command to rerun from console.
When you run `php bin/magento setup:install -i` shell looks like this:
```
Backend frontname (will be autogenerated if missing)? magento2.local
Encryption key?
Database server host? localhost
Database name? magento2
Database server username? dbuser
Database server engine?
Database server password? dbpass
Database table prefix?
Database type?
Database  initial set of commands?
If specified, then db connection validation will be skipped [optional]?
http Cache hosts?
Session save handler?
  [0] files
  [1] db
  [2] redis
 > 0
Fully qualified host name, IP address, or absolute path if using UNIX sockets?
Redis server listen port?
Redis server password?
Connection timeout, in seconds?
Unique string to enable persistent connections?
Redis database number?
Redis compression threshold?
Redis compression library. Values: gzip (default), lzf, lz4, snappy?
Redis log level. Values: 0 (least verbose) to 7 (most verbose)?
Maximum number of processes that can wait for a lock on one session?
Number of seconds to wait before trying to break a lock for frontend session?
Number of seconds to wait before trying to break a lock for Admin session?
Lifetime, in seconds, of session for non-bots on the first write (use 0 to disable)?
Lifetime, in seconds, of session for bots on the first write (use 0 to disable)?
Lifetime of session for bots on subsequent writes (use 0 to disable)?
Redis disable locking. Values: false (default), true?
Redis min session lifetime, in seconds?
Redis max session lifetime, in seconds?
Default cache handler?
  [0] redis
 > 0
Redis server?
Database number for the cache?
Redis server listen port?
Default cache handler?
  [0] redis
 > 0
Redis server?
Database number for the cache?
Redis server listen port?
Set to 1 to compress the full page cache (use 0 to disable)?

URL the store is supposed to be available at. Deprecated, use config:set with path web/unsecure/base_url?
Default language code. Deprecated, use config:set with path general/locale/code? en_US
Default time zone code. Deprecated, use config:set with path general/locale/timezone? America/New_York
Default currency code. Deprecated, use config:set with path currency/options/base, currency/options/default and currency/options/allow? USD
Use rewrites. Deprecated, use config:set with path web/seo/use_rewrites?
Use secure URLs. Enable this option only if SSL is available. Deprecated, use config:set with path web/secure/use_in_frontend?
Base URL for SSL connection. Deprecated, use config:set with path web/secure/base_url?
Run admin interface with SSL. Deprecated, use config:set with path web/secure/use_in_adminhtml?
Whether to use a "security key" feature in Magento Admin URLs and forms. Deprecated, use config:set with path admin/security/use_form_key?

(Required) Admin user? admin
(Required) Admin password? admin123
(Required) Admin email? admin@example.com
(Required) Admin first name? Magento
(Required) Admin last name? Admin

Try re-running command: php bin/magento setup:install --backend-frontname=magento2.local --db-host=localhost --db-name=magento2 --db-user=dbuser --db-passwordd=dbpass --session-save=files --cache-backend=redis --page-cache=redis --language=en_US --timezone=America/New_York --currency=USD --admin-user=admin --admin-password=admin123 --admin-email=admin@example.com --admin-firstname=Magento --admin-lastname=Admin

```
Magento does not actually check for values on input (like database host if it is valid IP, domain or localhost) but instead it checks everything on the end

### Manual testing scenarios
1. run in console `php bin/magento setup:install -i` or `php bin/magento setup:install --interactive`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
