### PR TITLE
FR#5768_22 Magento 2.0.7 XML sitemap is not generated by schedule

### DIFF
--- a/app/code/Magento/Cron/Model/Config/Backend/Sitemap.php
+++ b/app/code/Magento/Cron/Model/Config/Backend/Sitemap.php
@@ -77,7 +77,7 @@ class Sitemap extends \Magento\Framework\App\Config\Value
             $frequency == \Magento\Cron\Model\Config\Source\Frequency::CRON_WEEKLY ? '1' : '*', //# Day of the Week
         ];
 
-        $cronExprString = join(' ', $cronExprArray);
+        $cronExprString = implode(' ', $cronExprArray);
 
         try {
             $cronStringPath = $this->_configValueFactory->create()->load(self::CRON_STRING_PATH, 'path');

--- a/app/code/Magento/Cron/Model/Config/Backend/Sitemap.php
+++ b/app/code/Magento/Cron/Model/Config/Backend/Sitemap.php
@@ -80,22 +80,14 @@ class Sitemap extends \Magento\Framework\App\Config\Value
         $cronExprString = join(' ', $cronExprArray);
 
         try {
-            $this->_configValueFactory->create()->load(
-                self::CRON_STRING_PATH,
-                'path'
-            )->setValue(
-                $cronExprString
-            )->setPath(
-                self::CRON_STRING_PATH
-            )->save();
-            $this->_configValueFactory->create()->load(
-                self::CRON_MODEL_PATH,
-                'path'
-            )->setValue(
-                $this->_runModelPath
-            )->setPath(
-                self::CRON_MODEL_PATH
-            )->save();
+            $cronStringPath = $this->_configValueFactory->create()->load(self::CRON_STRING_PATH, 'path');
+            $cronStringPath->setValue($cronExprString);
+            $cronStringPath->setPath(self::CRON_STRING_PATH);
+            $cronStringPath->save();
+            $cronModelPath = $this->_configValueFactory->create()->load(self::CRON_MODEL_PATH, 'path');
+            $cronModelPath->setValue($this->_runModelPath);
+            $cronModelPath->setPath(self::CRON_MODEL_PATH);
+            $cronModelPath->save();
         } catch (\Exception $e) {
             throw new \Exception(__('We can\'t save the cron expression.'));
         }


### PR DESCRIPTION
Magento 2 sitemap generation frequency configuration was not working. When a administrator wants to enable the functionality of automatic sitemap generation the frequency was not saving in cron_schedule table.

### Description
The commit solves the issue on saving magento 2 automatic sitemap generation configuration. With these modifications the cron job is working properly.

### Fixed Issues (if relevant)
1. magento/magento2#5768: Magento 2.0.7 XML sitemap is not generated by schedule

### Manual testing scenarios
1.  go to admin>store>configurtion>catalog>xml sitemap
2. turn on generation and set up time.
3. Execute php bin/magento cron:run
3. Go to cron_schedule table and the cron job sitemap_generate is not in the table

With this modification if we do the same process the cron job appears in the table (If the time configured is nearby)

### Related PRs:
#11476

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)