### PR TITLE
FR#6891_21 Add-to-cart checkbox still visible when  = false [Backport 2.1 develop]

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -203,7 +203,7 @@ switch ($type = $block->getType()) {
                                 <?php echo $block->getReviewsSummaryHtml($_item, $templateType) ?>
                             <?php endif; ?>
 
-                            <?php if (!$_item->isComposite() && $_item->isSaleable() && $type == 'related'): ?>
+                            <?php if ($canItemsAddToCart && !$_item->isComposite() && $_item->isSaleable() && $type == 'related'): ?>
                                 <?php if (!$_item->getRequiredOptions()): ?>
                                     <div class="field choice related">
                                         <input type="checkbox" class="checkbox related" id="related-checkbox<?php /* @escapeNotVerified */ echo $_item->getId() ?>" name="related_products[]" value="<?php /* @escapeNotVerified */ echo $_item->getId() ?>" />
@@ -252,7 +252,7 @@ switch ($type = $block->getType()) {
                             <?php endif; ?>
                         </div>
                     </div>
-                    <?php echo($iterator == count($items)+1) ? '</li>' : '' ?>
+                    <?php echo($iterator == count($items) + 1) ? '</li>' : '' ?>
                 <?php endforeach ?>
             </ol>
         </div>


### PR DESCRIPTION
If the related products list has the purchase disabled the checkbox for adding products wont disappeared as expected.

### Description
The variable $canItemsAddToCart was not taking in care for disabling the product add to cart checkbox object in this file 

> vendor\magento\module-catalog\view\frontend\templates\product\list\items.phtml

### Fixed Issues (if relevant)
1. magento/magento2#6891: Add-to-cart checkbox still visible when $canItemsAddToCart = false

### Manual testing scenarios
Edit vendor\magento\module-catalog\view\frontend\templates\product\list\items.phtml
Set all instances of $canItemsAddToCart to false
Go to a product page (e.g., /caesar-warm-up-pant.html)
The add-to-cart checkboxes in Related Products should not be visible.

### Related PRs
#11610

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)