### PR TITLE
SOAP WSDL list should be in XML by default, not JSON

### DIFF
--- a/app/code/Magento/Webapi/etc/di.xml
+++ b/app/code/Magento/Webapi/etc/di.xml
@@ -36,7 +36,7 @@
             <argument name="renders" xsi:type="array">
                 <item name="default" xsi:type="array">
                     <item name="type" xsi:type="string">*/*</item>
-                    <item name="model" xsi:type="string">Magento\Framework\Webapi\Rest\Response\Renderer\Json</item>
+                    <item name="model" xsi:type="string">Magento\Framework\Webapi\Rest\Response\Renderer\Xml</item>
                 </item>
                 <item name="application_json" xsi:type="array">
                     <item name="type" xsi:type="string">application/json</item>


### PR DESCRIPTION
### Description
The SOAP WSDL list should be in XML by default, not JSON

See additional comments and details in https://github.com/magento/magento2/issues/4848

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/4848 Magento 2.0.7 SOAP Wsdl List in Json by default

### Manual testing scenarios
1. Run curl -i [magento2 webroot]/soap/default?wsdl_list=1 and confirm the output is in XML
2. Run curl -i --header 'Accept: application/json' [magento2 webroot]/soap/default?wsdl_list=1 and confirm the output is in JSON

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)