### PR TITLE
MAGETWO-75743: Fix for #9783 Multiple <depends> parameters in widget.…

### DIFF
--- a/app/code/Magento/Widget/Model/Config/Converter.php
+++ b/app/code/Magento/Widget/Model/Config/Converter.php
@@ -222,7 +222,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
     {
         $depends = [];
         foreach ($source->childNodes as $childNode) {
-            if ($childNode->nodeName == '#text') {
+            if ($childNode->nodeName === '#text') {
                 continue;
             }
             if ($childNode->nodeName !== 'parameter') {
@@ -231,12 +231,23 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
                 );
             }
             $parameterAttributes = $childNode->attributes;
-            $depends[$parameterAttributes->getNamedItem(
-                'name'
-            )->nodeValue] = [
-                'value' => $parameterAttributes->getNamedItem('value')->nodeValue,
-            ];
+            $dependencyName = $parameterAttributes->getNamedItem('name')->nodeValue;
+            $dependencyValue = $parameterAttributes->getNamedItem('value')->nodeValue;
+
+            if (!isset($depends[$dependencyName])) {
+                $depends[$dependencyName] = [
+                    'value' => $dependencyValue,
+                ];
+
+                continue;
+            } else if (!isset($depends[$dependencyName]['values'])) {
+                $depends[$dependencyName]['values'] = [$depends[$dependencyName]['value']];
+                unset($depends[$dependencyName]['value']);
+            }
+
+            $depends[$dependencyName]['values'][] = $dependencyValue;
         }
+
         return $depends;
     }
 

--- a/app/code/Magento/Widget/etc/widget.xsd
+++ b/app/code/Magento/Widget/etc/widget.xsd
@@ -212,8 +212,8 @@
         <xs:annotation>
             <xs:documentation>List of parameters this parameter depends on.</xs:documentation>
         </xs:annotation>
-        <xs:all>
+        <xs:sequence maxOccurs="unbounded">
             <xs:element name="parameter" type="dependsParameterType" />
-        </xs:all>
+        </xs:sequence>
     </xs:complexType>
 </xs:schema>

--- a/app/code/Magento/Widget/etc/widget_file.xsd
+++ b/app/code/Magento/Widget/etc/widget_file.xsd
@@ -212,8 +212,8 @@
         <xs:annotation>
             <xs:documentation>List of parameters this parameter depends on.</xs:documentation>
         </xs:annotation>
-        <xs:all>
+        <xs:sequence maxOccurs="unbounded">
             <xs:element name="parameter" type="dependsParameterType" />
-        </xs:all>
+        </xs:sequence>
     </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Allow multiple depends parameters to be allowed in `widget.xml`.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9783: Multiple <depends> parameters in widget.xml not allowed

### Manual testing scenarios
1. Create a custom module.
2. Create a `widget.xml` in your custom module and add a widget,
3. Create a parameter (field) inside parent tag `widgets>widget>parameters` with a `<depends>` tag, making it depend on the value of two other parameters as follows:
```
<parameter name="myfield" xsi:type="text" required="true" visible="true">
      <label translate="true">Example</label>
      <depends>
          <parameter name="dependency_one" value="1"/>
          <parameter name="dependency_two" value="1"/>
      </depends>
</parameter>
```
#### Expected result

The field should be shown only when both dependencies are met

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] All automated tests passed successfully (all builds on Travis CI are green)