### PR TITLE
Ensure database is cleared/Magento reinstalled when TESTS_CLEANUP is enabled

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -438,7 +438,7 @@ class Application
      * @return void
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function install()
+    public function install($cleanup)
     {
         $dirs = \Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS;
         $this->_ensureDirExists($this->installDir);
@@ -453,8 +453,9 @@ class Application
         $installParams = $this->getInstallCliParams();
 
         // performance optimization: restore DB from last good dump to make installation on top of it (much faster)
+        // do not restore from the database if the cleanup option is set to ensure we have a clean DB to test on
         $db = $this->getDbInstance();
-        if ($db->isDbDumpExists()) {
+        if ($db->isDbDumpExists() && !$cleanup) {
             $db->restoreFromDbDump();
         }
 

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -74,7 +74,7 @@ try {
         $application->cleanup();
     }
     if (!$application->isInstalled()) {
-        $application->install();
+        $application->install($settings->getAsBoolean('TESTS_CLEANUP'));
     }
     $application->initialize([]);
 


### PR DESCRIPTION
### Description
When TESTS_CLEANUP is set to enabled, the database should be cleared and Magento reinstalled each time the integration tests are run. This is the expected behavior and the documented behavior according to http://devdocs.magento.com/guides/v2.2/test/integration/integration_test_execution.html#the-testscleanup-constant

In this pull request, I've added a check for the TESTS_CLEANUP variable which we use and only restore the database from a previous dump (instead of installing from scratch) if TESTS_CLEANUP is not enabled. 

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/10025 Integration tests don't reset the database

### Manual testing scenarios
1. Follow the steps in http://devdocs.magento.com/guides/v2.2/test/integration/integration_test_execution.html
2. Ensure that TESTS_CLEANUP is enabled
3. Make some manual change to the integration test database
4. Run the integration tests again
5. Ensure that your change you made in step 3 is no longer present in the database.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)