### PR TITLE
Coupon codes not showing in invoice

### DIFF
--- a/app/code/Magento/Sales/etc/fieldset.xml
+++ b/app/code/Magento/Sales/etc/fieldset.xml
@@ -486,6 +486,12 @@
                 <aspect name="to_quote_address_shipping" />
                 <aspect name="to_cm"/>
             </field>
+            <field name="discount_description">
+                <aspect name="to_quote" />
+                <aspect name="to_invoice" />
+                <aspect name="to_shipment" />
+                <aspect name="to_cm" />
+            </field>
             <field name="shipping_amount">
                 <aspect name="to_quote_address_shipping" />
                 <aspect name="to_cm"/>


### PR DESCRIPTION
### Description
When Magento converts order to invoice, discount description doesn't show.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/10168

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
