### PR TITLE
Add price calculation improvement for product option value price

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -11,6 +11,7 @@ namespace Magento\Catalog\Model\Product\Option;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Option;
 use Magento\Framework\Model\AbstractModel;
+use Magento\Catalog\Pricing\Price\BasePrice;
 
 /**
  * Catalog product option select type model
@@ -223,7 +224,7 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
     public function getPrice($flag = false)
     {
         if ($flag && $this->getPriceType() == self::TYPE_PERCENT) {
-            $basePrice = $this->getOption()->getProduct()->getFinalPrice();
+            $basePrice = $this->getOption()->getProduct()->getPriceInfo()->getPrice(BasePrice::PRICE_CODE)->getValue();
             $price = $basePrice * ($this->_getData(self::KEY_PRICE) / 100);
             return $price;
         }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/ValueTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/ValueTest.php
@@ -164,13 +164,27 @@ class ValueTest extends \PHPUnit\Framework\TestCase
     private function getMockedProduct()
     {
         $mockBuilder = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
-            ->setMethods(['getFinalPrice', '__wakeup'])
+            ->setMethods(['getPriceInfo', '__wakeup'])
             ->disableOriginalConstructor();
         $mock = $mockBuilder->getMock();
 
-        $mock->expects($this->any())
-            ->method('getFinalPrice')
-            ->will($this->returnValue(10));
+        $priceInfoMock = $this->getMockForAbstractClass(
+            \Magento\Framework\Pricing\PriceInfoInterface::class,
+            [],
+            '',
+            false,
+            false,
+            true,
+            ['getPrice']
+        );
+
+        $priceMock = $this->getMockForAbstractClass(\Magento\Framework\Pricing\Price\PriceInterface::class);
+
+        $priceInfoMock->expects($this->any())->method('getPrice')->willReturn($priceMock);
+
+        $mock->expects($this->any())->method('getPriceInfo')->willReturn($priceInfoMock);
+
+        $priceMock->expects($this->any())->method('getValue')->willReturn(10);
 
         return $mock;
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The price calculation for the product option value relied on the getFinalPrice value, which if called without the qty parameter will not consider tier prices.
This method was updated to use the base price as calculated by the priceInfo object, just like in Magento\Catalog\Model\Product\Option.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5774: Tier price and custom options give bad results

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a product with a regular price.
2. Add a tier price with quantity 1, a customer group and a smaller price than the regular one.
3. Add a custom option using a type that will allow adding values (for example, Checkbox).
4. Add a value with Price Type: Percent, and a price value (for example, 100).
5. Login with a customer from the customer group used when adding the tier price.
6. Go to the product page, the product price should be the tier price added for the customer group and the price of the custom option value should be calculated based on the corresponding product tier price, and not the product regular price.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
