### PR TITLE
Fix toolbar-amount placing in mobile device

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -44,7 +44,6 @@
             line-height: @toolbar-mode-icon-font-size + 2;
             margin: 0;
             padding: 7px 0;
-            position: absolute;
             text-align: left;
             top: 0;
             vertical-align: middle;


### PR DESCRIPTION
The toolbar amount element is misplaced because of a `position: absolute`
### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10941: Responsive Design Issue on Mobile with Magento 2.1.9

### Manual testing scenarios
1. Create a cms page with this content:

```
{{widget type="Magento\Catalog\Block\Product\Widget\NewWidget" display_type="all_products" show_pager="1" products_per_page="4" products_count="16" template="product/widget/new/content/new_grid.phtml" page_var_name="pipexq"}}
{{widget type="Magento\Catalog\Block\Widget\RecentlyViewed" uiComponent="widget_recently_viewed" page_size="4" show_attributes="name,image,price" show_buttons="add_to_cart,add_to_compare,add_to_wishlist" template="product/widget/viewed/grid.phtml"}}
```

Before the result was:
![m2dev local-test-catalog nexus 5](https://user-images.githubusercontent.com/3061752/31547795-ed5a619e-b028-11e7-8a2d-db28f5886337.png)

After the fix the result is:
![m2dev local-test-catalog nexus 5 2](https://user-images.githubusercontent.com/3061752/31547821-09321452-b029-11e7-83c5-c20c278633fc.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
