### PR TITLE
[Backport 2.1-develop] #11343 #11478 In admin, url params may get url encoded more than once, fix backend url model

### DIFF
--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -207,7 +207,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
                 ];
             }
             if (is_array($routeParams)) {
-                $routeParams = array_merge($secret, $routeParams);
+                $routeParams = array_merge($routeParams, $secret);
             } else {
                 $routeParams = $secret;
             }

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -165,10 +165,10 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
     protected function _setRouteParams(array $data, $unsetOldParams = true)
     {
         if (isset($data['_nosecret'])) {
-            $this->setNoSecret(true);
+            $this->turnOffSecretKey();
             unset($data['_nosecret']);
         } else {
-            $this->setNoSecret(false);
+            $this->turnOnSecretKey();
         }
         unset($data['_scope_to_url']);
         return parent::_setRouteParams($data, $unsetOldParams);

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Backend\Model;
 
-
 /**
  * Class \Magento\Backend\Model\UrlInterface
  *
@@ -193,29 +192,27 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
             unset($routeParams['_cache_secret_key']);
             $cacheSecretKey = true;
         }
-        $result = parent::getUrl($routePath, $routeParams);
-        if (!$this->useSecretKey()) {
-            return $result;
-        }
+
         $this->_setRoutePath($routePath);
         $routeName = $this->_getRouteName('*');
         $controllerName = $this->_getControllerName(self::DEFAULT_CONTROLLER_NAME);
         $actionName = $this->_getActionName(self::DEFAULT_ACTION_NAME);
-        if ($cacheSecretKey) {
-            $secret = [self::SECRET_KEY_PARAM_NAME => "\${$routeName}/{$controllerName}/{$actionName}\$"];
-        } else {
-            $secret = [
-                self::SECRET_KEY_PARAM_NAME => $this->getSecretKey($routeName, $controllerName, $actionName),
-            ];
+
+        if ($this->useSecretKey()) {
+            if ($cacheSecretKey) {
+                $secret = [self::SECRET_KEY_PARAM_NAME => "\${$routeName}/{$controllerName}/{$actionName}\$"];
+            } else {
+                $secret = [
+                    self::SECRET_KEY_PARAM_NAME => $this->getSecretKey($routeName, $controllerName, $actionName),
+                ];
+            }
+            if (is_array($routeParams)) {
+                $routeParams = array_merge($secret, $routeParams);
+            } else {
+                $routeParams = $secret;
+            }
         }
-        if (is_array($routeParams)) {
-            $routeParams = array_merge($secret, $routeParams);
-        } else {
-            $routeParams = $secret;
-        }
-        if (is_array($this->_getRouteParams())) {
-            $routeParams = array_merge($this->_getRouteParams(), $routeParams);
-        }
+
         return parent::getUrl("{$routeName}/{$controllerName}/{$actionName}", $routeParams);
     }
 

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractBackendController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractBackendController.php
@@ -13,6 +13,11 @@ namespace Magento\TestFramework\TestCase;
 abstract class AbstractBackendController extends \Magento\TestFramework\TestCase\AbstractController
 {
     /**
+     * @var \Magento\Backend\Model\UrlInterface
+     */
+    protected $_urlBuilder;
+
+    /**
      * @var \Magento\Backend\Model\Auth\Session
      */
     protected $_session;
@@ -40,9 +45,8 @@ abstract class AbstractBackendController extends \Magento\TestFramework\TestCase
     {
         parent::setUp();
 
-        $this->_objectManager->get('Magento\Backend\Model\UrlInterface')->turnOffSecretKey();
-
-        $this->_auth = $this->_objectManager->get('Magento\Backend\Model\Auth');
+        $this->_urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
+        $this->_auth = $this->_objectManager->get(\Magento\Backend\Model\Auth::class);
         $this->_session = $this->_auth->getAuthStorage();
         $credentials = $this->_getAdminCredentials();
         $this->_auth->login($credentials['user'], $credentials['password']);
@@ -85,7 +89,6 @@ abstract class AbstractBackendController extends \Magento\TestFramework\TestCase
     ) {
         parent::assertSessionMessages($constraint, $messageType, $messageManagerClass);
     }
-
 
     public function testAclHasAccess()
     {

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
@@ -17,24 +17,26 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
      */
     public function testSaveActionRedirectsSuccessfully()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-
         /** @var $session \Magento\Backend\Model\Session */
-        $session = $objectManager->get('Magento\Backend\Model\Session');
+        $session = $this->_objectManager->get(\Magento\Backend\Model\Session::class);
         $session->setProductIds([1]);
 
         $this->dispatch('backend/catalog/product_action_attribute/save/store/0');
 
         $this->assertEquals(302, $this->getResponse()->getHttpResponseCode());
         /** @var \Magento\Backend\Model\UrlInterface $urlBuilder */
-        $urlBuilder = $objectManager->get('Magento\Framework\UrlInterface');
+        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class);
 
         /** @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper */
-        $attributeHelper = $objectManager->get('Magento\Catalog\Helper\Product\Edit\Action\Attribute');
+        $attributeHelper = $this->_objectManager
+            ->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class)
+            ->turnOffSecretKey();
+
         $expectedUrl = $urlBuilder->getUrl(
             'catalog/product/index',
             ['store' => $attributeHelper->getSelectedStoreId()]
         );
