### PR TITLE
[ISSUE-11140][BUGFIX] Skip store code admin from being detected in ca…

### DIFF
--- a/app/code/Magento/Store/App/Request/PathInfoProcessor.php
+++ b/app/code/Magento/Store/App/Request/PathInfoProcessor.php
@@ -43,7 +43,7 @@ class PathInfoProcessor implements \Magento\Framework\App\Request\PathInfoProces
         }
 
         if ($store->isUseStoreInUrl()) {
-            if (!$request->isDirectAccessFrontendName($storeCode) && $storeCode != Store::ADMIN_CODE ) {
+            if (!$request->isDirectAccessFrontendName($storeCode) && $storeCode != Store::ADMIN_CODE) {
                 $this->storeManager->setCurrentStore($storeCode);
                 $pathInfo = '/' . (isset($pathParts[1]) ? $pathParts[1] : '');
                 return $pathInfo;

--- a/app/code/Magento/Store/App/Request/PathInfoProcessor.php
+++ b/app/code/Magento/Store/App/Request/PathInfoProcessor.php
@@ -6,6 +6,7 @@
 namespace Magento\Store\App\Request;
 
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\Store;
 
 class PathInfoProcessor implements \Magento\Framework\App\Request\PathInfoProcessorInterface
 {
@@ -42,7 +43,7 @@ class PathInfoProcessor implements \Magento\Framework\App\Request\PathInfoProces
         }
 
         if ($store->isUseStoreInUrl()) {
-            if (!$request->isDirectAccessFrontendName($storeCode)) {
+            if (!$request->isDirectAccessFrontendName($storeCode) && $storeCode != Store::ADMIN_CODE ) {
                 $this->storeManager->setCurrentStore($storeCode);
                 $pathInfo = '/' . (isset($pathParts[1]) ? $pathParts[1] : '');
                 return $pathInfo;


### PR DESCRIPTION
…se of store code in url configured

Show a 404 error page if /admin is called but it was customized and the store code url is enabled

### Description

When store code url is configured for frontend, the url admin is also involved to set the pathinfo but it should be not as it is a different expected area and that admin store code is "hard coded" in DB and PHP Class

### Fixed Issues

1. magento/magento2#11140: Going to '/admin' while using storecodes in url and a different adminhtml url will throw exception

### Manual testing scenarios
1. Everything is explained into magento/magento2#11140

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
