### PR TITLE
Issue #11428: Cart Price Rule Label is not working

### DIFF
--- a/app/code/Magento/SalesRule/view/frontend/web/template/summary/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/summary/discount.html
@@ -7,7 +7,7 @@
 <!-- ko if: isDisplayed() -->
 <tr class="totals discount">
     <th class="mark" scope="row">
-        <span class="title" data-bind="text: title"></span>
+        <span class="title" data-bind="text: getCouponLabel()"></span>
         <span class="discount coupon" data-bind="text: getCouponCode()"></span>
     </th>
     <td class="amount">


### PR DESCRIPTION
### Description

Cart Price Rule Label is not working. The Total label for discounts was not the correct one, after this fix the label was "Discount" and with this change is the Cart Rule Label.

### Steps to reproduce

1. While creating the cart price rule, I have given the Label value as "Buy 2 and Get 1 Free".
2. In front end, Checkout page, It will show only the label as "Discount" not the given name has been reflected.

### Fixed Issues (if relevant)

The following modification fixes this magento 2 issue #11428 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
