### PR TITLE
[Backport 2.1-develop] #11328 : app:config:dump adds extra space every time in multiline array value

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -21,7 +21,7 @@ class PhpFormatter implements FormatterInterface
     public function format($data, array $comments = [])
     {
         if (!empty($comments) && is_array($data)) {
-            return "<?php\nreturn array (\n" . $this->formatData($data, $comments, '  ') . "\n);\n";
+            return "<?php\nreturn array (\n" . $this->formatData($data, $comments) . "\n);\n";
         }
         return "<?php\nreturn " . var_export($data, true) . ";\n";
     }
@@ -29,12 +29,12 @@ class PhpFormatter implements FormatterInterface
     /**
      * Format supplied data
      *
-     * @param $data
-     * @param $comments
+     * @param string[] $data
+     * @param string[] $comments
      * @param string $prefix
      * @return string
      */
-    protected function formatData($data, $comments, $prefix = '')
+    private function formatData($data, $comments = [], $prefix = '  ')
     {
         $elements = [];
 

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -51,13 +51,13 @@ class PhpFormatter implements FormatterInterface
                     $elements[] = $prefix . " */";
                 }
 
+                $elements[] = $prefix . var_export($key, true) . ' => ' .
+                    (!is_array($value) ? var_export($value, true) . ',' : '');
+
                 if (is_array($value)) {
-                    $elements[] = $prefix . var_export($key, true) . ' => ';
                     $elements[] = $prefix . 'array (';
                     $elements[] = $this->formatData($value, [], '  ' . $prefix);
                     $elements[] = $prefix . '),';
-                } else {
-                    $elements[] = $prefix . var_export($key, true) . ' => ' . var_export($value, true) . ',';
                 }
             }
             return implode("\n", $elements);

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -21,17 +21,48 @@ class PhpFormatter implements FormatterInterface
     public function format($data, array $comments = [])
     {
         if (!empty($comments) && is_array($data)) {
-            $elements = array();
-            foreach ($data as $key => $value) {
-                $comment = '  ';
-                if (!empty($comments[$key])) {
-                    $comment = "  /**\n * " . str_replace("\n", "\n * ", var_export($comments[$key], true)) . "\n */\n";
-                }
-                $space = is_array($value) ? " \n" : ' ';
-                $elements[] = $comment . var_export($key, true) . ' =>' . $space . var_export($value, true);
-            }
-            return "<?php\nreturn array (\n" . implode(",\n", str_replace("\n", "\n  ", $elements)) . "\n);\n";
+            return "<?php\nreturn array (\n" . $this->formatData($data, $comments, '  ') . "\n);\n";
         }
         return "<?php\nreturn " . var_export($data, true) . ";\n";
+    }
+
+    /**
+     * Format supplied data
+     *
+     * @param $data
+     * @param $comments
+     * @param string $prefix
+     * @return string
+     */
+    protected function formatData($data, $comments, $prefix = '')
+    {
+        $elements = [];
+
+        if (is_array($data)) {
+            foreach ($data as $key => $value) {
+                if (!empty($comments[$key])) {
+                    $elements[] = $prefix . '/**';
+                    $elements[] = $prefix . ' * For the section: ' . $key;
+
+                    foreach (explode("\n", $comments[$key]) as $commentLine) {
+                        $elements[] = $prefix . ' * ' . $commentLine;
+                    }
+
+                    $elements[] = $prefix . " */";
+                }
+
+                if (is_array($value)) {
+                    $elements[] = $prefix . var_export($key, true) . ' => ';
+                    $elements[] = $prefix . 'array (';
+                    $elements[] = $this->formatData($value, [], '  ' . $prefix);
+                    $elements[] = $prefix . '),';
+                } else {
+                    $elements[] = $prefix . var_export($key, true) . ' => ' . var_export($value, true) . ',';
+                }
+            }
+            return implode("\n", $elements);
+        }
+
+        return var_export($data, true);
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -68,7 +68,8 @@ return array (
     ),
   ),
   /**
-   * 'comment for namespace 2'
+   * For the section: ns2
+   * comment for namespace 2
    */
   'ns2' => 
   array (
@@ -86,7 +87,8 @@ TEXT;
 <?php
 return array (
   /**
-   * 'comment for namespace 1'
+   * For the section: ns1
+   * comment for namespace 1
    */
   'ns1' => 
   array (
@@ -102,8 +104,9 @@ return array (
     ),
   ),
   /**
-   * 'comment for namespace 2.
-   * Next comment for namespace 2'
+   * For the section: ns2
+   * comment for namespace 2.
+   * Next comment for namespace 2
    */
   'ns2' => 
   array (
@@ -113,11 +116,13 @@ return array (
     ),
   ),
   /**
-   * 'comment for namespace 3'
+   * For the section: ns3
+   * comment for namespace 3
    */
   'ns3' => 'just text',
   /**
-   * 'comment for namespace 4'
+   * For the section: ns4
+   * comment for namespace 4
    */
   'ns4' => 'just text',
 );

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Framework\App\Test\Unit\DeploymentConfig\Writer;
 
-use \Magento\Framework\App\DeploymentConfig\Writer\PhpFormatter;
+use Magento\Framework\App\DeploymentConfig\Writer\PhpFormatter;
 
 class PhpFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -78,7 +78,7 @@ return array (
     ),
   ),
   'ns3' => 'just text',