+
         $isRedirectPresent = false;
         foreach ($this->getResponse()->getHeaders() as $header) {
             if ($header->getFieldName() === 'Location' && strpos($header->getFieldValue(), $expectedUrl) === 0) {

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
@@ -24,25 +24,17 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
         $this->dispatch('backend/catalog/product_action_attribute/save/store/0');
 
         $this->assertEquals(302, $this->getResponse()->getHttpResponseCode());
-        /** @var \Magento\Backend\Model\UrlInterface $urlBuilder */
-        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
 
         /** @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper */
         $attributeHelper = $this->_objectManager->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class);
 
-        $expectedUrl = $urlBuilder->getUrl(
+        $this->_urlBuilder->turnOffSecretKey();
+        $expectedUrl = $this->_urlBuilder->getUrl(
             'catalog/product/index',
             ['store' => $attributeHelper->getSelectedStoreId()]
         );
 
-        $isRedirectPresent = false;
-        foreach ($this->getResponse()->getHeaders() as $header) {
-            if ($header->getFieldName() === 'Location' && strpos($header->getFieldValue(), $expectedUrl) === 0) {
-                $isRedirectPresent = true;
-            }
-        }
-
-        $this->assertTrue($isRedirectPresent);
+        $this->assertRedirect($this->stringStartsWith($expectedUrl));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/AttributeTest.php
@@ -25,12 +25,10 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
 
         $this->assertEquals(302, $this->getResponse()->getHttpResponseCode());
         /** @var \Magento\Backend\Model\UrlInterface $urlBuilder */
-        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class);
+        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class)->turnOffSecretKey();
 
         /** @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper */
-        $attributeHelper = $this->_objectManager
-            ->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class)
-            ->turnOffSecretKey();
+        $attributeHelper = $this->_objectManager->get(\Magento\Catalog\Helper\Product\Edit\Action\Attribute::class);
 
         $expectedUrl = $urlBuilder->getUrl(
             'catalog/product/index',

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
@@ -287,6 +287,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         ];
         $this->getRequest()->setPostValue($post);
         $this->getRequest()->setParam('id', 1);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
 
         /** Check that success message is set */
@@ -323,7 +324,8 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         $subscriber->loadByCustomerId($customerId);
         $this->assertNotEmpty($subscriber->getId());
         $this->assertEquals(1, $subscriber->getStatus());
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/key/'));
+
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/'));
     }
 
     /**
@@ -351,6 +353,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         ];
         $this->getRequest()->setPostValue($post);
         $this->getRequest()->setParam('id', 1);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
 
         /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
@@ -368,7 +371,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
 
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/key/'));
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/'));
     }
 
     /**
@@ -408,13 +411,14 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         ];
         $this->getRequest()->setPostValue($post);
         $this->getRequest()->setParam('id', 1);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
 
         /**
          * Check that no errors were generated and set to session
          */
         $this->assertSessionMessages($this->isEmpty(), \Magento\Framework\Message\MessageInterface::TYPE_ERROR);
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/key/'));
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'index/'));
     }
 
     /**
@@ -477,6 +481,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             ],
         ];
         $this->getRequest()->setPostValue($post);
+        $this->_urlBuilder->turnOffSecretKey();
         $this->dispatch('backend/customer/index/save');
         /*
          * Check that error message is set
@@ -489,7 +494,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             $post,
             Bootstrap::getObjectManager()->get(\Magento\Backend\Model\Session::class)->getCustomerFormData()
         );
-        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'new/key/'));
+        $this->assertRedirect($this->stringStartsWith($this->_baseControllerUrl . 'new/'));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterTemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterTemplateTest.php
@@ -150,11 +150,8 @@ class NewsletterTemplateTest extends \Magento\TestFramework\TestCase\AbstractBac
         /**
          * Check that correct redirect performed.
          */
-        $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Backend\Model\UrlInterface::class
-        );
-        $backendUrlModel->turnOffSecretKey();
-        $url = $backendUrlModel->getUrl('newsletter');
+        $this->_urlBuilder->turnOffSecretKey();
+        $url = $this->_urlBuilder->getUrl('*/template');
         $this->assertRedirect($this->stringStartsWith($url));
     }
 }


### PR DESCRIPTION
### Description

In admin, url params may get url encoded more than once, when \Magento\Backend\Model\Url::getUrl() is called many times within the same request. This can mess up parameters like grid filters, and others. Related with [PR#11479](https://github.com/magento/magento2/pull/11479)

### Fixed Issues

1. magento/magento2#11343: In admin, url params may get url encoded more than once
2. magento/magento2#11478: Search term in admin grid column filter is replaced with unicode characters

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. As explained in #11478 

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
