### PR TITLE
Change Precisions to 4 to solve #10790

### DIFF
--- a/app/code/Magento/Directory/Model/PriceCurrency.php
+++ b/app/code/Magento/Directory/Model/PriceCurrency.php
@@ -155,6 +155,6 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      */
     public function round($price)
     {
-         return round($price, 4);
+        return round($price, 4);
     }
 }

--- a/app/code/Magento/Directory/Model/PriceCurrency.php
+++ b/app/code/Magento/Directory/Model/PriceCurrency.php
@@ -155,6 +155,6 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      */
     public function round($price)
     {
-        return round($price, 2);
+         return round($price, 4);
     }
 }


### PR DESCRIPTION
Change Precisions to 4 to solve #10790

### Description
I changed the rounding precision in app/code/Magento/Directory/Model/PriceCurrency.php to 4, to avoid issues with rounding in some situations. See   #10790

### Fixed Issues (if relevant)
solves  #10790

### Manual testing scenarios
Download the Dump provided here https://github.com/magento/magento2/issues/10790#issuecomment-331135502
Install Magento and use this dump as Database
Add 2 of each Product A and B to you shopping card
Apply Code "100percent"
Total Order should be 0

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