-  'ns4' => 'just text'
+  'ns4' => 'just text',
 );
 
 TEXT;
@@ -119,7 +119,7 @@ return array (
   /**
    * 'comment for namespace 4'
    */
-  'ns4' => 'just text'
+  'ns4' => 'just text',
 );
 
 TEXT;

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -3,7 +3,6 @@
  * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Framework\App\Test\Unit\DeploymentConfig\Writer;
 
 use Magento\Framework\App\DeploymentConfig\Writer\PhpFormatter;
@@ -12,8 +11,8 @@ class PhpFormatterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider formatWithCommentDataProvider
-     * @param string|array $data
-     * @param array $comments
+     * @param string[] $data
+     * @param string[] $comments
      * @param string $expectedResult
      */
     public function testFormat($data, $comments, $expectedResult)
@@ -22,6 +21,9 @@ class PhpFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedResult, $formatter->format($data, $comments));
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
     public function formatWithCommentDataProvider()
     {
         $array = [
@@ -45,9 +47,9 @@ class PhpFormatterTest extends \PHPUnit_Framework_TestCase
         ];
         $comments1 = ['ns2' => 'comment for namespace 2'];
         $comments2 = [
-            'ns1' => 'comment for namespace 1',
-            'ns2' => "comment for namespace 2.\nNext comment for namespace 2",
-            'ns3' => 'comment for namespace 3',
+            'ns1' => 'comment for\' namespace 1',
+            'ns2' => "comment for namespace 2.\nNext comment for' namespace 2",
+            'ns3' => 'comment for" namespace 3',
             'ns4' => 'comment for namespace 4',
             'ns5' => 'comment for unexisted namespace 5',
         ];
@@ -88,7 +90,7 @@ TEXT;
 return array (
   /**
    * For the section: ns1
-   * comment for namespace 1
+   * comment for' namespace 1
    */
   'ns1' => 
   array (
@@ -106,7 +108,7 @@ return array (
   /**
    * For the section: ns2
    * comment for namespace 2.
-   * Next comment for namespace 2
+   * Next comment for' namespace 2
    */
   'ns2' => 
   array (
@@ -117,7 +119,7 @@ return array (
   ),
   /**
    * For the section: ns3
-   * comment for namespace 3
+   * comment for" namespace 3
    */
   'ns3' => 'just text',
   /**


### PR DESCRIPTION
### Related PRs:

* #11439 
* #11452 

app:config:dump adds extra space every time in multiline array value

### Description

Rewrite PhpFormatter::format method, to avoid add extra spaces

### Fixed Issues (if relevant)

1. magento/magento2#11328: app:config:dump adds extra space every time in multiline array value

### Manual testing scenarios

Described in issue #11328

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
