### PR TITLE
ProductRepository sku cache is corrupted when cacheLimit is reached

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -312,7 +312,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         if ($this->cacheLimit && count($this->instances) > $this->cacheLimit) {
             $offset = round($this->cacheLimit / -2);
             $this->instancesById = array_slice($this->instancesById, $offset, null, true);
-            $this->instances = array_slice($this->instances, $offset);
+            $this->instances = array_slice($this->instances, $offset, null, true);
         }
     }
 


### PR DESCRIPTION
Numeric SKUs are renumbered when array_slice is used to purge parts of the products-by-sku cache array. Per php documentation:
> Note that array_slice() will reorder and reset the numeric array indices by default. 

PHP considers numeric-looking values like `'123'` as numeric even when used as array indices. so although the `$product->getSku()` returns a string, the string might still look like a number and is then renumbered during `array_slice`. 

as `$this->instances` has the SKUs as keys, the resulting shortened array might contain indexes that now point to a wrong product, which can lead to the ProductRespository returning the wrong product for a given SKU.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
load >1000 products by sku, where the skus are numeric via `$productRepository->get($sku);`, then observe the `$productRepository->instance` array

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
