### PR TITLE
MAGETWO-10704: refactoring free shipping for live rates

### DIFF
--- a/app/code/Magento/Fedex/Model/Carrier.php
+++ b/app/code/Magento/Fedex/Model/Carrier.php
@@ -366,9 +366,7 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
 
         $weight = $this->getTotalNumOfBoxes($request->getPackageWeight());
         $r->setWeight($weight);
-        if ($request->getFreeMethodWeight() != $request->getPackageWeight()) {
-            $r->setFreeMethodWeight($request->getFreeMethodWeight());
-        }
+        $r->setFreeMethodWeight($request->getFreeMethodWeight());
 
         $r->setValue($request->getPackagePhysicalValue());
         $r->setValueWithDiscount($request->getPackageValueWithDiscount());

--- a/app/code/Magento/Quote/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total/Shipping.php
@@ -97,16 +97,18 @@ class Shipping extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
                         $rowWeight = $itemWeight * $itemQty;
                         $addressWeight += $rowWeight;
                         if ($addressFreeShipping || $child->getFreeShipping() === true) {
+                            $freeMethodWeight += $rowWeight;
                             $rowWeight = 0;
                         } elseif (is_numeric($child->getFreeShipping())) {
                             $freeQty = $child->getFreeShipping();
                             if ($itemQty > $freeQty) {
                                 $rowWeight = $itemWeight * ($itemQty - $freeQty);
+                                $freeMethodWeight += $itemWeight * $freeQty;
                             } else {
+                                $freeMethodWeight += $rowWeight;
                                 $rowWeight = 0;
                             }
                         }
-                        $freeMethodWeight += $rowWeight;
                         $item->setRowWeight($rowWeight);
                     }
                 }
@@ -115,16 +117,18 @@ class Shipping extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
                     $rowWeight = $itemWeight * $item->getQty();
                     $addressWeight += $rowWeight;
                     if ($addressFreeShipping || $item->getFreeShipping() === true) {
+                        $freeMethodWeight += $rowWeight;
                         $rowWeight = 0;
                     } elseif (is_numeric($item->getFreeShipping())) {
                         $freeQty = $item->getFreeShipping();
                         if ($item->getQty() > $freeQty) {
                             $rowWeight = $itemWeight * ($item->getQty() - $freeQty);
+                            $freeMethodWeight += $itemWeight * $freeQty;
                         } else {
+                            $freeMethodWeight += $rowWeight;
                             $rowWeight = 0;
                         }
                     }
-                    $freeMethodWeight += $rowWeight;
                     $item->setRowWeight($rowWeight);
                 }
             } else {
@@ -135,16 +139,18 @@ class Shipping extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
                 $rowWeight = $itemWeight * $item->getQty();
                 $addressWeight += $rowWeight;
                 if ($addressFreeShipping || $item->getFreeShipping() === true) {
+                    $freeMethodWeight += $rowWeight;
                     $rowWeight = 0;
                 } elseif (is_numeric($item->getFreeShipping())) {
                     $freeQty = $item->getFreeShipping();
                     if ($item->getQty() > $freeQty) {
                         $rowWeight = $itemWeight * ($item->getQty() - $freeQty);
+                        $freeMethodWeight += $itemWeight * $freeQty;
                     } else {
+                        $freeMethodWeight += $rowWeight;
                         $rowWeight = 0;
                     }
                 }
-                $freeMethodWeight += $rowWeight;
                 $item->setRowWeight($rowWeight);
             }
         }

