### PR TITLE
Fixed order items list for order printing

### DIFF
--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print.xml
@@ -17,7 +17,7 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\PrintShipment" name="sales.order.print" template="order/view.phtml">
-                <block class="Magento\Sales\Block\Order\PrintShipment" name="order_items" template="order/items.phtml">
+                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="order/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.renderers" as="renderer.list" />
                     <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="order/totals.phtml">
                         <arguments>


### PR DESCRIPTION
### Description
The block class defined in the XML layout for order items on the order print page is definitely not correct. As result, you cannot see the order items information upon the order printing. The `Magento\Sales\Block\Order\PrintShipment` is not responsible for showing order items. By changing the block class to `Magento\Sales\Block\Order\Items` we will have the order items upon the order printing

### Fixed Issues (if relevant)
1. magento/magento2#10530: Print order error on magento 2.1.8
2. magento/magento2#9830: Null order in Magento\Sales\Block\Order\PrintShipment.php

### Manual testing scenarios
1. Place an order as a registered customer
2. Go to My Account -> My Orders. Open the order and click on the "Print Order" link
3. You should see all order's information for printing including the order items
