### PR TITLE
Only resize images (cache) for themes which are being used instead of all installed themes

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -29,7 +29,7 @@ class Cache
     /**
      * @var ThemeCustomizationConfig
      */
-    protected $themeCustomizationConfig;
+    private $themeCustomizationConfig;
 
     /**
      * @var ImageHelper
@@ -160,7 +160,7 @@ class Cache
      *
      * @return array
      */
-    public function getThemesInUse()
+    private function getThemesInUse(): array
     {
         $themesInUse = [];
 
@@ -175,7 +175,9 @@ class Cache
 
         $connection = $this->attribute->getResource()->getConnection();
 
-        $productCustomDesignAttributeId = $this->attribute->loadByCode(4, 'custom_design')->getId();
+        $productEntityTypeId = \Magento\Catalog\Setup\CategorySetup::CATALOG_PRODUCT_ENTITY_TYPE_ID;
+
+        $productCustomDesignAttributeId = $this->attribute->loadByCode($productEntityTypeId, 'custom_design')->getId();
 
         $productSql = $connection
             ->select()
@@ -198,7 +200,9 @@ class Cache
             }
         }
 
-        $categoryCustomDesignAttributeId = $this->attribute->loadByCode(3, 'custom_design')->getId();
+        $categoryEntityTypeId = \Magento\Catalog\Setup\CategorySetup::CATEGORY_ENTITY_TYPE_ID;
+
+        $categoryCustomDesignAttributeId = $this->attribute->loadByCode($categoryEntityTypeId, 'custom_design')->getId();
 
         $categorySql = $connection
             ->select()

--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -8,8 +8,12 @@ namespace Magento\Catalog\Model\Product\Image;
 use Magento\Catalog\Helper\Image as ImageHelper;
 use Magento\Catalog\Model\Product;
 use Magento\Theme\Model\ResourceModel\Theme\Collection as ThemeCollection;
+use Magento\Theme\Model\Config\Customization as ThemeCustomizationConfig;
 use Magento\Framework\App\Area;
 use Magento\Framework\View\ConfigInterface;
