### PR TITLE
Send email to subscribers only when are new

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -395,6 +395,10 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
     {
         $this->loadByEmail($email);
 
+        if ($this->getId() && $this->getStatus() == self::STATUS_SUBSCRIBED) {
+            return $this->getStatus();
+        }
+
         if (!$this->getId()) {
             $this->setSubscriberConfirmCode($this->randomSequence());
         }


### PR DESCRIPTION
Only send email/confirmation email of subscription to newsletter only when subscriber is new in newsletter

### Description
Check if is necessary send email to a customer that is subscribed to newsletter. If this customer was subscribed previously not necessary send email. 

### Fixed Issues (if relevant)
1. magento/magento2#5439: Newsletter subscription

### Manual testing scenarios
1. Subscribe an email not subscribed previously (e.g: test@test.com)
2. this email will receive a confirmation email of subscription
3. Subscribe the same email (test@test.com)
4. this email NOT will recieve a confirmation email of subscription

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
