### PR TITLE
[Backport 2.2-develop] #11358 Fix full tax summary display breakdown

### DIFF
--- a/app/code/Magento/Tax/Model/ResourceModel/Calculation.php
+++ b/app/code/Magento/Tax/Model/ResourceModel/Calculation.php
@@ -190,6 +190,7 @@ class Calculation extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             ) || $rates[$i + 1]['priority'] != $priority || isset(
                 $rates[$i + 1]['process']
             ) && $rates[$i + 1]['process'] != $rate['process']
+            || $rates[$i + 1]['code'] != $rate['code']
             ) {
                 if (!empty($rates[$i]['calculate_subtotal'])) {
                     $row['percent'] = $currentRate;


### PR DESCRIPTION
Full Tax Summary display wrong numbers.

Related with [PR#11446](https://github.com/magento/magento2/pull/11446)

### Description
Full tax summary breakdown fails, as explained in magento/magento2#11358, solution taken from proposed gist: https://gist.github.com/heyqule/7c830137715544ff95baba50a5ed3d80

### Fixed Issues (if relevant)
1. magento/magento2#11358: Full Tax Summary display wrong numbers.

### Manual testing scenarios
As explained in magento/magento2#11358

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