+use Magento\Eav\Model\Config;
+use Magento\Eav\Model\Entity\Attribute;
+use Magento\Framework\ObjectManagerInterface;
 
 class Cache
 {
@@ -24,9 +28,29 @@ class Cache
     protected $themeCollection;
 
     /**
+     * @var ThemeCustomizationConfig
+     */
+    protected $themeCustomizationConfig;
+
+    /**
      * @var ImageHelper
      */
     protected $imageHelper;
+
+    /**
+     * @var Config
+     */
+    protected $eavConfig;
+
+    /**
+     * @var Attribute
+     */
+    protected $attribute;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
 
     /**
      * @var array
@@ -41,11 +65,19 @@ class Cache
     public function __construct(
         ConfigInterface $viewConfig,
         ThemeCollection $themeCollection,
-        ImageHelper $imageHelper
+        ImageHelper $imageHelper,
+        ThemeCustomizationConfig $themeCustomizationConfig,
+        Config $eavConfig,
+        Attribute $attribute,
+        ObjectManagerInterface $objectManager
     ) {
         $this->viewConfig = $viewConfig;
         $this->themeCollection = $themeCollection;
         $this->imageHelper = $imageHelper;
+        $this->themeCustomizationConfig = $themeCustomizationConfig;
+        $this->eavConfig = $eavConfig;
+        $this->attribute = $attribute;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -58,8 +90,10 @@ class Cache
     protected function getData()
     {
         if (!$this->data) {
+            $themesInUse = $this->getThemesInUse();
+
             /** @var \Magento\Theme\Model\Theme $theme */
-            foreach ($this->themeCollection->loadRegisteredThemes() as $theme) {
+            foreach ($themesInUse as $theme) {
                 $config = $this->viewConfig->getViewConfig([
                     'area' => Area::AREA_FRONTEND,
                     'themeModel' => $theme,
@@ -126,5 +160,88 @@ class Cache
         $this->imageHelper->save();
 
         return $this;
+    }
+
+    /**
+     * Get themes in use
+     *
+     * @return array
+     */
+    public function getThemesInUse()
+    {
+        $themesInUse = [];
+
+        $registeredThemes = $this->themeCollection->loadRegisteredThemes();
+        $storesByThemes   = $this->themeCustomizationConfig->getStoresByThemes();
+
+        foreach ($registeredThemes as $registeredTheme) {
+            if (array_key_exists($registeredTheme->getThemeId(), $storesByThemes)) {
+                $themesInUse[] = $registeredTheme;
+            }
+        }
+
+        $resource = $this->objectManager->get(\Magento\Framework\App\ResourceConnection::class);
+
+        $productCustomDesignAttributeId = $this->attribute->loadByCode(4, 'custom_design')->getId();
+
+        $productSql = $resource->getConnection()
+            ->select()
+            ->from(
+                ['eav' => $resource->getTableName('catalog_product_entity_varchar')],
+                ['value']
+            )
+            ->where('eav.attribute_id = ?', $productCustomDesignAttributeId)
+            ->where('eav.value > 0')
+            ->group('value');
+
+        $productThemeIds = $resource->getConnection()->fetchCol($productSql);
+
+        foreach ($productThemeIds as $productThemeId) {
+            if (array_key_exists($productThemeId, $storesByThemes)
+                && !array_key_exists($productThemeId, $themesInUse) ) {
+                $themesInUse[] = $this->themeCollection->load($productThemeId);
+            }
+        }
+
+        $categoryCustomDesignAttributeId = $this->attribute->loadByCode(3, 'custom_design')->getId();
+
+        $categorySql = $resource->getConnection()
+            ->select()
+            ->from(
+                ['eav' => $resource->getTableName('catalog_category_entity_varchar')],
+                ['value']
+            )
+            ->where('eav.attribute_id = ?', $categoryCustomDesignAttributeId)
+            ->where('eav.value > 0')
+            ->group('value');
+
+        $categoryThemeIds = $resource->getConnection()->fetchCol($categorySql);
+
+        foreach ($categoryThemeIds as $categoryThemeId) {
+            if (array_key_exists($categoryThemeId, $storesByThemes)
+                && !array_key_exists($categoryThemeId, $themesInUse) ) {
+                $themesInUse[] = $this->themeCollection->load($categoryThemeId);
+            }
+        }
+
+        $pageSql = $resource->getConnection()
+            ->select()
+            ->from(
+                ['page' => $resource->getTableName('cms_page')],
+                ['custom_theme']
+            )
+            ->where('custom_theme > 0')
+            ->group('custom_theme');
+
+        $pageThemeIds = $resource->getConnection()->fetchCol($pageSql);
+
+        foreach ($pageThemeIds as $pageThemeId) {
+            if (array_key_exists($pageThemeId, $storesByThemes)
+                && !array_key_exists($pageThemeId, $themesInUse) ) {
+                $themesInUse[] = $this->themeCollection->load($pageThemeId);
+            }
+        }
+
+        return $themesInUse;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -13,7 +13,6 @@ use Magento\Framework\App\Area;
 use Magento\Framework\View\ConfigInterface;
 use Magento\Eav\Model\Config;
 use Magento\Eav\Model\Entity\Attribute;
-use Magento\Framework\ObjectManagerInterface;
 
 class Cache
 {
@@ -47,10 +46,6 @@ class Cache
      */
     protected $attribute;
 
-    /**
-     * @var ObjectManagerInterface
-     */
-    protected $objectManager;
 
     /**
      * @var array
@@ -68,8 +63,7 @@ class Cache
         ImageHelper $imageHelper,
         ThemeCustomizationConfig $themeCustomizationConfig,
         Config $eavConfig,
-        Attribute $attribute,
-        ObjectManagerInterface $objectManager
+        Attribute $attribute
     ) {
         $this->viewConfig = $viewConfig;
         $this->themeCollection = $themeCollection;
@@ -77,7 +71,6 @@ class Cache
         $this->themeCustomizationConfig = $themeCustomizationConfig;
         $this->eavConfig = $eavConfig;
         $this->attribute = $attribute;
-        $this->objectManager = $objectManager;
     }
 
     /**
@@ -180,65 +173,71 @@ class Cache
             }
         }
 
-        $resource = $this->objectManager->get(\Magento\Framework\App\ResourceConnection::class);
+        $connection = $this->attribute->getResource()->getConnection();
 
         $productCustomDesignAttributeId = $this->attribute->loadByCode(4, 'custom_design')->getId();
 
-        $productSql = $resource->getConnection()
+        $productSql = $connection
             ->select()
             ->from(
-                ['eav' => $resource->getTableName('catalog_product_entity_varchar')],
+                ['eav' => $connection->getTableName('catalog_product_entity_varchar')],
                 ['value']
             )
             ->where('eav.attribute_id = ?', $productCustomDesignAttributeId)
             ->where('eav.value > 0')
             ->group('value');
 
-        $productThemeIds = $resource->getConnection()->fetchCol($productSql);
+        $productThemeIds = $connection->fetchCol($productSql);
 
-        foreach ($productThemeIds as $productThemeId) {
-            if (array_key_exists($productThemeId, $storesByThemes)
-                && !array_key_exists($productThemeId, $themesInUse) ) {
-                $themesInUse[] = $this->themeCollection->load($productThemeId);
+        if (count($productThemeIds)) {
+            foreach ($productThemeIds as $productThemeId) {
+                if (array_key_exists($productThemeId, $storesByThemes)
+                    && !array_key_exists($productThemeId, $themesInUse) ) {
+                    $themesInUse[] = $this->themeCollection->load($productThemeId);
+                }
             }
         }
 
         $categoryCustomDesignAttributeId = $this->attribute->loadByCode(3, 'custom_design')->getId();
 
-        $categorySql = $resource->getConnection()
+        $categorySql = $connection
             ->select()
             ->from(
-                ['eav' => $resource->getTableName('catalog_category_entity_varchar')],
+                ['eav' => $connection->getTableName('catalog_category_entity_varchar')],
                 ['value']
             )
             ->where('eav.attribute_id = ?', $categoryCustomDesignAttributeId)
             ->where('eav.value > 0')
             ->group('value');
 
-        $categoryThemeIds = $resource->getConnection()->fetchCol($categorySql);
+        $categoryThemeIds = $connection->fetchCol($categorySql);
 
-        foreach ($categoryThemeIds as $categoryThemeId) {
-            if (array_key_exists($categoryThemeId, $storesByThemes)
-                && !array_key_exists($categoryThemeId, $themesInUse) ) {
-                $themesInUse[] = $this->themeCollection->load($categoryThemeId);
+        if (count($categoryThemeIds)) {
+            foreach ($categoryThemeIds as $categoryThemeId) {
+                if (array_key_exists($categoryThemeId, $storesByThemes)
+                    && !array_key_exists($categoryThemeId, $themesInUse) ) {
+                    $themesInUse[] = $this->themeCollection->load($categoryThemeId);
+                }
             }
         }
 
-        $pageSql = $resource->getConnection()
+        $pageSql = $connection
             ->select()
             ->from(
-                ['page' => $resource->getTableName('cms_page')],
+                ['page' => $connection->getTableName('cms_page')],
                 ['custom_theme']
             )
             ->where('custom_theme > 0')
             ->group('custom_theme');
 
-        $pageThemeIds = $resource->getConnection()->fetchCol($pageSql);
+        $pageThemeIds = $connection->fetchCol($pageSql);
 
-        foreach ($pageThemeIds as $pageThemeId) {
-            if (array_key_exists($pageThemeId, $storesByThemes)
-                && !array_key_exists($pageThemeId, $themesInUse) ) {
-                $themesInUse[] = $this->themeCollection->load($pageThemeId);
+        if (count($pageThemeIds)) {
+            foreach ($pageThemeIds as $pageThemeId) {
+                if (array_key_exists($pageThemeId, $storesByThemes)
+                    && !array_key_exists($pageThemeId, $themesInUse) ) {
+                    $themesInUse[] = $this->themeCollection->load($pageThemeId);
+                }
             }
         }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/CacheTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/CacheTest.php
@@ -7,6 +7,7 @@ namespace Magento\Catalog\Test\Unit\Model\Product\Image;
 
 use Magento\Framework\App\Area;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\ObjectManagerInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -44,6 +45,26 @@ class CacheTest extends \PHPUnit\Framework\TestCase
     protected $themeCollection;
 
     /**
+     * @var \Magento\Theme\Model\Config\Customization|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $themeCustomizationConfig;
+
+    /**
+     * @var \Magento\Eav\Model\Config|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $eavConfig;
+
+    /**
+     * @var \Magento\Eav\Model\Entity\Attribute|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $attribute;
+
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $objectManagerInterface;
+
+    /**
      * @var \Magento\Catalog\Helper\Image|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $imageHelper;
@@ -74,6 +95,22 @@ class CacheTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->themeCustomizationConfig = $this->getMockBuilder(\Magento\Theme\Model\Config\Customization::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->eavConfig = $this->getMockBuilder(\Magento\Eav\Model\Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->attribute = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->objectManagerInterface = $this->getMockBuilder(\Magento\Framework\ObjectManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->mediaGalleryCollection = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -84,7 +121,11 @@ class CacheTest extends \PHPUnit\Framework\TestCase
             [
                 'viewConfig' => $this->viewConfig,
                 'themeCollection' => $this->themeCollection,
+                'themeCustomizationConfig' => $this->themeCustomizationConfig,
                 'imageHelper' => $this->imageHelper,
+                'config' => $this->eavConfig,
+                'attribute' => $this->attribute,
+                'objectManager' => $this->objectManagerInterface
             ]
         );
     }
@@ -125,6 +166,10 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->themeCollection->expects($this->once())
             ->method('loadRegisteredThemes')
             ->willReturn([$themeMock]);
+
+        $this->themeCustomizationConfig->expects($this->once())
+            ->method('getStoresByThemes')
+            ->willReturn([$themeMock->getThemeId() => [1]]);
 
         $this->viewConfig->expects($this->once())
             ->method('getViewConfig')


### PR DESCRIPTION
Only resize images (cache) for themes which are being used instead of all installed themes

### Description
Pull request is using [@vrann fix](https://github.com/magento/magento2/pull/8142/commits/35e3225f0478a7b952119dca2a800a76b9ae5f3e#diff-dbf04232abcedbe2e67996b043041b48) and it is upgraded to check (as suggested in comments) for used (custom) themes in products/categories/cms pages.

### Fixed Issues (if relevant)
1. magento/magento2#10363
2. magento/magento2#8145
3. magento/magento2#8142

### Manual testing scenarios
1. Add custom theme for product/category/cms page
2. Disable some theme
3. Upload product image
4. Check if cache image is generated for disabled theme

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
