### PR TITLE
[Backport 2.2-develop] #11586 Fix duplicated crontab 2>&1 expression

### DIFF
--- a/lib/internal/Magento/Framework/Shell/CommandRenderer.php
+++ b/lib/internal/Magento/Framework/Shell/CommandRenderer.php
@@ -16,8 +16,8 @@ class CommandRenderer implements CommandRendererInterface
      */
     public function render($command, array $arguments = [])
     {
+        $command = preg_replace('/(\s+2>&1)*(\s*\|)|$/', ' 2>&1$2', $command);
         $arguments = array_map('escapeshellarg', $arguments);
-        $command = preg_replace('/\s?\||$/', ' 2>&1$0', $command);
         if (empty($arguments)) {
             return $command;
         }

--- a/lib/internal/Magento/Framework/Shell/Test/Unit/CommandRendererTest.php
+++ b/lib/internal/Magento/Framework/Shell/Test/Unit/CommandRendererTest.php
@@ -5,27 +5,40 @@
  */
 namespace Magento\Framework\Shell\Test\Unit;
 
-use \Magento\Framework\Shell\CommandRenderer;
+use Magento\Framework\Shell\CommandRenderer;
 
 class CommandRendererTest extends \PHPUnit\Framework\TestCase
 {
-    public function testRender()
+    /**
+     * @param $expectedCommand
+     * @param $actualCommand
+     * @param $testArguments
+     * @dataProvider commandsDataProvider
+     */
+    public function testRender($expectedCommand, $actualCommand, $testArguments)
     {
-        $testArgument  = 'argument';
-        $testArgument2 = 'argument2';
         $commandRenderer = new CommandRenderer();
         $this->assertEquals(
-            "php -r " . escapeshellarg($testArgument) . " 2>&1 | grep " . escapeshellarg($testArgument2) . " 2>&1",
-            $commandRenderer->render('php -r %s | grep %s', [$testArgument, $testArgument2])
+            $expectedCommand,
+            $commandRenderer->render($actualCommand, $testArguments)
         );
     }
 
-    public function testRenderWithoutArguments()
+    public function commandsDataProvider()
     {
-        $commandRenderer = new CommandRenderer();
-        $this->assertEquals(
-            "php -r %s 2>&1 | grep %s 2>&1",
-            $commandRenderer->render('php -r %s | grep %s', [])
-        );
+        $testArgument  = 'argument';
+        $testArgument2 = 'argument2';
+
+        $expectedCommand = "php -r %s 2>&1 | grep %s 2>&1";
+        $expectedCommandArgs = "php -r '" . $testArgument . "' 2>&1 | grep '" . $testArgument2 . "' 2>&1";
+
+        return [
+            [$expectedCommand, 'php -r %s | grep %s', []],
+            [$expectedCommand, 'php -r %s 2>&1 | grep %s', []],
+            [$expectedCommand, 'php -r %s 2>&1 2>&1 | grep %s', []],
+            [$expectedCommandArgs, 'php -r %s | grep %s', [$testArgument, $testArgument2]],
+            [$expectedCommandArgs, 'php -r %s 2>&1 | grep %s', [$testArgument, $testArgument2]],
+            [$expectedCommandArgs, 'php -r %s 2>&1 2>&1 | grep %s', [$testArgument, $testArgument2]],
+        ];
     }
 }


### PR DESCRIPTION
### Description
Installing or removing crontab via command adds 2>&1 repeatedly, even for crontab entries not related with Magento, if they match a regular expression. See details in magento/magento2#11586.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11586: Cron install / remove via command messes up stderr 2>&1 entries

### Manual testing scenarios
As explained in magento/magento2#11586

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