--- a/app/code/Magento/Shipping/Model/Rate/Result.php
+++ b/app/code/Magento/Shipping/Model/Rate/Result.php
@@ -117,6 +117,23 @@ class Result
     }
 
     /**
+     * Return rate by method id
+     *
+     * @param $id
+     * @return \Magento\Quote\Model\Quote\Address\RateResult\Method|null
+     */
+    public function getRateByMethodId($id)
+    {
+        return array_reduce($this->_rates, function($foundItem, $item) use ($id) {
+            if (!$foundItem && $item->getMethod() == $id) {
+                return $item;
+            } else {
+                return $foundItem;
+            }
+        });
+    }
+
+    /**
      * Return quotes for specified type
      *
      * @param string $carrier

--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -339,9 +339,7 @@ class Carrier extends AbstractCarrierOnline implements CarrierInterface
         $weight = $this->_getCorrectWeight($weight);
 
         $rowRequest->setWeight($weight);
-        if ($request->getFreeMethodWeight() != $request->getPackageWeight()) {
-            $rowRequest->setFreeMethodWeight($request->getFreeMethodWeight());
-        }
+        $rowRequest->setFreeMethodWeight($request->getFreeMethodWeight());
 
         $rowRequest->setValue($request->getPackageValue());
         $rowRequest->setValueWithDiscount($request->getPackageValueWithDiscount());

--- a/app/code/Magento/Ups/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Ups/Test/Unit/Model/CarrierTest.php
@@ -150,6 +150,7 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
             'carriers/ups/specificerrmsg' => 'ups error message',
             'carriers/ups/min_package_weight' => 2,
             'carriers/ups/type' => 'UPS',
+            'carriers/ups/active' => true
         ];
 
         return isset($pathMap[$path]) ? $pathMap[$path] : null;
@@ -240,6 +241,20 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
         $request->setPackageWeight(1);
 
         $this->assertSame($this->rate, $this->model->collectRates($request));
+    }
+
+    public function testFreeShippingIsActive()
+    {
+        $this->scope->expects($this->once())->method('isSetFlag')->willReturn(true);
+
+        $request = new \Magento\Quote\Model\Quote\Address\RateRequest();
+        $request->setPackageWeight(1);
+        $request->setFreeMethodWeight(2);
+        $request->setBaseSubtotalInclTax(10);
+        $this->model->setRawRequest($request);
+        $result = $this->model->collectRates($request);
+
+        $this->assertSame($this->rate, $result[0]);
     }
 
     /**

--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -340,9 +340,7 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
         $r->setWeightPounds(floor($weight));
         $ounces = ($weight - floor($weight)) * self::OUNCES_POUND;
         $r->setWeightOunces(sprintf('%.' . self::$weightPrecision . 'f', $ounces));
-        if ($request->getFreeMethodWeight() != $request->getPackageWeight()) {
-            $r->setFreeMethodWeight($request->getFreeMethodWeight());
-        }
+        $r->setFreeMethodWeight($request->getFreeMethodWeight());
 
         $r->setValue($request->getPackageValue());
         $r->setValueWithDiscount($request->getPackageValueWithDiscount());


### PR DESCRIPTION
*In progress:*
https://github.com/magento/magento2/issues/10704

The original issue stated that cart price rules for free shipping were broken on UPS. In replicating this issue, I found that it was broken for UPS, USPS and Fede. Since most of the code was committed back in 2011, this likely is a leftover issue from back then.

### Description
At face value, fixing the live rates free shipping should be easy. Instead, I ended up refactoring the code surrounding the free shipping calculation.

One thing that is an assumption is that Row Weight and Free Method Weight are mutually exclusive. If there are 10 items in the cart and 7 of them qualify for free shipping while the other three don't and they all weigh 1lb, the Free Method Weight would be 7lbs and the Row Weight would be 3lbs.

I also took the opportunity to refactor the `\Magento\Shipping\Model\Carrier\AbstractCarrier::_updateFreeMethodQuote()` method. This method was reduced from 51 lines to 10 lines (four other functions were created in the process).

### Fixed Issues (if relevant)
1. magento/magento2#10704: Free shipping code is not working for UPS for magento 2

### Manual testing scenarios
1. Follow the testing scenario in the #10704.
2. Ideally, configure your Magento installation to use test account credentials from USPS, UPS and Fedex.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
