### PR TITLE
Fix AcountManagementTest unit test fail randomly

### DIFF
--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -12,16 +12,17 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\Data\ValidationResultsInterfaceFactory;
-use Magento\Customer\Model\EmailNotificationInterface;
 use Magento\Customer\Helper\View as CustomerViewHelper;
 use Magento\Customer\Model\Config\Share as ConfigShare;
 use Magento\Customer\Model\Customer as CustomerModel;
+use Magento\Customer\Model\Customer\CredentialsValidator;
 use Magento\Customer\Model\Metadata\Validator;
 use Magento\Eav\Model\Validator\Attribute\Backend;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\DataObjectFactory as ObjectFactory;
 use Magento\Framework\Encryption\EncryptorInterface as Encryptor;
 use Magento\Framework\Encryption\Helper\Security;
 use Magento\Framework\Event\ManagerInterface;
@@ -30,23 +31,22 @@ use Magento\Framework\Exception\EmailNotConfirmedException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\InvalidEmailOrPasswordException;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\MailException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\State\ExpiredException;
 use Magento\Framework\Exception\State\InputMismatchException;
 use Magento\Framework\Exception\State\InvalidTransitionException;
-use Magento\Framework\DataObjectFactory as ObjectFactory;
 use Magento\Framework\Exception\State\UserLockedException;
-use Magento\Framework\Registry;
-use Magento\Store\Model\ScopeInterface;
-use Psr\Log\LoggerInterface as PsrLogger;
-use Magento\Framework\Exception\MailException;
+use Magento\Framework\Intl\DateTimeFactory;
 use Magento\Framework\Mail\Template\TransportBuilder;
 use Magento\Framework\Math\Random;
 use Magento\Framework\Reflection\DataObjectProcessor;
