### PR TITLE
Check attribute unique between same fields in magento commerce [backport 2.1]

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -951,7 +951,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
                 'value' => trim($value),
             ];
 
-            $entityIdField = $attributeBackend->getEntityIdField();
+            $entityIdField = $object->getResource()->getLinkField();
             $select->from(
                 $attributeBackend->getTable(),
                 $entityIdField

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -928,28 +928,33 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     {
         $connection = $this->getConnection();
         $select = $connection->select();
-        if ($attribute->getBackend()->getType() === 'static') {
+
+        $entityIdField = $this->getEntityIdField();
+        $attributeBackend = $attribute->getBackend();
+        if ($attributeBackend->getType() === 'static') {
             $value = $object->getData($attribute->getAttributeCode());
             $bind = ['value' => trim($value)];
 
             $select->from(
                 $this->getEntityTable(),
-                $this->getEntityIdField()
+                $entityIdField
             )->where(
                 $attribute->getAttributeCode() . ' = :value'
             );
         } else {
             $value = $object->getData($attribute->getAttributeCode());
-            if ($attribute->getBackend()->getType() == 'datetime') {
+            if ($attributeBackend->getType() == 'datetime') {
                 $value = (new \DateTime($value))->format('Y-m-d H:i:s');
             }
             $bind = [
                 'attribute_id' => $attribute->getId(),
                 'value' => trim($value),
             ];
+
+            $entityIdField = $attributeBackend->getEntityIdField();
             $select->from(
-                $attribute->getBackend()->getTable(),
-                $object->getResource()->getLinkField()
+                $attributeBackend->getTable(),
+                $entityIdField
             )->where(
                 'attribute_id = :attribute_id'
             )->where(
@@ -964,9 +969,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
 
         $data = $connection->fetchCol($select, $bind);
 
-        if ($object->getId()) {
+        $objectId = $object->getData($entityIdField);
+        if ($objectId) {
             if (isset($data[0])) {
-                return $data[0] == $object->getId();
+                return $data[0] == $objectId;
             }
             return true;
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Related with the [PR11620](https://github.com/magento/magento2/pull/11620)
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Check attribute unique in Magento Commerce (EE) correctly

### Steps to reproduce
<!--- Provide a set of unambiguous steps to test the proposed code change -->
In Magento Commerce (EE).
1. Create a custom attribute unique and add it to the attribute set.
2. Create a new value for this attribute in a product and save it.
3. Save the product again.*

***If for any reason, the value row_id is different and entity_id. The check return how if the product to validate are different.**

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
