### PR TITLE
Braintree - fix for exception being thrown while processing configuration data

### DIFF
--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -66,6 +66,13 @@ class CountryCreditCard extends Value
     public function beforeSave()
     {
         $value = $this->getValue();
+        if(!is_array($value)) {
+            try {
+                $value = $this->serializer->unserialize($value);
+            } catch (\InvalidArgumentException $e) {
+                $value = [];
+            }
+        }
         $result = [];
         foreach ($value as $data) {
             if (empty($data['country_id']) || empty($data['cc_types'])) {


### PR DESCRIPTION
While setting up Magento by cli - process was crashing during processing configurations data from configuration file...

Issue was in Braintree module that was trying to iterate on string value.

