### PR TITLE
FIX #11022 in 2.1-develop: Filter Groups of search criteria parameter have not been included for further processing

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -72,10 +72,15 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
                     ->create(),
             ]
         );
+
         $this->searchCriteriaBuilder->setSortOrders((array)$searchCriteria->getSortOrders());
         $this->searchCriteriaBuilder->setCurrentPage($searchCriteria->getCurrentPage());
         $this->searchCriteriaBuilder->setPageSize($searchCriteria->getPageSize());
-        return $this->attributeSetRepository->getList($this->searchCriteriaBuilder->create());
+
+        $searchResult = $this->attributeSetRepository->getList($this->searchCriteriaBuilder->create());
+        $searchResult->setSearchCriteria($searchCriteria);
+
+        return $searchResult;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -62,7 +62,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
-        $this->searchCriteriaBuilder->setFilterGroups($searchCriteria->getFilterGroups());
+        $this->searchCriteriaBuilder->setFilterGroups((array)$searchCriteria->getFilterGroups());
         $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder

--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -62,6 +62,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
+        $this->searchCriteriaBuilder->setFilterGroups($searchCriteria->getFilterGroups());
         $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
@@ -71,6 +72,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
                     ->create(),
             ]
         );
+        $this->searchCriteriaBuilder->setSortOrders((array)$searchCriteria->getSortOrders());
         $this->searchCriteriaBuilder->setCurrentPage($searchCriteria->getCurrentPage());
         $this->searchCriteriaBuilder->setPageSize($searchCriteria->getPageSize());
         return $this->attributeSetRepository->getList($this->searchCriteriaBuilder->create());

--- a/app/code/Magento/Eav/Model/AttributeSetRepository.php
+++ b/app/code/Magento/Eav/Model/AttributeSetRepository.php
@@ -105,6 +105,10 @@ class AttributeSetRepository implements AttributeSetRepositoryInterface
             $collection->setEntityTypeFilter($this->eavConfig->getEntityType($entityTypeCode)->getId());
         }
 
+        foreach ($searchCriteria->getFilterGroups() as $group) {
+            $this->addFilterGroupToCollection($group, $collection);
+        }
+
         $collection->setCurPage($searchCriteria->getCurrentPage());
         $collection->setPageSize($searchCriteria->getPageSize());
 
@@ -113,6 +117,29 @@ class AttributeSetRepository implements AttributeSetRepositoryInterface
         $searchResults->setItems($collection->getItems());
         $searchResults->setTotalCount($collection->getSize());
         return $searchResults;
+    }
+
+    /**
+     * Helper function that adds a FilterGroup to the collection.
+     *
+     * @deprecated already removed in 2.2-develop. Use CollectionProcessorInterface to process search criteria
+     *
+     * @param \Magento\Framework\Api\Search\FilterGroup $filterGroup
+     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection $collection
+     * @return void
+     */
+    protected function addFilterGroupToCollection(
+        \Magento\Framework\Api\Search\FilterGroup $filterGroup,
+        \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection $collection
+    ) {
+        foreach ($filterGroup->getFilters() as $filter) {
+            /** entity type filter is already set on collection */
+            if ($filter->getField() === 'entity_type_code') {
+                continue;
+            }
+            $conditionType = $filter->getConditionType() ? $filter->getConditionType() : 'eq';
+            $collection->addFieldToFilter($filter->getField(), [$conditionType, $filter->getValue()]);
+        }
     }
 
     /**

--- a/app/code/Magento/Eav/Model/AttributeSetRepository.php
+++ b/app/code/Magento/Eav/Model/AttributeSetRepository.php
@@ -128,7 +128,7 @@ class AttributeSetRepository implements AttributeSetRepositoryInterface
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection $collection
      * @return void
      */
