### PR TITLE
#11343 #11478 In admin, url params may get url encoded more than once, fix backend url model

### DIFF
--- a/app/code/Magento/Backend/Helper/Data.php
+++ b/app/code/Magento/Backend/Helper/Data.php
@@ -195,7 +195,7 @@ class Data extends AbstractHelper
      */
     public function getHomePageUrl()
     {
-        return $this->_backendUrl->getRouteUrl('adminhtml');
+        return $this->_backendUrl->getUrl('adminhtml');
     }
 
     /**

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -202,7 +202,9 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
         }
 
         $cacheSecretKey = false;
-        if (is_array($routeParams) && isset($routeParams['_cache_secret_key'])) {
+        $routeParams = is_array($routeParams) ? $routeParams : [];
+
+        if (isset($routeParams['_cache_secret_key'])) {
             unset($routeParams['_cache_secret_key']);
             $cacheSecretKey = true;
         }
@@ -220,11 +222,13 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
                     self::SECRET_KEY_PARAM_NAME => $this->getSecretKey($routeName, $controllerName, $actionName),
                 ];
             }
-            if (is_array($routeParams)) {
-                $routeParams = array_merge($routeParams, $secret);
-            } else {
-                $routeParams = $secret;
-            }
+
+            $routeParams = array_merge($routeParams, $secret);
+        }
+
+        $routePathParams = $this->_getRouteParams();
+        if (is_array($routePathParams)) {
+            $routeParams = array_merge($routePathParams, $routeParams);
         }
 
         return parent::getUrl("{$routeName}/{$controllerName}/{$actionName}", $routeParams);

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -179,10 +179,10 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
     protected function _setRouteParams(array $data, $unsetOldParams = true)
     {
         if (isset($data['_nosecret'])) {
-            $this->setNoSecret(true);
+            $this->turnOffSecretKey();
             unset($data['_nosecret']);
         } else {
-            $this->setNoSecret(false);
+            $this->turnOnSecretKey();
         }
         unset($data['_scope_to_url']);
         return parent::_setRouteParams($data, $unsetOldParams);

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -221,7 +221,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
                 ];
             }
             if (is_array($routeParams)) {
-                $routeParams = array_merge($secret, $routeParams);
+                $routeParams = array_merge($routeParams, $secret);
             } else {
                 $routeParams = $secret;
             }

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Backend\Model;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Url\HostChecker;
-use Magento\Framework\App\ObjectManager;
 
 /**
  * Class \Magento\Backend\Model\UrlInterface
@@ -206,29 +206,27 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
             unset($routeParams['_cache_secret_key']);
             $cacheSecretKey = true;
         }
-        $result = parent::getUrl($routePath, $routeParams);
-        if (!$this->useSecretKey()) {
-            return $result;
-        }
+
         $this->_setRoutePath($routePath);
         $routeName = $this->_getRouteName('*');
         $controllerName = $this->_getControllerName(self::DEFAULT_CONTROLLER_NAME);
         $actionName = $this->_getActionName(self::DEFAULT_ACTION_NAME);
-        if ($cacheSecretKey) {
-            $secret = [self::SECRET_KEY_PARAM_NAME => "\${$routeName}/{$controllerName}/{$actionName}\$"];
-        } else {
-            $secret = [
-                self::SECRET_KEY_PARAM_NAME => $this->getSecretKey($routeName, $controllerName, $actionName),
-            ];
+
+        if ($this->useSecretKey()) {
+            if ($cacheSecretKey) {
+                $secret = [self::SECRET_KEY_PARAM_NAME => "\${$routeName}/{$controllerName}/{$actionName}\$"];
+            } else {
+                $secret = [
+                    self::SECRET_KEY_PARAM_NAME => $this->getSecretKey($routeName, $controllerName, $actionName),
+                ];
+            }
+            if (is_array($routeParams)) {
+                $routeParams = array_merge($secret, $routeParams);
+            } else {
+                $routeParams = $secret;
+            }
         }
-        if (is_array($routeParams)) {
-            $routeParams = array_merge($secret, $routeParams);
-        } else {
-            $routeParams = $secret;
-        }
-        if (is_array($this->_getRouteParams())) {
-            $routeParams = array_merge($this->_getRouteParams(), $routeParams);
-        }
+
         return parent::getUrl("{$routeName}/{$controllerName}/{$actionName}", $routeParams);
     }
 

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractBackendController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractBackendController.php
@@ -13,6 +13,11 @@ namespace Magento\TestFramework\TestCase;
 abstract class AbstractBackendController extends \Magento\TestFramework\TestCase\AbstractController
 {
     /**
+     * @var \Magento\Backend\Model\UrlInterface
+     */
+    protected $_urlBuilder;
+
+    /**
      * @var \Magento\Backend\Model\Auth\Session
      */
     protected $_session;
