### PR TITLE
Fixed double space typo

### DIFF
--- a/app/code/Magento/Paypal/i18n/en_US.csv
+++ b/app/code/Magento/Paypal/i18n/en_US.csv
@@ -367,7 +367,7 @@ expires,expires
 here,here
 " to learn more."," to learn more."
 "Important: ","Important: "
-"To use PayPal Payments Advanced, you must configure  your PayPal Payments Advanced account on the PayPal website.","To use PayPal Payments Advanced, you must configure  your PayPal Payments Advanced account on the PayPal website."
+"To use PayPal Payments Advanced, you must configure your PayPal Payments Advanced account on the PayPal website.","To use PayPal Payments Advanced, you must configure your PayPal Payments Advanced account on the PayPal website."
 "Once you log into your PayPal Advanced account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below","Once you log into your PayPal Advanced account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below"
 "To use PayPal Payflow Link, you must configure your PayPal Payflow Link account on the PayPal website.","To use PayPal Payflow Link, you must configure your PayPal Payflow Link account on the PayPal website."
 "Once you log into your PayPal Payflow Link account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below","Once you log into your PayPal Payflow Link account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below"

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/advanced.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/advanced.phtml
@@ -12,7 +12,7 @@
 <div class="payflow-settings-notice">
     <p>
         <strong class="important-label"><?= $block->escapeHtml(__('Important: ')) ?></strong>
-        <?= $block->escapeHtml(__('To use PayPal Payments Advanced, you must configure  your PayPal Payments Advanced account on the PayPal website.')) ?>
+        <?= $block->escapeHtml(__('To use PayPal Payments Advanced, you must configure your PayPal Payments Advanced account on the PayPal website.')) ?>
         <?= $block->escapeHtml(__('Once you log into your PayPal Advanced account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below')) ?>
     </p>
     <ul class="options-list">


### PR DESCRIPTION
- Changed typo where a string to be translated used double space "configure  your" instead of "configure your".
- Checked all files and changed the string everywhere to a single space. 

### Related Pull Requests
https://github.com/magento/magento2/pull/12961