-    protected function addFilterGroupToCollection(
+    private function addFilterGroupToCollection(
         \Magento\Framework\Api\Search\FilterGroup $filterGroup,
         \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection $collection
     ) {

--- a/app/code/Magento/Eav/Test/Unit/Model/AttributeSetRepositoryTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/AttributeSetRepositoryTest.php
@@ -215,7 +215,7 @@ class AttributeSetRepositoryTest extends \PHPUnit_Framework_TestCase
         $searchCriteriaMock->expects($this->exactly(2))->method('getFilterGroups')->willReturn([$filterGroupMock]);
 
         $filterMock = $this->getMock('\Magento\Framework\Api\Filter', [], [], '', false);
-        $filterGroupMock->expects($this->once())->method('getFilters')->willReturn([$filterMock]);
+        $filterGroupMock->expects($this->exactly(2))->method('getFilters')->willReturn([$filterMock]);
 
         $filterMock->expects($this->once())->method('getField')->willReturn('entity_type_code');
         $filterMock->expects($this->once())->method('getValue')->willReturn($entityTypeCode);

--- a/app/code/Magento/Eav/Test/Unit/Model/AttributeSetRepositoryTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/AttributeSetRepositoryTest.php
@@ -212,7 +212,7 @@ class AttributeSetRepositoryTest extends \PHPUnit_Framework_TestCase
         $searchCriteriaMock = $this->getMock('\Magento\Framework\Api\SearchCriteriaInterface');
 
         $filterGroupMock = $this->getMock('\Magento\Framework\Api\Search\FilterGroup', [], [], '', false);
-        $searchCriteriaMock->expects($this->once())->method('getFilterGroups')->willReturn([$filterGroupMock]);
+        $searchCriteriaMock->expects($this->exactly(2))->method('getFilterGroups')->willReturn([$filterGroupMock]);
 
         $filterMock = $this->getMock('\Magento\Framework\Api\Filter', [], [], '', false);
         $filterGroupMock->expects($this->once())->method('getFilters')->willReturn([$filterMock]);
@@ -273,7 +273,7 @@ class AttributeSetRepositoryTest extends \PHPUnit_Framework_TestCase
     public function testGetListIfEntityTypeCodeIsNull()
     {
         $searchCriteriaMock = $this->getMock('\Magento\Framework\Api\SearchCriteriaInterface');
-        $searchCriteriaMock->expects($this->once())->method('getFilterGroups')->willReturn([]);
+        $searchCriteriaMock->expects($this->exactly(2))->method('getFilterGroups')->willReturn([]);
 
         $collectionMock = $this->getMock(
             '\Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection',

--- a/app/code/Magento/Eav/Test/Unit/Model/AttributeSetRepositoryTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/AttributeSetRepositoryTest.php
@@ -217,7 +217,7 @@ class AttributeSetRepositoryTest extends \PHPUnit_Framework_TestCase
         $filterMock = $this->getMock('\Magento\Framework\Api\Filter', [], [], '', false);
         $filterGroupMock->expects($this->exactly(2))->method('getFilters')->willReturn([$filterMock]);
 
-        $filterMock->expects($this->once())->method('getField')->willReturn('entity_type_code');
+        $filterMock->expects($this->exactly(2))->method('getField')->willReturn('entity_type_code');
         $filterMock->expects($this->once())->method('getValue')->willReturn($entityTypeCode);
 
         $collectionMock = $this->getMock(

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/AttributeSetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/AttributeSetRepositoryTest.php
@@ -165,19 +165,9 @@ class AttributeSetRepositoryTest extends WebapiAbstract
     {
         $searchCriteria = [
             'searchCriteria' => [
-                'filter_groups' => [
-                    [
-                        'filters' => [
-                            [
-                                'field' => 'entity_type_code',
-                                'value' => 'catalog_product',
-                                'condition_type' => 'eq',
-                            ],
-                        ],
-                    ],
-                ],
+                'filter_groups' => [],
                 'current_page' => 1,
-                'page_size' => 2,
+                'page_size' => 2
             ],
         ];
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The Filter Groups and the Sort Order of the $searchCriteria parameter have not been included in the searchCriteria Object that is finally provided for the eav set repository.

This Pull request sets the filtergroups and sort order in the searchCriteriaBuilder

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11022: GET v1/products/attribute-sets/sets/list inconsistent return result

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create an additional product attribute set
1. call to GET http://URL/rest/v1/products/attribute-sets/sets/list?searchCriteria[filter_groups][0][filters][0][field]=attribute_set_name&searchCriteria[filter_groups][0][filters][0][condition_type]=eq&searchCriteria[filter_groups][0][filters][0][value]=default
2. Result should be only the default attribute set (before it always returned all product attribute sets)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

//cc @dmanners 