### PR TITLE
Retain additional cron history by default

### DIFF
--- a/app/code/Magento/Cron/etc/cron_groups.xml
+++ b/app/code/Magento/Cron/etc/cron_groups.xml
@@ -11,8 +11,8 @@
         <schedule_ahead_for>20</schedule_ahead_for>
         <schedule_lifetime>15</schedule_lifetime>
         <history_cleanup_every>10</history_cleanup_every>
-        <history_success_lifetime>60</history_success_lifetime>
-        <history_failure_lifetime>600</history_failure_lifetime>
+        <history_success_lifetime>10080</history_success_lifetime>
+        <history_failure_lifetime>10080</history_failure_lifetime>
         <use_separate_process>0</use_separate_process>
     </group>
 </config>

--- a/app/code/Magento/Indexer/etc/cron_groups.xml
+++ b/app/code/Magento/Indexer/etc/cron_groups.xml
@@ -11,8 +11,8 @@
         <schedule_ahead_for>4</schedule_ahead_for>
         <schedule_lifetime>2</schedule_lifetime>
         <history_cleanup_every>10</history_cleanup_every>
-        <history_success_lifetime>60</history_success_lifetime>
-        <history_failure_lifetime>600</history_failure_lifetime>
+        <history_success_lifetime>10080</history_success_lifetime>
+        <history_failure_lifetime>10080</history_failure_lifetime>
         <use_separate_process>1</use_separate_process>
     </group>
 </config>


### PR DESCRIPTION
### Description

Changes default cron success / failure history to seven days.

There's no reason the clear the history out so fast other than to make it impossible to audit, if / when there is an issue...

### Manual testing scenarios

1. In the admin panel go to Stores > Configuration > Advanced > System > Cron
2. Validate that "Success History Lifetime" and "Failure History Lifetime" is 10080 for both the default and the index group.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
