### PR TITLE
#11328 : app:config:dump adds extra space every time in multiline array value

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -21,7 +21,7 @@ class PhpFormatter implements FormatterInterface
     public function format($data, array $comments = [])
     {
         if (!empty($comments) && is_array($data)) {
-            return "<?php\nreturn array (\n" . $this->formatData($data, $comments, '  ') . "\n);\n";
+            return "<?php\nreturn array (\n" . $this->formatData($data, $comments) . "\n);\n";
         }
         return "<?php\nreturn " . var_export($data, true) . ";\n";
     }
@@ -29,12 +29,12 @@ class PhpFormatter implements FormatterInterface
     /**
      * Format supplied data
      *
-     * @param $data
-     * @param $comments
+     * @param string[] $data
+     * @param string[] $comments
      * @param string $prefix
      * @return string
      */
-    protected function formatData($data, $comments, $prefix = '')
+    private function formatData($data, $comments = [], $prefix = '  ')
     {
         $elements = [];
 

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -51,13 +51,13 @@ class PhpFormatter implements FormatterInterface
                     $elements[] = $prefix . " */";
                 }
 
+                $elements[] = $prefix . var_export($key, true) . ' => ' .
+                    (!is_array($value) ? var_export($value, true) . ',' : '');
+
                 if (is_array($value)) {
-                    $elements[] = $prefix . var_export($key, true) . ' => ';
                     $elements[] = $prefix . 'array (';
                     $elements[] = $this->formatData($value, [], '  ' . $prefix);
                     $elements[] = $prefix . '),';
-                } else {
-                    $elements[] = $prefix . var_export($key, true) . ' => ' . var_export($value, true) . ',';
                 }
             }
             return implode("\n", $elements);

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -11,8 +11,8 @@ class PhpFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider formatWithCommentDataProvider
-     * @param string|array $data
-     * @param array $comments
+     * @param string[] $data
+     * @param string[] $comments
      * @param string $expectedResult
      */
     public function testFormat($data, $comments, $expectedResult)

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\App\Test\Unit\DeploymentConfig\Writer;
 
-use \Magento\Framework\App\DeploymentConfig\Writer\PhpFormatter;
+use Magento\Framework\App\DeploymentConfig\Writer\PhpFormatter;
 
 class PhpFormatterTest extends \PHPUnit\Framework\TestCase
 {
@@ -81,7 +81,7 @@ return array (
     ),
   ),
   'ns3' => 'just text',
-  'ns4' => 'just text'
+  'ns4' => 'just text',
 );
 
 TEXT;
@@ -126,7 +126,7 @@ return array (
    * For the section: ns4
    * comment for namespace 4
    */
-  'ns4' => 'just text'
+  'ns4' => 'just text',
 );
 
 TEXT;


### PR DESCRIPTION
### Related PRs:

* #11439 
* #11451 

app:config:dump adds extra space every time in multiline array value

### Description

Rewrite PhpFormatter::format method, to avoid add extra spaces

### Fixed Issues (if relevant)

1. magento/magento2#11328: app:config:dump adds extra space every time in multiline array value

### Manual testing scenarios

Described in issue #11328

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
