### PR TITLE
Changed Validation to get store for block

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block.php
@@ -7,10 +7,10 @@ namespace Magento\Cms\Model\ResourceModel;
 
 use Magento\Cms\Api\Data\BlockInterface;
 use Magento\Framework\DB\Select;
+use Magento\Framework\EntityManager\EntityManager;
+use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Framework\EntityManager\EntityManager;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Store\Model\Store;
@@ -183,7 +183,7 @@ class Block extends AbstractDb
         $entityMetadata = $this->metadataPool->getMetadata(BlockInterface::class);
         $linkField = $entityMetadata->getLinkField();
 
-        if ($this->_storeManager->hasSingleStore()) {
+        if ($this->_storeManager->isSingleStoreMode()) {
             $stores = [Store::DEFAULT_STORE_ID];
         } else {
             $stores = (array)$object->getData('stores');
@@ -230,7 +230,7 @@ class Block extends AbstractDb
                 'cbs.' . $linkField . ' = cb.' . $linkField,
                 []
             )
-            ->where('cb.' . $entityMetadata->getIdentifierField()  . ' = :block_id');
+            ->where('cb.' . $entityMetadata->getIdentifierField() . ' = :block_id');
 
         return $connection->fetchCol($select, ['block_id' => (int)$id]);
     }


### PR DESCRIPTION
Changed validation to `getIsUniqueBlockToStores`
### Description

Changed validation to get `DEFAULT_STORE_ID` when the app is setted with `SingleStoreMode` in the other cases get store from object

### Fixed Issues (if relevant)
1. magento/magento2#4831: Inconsistent cms block validation and save methods
2. ...

### Manual testing scenarios
1. Make sure that you have only one store view and SingleStoreMode option to `no`
2. Create cms block example for All Store views
3. Create another cms block example for first store view only

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
