### PR TITLE
[Port 2.3-develop] Append shipment comment to shipment if appendComment is true

### DIFF
--- a/app/code/Magento/Sales/Model/Order/ShipmentDocumentFactory.php
+++ b/app/code/Magento/Sales/Model/Order/ShipmentDocumentFactory.php
@@ -90,6 +90,11 @@ class ShipmentDocumentFactory
                 $appendComment,
                 $comment->getIsVisibleOnFront()
             );
+
+            if ($appendComment) {
+                $shipment->setCustomerNote($comment->getComment());
+                $shipment->setCustomerNoteNotify($appendComment);
+            }
         }
 
         return $shipment;

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ShipmentDocumentFactoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ShipmentDocumentFactoryTest.php
@@ -92,7 +92,7 @@ class ShipmentDocumentFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->shipmentMock = $this->getMockBuilder(ShipmentInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addComment', 'addTrack'])
+            ->setMethods(['addComment', 'addTrack', 'setCustomerNote', 'setCustomerNoteNotify'])
             ->getMockForAbstractClass();
 
         $this->hydratorPoolMock = $this->getMockBuilder(HydratorPool::class)
@@ -166,7 +166,7 @@ class ShipmentDocumentFactoryTest extends \PHPUnit\Framework\TestCase
         if ($appendComment) {
             $comment = "New comment!";
             $visibleOnFront = true;
-            $this->commentMock->expects($this->once())
+            $this->commentMock->expects($this->exactly(2))
                 ->method('getComment')
                 ->willReturn($comment);
 
@@ -178,6 +178,10 @@ class ShipmentDocumentFactoryTest extends \PHPUnit\Framework\TestCase
                 ->method('addComment')
                 ->with($comment, $appendComment, $visibleOnFront)
                 ->willReturnSelf();
+
+            $this->shipmentMock->expects($this->once())
+                ->method('setCustomerNoteNotify')
+                ->with(true);
         }
 
         $this->assertEquals(


### PR DESCRIPTION
### Description
Add customer note to shipment if shipment is created with API and "appendComment" is set to `true`.

### Fixed Issues (if relevant)
1. magento/magento2#11207: Shipment API won't append comment to email

### Manual testing scenarios
1. Place an order via the website.
2. Create a shipment using the API with "appendComment": true.
3. Add comment to the shipment in same request.
3. Shipment email is being send with comment appended.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)