### PR TITLE
[ISSUE-10650][BUGFIX] Prevent running again already running cron job

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -64,7 +64,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected $runningSchedules;
+    private $runningSchedules;
 
     /**
      * @var \Magento\Cron\Model\ConfigInterface

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -346,7 +346,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      *
      * @return \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected function getRunningSchedules()
+    private function getRunningSchedules()
     {
         if (!$this->runningSchedules) {
             $this->runningSchedules = $this->_scheduleFactory->create()->getCollection()->addFieldToFilter(

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -260,7 +260,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      *
      * @return bool
      */
-    protected function isJobRunning($jobCode)
+    private function isJobRunning($jobCode)
     {
         $runningJobs = $this->getRunningSchedules();
 

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -64,7 +64,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected $_runningSchedules;
+    protected $runningSchedules;
 
     /**
      * @var \Magento\Cron\Model\ConfigInterface
@@ -262,7 +262,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      */
     protected function isJobRunning($jobCode)
     {
-        $runningJobs = $this->_getRunningSchedules();
+        $runningJobs = $this->getRunningSchedules();
 
         /** @var \Magento\Cron\Model\Schedule $schedule */
         foreach ($runningJobs as $schedule) {
@@ -346,15 +346,15 @@ class ProcessCronQueueObserver implements ObserverInterface
      *
      * @return \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected function _getRunningSchedules()
+    protected function getRunningSchedules()
     {
-        if (!$this->_runningSchedules) {
-            $this->_runningSchedules = $this->_scheduleFactory->create()->getCollection()->addFieldToFilter(
+        if (!$this->runningSchedules) {
+            $this->runningSchedules = $this->_scheduleFactory->create()->getCollection()->addFieldToFilter(
                 'status',
                 Schedule::STATUS_RUNNING
             )->load();
         }
-        return $this->_runningSchedules;
+        return $this->runningSchedules;
     }
 
     /**

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -262,7 +262,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(3))->method('create')->will($this->returnValue($scheduleMock));
 
         $this->_observer->execute($this->observer);
     }
@@ -333,7 +333,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->_collection);
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->willReturn($scheduleMock);
+        $this->_scheduleFactory->expects($this->exactly(3))->method('create')->willReturn($scheduleMock);
 
         $this->_observer->execute($this->observer);
     }
@@ -388,7 +388,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(3))->method('create')->will($this->returnValue($scheduleMock));
 
         $this->_observer->execute($this->observer);
     }
@@ -453,7 +453,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(3))->method('create')->will($this->returnValue($scheduleMock));
         $this->_objectManager
             ->expects($this->once())
             ->method('create')
@@ -524,7 +524,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
 
         // cron end execute some job
         $schedule->expects(
-            $this->at(6)
+            $this->at(7)
         )->method(
             'setStatus'
         )->with(
@@ -550,7 +550,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(3))->method('create')->will($this->returnValue($scheduleMock));
 
         $testCronJob = $this->getMockBuilder('CronJob')->setMethods(['execute'])->getMock();
         $testCronJob->expects($this->atLeastOnce())->method('execute')->with($schedule);


### PR DESCRIPTION
### Description

Create a logic to get running cron job and prevent them to be run again when pending job should be executed

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10650: Cron starts when it's already running

### Manual testing scenarios
1. Create a cron that takes a while (for example, sleep 15 minutes)
2. Schedule it to run every 5 minutes

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
