### PR TITLE
MAGETWO-81245: Handling all setProductsFilter items in array as arguments

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item/StockItemCriteriaMapper.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item/StockItemCriteriaMapper.php
@@ -99,12 +99,9 @@ class StockItemCriteriaMapper extends GenericMapper
     /**
      * @inheritdoc
      */
-    public function mapProductsFilter($products)
+    public function mapProductsFilter(...$products)
     {
         $productIds = [];
-        if (!is_array($products)) {
-            $products = [$products];
-        }
         foreach ($products as $product) {
             if ($product instanceof \Magento\Catalog\Model\Product) {
                 $productIds[] = $product->getId();

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status/StockStatusCriteriaMapper.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status/StockStatusCriteriaMapper.php
@@ -56,12 +56,9 @@ class StockStatusCriteriaMapper extends GenericMapper
      * @param int|array|\Magento\Catalog\Model\Product|\Magento\Catalog\Model\Product[] $products
      * @return void
      */
-    public function mapProductsFilter($products)
+    public function mapProductsFilter(...$products)
     {
         $productIds = [];
-        if (!is_array($products)) {
-            $products = [$products];
-        }
         foreach ($products as $product) {
             if ($product instanceof \Magento\Catalog\Model\Product) {
                 $productIds[] = $product->getId();


### PR DESCRIPTION

Capture arguments after call_user_func_array and keep other map* methods working as they work now.

### Description
Will pass products as arguments because of interface.

### Fixed Issues (if relevant)
1. magento/magento2#7678: StockItemCriteria::setProductsFilter doesn't work with array of ids

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
