### PR TITLE
Show product alerts in admin product detail [backport 2.2]

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Alerts.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Alerts.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts\Price;
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts\Stock;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\View\LayoutFactory;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Ui\Component\Form\Fieldset;
+
+class Alerts extends AbstractModifier
+{
+    const DATA_SCOPE       = 'data';
+    const DATA_SCOPE_STOCK = 'stock';
+    const DATA_SCOPE_PRICE = 'price';
+
+    /**
+     * @var string
+     */
+    private static $previousGroup = 'related';
+
+    /**
+     * @var int
+     */
+    private static $sortOrder = 110;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var LayoutFactory
+     */
+    private $layoutFactory;
+
+
+    /**
+     * Alerts constructor.
+     * @param ScopeConfigInterface $scopeConfig
+     * @param LayoutFactory $layoutFactory
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        LayoutFactory $layoutFactory
+    ) {
+        $this->scopeConfig = $scopeConfig;
+        $this->layoutFactory = $layoutFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @since 101.0.0
+     */
+    public function modifyData(array $data)
+    {
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @since 101.0.0
+     */
+    public function modifyMeta(array $meta)
+    {
+        if (!$this->canShowTab()) {
+            return $meta;
+        }
+
+        $meta = array_replace_recursive(
+            $meta,
+            [
+                'alerts' => [
+                    'arguments' => [
+                        'data' => [
+                            'config' => [
+                                'additionalClasses' => 'admin__fieldset-section',
+                                'label' => __('Product Alerts'),
+                                'collapsible' => true,
+                                'componentType' => Fieldset::NAME,
+                                'dataScope' => static::DATA_SCOPE,
+                                'sortOrder' =>
+                                    $this->getNextGroupSortOrder(
+                                        $meta,
+                                        self::$previousGroup,
+                                        self::$sortOrder
+                                    ),
+                            ],
+                        ],
+                    ],
+                    'children' => [
+                        static::DATA_SCOPE_STOCK => $this->getAlertStockFieldset(),
+                        static::DATA_SCOPE_PRICE => $this->getAlertPriceFieldset()
+                    ],
+                ],
+            ]
+        );
+
+        return $meta;
+    }
+
+    /**
+     * @return bool
+     */
+    private function canShowTab()
+    {
+        $alertPriceAllow = $this->scopeConfig->getValue(
+            'catalog/productalert/allow_price',
+            ScopeInterface::SCOPE_STORE
+        );
+        $alertStockAllow = $this->scopeConfig->getValue(
+            'catalog/productalert/allow_stock',
+            ScopeInterface::SCOPE_STORE
+        );
+
+        return ($alertPriceAllow || $alertStockAllow);
+    }
+
+    /**
+     * Prepares config for the alert stock products fieldset
+     * @return array
+     */
+    private function getAlertStockFieldset()
+    {
+        return [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'label' => __('Alert stock'),
+                        'componentType' => 'container',
+                        'component' => 'Magento_Ui/js/form/components/html',
+                        'additionalClasses' => 'admin__fieldset-note',
+                        'content' =>
+                            '<h4>' . __('Alert Stock') . '</h4>' .
+                            $this->layoutFactory->create()->createBlock(
+                                Stock::class
+                            )->toHtml(),
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Prepares config for the alert price products fieldset
+     * @return array
+     */
+    private function getAlertPriceFieldset()
+    {
+        return [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'label' => __('Alert price'),
+                        'componentType' => 'container',
+                        'component' => 'Magento_Ui/js/form/components/html',
+                        'additionalClasses' => 'admin__fieldset-note',
+                        'content' =>
+                            '<h4>' . __('Alert Price') . '</h4>' .
+                            $this->layoutFactory->create()->createBlock(
+                                Price::class
+                            )->toHtml(),
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Alerts.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Alerts.php
@@ -38,8 +38,7 @@ class Alerts extends AbstractModifier
      * @var LayoutFactory
      */
     private $layoutFactory;
-
-
+    
     /**
      * Alerts constructor.
      * @param ScopeConfigInterface $scopeConfig

--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -143,6 +143,10 @@
                     <item name="class" xsi:type="string">Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Attributes</item>
                     <item name="sortOrder" xsi:type="number">120</item>
                 </item>
+                <item name="alerts" xsi:type="array">
+                    <item name="class" xsi:type="string">Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Alerts</item>
+                    <item name="sortOrder" xsi:type="number">130</item>
+                </item>
                 <item name="advanced-pricing-tier-price-type" xsi:type="array">
                     <item name="class" xsi:type="string">Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\TierPrice</item>
                     <item name="sortOrder" xsi:type="number">150</item>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Related PRs:

#11448 
#11449

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Show the product alerts in the admin panel when a customer is subscribed to the stock or price of a product
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#[10007](https://github.com/magento/magento2/issues/10007): ProductAlert: Product alerts not showing in admin side product edit page

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
