### PR TITLE
MAGETWO-81311: Check the length of the array before attempting to sli…

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
@@ -118,8 +118,8 @@ define([
 
             this._super();
 
-            scope = this.dataScope;
-            name = scope.split('.').length > 1 ? scope.split('.').slice(1) : scope.split('.');
+            scope = this.dataScope.split('.');
+            name = scope.length > 1 ? scope.slice(1) : scope;
 
             valueUpdate = this.showFallbackReset ? 'afterkeydown' : this.valueUpdate;
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
@@ -119,7 +119,7 @@ define([
             this._super();
 
             scope = this.dataScope;
-            name = scope.split('.').slice(1);
+            name = (scope.split('.').length > 1) ? scope.split('.').slice(1) : scope.split('.');
 
             valueUpdate = this.showFallbackReset ? 'afterkeydown' : this.valueUpdate;
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
@@ -119,7 +119,7 @@ define([
             this._super();
 
             scope = this.dataScope;
-            name = (scope.split('.').length > 1) ? scope.split('.').slice(1) : scope.split('.');
+            name = scope.split('.').length > 1 ? scope.split('.').slice(1) : scope.split('.');
 
             valueUpdate = this.showFallbackReset ? 'afterkeydown' : this.valueUpdate;
 


### PR DESCRIPTION
…ce it. Slicing an array of one will create an empty result. Issue: 9944

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
https://github.com/magento/magento2/issues/9944

In the UI form element abstract.js, there is a case where the dataScope passed to the initConfig function may not have the string "data" appended to the name. In this case, performing a 'slice' on an array of 1 will create an empty result. In these cases, I have added a check to ensure that the array is at least greater than 1 before slicing, otherwise, use the result of splitting the scope variable.

In these cases you will always end of with something like: 
["data_value"] or ["data_value", "data_value_two"]

Instead of a potential: [], which when used as the inputName would result in an empty input name attribute on the form element.


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9944: Name attribute shows empty when creating custom fields on product creation form

### Manual testing scenarios
1. Open the original Issue (https://github.com/magento/magento2/issues/9944)
2. Create a module with a product_form.xml ui component
3. Use a fieldname as a single string. (ie "placeholder")
4. View the field in the product create form and ensure that there is an html name element with the same value that is in the product_form.xml

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
