### PR TITLE
Fix depends field not working for radio elements

### DIFF
--- a/lib/web/mage/adminhtml/form.js
+++ b/lib/web/mage/adminhtml/form.js
@@ -386,7 +386,7 @@ define([
          * @param {Object} config
          */
         initialize: function (elementsMap, config) {
-            var idTo, idFrom;
+            var idTo, idFrom, values, fromId, radioFrom;
 
             if (config) {
                 this._config = config;
@@ -400,10 +400,21 @@ define([
                             'change',
                             this.trackChange.bindAsEventListener(this, idTo, elementsMap[idTo])
                         );
-                        this.trackChange(null, idTo, elementsMap[idTo]);
                     } else {
-                        this.trackChange(null, idTo, elementsMap[idTo]);
+                        // Check if radio button
+                        values = elementsMap[idTo][idFrom].values;
+                        fromId = $(idFrom + values[0]);
+                        radioFrom = fromId ? $$('[name="' + fromId.name + '"]') : false;
+
+                        if (radioFrom) {
+                            radioFrom.invoke(
+                                'on',
+                                'change',
+                                this.trackChange.bindAsEventListener(this, idTo, elementsMap[idTo])
+                            );
+                        }
                     }
+                    this.trackChange(null, idTo, elementsMap[idTo]);
                 }
             }
         },
@@ -428,7 +439,7 @@ define([
             // define whether the target should show up
             var shouldShowUp = true,
                 idFrom, from, values, isInArray, isNegative, headElement, isInheritCheckboxChecked, target, inputs,
-                isAnInputOrSelect, currentConfig,rowElement;
+                isAnInputOrSelect, currentConfig, rowElement, fromId, radioFrom;
 
             for (idFrom in valuesFrom) { //eslint-disable-line guard-for-in
                 from = $(idFrom);
@@ -439,6 +450,17 @@ define([
                     isNegative = valuesFrom[idFrom].negative;
 
                     if (!from || isInArray && isNegative || !isInArray && !isNegative) {
+                        shouldShowUp = false;
+                    }
+                // Check if radio button
+                } else {
+                    values = valuesFrom[idFrom].values;
+                    fromId = $(idFrom + values[0]);
+                    radioFrom = fromId ? $$('[name="' + fromId.name + '"]:checked') : [];
+                    isInArray = radioFrom.length > 0 && values.indexOf(radioFrom[0].value) !== -1;
+                    isNegative = valuesFrom[idFrom].negative;
+
+                    if (!radioFrom || isInArray && isNegative || !isInArray && !isNegative) {
                         shouldShowUp = false;
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fixes issue with configuration fields not toggling when `<depends>` is used on radio elements.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Currently the `<depends>` field only works when used on elements of `select` type, this PR aims to replicate the same functionality for fields with `radios` type.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9360: <depends> field doesn't work in system.xml for "radios" fields

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create field with type `radios` and corresponding field that dependant on one of its values as mentioned it #9360
2. Navigate to backend and find configuration page with created field.
3. Toggle radio options on and off, dependant field should hide/show as expected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