+use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\StringUtils as StringHelper;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Customer\Model\Customer\CredentialsValidator;
+use Psr\Log\LoggerInterface as PsrLogger;
 
 /**
  * Handle various customer account actions
@@ -294,6 +294,11 @@ class AccountManagement implements AccountManagementInterface
     private $credentialsValidator;
 
     /**
+     * @var DateTimeFactory
+     */
+    private $dateTimeFactory;
+
+    /**
      * @param CustomerFactory $customerFactory
      * @param ManagerInterface $eventManager
      * @param StoreManagerInterface $storeManager
@@ -318,6 +323,7 @@ class AccountManagement implements AccountManagementInterface
      * @param ObjectFactory $objectFactory
      * @param ExtensibleDataObjectConverter $extensibleDataObjectConverter
      * @param CredentialsValidator|null $credentialsValidator
+     * @param DateTimeFactory $dateTimeFactory
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -344,7 +350,8 @@ class AccountManagement implements AccountManagementInterface
         CustomerModel $customerModel,
         ObjectFactory $objectFactory,
         ExtensibleDataObjectConverter $extensibleDataObjectConverter,
-        CredentialsValidator $credentialsValidator = null
+        CredentialsValidator $credentialsValidator = null,
+        DateTimeFactory $dateTimeFactory = null
     ) {
         $this->customerFactory = $customerFactory;
         $this->eventManager = $eventManager;
@@ -369,8 +376,9 @@ class AccountManagement implements AccountManagementInterface
         $this->customerModel = $customerModel;
         $this->objectFactory = $objectFactory;
         $this->extensibleDataObjectConverter = $extensibleDataObjectConverter;
-        $this->credentialsValidator = $credentialsValidator ?: ObjectManager::getInstance()
-            ->get(CredentialsValidator::class);
+        $this->credentialsValidator =
+            $credentialsValidator ?: ObjectManager::getInstance()->get(CredentialsValidator::class);
+        $this->dateTimeFactory = $dateTimeFactory ?: ObjectManager::getInstance()->get(DateTimeFactory::class);
     }
 
     /**
@@ -380,7 +388,6 @@ class AccountManagement implements AccountManagementInterface
      */
     private function getAuthentication()
     {
-
         if (!($this->authentication instanceof AuthenticationInterface)) {
             return \Magento\Framework\App\ObjectManager::getInstance()->get(
                 \Magento\Customer\Model\AuthenticationInterface::class
@@ -613,16 +620,16 @@ class AccountManagement implements AccountManagementInterface
         $return = 0;
 
         if (preg_match('/[0-9]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
         if (preg_match('/[A-Z]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
         if (preg_match('/[a-z]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
         if (preg_match('/[^a-zA-Z0-9]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
 
         if ($counter < $requiredNumber) {
@@ -890,16 +897,14 @@ class AccountManagement implements AccountManagementInterface
 
         $result = $this->getEavValidator()->isValid($customerModel);
         if ($result === false && is_array($this->getEavValidator()->getMessages())) {
-            return $validationResults->setIsValid(false)
-                ->setMessages(
-                    call_user_func_array(
-                        'array_merge',
-                        $this->getEavValidator()->getMessages()
-                    )
-                );
+            return $validationResults->setIsValid(false)->setMessages(
+                call_user_func_array(
+                    'array_merge',
+                    $this->getEavValidator()->getMessages()
+                )
+            );
         }
-        return $validationResults->setIsValid(true)
-            ->setMessages([]);
+        return $validationResults->setIsValid(true)->setMessages([]);
     }
 
     /**
@@ -949,10 +954,12 @@ class AccountManagement implements AccountManagementInterface
     private function validateResetPasswordToken($customerId, $resetPasswordLinkToken)
     {
         if (empty($customerId) || $customerId < 0) {
-            throw new InputException(__(
-                'Invalid value of "%value" provided for the %fieldName field.',
-                ['value' => $customerId, 'fieldName' => 'customerId']
-            ));
+            throw new InputException(
+                __(
+                    'Invalid value of "%value" provided for the %fieldName field.',
+                    ['value' => $customerId, 'fieldName' => 'customerId']
+                )
+            );
         }
         if (!is_string($resetPasswordLinkToken) || empty($resetPasswordLinkToken)) {
             $params = ['fieldName' => 'resetPasswordLinkToken'];
@@ -1178,8 +1185,8 @@ class AccountManagement implements AccountManagementInterface
 
         $expirationPeriod = $this->customerModel->getResetPasswordLinkExpirationPeriod();
 
-        $currentTimestamp = (new \DateTime())->getTimestamp();
-        $tokenTimestamp = (new \DateTime($rpTokenCreatedAt))->getTimestamp();
+        $currentTimestamp = $this->dateTimeFactory->create()->getTimestamp();
+        $tokenTimestamp = $this->dateTimeFactory->create($rpTokenCreatedAt)->getTimestamp();
         if ($tokenTimestamp > $currentTimestamp) {
             return true;
         }
@@ -1215,7 +1222,9 @@ class AccountManagement implements AccountManagementInterface
         if (is_string($passwordLinkToken) && !empty($passwordLinkToken)) {
             $customerSecure = $this->customerRegistry->retrieveSecureData($customer->getId());
             $customerSecure->setRpToken($passwordLinkToken);
-            $customerSecure->setRpTokenCreatedAt((new \DateTime())->format(DateTime::DATETIME_PHP_FORMAT));
+            $customerSecure->setRpTokenCreatedAt(
+                $this->dateTimeFactory->create()->format(DateTime::DATETIME_PHP_FORMAT)
+            );
             $this->customerRepository->save($customer);
         }
         return true;
@@ -1304,8 +1313,8 @@ class AccountManagement implements AccountManagementInterface
         // No need to flatten the custom attributes or nested objects since the only usage is for email templates and
         // object passed for events
         $mergedCustomerData = $this->customerRegistry->retrieveSecureData($customer->getId());
-        $customerData = $this->dataProcessor
-            ->buildOutputDataArray($customer, \Magento\Customer\Api\Data\CustomerInterface::class);
+        $customerData =
+            $this->dataProcessor->buildOutputDataArray($customer, \Magento\Customer\Api\Data\CustomerInterface::class);
         $mergedCustomerData->addData($customerData);
         $mergedCustomerData->setData('name', $this->customerViewHelper->getCustomerName($customer));
         return $mergedCustomerData;


### PR DESCRIPTION
Surprisingly, after testing succesfully locally unit tests, I've found this error in Travis, in unit tests performed by \Magento\Customer\Test\Unit\Model\AccountManagementTest class:
![captura de pantalla 2017-10-21 a las 1 25 35](https://user-images.githubusercontent.com/17545750/31846761-5da737e6-b610-11e7-9371-bc219e257038.png)
Simply rebuilding the job worked and all the tests passed, but this error may happen again at any time, due to how are mocks built in that class:

- A datetime variable is set from current time:
<img width="585" alt="captura de pantalla 2017-10-21 a las 3 36 13" src="https://user-images.githubusercontent.com/17545750/31846815-1556d7fc-b611-11e7-81de-1f0e62e8f261.png">

- Below, customerSecure mock expects setRpTokenCreatedAt method to be called with previous datetime value will return self:
<img width="398" alt="captura de pantalla 2017-10-21 a las 3 37 44" src="https://user-images.githubusercontent.com/17545750/31846829-5014fff4-b611-11e7-80b3-d8ce78ce217e.png">

- But testing the method, the customerSecure::setRpTokenCreatedAt method is called with the current datetime, that may be NOT the previous one, so tests fails because method was not expected to be called with new date value:
<img width="752" alt="captura de pantalla 2017-10-21 a las 3 42 41" src="https://user-images.githubusercontent.com/17545750/31846889-16381522-b612-11e7-9059-b2628eac645a.png">

- The test assumes the mock creation and the mocked method call will happen in the same second, thing that may not be true and it's irrelevant for tests using \Magento\Customer\Test\Unit\Model\AccountManagementTest::prepareInitiatePasswordReset method:
<img width="552" alt="captura de pantalla 2017-10-21 a las 3 44 35" src="https://user-images.githubusercontent.com/17545750/31846896-3437199c-b612-11e7-8d4a-5cc901d28584.png">

Removing expected date fix this rare, weird, but actually happening, issue.

### Manual testing scenarios
1. To simulate this, change 
`$dateTime = date(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT);`
 to
`$dateTime = '2017-10-20 00:00:00';` 
in \Magento\Customer\Test\Unit\Model\AccountManagementTest::prepareInitiatePasswordReset method.
2. Run unit test over this class.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
