### PR TITLE
FR#7689_21 quote_address_id not copied when converting quote address to order address [Backport 2.1 develop]

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -7,21 +7,21 @@
 namespace Magento\Quote\Model;
 
 use Magento\Authorization\Model\UserContextInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\StateException;
-use Magento\Quote\Model\Quote as QuoteEntity;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\ToOrder as ToOrderConverter;
 use Magento\Quote\Model\Quote\Address\ToOrderAddress as ToOrderAddressConverter;
+use Magento\Quote\Model\Quote as QuoteEntity;
 use Magento\Quote\Model\Quote\Item\ToOrderItem as ToOrderItemConverter;
 use Magento\Quote\Model\Quote\Payment\ToOrderPayment as ToOrderPaymentConverter;
-use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Sales\Api\Data\OrderInterfaceFactory as OrderFactory;
 use Magento\Sales\Api\OrderManagementInterface as OrderManagement;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Quote\Model\Quote\Address;
-use Magento\Framework\App\ObjectManager;
 
 /**
  * Class QuoteManagement
@@ -263,7 +263,6 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                 __('Cannot assign customer to the given cart. Customer already has active cart.')
             );
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-
         }
 
         $quote->setCustomer($customer);
@@ -276,7 +275,6 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         }
         $this->quoteRepository->save($quote);
         return true;
-
     }
 
     /**
@@ -449,7 +447,8 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                 $quote->getShippingAddress(),
                 [
                     'address_type' => 'shipping',
-                    'email' => $quote->getCustomerEmail()
+                    'email' => $quote->getCustomerEmail(),
+                    'quote_address_id' => $quote->getShippingAddress()->getId()
                 ]
             );
             $addresses[] = $shippingAddress;
@@ -460,7 +459,8 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
             $quote->getBillingAddress(),
             [
                 'address_type' => 'billing',
-                'email' => $quote->getCustomerEmail()
+                'email' => $quote->getCustomerEmail(),
+                'quote_address_id' => $quote->getBillingAddress()->getId()
             ]
         );
         $addresses[] = $billingAddress;
@@ -476,7 +476,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         $order->setCustomerFirstname($quote->getCustomerFirstname());
         $order->setCustomerMiddlename($quote->getCustomerMiddlename());
         $order->setCustomerLastname($quote->getCustomerLastname());
-        
+
         $this->eventManager->dispatch(
             'sales_model_service_quote_submit_before',
             [

--- a/app/code/Magento/Sales/Api/Data/OrderAddressInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderAddressInterface.php
@@ -333,10 +333,10 @@ interface OrderAddressInterface extends \Magento\Framework\Api\ExtensibleDataInt
     /**
      * Sets the country address ID for the order address.
      *
-     * @param int $id
+     * @param int $addressId
      * @return $this
      */
-    public function setCustomerAddressId($id);
+    public function setCustomerAddressId($addressId);
 
     /**
      * Sets the quote address ID for the order address.

--- a/app/code/Magento/Sales/Api/Data/OrderAddressInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderAddressInterface.php
@@ -27,6 +27,11 @@ interface OrderAddressInterface extends \Magento\Framework\Api\ExtensibleDataInt
      * Customer address ID.
      */
     const CUSTOMER_ADDRESS_ID = 'customer_address_id';
+
+    /**
+     * Quote address ID.
+     */
+    const QUOTE_ADDRESS_ID = 'quote_address_id';
     /*
      * Region ID.
      */
@@ -154,6 +159,13 @@ interface OrderAddressInterface extends \Magento\Framework\Api\ExtensibleDataInt
      * @return int|null Country address ID.
      */
     public function getCustomerAddressId();
+
+    /**
+     * Gets the quote address ID for the order address.
+     *
+     * @return int|null Quote address ID.
+     */
+    public function getQuoteAddressId();
 
     /**
      * Gets the customer ID for the order address.
@@ -325,6 +337,14 @@ interface OrderAddressInterface extends \Magento\Framework\Api\ExtensibleDataInt
      * @return $this
      */
     public function setCustomerAddressId($id);
+
+    /**
+     * Sets the quote address ID for the order address.
+     *
+     * @param int $id
+     * @return $this
+     */
+    public function setQuoteAddressId($id);
 
     /**
      * Sets the region ID for the order address.

--- a/app/code/Magento/Sales/Model/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Order/Address.php
@@ -536,9 +536,9 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     /**
      * {@inheritdoc}
      */
-    public function setQuoteAddressId($id)
+    public function setQuoteAddressId($addressId)
     {
-        return $this->setData(OrderAddressInterface::QUOTE_ADDRESS_ID, $id);
+        return $this->setData(OrderAddressInterface::QUOTE_ADDRESS_ID, $addressId);
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Order/Address.php
@@ -5,10 +5,9 @@
  */
 namespace Magento\Sales\Model\Order;
 
-use Magento\Customer\Api\Data\RegionInterfaceFactory;
+use Magento\Customer\Model\Address\AddressModelInterface;
 use Magento\Sales\Api\Data\OrderAddressInterface;
 use Magento\Sales\Model\AbstractModel;
-use Magento\Customer\Model\Address\AddressModelInterface;
 
 /**
  * Sales order address model
@@ -88,7 +87,6 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
             $resourceCollection,
             $data
         );
-
     }
 
     /**
@@ -309,6 +307,16 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     }
 
     /**
+     * Returns quote_address_id
+     *
+     * @return int
+     */
+    public function getQuoteAddressId()
+    {
+        return $this->getData(OrderAddressInterface::QUOTE_ADDRESS_ID);
+    }
+
+    /**
      * Returns customer_id
      *
      * @return int
@@ -523,6 +531,14 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
     public function setCustomerAddressId($id)
     {
         return $this->setData(OrderAddressInterface::CUSTOMER_ADDRESS_ID, $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setQuoteAddressId($id)
+    {
+        return $this->setData(OrderAddressInterface::QUOTE_ADDRESS_ID, $id);
     }
 
     /**


### PR DESCRIPTION
When an order is created the quote address id are not saving in the order address table.

### Description
I modified the place order function for save the quote_addres_id in order_address table properly. It was necessary to modify the Order Address Api interface for adding new getters and setters methods and Quote Management Model Logic.

### Fixed Issues (if relevant)
1. magento/magento2#7689: quote_address_id not copied when converting quote address to order address

### Manual testing scenarios
1. Add products to the cart
2. Place a guest order 
3. Check table order_address and detect that quote_addres_id is empty

With these modifications this field is saving properly.

### Related PRs
#11613

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)