@@ -40,8 +45,7 @@ abstract class AbstractBackendController extends \Magento\TestFramework\TestCase
     {
         parent::setUp();
 
-        $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
-
+        $this->_urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
         $this->_auth = $this->_objectManager->get(\Magento\Backend\Model\Auth::class);
         $this->_session = $this->_auth->getAuthStorage();
         $credentials = $this->_getAdminCredentials();

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/AuthTest.php
@@ -91,6 +91,7 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractController
         $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
             \Magento\Backend\Model\UrlInterface::class
         );
+        $backendUrlModel->turnOffSecretKey();
         $url = $backendUrlModel->getStartupPageUrl();
         $expected = $backendUrlModel->getUrl($url);
         $this->assertRedirect($this->stringStartsWith($expected));
@@ -137,6 +138,11 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractController
     {
         $this->_login();
         $this->dispatch('backend/admin/auth/logout');
+        /** @var $backendUrlModel \Magento\Backend\Model\UrlInterface */
+        $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Backend\Model\UrlInterface::class
+        );
+        $backendUrlModel->turnOffSecretKey();
         $this->assertRedirect(
             $this->equalTo(
                 \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
@@ -156,6 +162,11 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractController
     {
         $this->_login();
         $this->dispatch('backend/admin/auth/deniedJson');
+        /** @var $backendUrlModel \Magento\Backend\Model\UrlInterface */
+        $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Backend\Model\UrlInterface::class
+        );
+        $backendUrlModel->turnOffSecretKey();
         $data = [
             'ajaxExpired' => 1,
             'ajaxRedirect' => \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
@@ -176,6 +187,11 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractController
     {
         $this->_login();
         $this->dispatch('backend/admin/auth/deniedIframe');
+        /** @var $backendUrlModel \Magento\Backend\Model\UrlInterface */
+        $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Backend\Model\UrlInterface::class
+        );
+        $backendUrlModel->turnOffSecretKey();
         $homeUrl = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
             \Magento\Backend\Helper\Data::class
         )->getHomePageUrl();

--- a/dev/tests/integration/testsuite/Magento/Backend/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Helper/DataTest.php
@@ -108,9 +108,8 @@ class DataTest extends \PHPUnit\Framework\TestCase
         /**
          * perform login
          */
-        \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Backend\Model\UrlInterface::class
-        )->turnOffSecretKey();
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
 
         $auth = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Auth::class);
         $auth->login(\Magento\TestFramework\Bootstrap::ADMIN_NAME, \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD);
@@ -120,9 +119,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
          * perform logout
          */
         $auth->logout();
-        \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Backend\Model\UrlInterface::class
-        )->turnOnSecretKey();
+        $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOnSecretKey();
 
         $this->assertFalse($this->_helper->getCurrentUserId());
     }
@@ -141,8 +138,11 @@ class DataTest extends \PHPUnit\Framework\TestCase
 
     public function testGetHomePageUrl()
     {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
+
         $this->assertStringEndsWith(
-            'index.php/backend/admin/',
+            'index.php/backend/admin/index/index/',
             $this->_helper->getHomePageUrl(),
             'Incorrect home page URL'
         );

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
@@ -17,24 +17,26 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
      */
     public function testSaveActionRedirectsSuccessfully()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-
         /** @var $session \Magento\Backend\Model\Session */
-        $session = $objectManager->get(\Magento\Backend\Model\Session::class);
+        $session = $this->_objectManager->get(\Magento\Backend\Model\Session::class);
         $session->setProductIds([1]);
 
         $this->dispatch('backend/catalog/product_action_attribute/save/store/0');
 
         $this->assertEquals(302, $this->getResponse()->getHttpResponseCode());
         /** @var \Magento\Backend\Model\UrlInterface $urlBuilder */
-        $urlBuilder = $objectManager->get(\Magento\Framework\UrlInterface::class);
+        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class);
 
         /** @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper */
-        $attributeHelper = $objectManager->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class);
+        $attributeHelper = $this->_objectManager
+            ->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class)
+            ->turnOffSecretKey();
+
         $expectedUrl = $urlBuilder->getUrl(
             'catalog/product/index',
             ['store' => $attributeHelper->getSelectedStoreId()]
         );
