### PR TITLE
Fixed missing 'size' and 'type' props on a third-party category images

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/DataProvider.php
+++ b/app/code/Magento/Catalog/Model/Category/DataProvider.php
@@ -494,8 +494,8 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
 
                     $categoryData[$attributeCode][0]['name'] = $fileName;
                     $categoryData[$attributeCode][0]['url'] = $category->getImageUrl($attributeCode);
-                    $categoryData['image'][0]['size'] = isset($stat) ? $stat['size'] : 0;
-                    $categoryData['image'][0]['type'] = $mime;
+                    $categoryData[$attributeCode][0]['size'] = isset($stat) ? $stat['size'] : 0;
+                    $categoryData[$attributeCode][0]['type'] = $mime;
                 }
             }
         }


### PR DESCRIPTION
### Description
Fixes hardcoded 'image' key when processing `ImageBackendModel` attribute.

### Manual testing scenarios
1. In order to test the issue, you need to create custom `ImageBackendModel` attribute and add it to the category edit form
2. Upload third-party image (leave the image field empty) and save category
3. Third-party image will not have required 'size' and 'type' properties during page rendering
4. The main image will have 'size' and 'type' properties of third-party image

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
