### PR TITLE
Added carrier code to ID to distinguish shipping methods [port 2.3]

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/cart/shipping-rates.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/cart/shipping-rates.html
@@ -24,10 +24,10 @@
                                 checked: $parents[1].selectedShippingMethod,
                                 attr: {
                                         value: carrier_code + '_' + method_code,
-                                        id: 's_method_' + method_code
+                                        id: 's_method_' + carrier_code + '_' + method_code
                                         }
                                 "/>
-                    <label class="label" data-bind="attr: {for: 's_method_' + method_code}">
+                    <label class="label" data-bind="attr: {for: 's_method_' + carrier_code + '_' + method_code}">
                         <!-- ko text: $data.method_title --><!-- /ko -->
                         <each args="element.getRegion('price')" render="" />
                     </label>


### PR DESCRIPTION
Added carrier code to ID to distinguish shipping methods with the same method name but differing carrier code

<!--- Provide a general summary of the Pull Request in the Title above -->
Shipping method radios have duplicate element IDs on cart page, which makes it impossible to select the second method.

### Description
Make the element ID unique by adding in the carrier code into the ID. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10795: Shipping method radios have duplicate IDs on cart page

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a shipping method with a unique carrier name but a method name that is in use, such as 'freeshipping' (make sure to of course enable the freeshipping option and have it appear in the checklist).

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
