### PR TITLE
MAGETWO-81245: All arguments for mapping methods  must be compatible with call_user_func_array

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item/StockItemCriteria.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item/StockItemCriteria.php
@@ -21,7 +21,7 @@ class StockItemCriteria extends AbstractCriteria implements \Magento\CatalogInve
     public function __construct($mapper = '')
     {
         $this->mapperInterfaceName = $mapper ?: \Magento\CatalogInventory\Model\ResourceModel\Stock\Item\StockItemCriteriaMapper::class;
-        $this->data['initial_condition'] = true;
+        $this->data['initial_condition'] = [true];
     }
 
     /**
@@ -38,7 +38,7 @@ class StockItemCriteria extends AbstractCriteria implements \Magento\CatalogInve
      */
     public function setStockFilter($stock)
     {
-        $this->data['stock_filter'] = $stock;
+        $this->data['stock_filter'] = [$stock];
         return true;
     }
 
@@ -47,7 +47,7 @@ class StockItemCriteria extends AbstractCriteria implements \Magento\CatalogInve
      */
     public function setScopeFilter($scope)
     {
-        $this->data['website_filter'] = $scope;
+        $this->data['website_filter'] = [$scope];
         return true;
     }
 
@@ -56,7 +56,7 @@ class StockItemCriteria extends AbstractCriteria implements \Magento\CatalogInve
      */
     public function setProductsFilter($products)
     {
-        $this->data['products_filter'] = $products;
+        $this->data['products_filter'] = [$products];
         return true;
     }
 
@@ -65,7 +65,7 @@ class StockItemCriteria extends AbstractCriteria implements \Magento\CatalogInve
      */
     public function setManagedFilter($isStockManagedInConfig)
     {
-        $this->data['managed_filter'] = $isStockManagedInConfig;
+        $this->data['managed_filter'] = [$isStockManagedInConfig];
         return true;
     }
 

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status/StockStatusCriteria.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status/StockStatusCriteria.php
@@ -21,7 +21,7 @@ class StockStatusCriteria extends AbstractCriteria implements \Magento\CatalogIn
     public function __construct($mapper = '')
     {
         $this->mapperInterfaceName = $mapper ?: \Magento\CatalogInventory\Model\ResourceModel\Stock\Status\StockStatusCriteriaMapper::class;
-        $this->data['initial_condition'] = true;
+        $this->data['initial_condition'] = [true];
     }
 
     /**
@@ -29,7 +29,7 @@ class StockStatusCriteria extends AbstractCriteria implements \Magento\CatalogIn
      */
     public function setScopeFilter($scope)
     {
-        $this->data['website_filter'] = $scope;
+        $this->data['website_filter'] = [$scope];
     }
 
     /**
@@ -37,7 +37,7 @@ class StockStatusCriteria extends AbstractCriteria implements \Magento\CatalogIn
      */
     public function setProductsFilter($products)
     {
-        $this->data['products_filter'] = $products;
+        $this->data['products_filter'] = [$products];
     }
 
     /**
@@ -45,7 +45,7 @@ class StockStatusCriteria extends AbstractCriteria implements \Magento\CatalogIn
      */
     public function setQtyFilter($qty)
     {
-        $this->data['qty_filter'] = $qty;
+        $this->data['qty_filter'] = [$qty];
     }
 
     /**

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/StockCriteria.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/StockCriteria.php
@@ -19,7 +19,7 @@ class StockCriteria extends AbstractCriteria implements \Magento\CatalogInventor
     {
         $this->mapperInterfaceName =
             $mapper ?: \Magento\CatalogInventory\Model\ResourceModel\Stock\StockCriteriaMapper::class;
-        $this->data['initial_condition'] = true;
+        $this->data['initial_condition'] = [true];
     }
 
     /**
@@ -27,7 +27,7 @@ class StockCriteria extends AbstractCriteria implements \Magento\CatalogInventor
      */
     public function setScopeFilter($scope)
     {
-        $this->data['website_filter'] = $scope;
+        $this->data['website_filter'] = [$scope];
         return true;
     }
 

--- a/lib/internal/Magento/Framework/DB/AbstractMapper.php
+++ b/lib/internal/Magento/Framework/DB/AbstractMapper.php
@@ -124,7 +124,7 @@ abstract class AbstractMapper implements MapperInterface
             $mapperMethod = 'map' . $camelCaseKey;
             if (method_exists($this, $mapperMethod)) {
                 if (!is_array($value)) {
-                    $value = [$value];
+                    throw new \InvalidArgumentException('Wrong type of argument, expecting array for '. $mapperMethod);
                 }
                 call_user_func_array([$this, $mapperMethod], $value);
             }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/AbstractMapperTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/AbstractMapperTest.php
@@ -141,6 +141,49 @@ class AbstractMapperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->selectMock, $mapper->map($criteriaMock));
     }
 
+
+    public function testMapException()
+    {
+        $mapperMethods = [
+            'my-test-value1' => 'mapMyMapperMethodOne'
+        ];
+
+        $criteriaParts = [
+            'my_mapper_method_one' => 'my-test-value1'
+        ];
+        /** @var \Magento\Framework\DB\AbstractMapper|\PHPUnit_Framework_MockObject_MockObject $mapper */
+        $mapper = $this->getMockForAbstractClass(
+            \Magento\Framework\DB\AbstractMapper::class,
+            [
+                'logger' => $this->loggerMock,
+                'fetchStrategy' => $this->fetchStrategyMock,
+                'objectFactory' => $this->objectFactoryMock,
+                'mapperFactory' => $this->mapperFactoryMock,
+                'select' => $this->selectMock
+            ],
+            '',
+            true,
+            true,
+            true,
+            $mapperMethods
+        );
+        $criteriaMock = $this->getMockForAbstractClass(
+            \Magento\Framework\Api\CriteriaInterface::class,
+            [],
+            '',
+            false,
+            true,
+            true,
+            ['toArray']
+        );
+        $criteriaMock->expects($this->once())
+            ->method('toArray')
+            ->will($this->returnValue($criteriaParts));
+        $this->expectException(\InvalidArgumentException::class);
+        $mapper->map($criteriaMock);
+
+    }
+
     /**
      * Run test addExpressionFieldToSelect method
      *
@@ -254,8 +297,8 @@ class AbstractMapperTest extends \PHPUnit\Framework\TestCase
                     'my-test-value2' => 'mapMyMapperMethodTwo',
                 ],
                 'criteriaParts' => [
-                    'my_mapper_method_one' => 'my-test-value1',
-                    'my_mapper_method_two' => 'my-test-value2',
+                    'my_mapper_method_one' => ['my-test-value1'],
+                    'my_mapper_method_two' => ['my-test-value2'],
                 ],
             ]
         ];


### PR DESCRIPTION
Making standard data structure for use in map().

### Description
Making all elements of criteria arrays for use in call_user_func_array. 
Throw exception if it not. 

### Fixed Issues (if relevant)
1. magento/magento2#7678: StockItemCriteria::setProductsFilter doesn't work with array of ids

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
