### PR TITLE
Fix "pattern" UI Component validation

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -360,7 +360,7 @@ define([
         ],
         'pattern': [
             function (value, param) {
-                return param.test(value);
+                return new RegExp(param).test(value);
             },
             $.mage.__('Invalid format.')
         ],


### PR DESCRIPTION
### Description
Convert `param` string to regular expression using constructor and test on the `RegExp` object.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9919: Pattern Validation via UI Component Fails to Interpret String as RegEx Pattern

### Manual testing scenarios
1. Create a custom UI Component form
2. Add a `validation` item to an input field
3. Specify a `pattern` validation rule with a custom regular expression pattern.  E.g.

        <item name="validation" xsi:type="array">
            <item name="required-entry" xsi:type="boolean">true</item>
            <item name="no-whitespace" xsi:type="boolean">true</item>
            <item name="pattern" xsi:type="string">^[a-zA-Z][a-zA-Z0-9_.-]{3,}$</item>
        </item>

4. View form in admin browser and enter valid and invalid values (e.g. `3sdf` and `asd3`)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
