### PR TITLE
Fix Issue #7225 - Remove hardcoding of apply_to when saving attributes

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -193,7 +193,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
                 );
             }
 
-            $data += ['is_filterable' => 0, 'is_filterable_in_search' => 0, 'apply_to' => []];
+            $data += ['is_filterable' => 0, 'is_filterable_in_search' => 0];
 
             if (is_null($model->getIsUserDefined()) || $model->getIsUserDefined() != 0) {
                 $data['backend_type'] = $model->getBackendTypeByInput($data['frontend_input']);


### PR DESCRIPTION
Remove hardcoding of apply_to when saving attributes

### Description
If an empty dropdown is created via InstallData script, and its constrained to a product type, when later adding options manually via the Admin, the constrain is removed.
This PR removes the hardcoding of an empty `apply_to` value when saving attributes.

### Fixed Issues (if relevant)
1. [[BUG] [Magento 2.1.2] Programmatically creating an empty dropdown attribute, "apply_to" is set to NULL (from "simple") after adding options through store admin](https://github.com/magento/magento2/issues/7225)

### Manual testing scenarios
1. Create an empty dropdown product attribute named "test_dropdown" programmatically through InstallData.php, set "apply_to" to "simple".
1. After setup:upgrade, things are going fine. In store admin, the "test_dropdown" attribute is shown on simple product create or edit page (an empty dropdown), and is hidden on other products create or edit page. The content of "apply_to" field of the current attribute in database table of "catalog_eav_attribute" is also "simple".
3. After adding attribute options through store admin, the "test_dropdown" remains constrained to the "simple" product type. The content of "apply_to" field of the current attribute in database table of "catalog_eav_attribute" is still "simple".

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)