### PR TITLE
[Backport 2.1-develop] #11586 Fix duplicated crontab 2>&1 expression

### DIFF
--- a/lib/internal/Magento/Framework/Shell/CommandRenderer.php
+++ b/lib/internal/Magento/Framework/Shell/CommandRenderer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Framework\Shell;
@@ -16,9 +16,11 @@ class CommandRenderer implements CommandRendererInterface
      */
     public function render($command, array $arguments = [])
     {
+        $command = preg_replace('/(\s+2>&1)*(\s*\|)|$/', ' 2>&1$2', $command);
         $arguments = array_map('escapeshellarg', $arguments);
-        $command = preg_replace('/\s?\||$/', ' 2>&1$0', $command);
-        $command = vsprintf($command, $arguments);
-        return $command;
+        if (empty($arguments)) {
+            return $command;
+        }
+        return vsprintf($command, $arguments);
     }
 }

--- a/lib/internal/Magento/Framework/Shell/CommandRenderer.php
+++ b/lib/internal/Magento/Framework/Shell/CommandRenderer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Framework\Shell;

--- a/lib/internal/Magento/Framework/Shell/Test/Unit/CommandRendererTest.php
+++ b/lib/internal/Magento/Framework/Shell/Test/Unit/CommandRendererTest.php
@@ -1,22 +1,44 @@
 <?php
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Framework\Shell\Test\Unit;
 
-use \Magento\Framework\Shell\CommandRenderer;
+use Magento\Framework\Shell\CommandRenderer;
 
 class CommandRendererTest extends \PHPUnit_Framework_TestCase
 {
-    public function testRender()
+    /**
+     * @param $expectedCommand
+     * @param $actualCommand
+     * @param $testArguments
+     * @dataProvider commandsDataProvider
+     */
+    public function testRender($expectedCommand, $actualCommand, $testArguments)
+    {
+        $commandRenderer = new CommandRenderer();
+        $this->assertEquals(
+            $expectedCommand,
+            $commandRenderer->render($actualCommand, $testArguments)
+        );
+    }
+
+    public function commandsDataProvider()
     {
         $testArgument  = 'argument';
         $testArgument2 = 'argument2';
-        $commandRenderer = new CommandRenderer();
-        $this->assertEquals(
-            "php -r " . escapeshellarg($testArgument) . " 2>&1 | grep " . escapeshellarg($testArgument2) . " 2>&1",
-            $commandRenderer->render('php -r %s | grep %s', [$testArgument, $testArgument2])
-        );
+
+        $expectedCommand = "php -r %s 2>&1 | grep %s 2>&1";
+        $expectedCommandArgs = "php -r '" . $testArgument . "' 2>&1 | grep '" . $testArgument2 . "' 2>&1";
+
+        return [
+            [$expectedCommand, 'php -r %s | grep %s', []],
+            [$expectedCommand, 'php -r %s 2>&1 | grep %s', []],
+            [$expectedCommand, 'php -r %s 2>&1 2>&1 | grep %s', []],
+            [$expectedCommandArgs, 'php -r %s | grep %s', [$testArgument, $testArgument2]],
+            [$expectedCommandArgs, 'php -r %s 2>&1 | grep %s', [$testArgument, $testArgument2]],
+            [$expectedCommandArgs, 'php -r %s 2>&1 2>&1 | grep %s', [$testArgument, $testArgument2]],
+        ];
     }
 }

--- a/lib/internal/Magento/Framework/Shell/Test/Unit/CommandRendererTest.php
+++ b/lib/internal/Magento/Framework/Shell/Test/Unit/CommandRendererTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Framework\Shell\Test\Unit;


### PR DESCRIPTION
### Description
Installing or removing crontab via command adds 2>&1 repeatedly, even for crontab entries not related with Magento, if they match a regular expression. See details in magento/magento2#11586.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11586: Cron install / remove via command messes up stderr 2>&1 entries

### Manual testing scenarios
As explained in magento/magento2#11586

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
