### PR TITLE
[Backport 2.2-develop] Fix AcountManagementTest unit test fail randomly

### DIFF
--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -12,16 +12,17 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\Data\ValidationResultsInterfaceFactory;
-use Magento\Customer\Model\EmailNotificationInterface;
 use Magento\Customer\Helper\View as CustomerViewHelper;
 use Magento\Customer\Model\Config\Share as ConfigShare;
 use Magento\Customer\Model\Customer as CustomerModel;
+use Magento\Customer\Model\Customer\CredentialsValidator;
 use Magento\Customer\Model\Metadata\Validator;
 use Magento\Eav\Model\Validator\Attribute\Backend;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\DataObjectFactory as ObjectFactory;
 use Magento\Framework\Encryption\EncryptorInterface as Encryptor;
 use Magento\Framework\Encryption\Helper\Security;
 use Magento\Framework\Event\ManagerInterface;
@@ -30,23 +31,22 @@ use Magento\Framework\Exception\EmailNotConfirmedException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\InvalidEmailOrPasswordException;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\MailException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\State\ExpiredException;
 use Magento\Framework\Exception\State\InputMismatchException;
 use Magento\Framework\Exception\State\InvalidTransitionException;
-use Magento\Framework\DataObjectFactory as ObjectFactory;
 use Magento\Framework\Exception\State\UserLockedException;
-use Magento\Framework\Registry;
-use Magento\Store\Model\ScopeInterface;
-use Psr\Log\LoggerInterface as PsrLogger;
-use Magento\Framework\Exception\MailException;
+use Magento\Framework\Intl\DateTimeFactory;
 use Magento\Framework\Mail\Template\TransportBuilder;
 use Magento\Framework\Math\Random;
 use Magento\Framework\Reflection\DataObjectProcessor;
