### PR TITLE
Add "optional" translation in checkout password field

### DIFF
--- a/app/code/Magento/Checkout/i18n/en_US.csv
+++ b/app/code/Magento/Checkout/i18n/en_US.csv
@@ -176,3 +176,4 @@ Payment,Payment
 "Not yet calculated","Not yet calculated"
 "We received your order!","We received your order!"
 "Thank you for your purchase!","Thank you for your purchase!"
+"optional", "optional"


### PR DESCRIPTION
### Description
Original PR #10056.

Translatable placeholder is added in the template but not the .csv file.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Install non English language pack.
1. Open Guest Mode browsing.
2. Go to checkout.
3. Enter the email address of a customer which already exists.
4. Placeholder is not translated.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
