### PR TITLE
Delete attribute_set_id from report most viewed products

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Collection.php
@@ -323,8 +323,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         )->join(
             ['e' => $this->getProductEntityTableName()],
             $this->getConnection()->quoteInto(
-                'e.entity_id = report_table_views.object_id AND e.attribute_set_id = ?',
-                $this->getProductAttributeSetId()
+                'e.entity_id = report_table_views.object_id',
+                null
             )
         )->where(
             'report_table_views.event_type_id = ?',


### PR DESCRIPTION
Delete attribute_set_id from report most viewed products

### Description
The problem is the method to get Views count product try to get `attribute_set_id` from table `catalog_product_entity` but this `attribute_set_id` its default productEntityType:
`$this->setProductAttributeSetId($product->getEntityType()->getDefaultAttributeSetId());` per default this value is: 4 in table `eav_entity_type`, the products can have differente attribute_set_id that differs from `eav_entity_type.default_attribute_set_id`

Wrong Query:
```
SELECT COUNT(report_table_views.event_id) AS `views`, `e`.* 
FROM `report_event` AS `report_table_views`
INNER JOIN `catalog_product_entity` AS `e` 
       ON e.entity_id = report_table_views.object_id 
       AND e.attribute_set_id = '4' 
WHERE (report_table_views.event_type_id = 1) 
GROUP BY `e`.`entity_id` 
HAVING (COUNT(report_table_views.event_id) > 0) 
ORDER BY `views` DESC
;
```

Table `catalog_product_entity` with sample_data (result):
```
+-----------+------------------+---------+---------+-------------+------------------+---------------------+---------------------+
| entity_id | attribute_set_id | type_id | sku     | has_options | required_options | created_at          | updated_at          |
+-----------+------------------+---------+---------+-------------+------------------+---------------------+---------------------+
|         1 |               15 | simple  | 24-MB01 |           0 |                0 | 2017-10-20 22:54:40 | 2017-10-20 22:54:40 |
|         2 |               15 | simple  | 24-MB04 |           0 |                0 | 2017-10-20 22:54:41 | 2017-10-20 22:54:41 |
|         3 |               15 | simple  | 24-MB03 |           0 |                0 | 2017-10-20 22:54:42 | 2017-10-20 22:54:42 |
|         4 |               15 | simple  | 24-MB05 |           0 |                0 | 2017-10-20 22:54:42 | 2017-10-20 22:54:42 |
|         5 |               15 | simple  | 24-MB06 |           0 |                0 | 2017-10-20 22:54:42 | 2017-10-20 22:54:42 |
|         6 |               15 | simple  | 24-MB02 |           0 |                0 | 2017-10-20 22:54:43 | 2017-10-20 22:54:43 |
|         7 |               15 | simple  | 24-UB02 |           0 |                0 | 2017-10-20 22:54:43 | 2017-10-20 22:54:43 |
|         8 |               15 | simple  | 24-WB01 |           0 |                0 | 2017-10-20 22:54:43 | 2017-10-20 22:54:43 |
|         9 |               15 | simple  | 24-WB02 |           0 |                0 | 2017-10-20 22:54:43 | 2017-10-20 22:54:43 |
|        10 |               15 | simple  | 24-WB05 |           0 |                0 | 2017-10-20 22:54:44 | 2017-10-20 22:54:44 |
+-----------+------------------+---------+---------+-------------+------------------+---------------------+---------------------+
```

You can see the `attribute_set_id` from `catalog_product_entity` can differ from default `4`

### Fixed Issues (if relevant)
1. magento/magento2#6098: Admin dashboard Most Viewed Products Tab statistics not updating
2. magento/magento2#8095: Products image not showing when add ->addViewsCount() in most-viewed products
3. magento/magento2#9768: Admin dashboard Most Viewed Products Tab only gives default attribute set's products

### Manual testing scenarios
1. Visit some products
2. Logged in admin panel.
3. Go to "Most Viewed Products" tab just under graph.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