+use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\StringUtils as StringHelper;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Customer\Model\Customer\CredentialsValidator;
+use Psr\Log\LoggerInterface as PsrLogger;
 
 /**
  * Handle various customer account actions
@@ -294,6 +294,11 @@ class AccountManagement implements AccountManagementInterface
     private $credentialsValidator;
 
     /**
+     * @var DateTimeFactory
+     */
+    private $dateTimeFactory;
+
+    /**
      * @param CustomerFactory $customerFactory
      * @param ManagerInterface $eventManager
      * @param StoreManagerInterface $storeManager
@@ -318,6 +323,7 @@ class AccountManagement implements AccountManagementInterface
      * @param ObjectFactory $objectFactory
      * @param ExtensibleDataObjectConverter $extensibleDataObjectConverter
      * @param CredentialsValidator|null $credentialsValidator
+     * @param DateTimeFactory $dateTimeFactory
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -344,7 +350,8 @@ class AccountManagement implements AccountManagementInterface
         CustomerModel $customerModel,
         ObjectFactory $objectFactory,
         ExtensibleDataObjectConverter $extensibleDataObjectConverter,
-        CredentialsValidator $credentialsValidator = null
+        CredentialsValidator $credentialsValidator = null,
+        DateTimeFactory $dateTimeFactory = null
     ) {
         $this->customerFactory = $customerFactory;
         $this->eventManager = $eventManager;
@@ -369,8 +376,9 @@ class AccountManagement implements AccountManagementInterface
         $this->customerModel = $customerModel;
         $this->objectFactory = $objectFactory;
         $this->extensibleDataObjectConverter = $extensibleDataObjectConverter;
-        $this->credentialsValidator = $credentialsValidator ?: ObjectManager::getInstance()
-            ->get(CredentialsValidator::class);
+        $this->credentialsValidator =
+            $credentialsValidator ?: ObjectManager::getInstance()->get(CredentialsValidator::class);
+        $this->dateTimeFactory = $dateTimeFactory ?: ObjectManager::getInstance()->get(DateTimeFactory::class);
     }
 
     /**
@@ -380,7 +388,6 @@ class AccountManagement implements AccountManagementInterface
      */
     private function getAuthentication()
     {
-
         if (!($this->authentication instanceof AuthenticationInterface)) {
             return \Magento\Framework\App\ObjectManager::getInstance()->get(
                 \Magento\Customer\Model\AuthenticationInterface::class
@@ -613,16 +620,16 @@ class AccountManagement implements AccountManagementInterface
         $return = 0;
 
         if (preg_match('/[0-9]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
         if (preg_match('/[A-Z]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
         if (preg_match('/[a-z]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
         if (preg_match('/[^a-zA-Z0-9]+/', $password)) {
-            $counter ++;
+            $counter++;
         }
 
         if ($counter < $requiredNumber) {
@@ -890,16 +897,14 @@ class AccountManagement implements AccountManagementInterface
 
         $result = $this->getEavValidator()->isValid($customerModel);
         if ($result === false && is_array($this->getEavValidator()->getMessages())) {
-            return $validationResults->setIsValid(false)
-                ->setMessages(
-                    call_user_func_array(
-                        'array_merge',
-                        $this->getEavValidator()->getMessages()
-                    )
-                );
+            return $validationResults->setIsValid(false)->setMessages(
+                call_user_func_array(
+                    'array_merge',
+                    $this->getEavValidator()->getMessages()
+                )
+            );
         }
-        return $validationResults->setIsValid(true)
-            ->setMessages([]);
+        return $validationResults->setIsValid(true)->setMessages([]);
     }
 
     /**
@@ -949,10 +954,12 @@ class AccountManagement implements AccountManagementInterface
     private function validateResetPasswordToken($customerId, $resetPasswordLinkToken)
     {
         if (empty($customerId) || $customerId < 0) {
-            throw new InputException(__(
-                'Invalid value of "%value" provided for the %fieldName field.',
-                ['value' => $customerId, 'fieldName' => 'customerId']
-            ));
+            throw new InputException(
+                __(
+                    'Invalid value of "%value" provided for the %fieldName field.',
+                    ['value' => $customerId, 'fieldName' => 'customerId']
+                )
+            );
         }
         if (!is_string($resetPasswordLinkToken) || empty($resetPasswordLinkToken)) {
             $params = ['fieldName' => 'resetPasswordLinkToken'];
@@ -1076,10 +1083,10 @@ class AccountManagement implements AccountManagementInterface
          * self::NEW_ACCOUNT_EMAIL_CONFIRMATION             email with confirmation link
          */
         $types = [
-            self::NEW_ACCOUNT_EMAIL_REGISTERED => self::XML_PATH_REGISTER_EMAIL_TEMPLATE,
+            self::NEW_ACCOUNT_EMAIL_REGISTERED             => self::XML_PATH_REGISTER_EMAIL_TEMPLATE,
             self::NEW_ACCOUNT_EMAIL_REGISTERED_NO_PASSWORD => self::XML_PATH_REGISTER_NO_PASSWORD_EMAIL_TEMPLATE,
-            self::NEW_ACCOUNT_EMAIL_CONFIRMED => self::XML_PATH_CONFIRMED_EMAIL_TEMPLATE,
-            self::NEW_ACCOUNT_EMAIL_CONFIRMATION => self::XML_PATH_CONFIRM_EMAIL_TEMPLATE,
+            self::NEW_ACCOUNT_EMAIL_CONFIRMED              => self::XML_PATH_CONFIRMED_EMAIL_TEMPLATE,
+            self::NEW_ACCOUNT_EMAIL_CONFIRMATION           => self::XML_PATH_CONFIRM_EMAIL_TEMPLATE,
         ];
         return $types;
     }
@@ -1109,12 +1116,11 @@ class AccountManagement implements AccountManagementInterface
             $email = $customer->getEmail();
         }
 
-        $transport = $this->transportBuilder->setTemplateIdentifier($templateId)
-            ->setTemplateOptions(['area' => Area::AREA_FRONTEND, 'store' => $storeId])
-            ->setTemplateVars($templateParams)
-            ->setFrom($this->scopeConfig->getValue($sender, ScopeInterface::SCOPE_STORE, $storeId))
-            ->addTo($email, $this->customerViewHelper->getCustomerName($customer))
-            ->getTransport();
+        $transport = $this->transportBuilder->setTemplateIdentifier($templateId)->setTemplateOptions(
+            ['area' => Area::AREA_FRONTEND, 'store' => $storeId]
+        )->setTemplateVars($templateParams)->setFrom(
+            $this->scopeConfig->getValue($sender, ScopeInterface::SCOPE_STORE, $storeId)
+        )->addTo($email, $this->customerViewHelper->getCustomerName($customer))->getTransport();
 
         $transport->sendMessage();
 
@@ -1178,8 +1184,8 @@ class AccountManagement implements AccountManagementInterface
 
         $expirationPeriod = $this->customerModel->getResetPasswordLinkExpirationPeriod();
 
-        $currentTimestamp = (new \DateTime())->getTimestamp();
-        $tokenTimestamp = (new \DateTime($rpTokenCreatedAt))->getTimestamp();
+        $currentTimestamp = $this->dateTimeFactory->create()->getTimestamp();
+        $tokenTimestamp = $this->dateTimeFactory->create($rpTokenCreatedAt)->getTimestamp();
         if ($tokenTimestamp > $currentTimestamp) {
             return true;
         }
@@ -1215,7 +1221,9 @@ class AccountManagement implements AccountManagementInterface
         if (is_string($passwordLinkToken) && !empty($passwordLinkToken)) {
             $customerSecure = $this->customerRegistry->retrieveSecureData($customer->getId());
             $customerSecure->setRpToken($passwordLinkToken);
-            $customerSecure->setRpTokenCreatedAt((new \DateTime())->format(DateTime::DATETIME_PHP_FORMAT));
+            $customerSecure->setRpTokenCreatedAt(
+                $this->dateTimeFactory->create()->format(DateTime::DATETIME_PHP_FORMAT)
+            );
             $this->customerRepository->save($customer);
         }
         return true;
@@ -1304,8 +1312,8 @@ class AccountManagement implements AccountManagementInterface
         // No need to flatten the custom attributes or nested objects since the only usage is for email templates and
         // object passed for events
         $mergedCustomerData = $this->customerRegistry->retrieveSecureData($customer->getId());
-        $customerData = $this->dataProcessor
-            ->buildOutputDataArray($customer, \Magento\Customer\Api\Data\CustomerInterface::class);
+        $customerData =
+            $this->dataProcessor->buildOutputDataArray($customer, \Magento\Customer\Api\Data\CustomerInterface::class);
         $mergedCustomerData->addData($customerData);
         $mergedCustomerData->setData('name', $this->customerViewHelper->getCustomerName($customer));
         return $mergedCustomerData;

--- a/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
@@ -10,6 +10,7 @@ use Magento\Customer\Model\AuthenticationInterface;
 use Magento\Customer\Model\EmailNotificationInterface;
 use Magento\Framework\App\Area;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Intl\DateTimeFactory;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Store\Model\ScopeInterface;
 
@@ -115,6 +116,11 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
     protected $emailNotificationMock;
 
     /**
+     * @var DateTimeFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $dateTimeFactory;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp()
@@ -163,6 +169,8 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->dateTimeFactory = $this->createMock(DateTimeFactory::class);
+
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->accountManagement = $this->objectManagerHelper->getObject(
             \Magento\Customer\Model\AccountManagement::class,
@@ -190,6 +198,7 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
                 'customerModel' => $this->customer,
                 'objectFactory' => $this->objectFactory,
                 'extensibleDataObjectConverter' => $this->extensibleDataObjectConverter,
+                'dateTimeFactory' => $this->dateTimeFactory,
             ]
         );
         $reflection = new \ReflectionClass(get_class($this->accountManagement));
@@ -552,6 +561,8 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
         $customerEmail = 'email@email.com';
         $newLinkToken = '2jh43j5h2345jh23lh452h345hfuzasd96ofu';
 
+        $datetime = $this->prepareDateTimeFactory();
+
         $address = $this->getMockBuilder(\Magento\Customer\Api\Data\AddressInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -624,7 +635,9 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->method('setRpToken')
             ->with($newLinkToken);
         $customerSecure->expects($this->any())
-            ->method('setRpTokenCreatedAt');
+            ->method('setRpTokenCreatedAt')
+            ->with($datetime)
+            ->willReturnSelf();
         $customerSecure->expects($this->any())
             ->method('getPasswordHash')
             ->willReturn(null);
@@ -756,6 +769,8 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
         $minPasswordLength = 5;
         $minCharacterSetsNum = 2;
 
+        $datetime = $this->prepareDateTimeFactory();
+
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
             ->willReturnMap(
@@ -865,7 +880,9 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->method('setRpToken')
             ->with($newLinkToken);
         $customerSecure->expects($this->any())
-            ->method('setRpTokenCreatedAt');
+            ->method('setRpTokenCreatedAt')
+            ->with($datetime)
+            ->willReturnSelf();
         $customerSecure->expects($this->any())
             ->method('getPasswordHash')
             ->willReturn($hash);
@@ -995,7 +1012,7 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
     {
         $websiteId = 1;
 
-        $dateTime = date(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT);
+        $datetime = $this->prepareDateTimeFactory();
 
         $customerData = ['key' => 'value'];
         $customerName = 'Customer Name';
@@ -1047,7 +1064,7 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->customerSecure->expects($this->any())
             ->method('setRpTokenCreatedAt')
-            ->with($dateTime)
+            ->with($datetime)
             ->willReturnSelf();
         $this->customerSecure->expects($this->any())
             ->method('addData')
@@ -1257,17 +1274,19 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->method('getRpToken')
             ->willReturn('newStringToken');
 
-        $date = date('Y-m-d', strtotime('-1 year'));
+        $pastDateTime = '2016-10-25 00:00:00';
 
         $this->customerSecure
             ->expects($this->any())
             ->method('getRpTokenCreatedAt')
-            ->willReturn($date);
+            ->willReturn($pastDateTime);
 
         $this->customer = $this->getMockBuilder(\Magento\Customer\Model\Customer::class)
             ->disableOriginalConstructor()
             ->setMethods(['getResetPasswordLinkExpirationPeriod'])
             ->getMock();
+
+        $this->prepareDateTimeFactory();
 
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->accountManagement = $this->objectManagerHelper->getObject(
@@ -1277,6 +1296,7 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
                 'customerRegistry' => $this->customerRegistry,
                 'customerRepository' => $this->customerRepository,
                 'customerModel' => $this->customer,
+                'dateTimeFactory' => $this->dateTimeFactory,
             ]
         );
         $reflection = new \ReflectionClass(get_class($this->accountManagement));
@@ -1320,7 +1340,7 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->with(null);
         $customerSecure->expects($this->once())
             ->method('setRpTokenCreatedAt')
-            ->with(null);
+            ->willReturnSelf();
         $customerSecure->expects($this->any())
             ->method('getPasswordHash')
             ->willReturn($passwordHash);
@@ -1586,6 +1606,8 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
         $storeId = 1;
         $hash = '4nj54lkj5jfi03j49f8bgujfgsd';
 
+        $datetime = $this->prepareDateTimeFactory();
+
         //Handle store
         $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)->disableOriginalConstructor()->getMock();
         $store->expects($this->any())
@@ -1630,7 +1652,7 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->expects($this->any())
             ->method("getId")
             ->willReturn($customerId);
-        //Return Customer from customer repositoryå
+        //Return Customer from customer repository
         $this->customerRepository
             ->expects($this->atLeastOnce())
             ->method('save')
@@ -1672,5 +1694,31 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
             ->willReturn($store);
 
         $this->assertSame($customer, $this->accountManagement->createAccountWithPasswordHash($customer, $hash));
+    }
+
+    /**
+     * @return string
+     */
+    private function prepareDateTimeFactory()
+    {
+        $dateTime = '2017-10-25 18:57:08';
+        $timestamp = '1508983028';
+        $dateTimeMock = $this->createMock(\DateTime::class);
+        $dateTimeMock->expects($this->any())
+            ->method('format')
+            ->with(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT)
+            ->willReturn($dateTime);
+
+        $dateTimeMock
+            ->expects($this->any())
+            ->method('getTimestamp')
+            ->willReturn($timestamp);
+
+        $this->dateTimeFactory
+            ->expects($this->any())
+            ->method('create')
+            ->willReturn($dateTimeMock);
+
+        return $dateTime;
     }
 }


### PR DESCRIPTION
Surprisingly, after testing succesfully locally unit tests, I've found this error in Travis, in unit tests performed by \Magento\Customer\Test\Unit\Model\AccountManagementTest class:
![captura de pantalla 2017-10-21 a las 1 25 35](https://user-images.githubusercontent.com/17545750/31846761-5da737e6-b610-11e7-9371-bc219e257038.png)
Simply rebuilding the job worked and all the tests passed, but this error may happen again at any time, due to how are mocks built in that class:

- A datetime variable is set from current time:
<img width="585" alt="captura de pantalla 2017-10-21 a las 3 36 13" src="https://user-images.githubusercontent.com/17545750/31846815-1556d7fc-b611-11e7-81de-1f0e62e8f261.png">

- Below, customerSecure mock expects setRpTokenCreatedAt method to be called with previous datetime value will return self:
<img width="398" alt="captura de pantalla 2017-10-21 a las 3 37 44" src="https://user-images.githubusercontent.com/17545750/31846829-5014fff4-b611-11e7-80b3-d8ce78ce217e.png">

- But testing the method, the customerSecure::setRpTokenCreatedAt method is called with the current datetime, that may be NOT the previous one, so tests fails because method was not expected to be called with new date value:
<img width="752" alt="captura de pantalla 2017-10-21 a las 3 42 41" src="https://user-images.githubusercontent.com/17545750/31846889-16381522-b612-11e7-9059-b2628eac645a.png">

- The test assumes the mock creation and the mocked method call will happen in the same second, thing that may not be true and it's irrelevant for tests using \Magento\Customer\Test\Unit\Model\AccountManagementTest::prepareInitiatePasswordReset method:
<img width="552" alt="captura de pantalla 2017-10-21 a las 3 44 35" src="https://user-images.githubusercontent.com/17545750/31846896-3437199c-b612-11e7-8d4a-5cc901d28584.png">

Removing expected date fix this rare, weird, but actually happening, issue.

### Manual testing scenarios
1. To simulate this, change 
`$dateTime = date(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT);`
 to
`$dateTime = '2017-10-20 00:00:00';` 
in \Magento\Customer\Test\Unit\Model\AccountManagementTest::prepareInitiatePasswordReset method.
2. Run unit test over this class.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

### Related Pull Requests
https://github.com/magento/magento2/pull/11605