### PR TITLE
FIX Strict-Transport-Security bug in magento backend

### DIFF
--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -168,7 +168,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
             return true;
         }
 
-        // backend specific checks 
+        // backend specific checks
         // if ($this->hasData('secure_is_forced') already processed in parent class
 
         if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -167,9 +167,9 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
         if ($this->hasData('secure_is_forced')) {
             return $this->getData('secure');
         }
-		if($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')){
-			return $this->getData('secure');
-		}
+        if($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')){
+            return $this->getData('secure');
+        }
         return parent::_isSecure();
     }
 

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -164,13 +164,24 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
      */
     protected function _isSecure()
     {
-        if ($this->hasData('secure_is_forced')) {
-            return $this->getData('secure');
-        }
-        if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {
+        if (true === parent::_isSecure()) {
             return true;
         }
-        return parent::_isSecure();
+
+        // backend specific checks 
+        // if ($this->hasData('secure_is_forced') already processed in parent class
+        
+        if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {
+            if ($this->getRouteParamsResolver()->hasData('secure')) {
+                // we still respect options provided programatically as for secure request in parent class
+                return (bool) $this->getRouteParamsResolver()->getData('secure');
+            }    
+            return true;
+        } else {
+            // if web/secure/use_in_adminhtml == 0 that means we do not care but not that HTTP should be used
+        }
+
+        return false;
     }
 
     /**

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -158,6 +158,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
 
     /**
      * Retrieve is secure mode for ULR logic
+     * If secure mode is not set up, use default magento behavior
      *
      * @return bool
      */
@@ -166,7 +167,10 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
         if ($this->hasData('secure_is_forced')) {
             return $this->getData('secure');
         }
-        return $this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml');
+		if($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')){
+			return $this->getData('secure');
+		}
+        return parent::_isSecure();
     }
 
     /**

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -168,7 +168,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
             return $this->getData('secure');
         }
         if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {
-            return $this->getData('secure');
+            return true;
         }
         return parent::_isSecure();
     }

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -170,12 +170,12 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
 
         // backend specific checks 
         // if ($this->hasData('secure_is_forced') already processed in parent class
-        
+
         if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {
             if ($this->getRouteParamsResolver()->hasData('secure')) {
                 // we still respect options provided programatically as for secure request in parent class
                 return (bool) $this->getRouteParamsResolver()->getData('secure');
-            }    
+            }
             return true;
         } else {
             // if web/secure/use_in_adminhtml == 0 that means we do not care but not that HTTP should be used

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -167,7 +167,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
         if ($this->hasData('secure_is_forced')) {
             return $this->getData('secure');
         }
-        if($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')){
+        if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {
             return $this->getData('secure');
         }
         return parent::_isSecure();

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -164,12 +164,16 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
      */
     protected function _isSecure()
     {
-        if (true === parent::_isSecure()) {
+        if ($this->_request->isSecure()) {
+            if ($this->getRouteParamsResolver()->hasData('secure')) {
+                return (bool) $this->getRouteParamsResolver()->getData('secure');
+            }
             return true;
         }
 
-        // backend specific checks
-        // if ($this->hasData('secure_is_forced') already processed in parent class
+        if ($this->getRouteParamsResolver()->hasData('secure_is_forced')) {
+            return (bool) $this->getRouteParamsResolver()->getData('secure');
+        }
 
         if ($this->_scopeConfig->isSetFlag('web/secure/use_in_adminhtml')) {
             if ($this->getRouteParamsResolver()->hasData('secure')) {


### PR DESCRIPTION
this commit fixes the infinite redirect loop in magento administration when user tries to update from non http to https.

default magento behavior is that if user opens https connection, it uses the https stream. If magento administration does not contain any configuration wheater to use https, only http is used, and redirection by browser does inifinite redirection. If magento config does not setup strict https (because with upgrade the https is not enabled at first) magento redirects administrator from https stream to http which is Strict-Transport-Security bug.

this PR fixes issue #11350 and  #11356 

please do not let @orlangur to process this one, because he believes that inifinite redircts in magento are not an issue, and he believes that magento behavior against Strict-Transport-Security is not an issue. Please note that it is severe issue, and should be fixed ASAP.

### Description
Magento should not redirect https stream to http

### Fixed Issues (if relevant)
1. magento/magento2#11350
2. magento/magento2#11356 

### Manual testing scenarios
1. Set up magento using only http
2. Allow https in web browser
3. This issue fixes the issue that user then cannot get to admin login screen because he gets inifinite redirect loop

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
yes
 - [ ] All commits are accompanied by meaningful commit messages
yes
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
not possible because it requires changes in web browser
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
todo