+
         $isRedirectPresent = false;
         foreach ($this->getResponse()->getHeaders() as $header) {
             if ($header->getFieldName() === 'Location' && strpos($header->getFieldValue(), $expectedUrl) === 0) {

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
@@ -24,25 +24,17 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
         $this->dispatch('backend/catalog/product_action_attribute/save/store/0');
 
         $this->assertEquals(302, $this->getResponse()->getHttpResponseCode());
-        /** @var \Magento\Backend\Model\UrlInterface $urlBuilder */
-        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
 
         /** @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper */
         $attributeHelper = $this->_objectManager->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class);
 
-        $expectedUrl = $urlBuilder->getUrl(
+        $this->_urlBuilder->turnOffSecretKey();
+        $expectedUrl = $this->_urlBuilder->getUrl(
             'catalog/product/index',
             ['store' => $attributeHelper->getSelectedStoreId()]
         );
 
-        $isRedirectPresent = false;
-        foreach ($this->getResponse()->getHeaders() as $header) {
-            if ($header->getFieldName() === 'Location' && strpos($header->getFieldValue(), $expectedUrl) === 0) {
-                $isRedirectPresent = true;
-            }
-        }
-
-        $this->assertTrue($isRedirectPresent);
+        $this->assertRedirect($this->stringStartsWith($expectedUrl));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
@@ -25,12 +25,10 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
 
         $this->assertEquals(302, $this->getResponse()->getHttpResponseCode());
         /** @var \Magento\Backend\Model\UrlInterface $urlBuilder */
-        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class);
+        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
 
         /** @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper */
-        $attributeHelper = $this->_objectManager
-            ->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class)
-            ->turnOffSecretKey();
+        $attributeHelper = $this->_objectManager->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class);
 
         $expectedUrl = $urlBuilder->getUrl(
             'catalog/product/index',

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
@@ -287,6 +287,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         ];
         $this->getRequest()->setPostValue($post);
         $this->getRequest()->setParam('id', 1);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
 
         /** Check that success message is set */
@@ -324,7 +325,8 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         $subscriber->loadByCustomerId($customerId);
         $this->assertNotEmpty($subscriber->getId());
         $this->assertEquals(1, $subscriber->getStatus());
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/key/'));
+
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/'));
     }
 
     /**
@@ -352,6 +354,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         ];
         $this->getRequest()->setPostValue($post);
         $this->getRequest()->setParam('id', 1);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
 
         /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
@@ -369,7 +372,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
 
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/key/'));
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/'));
     }
 
     /**
@@ -409,13 +412,14 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         ];
         $this->getRequest()->setPostValue($post);
         $this->getRequest()->setParam('id', 1);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
 
         /**
          * Check that no errors were generated and set to session
          */
         $this->assertSessionMessages($this->isEmpty(), \Magento\Framework\Message\MessageInterface::TYPE_ERROR);
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/key/'));
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/'));
     }
 
     /**
@@ -478,6 +482,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             ],
         ];
         $this->getRequest()->setPostValue($post);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
         /*
          * Check that error message is set
@@ -490,7 +495,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             $post,
             Bootstrap::getObjectManager()->get(\Magento\Backend\Model\Session::class)->getCustomerFormData()
         );
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'new/key/'));
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'new/'));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/UrlTest.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Framework;
 
-use Zend\Stdlib\Parameters;
 use Magento\TestFramework\Helper\Bootstrap;
+use Zend\Stdlib\Parameters;
 
 class UrlTest extends \PHPUnit\Framework\TestCase
 {
@@ -231,6 +231,9 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     /**
      * Note: isolation flushes the URL memory cache
      * @magentoAppIsolation enabled
+     *
+     * @deprecated 101.0.1 getRouteUrl method will become private, and will disappear from the interface, url
+     * creation is centralized through getUrl method
      */
     public function testGetRouteUrl()
     {

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterTemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterTemplateTest.php
@@ -146,11 +146,8 @@ class NewsletterTemplateTest extends \Magento\TestFramework\TestCase\AbstractBac
         /**
          * Check that correct redirect performed.
          */
-        $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Backend\Model\UrlInterface::class
-        );
-        $backendUrlModel->turnOffSecretKey();
-        $url = $backendUrlModel->getUrl('newsletter');
+        $this->_urlBuilder->turnOffSecretKey();
+        $url = $this->_urlBuilder->getUrl('*/template');
         $this->assertRedirect($this->stringStartsWith($url));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/AuthTest.php
