### PR TITLE
Add interaction to admin:user:create command

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/AdminUserCreateCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/AdminUserCreateCommandTest.php
@@ -5,14 +5,21 @@
  */
 namespace Magento\Setup\Test\Unit\Console\Command;
 
-use Magento\Setup\Model\AdminAccount;
 use Magento\Setup\Console\Command\AdminUserCreateCommand;
+use Magento\Setup\Model\AdminAccount;
 use Magento\Setup\Mvc\Bootstrap\InitParamListener;
 use Magento\User\Model\UserValidationRules;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class AdminUserCreateCommandTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Console\Helper\QuestionHelper
+     */
+    private $questionHelperMock;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Setup\Model\InstallerFactory
      */
@@ -27,6 +34,10 @@ class AdminUserCreateCommandTest extends \PHPUnit\Framework\TestCase
     {
         $this->installerFactoryMock = $this->createMock(\Magento\Setup\Model\InstallerFactory::class);
         $this->command = new AdminUserCreateCommand($this->installerFactoryMock, new UserValidationRules());
+
+        $this->questionHelperMock = $this->getMockBuilder(QuestionHelper::class)
+            ->setMethods(['ask'])
+            ->getMock();
     }
 
     public function testExecute()
@@ -50,8 +61,68 @@ class AdminUserCreateCommandTest extends \PHPUnit\Framework\TestCase
         $installerMock = $this->createMock(\Magento\Setup\Model\Installer::class);
         $installerMock->expects($this->once())->method('installAdminUser')->with($data);
         $this->installerFactoryMock->expects($this->once())->method('create')->willReturn($installerMock);
-        $commandTester->execute($options);
+        $commandTester->execute($options, ['interactive' => false]);
         $this->assertEquals('Created Magento administrator user named user' . PHP_EOL, $commandTester->getDisplay());
+    }
+
+    public function testInteraction()
+    {
+        $application = new Application();
+        $application->add($this->command);
+
+        $this->questionHelperMock->expects($this->at(0))
+            ->method('ask')
+            ->will($this->returnValue('admin'));
+
+        $this->questionHelperMock->expects($this->at(1))
+            ->method('ask')
+            ->will($this->returnValue('Password123'));
+
+        $this->questionHelperMock->expects($this->at(2))
+            ->method('ask')
+            ->will($this->returnValue('john.doe@example.com'));
+
+        $this->questionHelperMock->expects($this->at(3))
+            ->method('ask')
+            ->will($this->returnValue('John'));
+
+        $this->questionHelperMock->expects($this->at(4))
+            ->method('ask')
+            ->will($this->returnValue('Doe'));
+
+        // We override the standard helper with our mock
+        $this->command->getHelperSet()->set($this->questionHelperMock, 'question');
+
+        $installerMock = $this->createMock(\Magento\Setup\Model\Installer::class);
+
+        $expectedData = [
+            'admin-user' => 'admin',
+            'admin-password' => 'Password123',
+            'admin-email' => 'john.doe@example.com',
+            'admin-firstname' => 'John',
+            'admin-lastname' => 'Doe',
+            'magento-init-params' => null,
+            'help' => false,
+            'quiet' => false,
+            'verbose' => false,
+            'version' => false,
+            'ansi' => false,
+            'no-ansi' => false,
+            'no-interaction' => false,
+        ];
+
+        $installerMock->expects($this->once())->method('installAdminUser')->with($expectedData);
+        $this->installerFactoryMock->expects($this->once())->method('create')->willReturn($installerMock);
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([
+            'command' => $this->command->getName(),
+        ]);
+
+        $this->assertEquals(
+            'Created Magento administrator user named admin' . PHP_EOL,
+            $commandTester->getDisplay()
+        );
     }
 
     public function testGetOptionsList()


### PR DESCRIPTION
### Description
Add interaction to "admin:user:create" command. This is more convenient and user friendly.
The interaction is done by Symfony Question helper. This is a default class of the Symfony Console component.
If a required option is not passed, the command will ask for the input value. The password is validated against the standard user password validator.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
