### PR TITLE
FR#ProductAlertsCron_22 Magento Product Alerts cron is not generated …

### DIFF
--- a/app/code/Magento/Cron/Model/Config/Backend/Product/Alert.php
+++ b/app/code/Magento/Cron/Model/Config/Backend/Product/Alert.php
@@ -82,22 +82,14 @@ class Alert extends \Magento\Framework\App\Config\Value
         $cronExprString = join(' ', $cronExprArray);
 
         try {
-            $this->_configValueFactory->create()->load(
-                self::CRON_STRING_PATH,
-                'path'
-            )->setValue(
-                $cronExprString
-            )->setPath(
-                self::CRON_STRING_PATH
-            )->save();
-            $this->_configValueFactory->create()->load(
-                self::CRON_MODEL_PATH,
-                'path'
-            )->setValue(
-                $this->_runModelPath
-            )->setPath(
-                self::CRON_MODEL_PATH
-            )->save();
+            $cronStringPath = $this->_configValueFactory->create()->load(self::CRON_STRING_PATH, 'path');
+            $cronStringPath->setValue($cronExprString);
+            $cronStringPath->setPath(self::CRON_STRING_PATH);
+            $cronStringPath->save();
+            $cronModelPath = $this->_configValueFactory->create()->load(self::CRON_MODEL_PATH, 'path');
+            $cronModelPath->setValue($this->_runModelPath);
+            $cronModelPath->setPath(self::CRON_MODEL_PATH);
+            $cronModelPath->save();
         } catch (\Exception $e) {
             throw new \Exception(__('We can\'t save the cron expression.'));
         }

--- a/app/code/Magento/Cron/Model/Config/Backend/Product/Alert.php
+++ b/app/code/Magento/Cron/Model/Config/Backend/Product/Alert.php
@@ -79,7 +79,7 @@ class Alert extends \Magento\Framework\App\Config\Value
             $frequency == \Magento\Cron\Model\Config\Source\Frequency::CRON_WEEKLY ? '1' : '*', //Day of the Week
         ];
 
-        $cronExprString = join(' ', $cronExprArray);
+        $cronExprString = implode(' ', $cronExprArray);
 
         try {
             $cronStringPath = $this->_configValueFactory->create()->load(self::CRON_STRING_PATH, 'path');


### PR DESCRIPTION
Magento 2 product alerts cron configuration was not working. When a administrator wants to enable the functionality of product alerts the frequency was not saving in cron_schedule table.

### Description
The commit solves the issue on saving magento 2 automatic product alerts configuration. With these modifications the cron job is working properly.

### Manual testing scenarios
1.  go to admin>store>configurtion>catalog>catalog
2. turn on generation and set up time.
3. Execute php bin/magento cron:run
3. Go to cron_schedule table and the cron job catalog_product_alert is not in the table

With this modification if we do the same process the cron job appears in the table (If the time 
configured is nearby)

### Related PRs
#11567

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)