### PR TITLE
FR#10231_21 Custom URL Rewrite Not working

### DIFF
--- a/app/code/Magento/Store/etc/frontend/di.xml
+++ b/app/code/Magento/Store/etc/frontend/di.xml
@@ -18,7 +18,7 @@
                 <item name="standard" xsi:type="array">
                     <item name="class" xsi:type="string">Magento\Framework\App\Router\Base</item>
                     <item name="disable" xsi:type="boolean">false</item>
-                    <item name="sortOrder" xsi:type="string">20</item>
+                    <item name="sortOrder" xsi:type="string">30</item>
                 </item>
                 <item name="default" xsi:type="array">
                     <item name="class" xsi:type="string">Magento\Framework\App\Router\DefaultRouter</item>

--- a/app/code/Magento/UrlRewrite/etc/frontend/di.xml
+++ b/app/code/Magento/UrlRewrite/etc/frontend/di.xml
@@ -12,7 +12,7 @@
                 <item name="urlrewrite" xsi:type="array">
                     <item name="class" xsi:type="string">Magento\UrlRewrite\Controller\Router</item>
                     <item name="disable" xsi:type="boolean">false</item>
-                    <item name="sortOrder" xsi:type="string">40</item>
+                    <item name="sortOrder" xsi:type="string">20</item>
                 </item>
             </argument>
         </arguments>


### PR DESCRIPTION
Magento custom url rewrites functionality is not working when adding a redirection of magento controllers. For example a custom redirection from /customer/account/create to another page.

### Description
This commit modifies the order that magento loads the routerList pushing **urlrewrite** router before magento base router. Thats the same order that Magento 1 uses in the function **dispatch()** on **web/app/code/core/Mage/Core/Controller/Varien/Front.php** controller.

### Related PRs:
#11470 
#11471 

### Fixed Issues (if relevant)
1. magento/magento2#10231: Custom URL Rewrite Not working 

### Manual testing scenarios
1. Add New Custom URL Rewrite
2. Set Request Path customer/account/create and Target Path  customer/account/login
3. It should redirect customer/account/create page To customer/account/login page same like Magento 1.x

When adding this modification the expected result is accomplish

### Other possible solutions 
This is my first option for fix the issue and the other one, if this one is not accepted, it will be add a new router called "customurlrewrite" that only checks for custom url types (Maybe better for performance) and loading it before magento base router.

### Annotations
I found that this issue happens in magento 2 and 2.2 version too.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)