### PR TITLE
#5770 FIX Catalog Rule Product Index is not reindexing after save

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Rule/Job.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Job.php
@@ -55,6 +55,7 @@ class Job extends \Magento\Framework\DataObject
     {
         try {
             $this->ruleProcessor->markIndexerAsInvalid();
+            $this->ruleProcessor->reindexAll();
             $this->setSuccess(__('Updated rules applied.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->setError($e->getMessage());


### PR DESCRIPTION
**Description**
After editing a catalog rule, the rule is never applied.


**Fixed Issues (if relevant)**
#5770