### PR TITLE
Products added to cart with REST API give total prices equal to zero

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -232,7 +232,6 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         $quote->setShippingAddress($this->quoteAddressFactory->create());
 
         try {
-            $quote->getBillingAddress()->setCollectShippingRates(true);
             $quote->getShippingAddress()->setCollectShippingRates(true);
 
             $this->quoteRepository->save($quote);

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -232,6 +232,8 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         $quote->setShippingAddress($this->quoteAddressFactory->create());
 
         try {
+            $quote->getBillingAddress();
+            $quote->getShippingAddress()->setCollectShippingRates(true);
             $this->quoteRepository->save($quote);
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('Cannot create quote'));

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -232,6 +232,9 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         $quote->setShippingAddress($this->quoteAddressFactory->create());
 
         try {
+            $quote->getBillingAddress()->setCollectShippingRates(true);
+            $quote->getShippingAddress()->setCollectShippingRates(true);
+
             $this->quoteRepository->save($quote);
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('Cannot create quote'));


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Products added to cart with REST API give total prices equal to zero

### Description
When adding a product trough the (web) API to an empty cart, the product gets a price of zero.

<!--- Provide a description of the changes proposed in the pull request -->
To quote @degaray in https://github.com/magento/magento2/issues/2991#issuecomment-174325730, "The problem is here: `Magento\Quote\Model\Quote\TotalsCollector::collect` because all totals are set to zero and then all totals are calculated per address set. Since no address is set, then no totals are calculated, and as result, it does not calculate any total."

Adding these collect shipping method calls will set a blank address, and cause the price to show up correctly.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#2991: Products added to cart with REST API give total prices equal to zero

### Related Issues
1. magento/magento2#4532 Virtual products not showing totals in cart (PR)

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. See https://github.com/magento/magento2/issues/2991#issuecomment-174598611

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

(sorry for the commits mess, apparently I suck at rebasing)