@@ -33,6 +33,10 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractBackendController
     {
         $this->getRequest()->setPostValue('email', 'test@test.com');
         $this->dispatch('backend/admin/auth/forgotpassword');
+
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
+
         $this->assertRedirect(
             $this->equalTo(
                 \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
@@ -60,6 +64,10 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractBackendController
 
         $this->getRequest()->setPostValue('email', 'adminUser@example.com');
         $this->dispatch('backend/admin/auth/forgotpassword');
+
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
+
         $this->assertRedirect(
             $this->equalTo(
                 \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
@@ -157,6 +165,7 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractBackendController
         /** @var \Magento\Backend\Helper\Data $backendHelper */
         $backendHelper = $objectManager->get(\Magento\Backend\Helper\Data::class);
         if ($isPasswordChanged) {
+            $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
             $this->assertRedirect($this->equalTo($backendHelper->getHomePageUrl()));
         } else {
             $this->assertRedirect(
@@ -204,6 +213,7 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractBackendController
         );
 
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
 
         /** @var \Magento\Backend\Helper\Data $backendHelper */
         $backendHelper = $objectManager->get(\Magento\Backend\Helper\Data::class);

--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -515,6 +515,12 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * Retrieve route URL test
+     *
+     * @deprecated 101.0.1 getRouteUrl method will become private, and will disappear from the interface, url
+     * creation is centralized through getUrl method
+     */
     public function testGetRouteUrlWithValidUrl()
     {
         $model = $this->getUrlModel(['routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(false)]);

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -735,14 +735,28 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
      * @param string $routePath
      * @param array $routeParams
      * @return string
+     * @deprecated 101.0.1 getRouteUrl method will become private, and will disappear from the interface, url
+     * creation is centralized through getUrl method
      */
     public function getRouteUrl($routePath = null, $routeParams = null)
+    {
+        return $this->getRouteUrlByParams($routePath, $routeParams);
+    }
+
+    /**
+     * Retrieve route URL
+     *
+     * @param string $routePath
+     * @param array $routeParams
+     * @return string
+     */
+    private function getRouteUrlByParams($routePath = null, $routeParams = null)
     {
         if (filter_var($routePath, FILTER_VALIDATE_URL)) {
             return $routePath;
         }
 
-        $this->getRouteParamsResolver()->unsetData('route_params');
+        $this->getRouteParamsResolver()->setRouteParams([]);
 
         if (isset($routeParams['_direct'])) {
             if (is_array($routeParams)) {
@@ -932,7 +946,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             $noSid = (bool)$routeParams['_nosid'];
             unset($routeParams['_nosid']);
         }
-        $url = $this->getRouteUrl($routePath, $routeParams);
+        $url = $this->getRouteUrlByParams($routePath, $routeParams);
 
         /**
          * Apply query params, need call after getRouteUrl for rewrite _current values

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -528,15 +528,18 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
         }
         $this->_setActionName($action);
 
+        $routePathParams = [];
         if (!empty($routePieces)) {
             while (!empty($routePieces)) {
                 $key = array_shift($routePieces);
                 if (!empty($routePieces)) {
                     $value = array_shift($routePieces);
-                    $this->getRouteParamsResolver()->setRouteParam($key, $value);
+                    $routePathParams[$key] = $value;
                 }
             }
         }
+
+        $this->getRouteParamsResolver()->setRouteParams($routePathParams);
 
         return $this;
     }

--- a/lib/internal/Magento/Framework/UrlInterface.php
+++ b/lib/internal/Magento/Framework/UrlInterface.php
@@ -77,6 +77,8 @@ interface UrlInterface
      * @param string $routePath
      * @param array $routeParams
      * @return string
+     * @deprecated 101.0.1 getRouteUrl method will become private, and will disappear from the interface, url
+     * creation is centralized through getUrl method
      */
     public function getRouteUrl($routePath = null, $routeParams = null);
 


### PR DESCRIPTION
### Description

In admin, url params may get url encoded more than once, when \Magento\Backend\Model\Url::getUrl() is called many times within the same request. This can mess up parameters like grid filters, and others.

### Fixed Issues

1. magento/magento2#11343: In admin, url params may get url encoded more than once
2. magento/magento2#11478: Search term in admin grid column filter is replaced with unicode characters

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. As explained in #11478 

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
