### PR TITLE
Fix category id retrieval

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -104,7 +104,7 @@ class ListProduct extends AbstractProduct implements IdentityInterface
                 // if the product is associated with any category
                 if ($categories->count()) {
                     // show products from this category
-                    $this->setCategoryId(current($categories->getIterator()));
+                    $this->setCategoryId(current($categories->getIterator())->getId());
                 }
             }
 


### PR DESCRIPTION
A category instance is passed when a category id is supposed to be received.

### Description
In magento2/app/code/Magento/Catalog/Block/Product/ListProduct.php, in _getProductCollection function, the following code set categoryId with a category instance.

 
```
// if the product is associated with any category
                if ($categories->count()) {
                    // show products from this category
                    $this->setCategoryId(current($categories->getIterator()));
                }
```

That causes the following code to fail later :
`$category = $this->categoryRepository->get($this->getCategoryId());
`

### Manual testing scenarios
1. In the backoffice, add a product to the upsell product list
2. Go to the frontend product page to verify the bug is occuring
You should have the following error : 

> Exception #0 (Exception): Warning: Illegal offset type in /var/www/html/_0521-barbarabui/vendor/magento/module-catalog/Model/CategoryRepository.php on line 133


3. After the fix the bug doesn't occur anymore.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
