### PR TITLE
migrated pull request #11459 to 2.3 develop

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -203,72 +203,157 @@
     RedirectMatch 403 /\.git
 
     <Files composer.json>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files composer.lock>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files .gitignore>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files .htaccess>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files .htaccess.sample>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files .php_cs.dist>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files .travis.yml>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files CHANGELOG.md>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files COPYING.txt>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files Gruntfile.js>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files LICENSE.txt>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files LICENSE_AFL.txt>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files nginx.conf.sample>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files package.json>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files php.ini.sample>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files README.md>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
     <Files magento_umask>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
 
 # For 404s and 403s that aren't handled by the application, show plain 404 response

--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/.htaccess
+++ b/dev/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfVersion < 2.4>
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/cache/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/cache/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfVersion < 2.4>
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfVersion < 2.4>
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/cache/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/cache/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfVersion < 2.4>
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfVersion < 2.4>
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/cache/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/cache/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfVersion < 2.4>
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/generated/.htaccess
+++ b/generated/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/phpserver/.htaccess
+++ b/phpserver/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -190,8 +190,13 @@
 ## Deny access to release notes to prevent disclosure of the installed Magento version
 
     <Files RELEASE_NOTES.txt>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
 
 # For 404s and 403s that aren't handled by the application, show plain 404 response
@@ -207,8 +212,13 @@ ErrorDocument 403 /errors/404.php
 ###########################################
 ## Deny access  to cron.php
     <Files cron.php>
-        order allow,deny
-        deny from all
+        <IfVersion < 2.4>
+            order allow,deny
+            deny from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all denied
+        </IfVersion>
     </Files>
 
 <IfModule mod_headers.c>

--- a/pub/media/.htaccess
+++ b/pub/media/.htaccess
@@ -1,4 +1,4 @@
-Options All -Indexes
+Options -Indexes
 
 <IfModule mod_php5.c>
 php_flag engine 0

--- a/pub/media/customer/.htaccess
+++ b/pub/media/customer/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/pub/media/downloadable/.htaccess
+++ b/pub/media/downloadable/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/pub/media/import/.htaccess
+++ b/pub/media/import/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/pub/media/theme_customization/.htaccess
+++ b/pub/media/theme_customization/.htaccess
@@ -1,5 +1,10 @@
-Options All -Indexes
+Options -Indexes
 <Files ~ "\.xml$">
-    Order allow,deny
-    Deny from all
+    <IfVersion < 2.4>
+        order allow,deny
+        deny from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all denied
+    </IfVersion>
 </Files>

--- a/setup/config/.htaccess
+++ b/setup/config/.htaccess
@@ -1,2 +1,8 @@
-order allow,deny
-deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/setup/performance-toolkit/.htaccess
+++ b/setup/performance-toolkit/.htaccess
@@ -1,2 +1,8 @@
-order allow,deny
-deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/setup/src/.htaccess
+++ b/setup/src/.htaccess
@@ -1,2 +1,8 @@
-order allow,deny
-deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/setup/view/.htaccess
+++ b/setup/view/.htaccess
@@ -1,2 +1,8 @@
-order allow,deny
-deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/var/.htaccess
+++ b/var/.htaccess
@@ -1,2 +1,8 @@
-Order deny,allow
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,2 +1,8 @@
-Order allow,deny
-Deny from all
+<IfVersion < 2.4>
+    order allow,deny
+    deny from all
+</IfVersion>
+<IfVersion >= 2.4>
+    Require all denied
+</IfVersion>
+


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
See https://github.com/magento/magento2/pull/11459
This is the 2.3 Version

Description

In all .htaccess Files, the Apache 2.2 Auth Blocks like


            order allow,deny
            deny from all

have been replaced with this block:

        <IfVersion < 2.4>
            order allow,deny
            deny from all
        </IfVersion>
        <IfVersion >= 2.4>
            Require all denied
        </IfVersion>

Fixed Issues (if relevant)

    magento/magento2#10810: Add support of apache2.4 commands in htaccess

Manual testing scenarios

    Install on Apache 2.4 and check whether all file access rules work as intended
    Install on Apache 2.2 and check whether all file access rules work as intended


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
