### PR TITLE
[Backport 2.2-develop] #11324 REST API - Only associate automatically product with all websites when creating product in All Store Views scope

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -340,16 +340,17 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         foreach ($productData as $key => $value) {
             $product->setData($key, $value);
         }
-        $this->assignProductToWebsites($product);
+        $this->assignProductToWebsites($product, $createNew);
 
         return $product;
     }
 
     /**
      * @param \Magento\Catalog\Model\Product $product
+     * @param bool $createNew
      * @return void
      */
-    private function assignProductToWebsites(\Magento\Catalog\Model\Product $product)
+    private function assignProductToWebsites(\Magento\Catalog\Model\Product $product, $createNew)
     {
         $websiteIds = $product->getWebsiteIds();
 
@@ -362,7 +363,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             );
         }
 
-        if ($this->storeManager->getStore(true)->getCode() == \Magento\Store\Model\Store::ADMIN_CODE) {
+        if ($createNew && $this->storeManager->getStore(true)->getCode() == \Magento\Store\Model\Store::ADMIN_CODE) {
             $websiteIds = array_keys($this->storeManager->getWebsites());
         }
 


### PR DESCRIPTION
Updating a product via the REST API using PUT /rest/all/V1/products/example_sku assigns it to all websites automatically.

Related with [PR#11443](https://github.com/magento/magento2/pull/11443)

### Description
Only associate automatically product with all websites when creating product in All Store Views scope.

### Fixed Issues (if relevant)
1. magento/magento2#11324: Updating a product via the REST API assigns it to all websites automatically.


### Manual testing scenarios
As described in magento/magento2#11324

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
