### PR TITLE
9007: Get MAGETWO-52856 into Magento 2.1.x

### DIFF
--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -144,6 +144,7 @@ class ShippingInformationManagement implements \Magento\Checkout\Api\ShippingInf
 
         /** @var \Magento\Quote\Model\Quote $quote */
         $quote = $this->quoteRepository->getActive($cartId);
+        $address->setLimitCarrier($carrierCode);
         $quote = $this->prepareShippingAssignment($quote, $address, $carrierCode . '_' . $methodCode);
         $this->validateQuote($quote);
         $quote->setIsMultiShipping(false);

--- a/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
@@ -6,6 +6,9 @@
 
 namespace Magento\Checkout\Test\Unit\Model;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
@@ -59,11 +59,11 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
             [
                 'billingAddressManagement' => $this->billingAddressManagementMock,
                 'paymentMethodManagement' => $this->paymentMethodManagementMock,
-                'cartManagement' => $this->cartManagementMock
+                'cartManagement' => $this->cartManagementMock,
+                'cartRepository' => $this->cartRepositoryMock
             ]
         );
         $objectManager->setBackwardCompatibleProperty($this->model, 'logger', $this->loggerMock);
-        $objectManager->setBackwardCompatibleProperty($this->model, 'cartRepository', $this->cartRepositoryMock);
     }
 
     public function testSavePaymentInformationAndPlaceOrder()

--- a/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
@@ -33,6 +33,11 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
      */
     private $loggerMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cartRepositoryMock;
+
     protected function setUp()
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -45,7 +50,7 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $this->cartManagementMock = $this->getMock(\Magento\Quote\Api\CartManagementInterface::class);
 
         $this->loggerMock = $this->getMock(\Psr\Log\LoggerInterface::class);
-
+        $this->cartRepositoryMock = $this->getMockBuilder(\Magento\Quote\Api\CartRepositoryInterface::class)->getMock();
         $this->model = $objectManager->getObject(
             \Magento\Checkout\Model\PaymentInformationManagement::class,
             [
@@ -55,6 +60,7 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $objectManager->setBackwardCompatibleProperty($this->model, 'logger', $this->loggerMock);
+        $objectManager->setBackwardCompatibleProperty($this->model, 'cartRepository', $this->cartRepositoryMock);
     }
 
     public function testSavePaymentInformationAndPlaceOrder()
@@ -64,9 +70,7 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $paymentMock = $this->getMock(\Magento\Quote\Api\Data\PaymentInterface::class);
         $billingAddressMock = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
 
-        $this->billingAddressManagementMock->expects($this->once())
-            ->method('assign')
-            ->with($cartId, $billingAddressMock);
+        $this->getMockForAssignBillingAddress($cartId, $billingAddressMock);
         $this->paymentMethodManagementMock->expects($this->once())->method('set')->with($cartId, $paymentMock);
         $this->cartManagementMock->expects($this->once())->method('placeOrder')->with($cartId)->willReturn($orderId);
 
@@ -86,9 +90,7 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $paymentMock = $this->getMock(\Magento\Quote\Api\Data\PaymentInterface::class);
         $billingAddressMock = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
 
-        $this->billingAddressManagementMock->expects($this->once())
-            ->method('assign')
-            ->with($cartId, $billingAddressMock);
+        $this->getMockForAssignBillingAddress($cartId, $billingAddressMock);
         $this->paymentMethodManagementMock->expects($this->once())->method('set')->with($cartId, $paymentMock);
         $exception = new \Exception(__('DB exception'));
         $this->loggerMock->expects($this->once())->method('critical');
@@ -103,7 +105,6 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $orderId = 200;
         $paymentMock = $this->getMock(\Magento\Quote\Api\Data\PaymentInterface::class);
 
-        $this->billingAddressManagementMock->expects($this->never())->method('assign');
         $this->paymentMethodManagementMock->expects($this->once())->method('set')->with($cartId, $paymentMock);
         $this->cartManagementMock->expects($this->once())->method('placeOrder')->with($cartId)->willReturn($orderId);
 
@@ -119,9 +120,7 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $paymentMock = $this->getMock(\Magento\Quote\Api\Data\PaymentInterface::class);
         $billingAddressMock = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
 
-        $this->billingAddressManagementMock->expects($this->once())
-            ->method('assign')
-            ->with($cartId, $billingAddressMock);
+        $this->getMockForAssignBillingAddress($cartId, $billingAddressMock);
         $this->paymentMethodManagementMock->expects($this->once())->method('set')->with($cartId, $paymentMock);
 
         $this->assertTrue($this->model->savePaymentInformation($cartId, $paymentMock, $billingAddressMock));
@@ -132,7 +131,6 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $cartId = 100;
         $paymentMock = $this->getMock(\Magento\Quote\Api\Data\PaymentInterface::class);
 
-        $this->billingAddressManagementMock->expects($this->never())->method('assign');
         $this->paymentMethodManagementMock->expects($this->once())->method('set')->with($cartId, $paymentMock);
 
         $this->assertTrue($this->model->savePaymentInformation($cartId, $paymentMock));
@@ -148,9 +146,8 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $paymentMock = $this->getMock(\Magento\Quote\Api\Data\PaymentInterface::class);
         $billingAddressMock = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
 
-        $this->billingAddressManagementMock->expects($this->once())
-            ->method('assign')
-            ->with($cartId, $billingAddressMock);
+        $this->getMockForAssignBillingAddress($cartId, $billingAddressMock);
+
         $this->paymentMethodManagementMock->expects($this->once())->method('set')->with($cartId, $paymentMock);
         $phrase = new \Magento\Framework\Phrase(__('DB exception'));
         $exception = new \Magento\Framework\Exception\LocalizedException($phrase);
@@ -158,5 +155,32 @@ class PaymentInformationManagementTest extends \PHPUnit_Framework_TestCase
         $this->cartManagementMock->expects($this->once())->method('placeOrder')->willThrowException($exception);
 
         $this->model->savePaymentInformationAndPlaceOrder($cartId, $paymentMock, $billingAddressMock);
+    }
+
+    /**
+     * @param int $cartId
+     * @param \PHPUnit_Framework_MockObject_MockObject $billingAddressMock
+     */
+    private function getMockForAssignBillingAddress($cartId, $billingAddressMock)
+    {
+        $billingAddressId = 1;
+        $quoteMock = $this->getMock(\Magento\Quote\Model\Quote::class, [], [], '', false);
+        $quoteBillingAddress = $this->getMock(\Magento\Quote\Model\Quote\Address::class, [], [], '', false);
+        $quoteShippingAddress = $this->getMock(
+            \Magento\Quote\Model\Quote\Address::class,
+            ['setLimitCarrier', 'getShippingMethod'],
+            [],
+            '',
+            false
+        );
+        $this->cartRepositoryMock->expects($this->any())->method('getActive')->with($cartId)->willReturn($quoteMock);
+        $quoteMock->expects($this->once())->method('getBillingAddress')->willReturn($quoteBillingAddress);
+        $quoteMock->expects($this->once())->method('getShippingAddress')->willReturn($quoteShippingAddress);
+        $quoteBillingAddress->expects($this->once())->method('getId')->willReturn($billingAddressId);
+        $quoteMock->expects($this->once())->method('removeAddress')->with($billingAddressId);
+        $quoteMock->expects($this->once())->method('setBillingAddress')->with($billingAddressMock);
+        $quoteMock->expects($this->once())->method('setDataChanges')->willReturnSelf();
+        $quoteShippingAddress->expects($this->any())->method('getShippingMethod')->willReturn('flatrate_flatrate');
+        $quoteShippingAddress->expects($this->once())->method('setLimitCarrier')->with('flatrate')->willReturnSelf();
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Checkout\Test\Unit\Model;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
 class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -35,75 +39,68 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    protected $loggerMock;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $addressRepositoryMock;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $scopeConfigMock;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $shippingAddressMock;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $quoteMock;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $totalsCollectorMock;
+    private $quoteMock;
 
     /**
      * @var \Magento\Checkout\Model\ShippingInformationManagement
      */
-    protected $model;
+    private $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $shippingAssignmentFactoryMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cartExtensionFactoryMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $shippingFactoryMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cartExtensionMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $shippingAssignmentMock;
+
+    /**
+     * @var \Magento\Checkout\Model\ShippingInformationManagement|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $shippingMock;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var \Magento\Quote\Model\Quote\Address|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $shippingAddressMock;
 
     protected function setUp()
     {
-        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-
-        $this->paymentMethodManagementMock = $this->getMock('\Magento\Quote\Api\PaymentMethodManagementInterface');
+        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->paymentMethodManagementMock = $this->getMock(\Magento\Quote\Api\PaymentMethodManagementInterface::class);
         $this->paymentDetailsFactoryMock = $this->getMock(
-            '\Magento\Checkout\Model\PaymentDetailsFactory',
+            \Magento\Checkout\Model\PaymentDetailsFactory::class,
             ['create'],
             [],
             '',
             false
         );
-        $this->cartTotalsRepositoryMock = $this->getMock('\Magento\Quote\Api\CartTotalRepositoryInterface');
-        $this->quoteRepositoryMock = $this->getMock('\Magento\Quote\Api\CartRepositoryInterface');
-        $this->addressValidatorMock = $this->getMock('\Magento\Quote\Model\QuoteAddressValidator', [], [], '', false);
-        $this->loggerMock = $this->getMock('\Psr\Log\LoggerInterface');
-        $this->addressRepositoryMock = $this->getMock('\Magento\Customer\Api\AddressRepositoryInterface');
-        $this->scopeConfigMock = $this->getMock('\Magento\Framework\App\Config\ScopeConfigInterface');
-        $this->totalsCollectorMock =
-            $this->getMock('Magento\Quote\Model\Quote\TotalsCollector', [], [], '', false);
-        $this->model = $objectManager->getObject(
-            '\Magento\Checkout\Model\ShippingInformationManagement',
-            [
-                'paymentMethodManagement' => $this->paymentMethodManagementMock,
-                'paymentDetailsFactory' => $this->paymentDetailsFactoryMock,
-                'cartTotalsRepository' => $this->cartTotalsRepositoryMock,
-                'quoteRepository' => $this->quoteRepositoryMock,
-                'addressValidator' => $this->addressValidatorMock,
-                'logger' => $this->loggerMock,
-                'addressRepository' => $this->addressRepositoryMock,
-                'scopeConfig' => $this->scopeConfigMock,
-                'totalsCollector' => $this->totalsCollectorMock
-            ]
-        );
-
+        $this->cartTotalsRepositoryMock = $this->getMock(\Magento\Quote\Api\CartTotalRepositoryInterface::class);
+        $this->quoteRepositoryMock = $this->getMock(\Magento\Quote\Api\CartRepositoryInterface::class);
         $this->shippingAddressMock = $this->getMock(
-            '\Magento\Quote\Model\Quote\Address',
+            \Magento\Quote\Model\Quote\Address::class,
             [
                 'getSaveInAddressBook',
                 'getSameAsBilling',
@@ -117,7 +114,8 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
                 'importCustomerAddressData',
                 'save',
                 'getShippingRateByCode',
-                'getShippingMethod'
+                'getShippingMethod',
+                'setLimitCarrier'
             ],
             [],
             '',
@@ -125,7 +123,7 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->quoteMock = $this->getMock(
-            '\Magento\Quote\Model\Quote',
+            \Magento\Quote\Model\Quote::class,
             [
                 'isVirtual',
                 'getItemsCount',
@@ -135,39 +133,47 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
                 'getStoreId',
                 'setShippingAddress',
                 'getShippingAddress',
-                'collectTotals'
+                'collectTotals',
+                'getExtensionAttributes',
+                'setExtensionAttributes',
+                'setBillingAddress'
             ],
             [],
             '',
             false
         );
-    }
 
-    /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage Cart contains virtual product(s) only. Shipping address is not applicable.
-     */
-    public function testSaveAddressInformationIfCartIsVirtual()
-    {
-        $this->markTestSkipped('MAGETWO-48531');
-        $cartId = 100;
-        $carrierCode = 'carrier_code';
-        $shippingMethod = 'shipping_method';
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
+        $this->shippingAssignmentFactoryMock =
+            $this->getMock(\Magento\Quote\Model\ShippingAssignmentFactory::class, ['create'], [], '', false);
+        $this->cartExtensionFactoryMock =
+            $this->getMock(\Magento\Quote\Api\Data\CartExtensionInterfaceFactory::class, ['create'], [], '', false);
+        $this->shippingFactoryMock =
+            $this->getMock(\Magento\Quote\Model\ShippingFactory::class, ['create'], [], '', false);
 
-        $addressInformationMock->expects($this->once())
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-        $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
-        $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
-
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(true);
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('getActive')
-            ->with($cartId)
-            ->willReturn($this->quoteMock);
-
-        $this->model->saveAddressInformation($cartId, $addressInformationMock);
+        $this->model = $this->objectManager->getObject(
+            \Magento\Checkout\Model\ShippingInformationManagement::class,
+            [
+                'paymentMethodManagement' => $this->paymentMethodManagementMock,
+                'paymentDetailsFactory' => $this->paymentDetailsFactoryMock,
+                'cartTotalsRepository' => $this->cartTotalsRepositoryMock,
+                'quoteRepository' => $this->quoteRepositoryMock,
+            ]
+        );
+        $this->objectManager->setBackwardCompatibleProperty(
+            $this->model,
+            'shippingAssignmentFactory',
+            $this->shippingAssignmentFactoryMock
+        );
+        $this->objectManager->setBackwardCompatibleProperty(
+            $this->model,
+            'cartExtensionFactory',
+            $this->cartExtensionFactoryMock
+        );
+        $this->objectManager->setBackwardCompatibleProperty(
+            $this->model,
+            'shippingFactory',
+            $this->shippingFactoryMock
+        );
     }
 
     /**
@@ -176,19 +182,23 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
      */
     public function testSaveAddressInformationIfCartIsEmpty()
     {
-        $this->markTestSkipped('MAGETWO-48531');
         $cartId = 100;
         $carrierCode = 'carrier_code';
         $shippingMethod = 'shipping_method';
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
+        $addressInformationMock = $this->getMock(\Magento\Checkout\Api\Data\ShippingInformationInterface::class);
 
+        $billingAddress = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
         $addressInformationMock->expects($this->once())
             ->method('getShippingAddress')
             ->willReturn($this->shippingAddressMock);
+        $addressInformationMock->expects($this->once())->method('getBillingAddress')->willReturn($billingAddress);
         $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
         $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
 
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
+        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn('USA');
+
+        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+
         $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(0);
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getActive')
@@ -199,17 +209,71 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $shippingMethod
+     */
+    private function setShippingAssignmentsMocks($shippingMethod)
+    {
+        $this->quoteMock->expects($this->once())->method('getExtensionAttributes')->willReturn(null);
+        $this->shippingAddressMock->expects($this->once())->method('setLimitCarrier');
+        $this->cartExtensionMock = $this->getMock(
+            \Magento\Quote\Api\Data\CartExtension::class,
+            ['getShippingAssignments', 'setShippingAssignments'],
+            [],
+            '',
+            false
+        );
+        $this->cartExtensionFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->cartExtensionMock);
+        $this->cartExtensionMock->expects($this->once())->method('getShippingAssignments')->willReturn(null);
+
+        $this->shippingAssignmentMock = $this->getMock(
+            \Magento\Quote\Model\ShippingAssignment::class,
+            [],
+            [],
+            '',
+            false
+        );
+        $this->shippingAssignmentFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->shippingAssignmentMock);
+        $this->shippingAssignmentMock->expects($this->once())->method('getShipping')->willReturn(null);
+
+        $this->shippingMock = $this->getMock(\Magento\Quote\Model\Shipping::class, [], [], '', false);
+        $this->shippingFactoryMock->expects($this->once())->method('create')->willReturn($this->shippingMock);
+
+        $this->shippingMock->expects($this->once())
+            ->method('setAddress')
+            ->with($this->shippingAddressMock)
+            ->willReturnSelf();
+        $this->shippingMock->expects($this->once())->method('setMethod')->with($shippingMethod)->willReturnSelf();
+
+        $this->shippingAssignmentMock->expects($this->once())
+            ->method('setShipping')
+            ->with($this->shippingMock)
+            ->willReturnSelf();
+
+        $this->cartExtensionMock->expects($this->once())
+            ->method('setShippingAssignments')
+            ->with([$this->shippingAssignmentMock])
+            ->willReturnSelf();
+
+        $this->quoteMock->expects($this->once())
+            ->method('setExtensionAttributes')
+            ->with($this->cartExtensionMock)
+            ->willReturnSelf();
+    }
+
+    /**
      * @expectedException \Magento\Framework\Exception\StateException
      * @expectedExceptionMessage Shipping address is not set
      */
     public function testSaveAddressInformationIfShippingAddressNotSet()
     {
-        $this->markTestSkipped('MAGETWO-48531');
         $cartId = 100;
         $carrierCode = 'carrier_code';
         $shippingMethod = 'shipping_method';
-        $customerAddressId = 200;
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
+        $addressInformationMock = $this->getMock(\Magento\Checkout\Api\Data\ShippingInformationInterface::class);
 
         $addressInformationMock->expects($this->once())
             ->method('getShippingAddress')
@@ -217,285 +281,10 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
         $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
         $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
 
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('getActive')
-            ->with($cartId)
-            ->willReturn($this->quoteMock);
+        $billingAddress = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
+        $addressInformationMock->expects($this->once())->method('getBillingAddress')->willReturn($billingAddress);
 
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(5);
-
-        $this->shippingAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getCustomerAddressId')
-            ->willReturn($customerAddressId);
-
-        $this->addressValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with($this->shippingAddressMock)
-            ->willReturn(true);
-
-        $this->quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->shippingAddressMock)
-            ->willReturnSelf();
-        $this->quoteMock->expects($this->exactly(2))
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-
-        $customerAddressMock = $this->getMock('\Magento\Customer\Api\Data\AddressInterface');
-        $this->addressRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
-
-        $this->shippingAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(false);
-
-        $this->model->saveAddressInformation($cartId, $addressInformationMock);
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage Unable to save address. Please check input data.
-     */
-    public function testSaveAddressInformationThrowExceptionWhileAddressSaving()
-    {
-        $this->markTestSkipped('MAGETWO-48531');
-        $cartId = 100;
-        $carrierCode = 'carrier_code';
-        $shippingMethod = 'shipping_method';
-        $customerAddressId = 200;
-        $exception = new \Exception();
-
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
-        $addressInformationMock->expects($this->once())
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-        $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
-        $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
-
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('getActive')
-            ->with($cartId)
-            ->willReturn($this->quoteMock);
-
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(5);
-
-        $this->shippingAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getCustomerAddressId')
-            ->willReturn($customerAddressId);
-        $this->shippingAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(1);
-        $this->totalsCollectorMock
-            ->expects($this->once())
-            ->method('collectAddressTotals')
-            ->willThrowException($exception);
-        $this->addressValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with($this->shippingAddressMock)
-            ->willReturn(true);
-
-        $this->quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->shippingAddressMock)
-            ->willReturnSelf();
-        $this->quoteMock->expects($this->exactly(2))
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-
-        $customerAddressMock = $this->getMock('\Magento\Customer\Api\Data\AddressInterface');
-        $this->addressRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
-
-        $this->shippingAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-
-        $this->loggerMock->expects($this->once())->method('critical')->with($exception);
-
-        $this->model->saveAddressInformation($cartId, $addressInformationMock);
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage Carrier with such method not found: carrier_code, shipping_method
-     */
-    public function testSaveAddressInformationIfCarrierCodeIsInvalid()
-    {
-        $this->markTestSkipped('MAGETWO-48531');
-        $cartId = 100;
-        $carrierCode = 'carrier_code';
-        $shippingMethod = 'shipping_method';
-        $customerAddressId = 200;
-
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(5);
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('getActive')
-            ->with($cartId)
-            ->willReturn($this->quoteMock);
-
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
-        $addressInformationMock->expects($this->once())
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-        $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
-        $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
-
-        $this->shippingAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getCustomerAddressId')
-            ->willReturn($customerAddressId);
-
-        $this->addressValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with($this->shippingAddressMock)
-            ->willReturn(true);
-
-        $this->quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->shippingAddressMock)
-            ->willReturnSelf();
-        $this->quoteMock->expects($this->exactly(2))
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-
-        $customerAddressMock = $this->getMock('\Magento\Customer\Api\Data\AddressInterface');
-        $this->addressRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
-
-        $this->shippingAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(1);
-        $this->totalsCollectorMock
-            ->expects($this->once())
-            ->method('collectAddressTotals')
-            ->with($this->quoteMock, $this->shippingAddressMock);
-        $this->shippingAddressMock->expects($this->once())->method('getShippingMethod')->willReturn($shippingMethod);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getShippingRateByCode')
-            ->with($shippingMethod)
-            ->willReturn(false);
-
-        $this->model->saveAddressInformation($cartId, $addressInformationMock);
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage Wrong minimum amount.
-     */
-    public function testSaveAddressInformationIfMinimumAmountIsNotValid()
-    {
-        $this->markTestSkipped('MAGETWO-48531');
-        $cartId = 100;
-        $carrierCode = 'carrier_code';
-        $shippingMethod = 'shipping_method';
-        $customerAddressId = 200;
-        $storeId = 500;
-        $minAmountExceptionMessage = __('Wrong minimum amount.');
-
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(5);
-        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(true);
-        $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(false)->willReturnSelf();
-        $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(true)->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getStoreId')->willReturn($storeId);
-
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('getActive')
-            ->with($cartId)
-            ->willReturn($this->quoteMock);
-
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
-        $addressInformationMock->expects($this->once())
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-        $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
-        $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
-
-        $this->shippingAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getCustomerAddressId')
-            ->willReturn($customerAddressId);
-
-        $this->addressValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with($this->shippingAddressMock)
-            ->willReturn(true);
-
-        $this->quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->shippingAddressMock)
-            ->willReturnSelf();
-        $this->quoteMock->expects($this->exactly(2))
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-
-        $customerAddressMock = $this->getMock('\Magento\Customer\Api\Data\AddressInterface');
-        $this->addressRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
-
-        $this->shippingAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(1);
-        $this->totalsCollectorMock
-            ->expects($this->once())
-            ->method('collectAddressTotals')
-            ->with($this->quoteMock, $this->shippingAddressMock);
-        $this->shippingAddressMock->expects($this->once())->method('getShippingMethod')->willReturn($shippingMethod);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getShippingRateByCode')
-            ->with($shippingMethod)
-            ->willReturn($this->getMock('\Magento\Quote\Model\Quote\Address\Rate', [], [], '', false));
-
-        $this->scopeConfigMock->expects($this->once())
-            ->method('getValue')
-            ->with('sales/minimum_order/error_message', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
-            ->willReturn($minAmountExceptionMessage);
+        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(null);
 
         $this->model->saveAddressInformation($cartId, $addressInformationMock);
     }
@@ -506,178 +295,144 @@ class ShippingInformationManagementTest extends \PHPUnit_Framework_TestCase
      */
     public function testSaveAddressInformationIfCanNotSaveQuote()
     {
-        $this->markTestSkipped('MAGETWO-48531');
         $cartId = 100;
         $carrierCode = 'carrier_code';
         $shippingMethod = 'shipping_method';
-        $customerAddressId = 200;
-        $exception = new \Exception();
-
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(5);
-        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(true);
-        $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(false)->willReturnSelf();
-        $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(true)->willReturn(true);
-        $this->quoteMock->expects($this->once())->method('collectTotals')->willReturnSelf();
+        $addressInformationMock = $this->getMock(\Magento\Checkout\Api\Data\ShippingInformationInterface::class);
 
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getActive')
             ->with($cartId)
             ->willReturn($this->quoteMock);
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('save')
-            ->with($this->quoteMock)
-            ->willThrowException($exception);
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
+
         $addressInformationMock->expects($this->once())
             ->method('getShippingAddress')
             ->willReturn($this->shippingAddressMock);
         $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
         $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
 
-        $this->shippingAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getCustomerAddressId')
-            ->willReturn($customerAddressId);
+        $billingAddress = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
+        $addressInformationMock->expects($this->once())->method('getBillingAddress')->willReturn($billingAddress);
 
-        $this->addressValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with($this->shippingAddressMock)
-            ->willReturn(true);
+        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn('USA');
 
-        $this->quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->shippingAddressMock)
-            ->willReturnSelf();
-        $this->quoteMock->expects($this->exactly(2))
+        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+
+        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(100);
+        $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(false)->willReturnSelf();
+        $this->quoteMock->expects($this->once())->method('setBillingAddress')->with($billingAddress)->willReturnSelf();
+
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('save')
+            ->with($this->quoteMock)
+            ->willThrowException(new \Exception());
+
+        $this->model->saveAddressInformation($cartId, $addressInformationMock);
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
+     * @expectedExceptionMessage Carrier with such method not found: carrier_code, shipping_method
+     */
+    public function testSaveAddressInformationIfCarrierCodeIsInvalid()
+    {
+        $cartId = 100;
+        $carrierCode = 'carrier_code';
+        $shippingMethod = 'shipping_method';
+        $addressInformationMock = $this->getMock(\Magento\Checkout\Api\Data\ShippingInformationInterface::class);
+
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('getActive')
+            ->with($cartId)
+            ->willReturn($this->quoteMock);
+        $addressInformationMock->expects($this->once())
             ->method('getShippingAddress')
             ->willReturn($this->shippingAddressMock);
+        $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
+        $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
 
-        $customerAddressMock = $this->getMock('\Magento\Customer\Api\Data\AddressInterface');
-        $this->addressRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
+        $billingAddress = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
+        $addressInformationMock->expects($this->once())->method('getBillingAddress')->willReturn($billingAddress);
+        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn('USA');
 
-        $this->shippingAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('save')->willReturnSelf();
-        $this->totalsCollectorMock
-            ->expects($this->once())
-            ->method('collectAddressTotals')
-            ->with($this->quoteMock, $this->shippingAddressMock);
+        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+
+        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(100);
+        $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(false)->willReturnSelf();
+        $this->quoteMock->expects($this->once())->method('setBillingAddress')->with($billingAddress)->willReturnSelf();
+        $this->quoteMock->expects($this->once())->method('getShippingAddress')->willReturn($this->shippingAddressMock);
+
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('save')
+            ->with($this->quoteMock);
+
         $this->shippingAddressMock->expects($this->once())->method('getShippingMethod')->willReturn($shippingMethod);
         $this->shippingAddressMock->expects($this->once())
             ->method('getShippingRateByCode')
             ->with($shippingMethod)
-            ->willReturn($this->getMock('\Magento\Quote\Model\Quote\Address\Rate', [], [], '', false));
-
-        $this->loggerMock->expects($this->once())->method('critical')->with($exception);
+            ->willReturn(false);
 
         $this->model->saveAddressInformation($cartId, $addressInformationMock);
     }
 
     public function testSaveAddressInformation()
     {
-        $this->markTestSkipped('MAGETWO-48531');
         $cartId = 100;
         $carrierCode = 'carrier_code';
         $shippingMethod = 'shipping_method';
-        $customerAddressId = 200;
-
-        $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
-        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(5);
-        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(true);
-        $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(false)->willReturnSelf();
-        $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(true)->willReturn(true);
-        $this->quoteMock->expects($this->once())->method('collectTotals')->willReturnSelf();
+        $addressInformationMock = $this->getMock(\Magento\Checkout\Api\Data\ShippingInformationInterface::class);
 
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getActive')
             ->with($cartId)
             ->willReturn($this->quoteMock);
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('save')
-            ->with($this->quoteMock);
-
-        $addressInformationMock = $this->getMock('\Magento\Checkout\Api\Data\ShippingInformationInterface');
         $addressInformationMock->expects($this->once())
             ->method('getShippingAddress')
             ->willReturn($this->shippingAddressMock);
         $addressInformationMock->expects($this->once())->method('getShippingCarrierCode')->willReturn($carrierCode);
         $addressInformationMock->expects($this->once())->method('getShippingMethodCode')->willReturn($shippingMethod);
 
-        $this->shippingAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->shippingAddressMock->expects($this->once())
-            ->method('getCustomerAddressId')
-            ->willReturn($customerAddressId);
+        $billingAddress = $this->getMock(\Magento\Quote\Api\Data\AddressInterface::class);
+        $addressInformationMock->expects($this->once())->method('getBillingAddress')->willReturn($billingAddress);
+        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn('USA');
 
-        $this->addressValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with($this->shippingAddressMock)
-            ->willReturn(true);
+        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
 
-        $this->quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->shippingAddressMock)
-            ->willReturnSelf();
-        $this->quoteMock->expects($this->exactly(2))
-            ->method('getShippingAddress')
-            ->willReturn($this->shippingAddressMock);
-        $customerAddressMock = $this->getMock('\Magento\Customer\Api\Data\AddressInterface');
-        $this->addressRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
+        $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(100);
+        $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(false)->willReturnSelf();
+        $this->quoteMock->expects($this->once())->method('setBillingAddress')->with($billingAddress)->willReturnSelf();
+        $this->quoteMock->expects($this->once())->method('getShippingAddress')->willReturn($this->shippingAddressMock);
 
-        $this->shippingAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-        $this->shippingAddressMock->expects($this->once())->method('getCountryId')->willReturn(1);
-        $this->totalsCollectorMock
-            ->expects($this->once())
-            ->method('collectAddressTotals')
-            ->with($this->quoteMock, $this->shippingAddressMock);
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('save')
+            ->with($this->quoteMock);
+
         $this->shippingAddressMock->expects($this->once())->method('getShippingMethod')->willReturn($shippingMethod);
         $this->shippingAddressMock->expects($this->once())
             ->method('getShippingRateByCode')
             ->with($shippingMethod)
-            ->willReturn($this->getMock('\Magento\Quote\Model\Quote\Address\Rate', [], [], '', false));
+            ->willReturn('rates');
 
-        $paymentDetailsMock = $this->getMock('\Magento\Checkout\Api\Data\PaymentDetailsInterface');
+        $paymentDetailsMock = $this->getMock(\Magento\Checkout\Api\Data\PaymentDetailsInterface::class);
         $this->paymentDetailsFactoryMock->expects($this->once())->method('create')->willReturn($paymentDetailsMock);
 
-        $paymentMethodMock = $this->getMock('\Magento\Quote\Api\Data\PaymentMethodInterface');
+        $paymentMethodMock = $this->getMock(\Magento\Quote\Api\Data\PaymentMethodInterface::class);
         $this->paymentMethodManagementMock->expects($this->once())
             ->method('getList')
             ->with($cartId)
             ->willReturn([$paymentMethodMock]);
-        $totalsMock = $this->getMock('\Magento\Quote\Api\Data\TotalsInterface');
-        $this->cartTotalsRepositoryMock->expects($this->once())->method('get')->with($cartId)->willReturn($totalsMock);
+
+        $cartTotalsMock = $this->getMock(\Magento\Quote\Api\Data\TotalsInterface::class);
+        $this->cartTotalsRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($cartId)
+            ->willReturn($cartTotalsMock);
 
         $paymentDetailsMock->expects($this->once())
             ->method('setPaymentMethods')
             ->with([$paymentMethodMock])
             ->willReturnSelf();
-        $paymentDetailsMock->expects($this->once())->method('setTotals')->with($totalsMock)->willReturnSelf();
+        $paymentDetailsMock->expects($this->once())->method('setTotals')->with($cartTotalsMock)->willReturnSelf();
 
         $this->assertEquals(
             $paymentDetailsMock,

--- a/app/code/Magento/Quote/Model/CustomerManagement.php
+++ b/app/code/Magento/Quote/Model/CustomerManagement.php
@@ -47,7 +47,7 @@ class CustomerManagement
     }
 
     /**
-     * Populate customer model
+     * Populate customer model.
      *
      * @param Quote $quote
      * @return void
@@ -62,8 +62,6 @@ class CustomerManagement
                 $quote->getPasswordHash()
             );
             $quote->setCustomer($customer);
-        } else {
-            $this->customerRepository->save($customer);
         }
         if (!$quote->getBillingAddress()->getId() && $customer->getDefaultBilling()) {
             $quote->getBillingAddress()->importCustomerAddressData(

--- a/app/code/Magento/Quote/Test/Unit/Model/CustomerManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/CustomerManagementTest.php
@@ -53,7 +53,7 @@ class CustomerManagementTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->customerRepositoryMock = $this->getMockForAbstractClass(
-            'Magento\Customer\Api\CustomerRepositoryInterface',
+            \Magento\Customer\Api\CustomerRepositoryInterface::class,
             [],
             '',
             false,
@@ -62,7 +62,7 @@ class CustomerManagementTest extends \PHPUnit_Framework_TestCase
             ['getById']
         );
         $this->customerAddressRepositoryMock = $this->getMockForAbstractClass(
-            'Magento\Customer\Api\AddressRepositoryInterface',
+            \Magento\Customer\Api\AddressRepositoryInterface::class,
             [],
             '',
             false,
@@ -71,7 +71,7 @@ class CustomerManagementTest extends \PHPUnit_Framework_TestCase
             ['getById']
         );
         $this->accountManagementMock = $this->getMockForAbstractClass(
-            'Magento\Customer\Api\AccountManagementInterface',
+            \Magento\Customer\Api\AccountManagementInterface::class,
             [],
             '',
             false,
@@ -80,21 +80,21 @@ class CustomerManagementTest extends \PHPUnit_Framework_TestCase
             []
         );
         $this->quoteMock = $this->getMock(
-            'Magento\Quote\Model\Quote',
+            \Magento\Quote\Model\Quote::class,
             ['getId', 'getCustomer', 'getBillingAddress', 'getShippingAddress', 'setCustomer', 'getPasswordHash'],
             [],
             '',
             false
         );
         $this->quoteAddressMock = $this->getMock(
-            'Magento\Quote\Model\Quote\Address',
+            \Magento\Quote\Model\Quote\Address::class,
             [],
             [],
             '',
             false
         );
         $this->customerMock = $this->getMockForAbstractClass(
-            'Magento\Customer\Api\Data\CustomerInterface',
+            \Magento\Customer\Api\Data\CustomerInterface::class,
             [],
             '',
             false,
@@ -103,7 +103,7 @@ class CustomerManagementTest extends \PHPUnit_Framework_TestCase
             ['getId', 'getDefaultBilling']
         );
         $this->customerAddressMock = $this->getMockForAbstractClass(
-            'Magento\Customer\Api\Data\AddressInterface',
+            \Magento\Customer\Api\Data\AddressInterface::class,
             [],
             '',
             false,
@@ -156,6 +156,36 @@ class CustomerManagementTest extends \PHPUnit_Framework_TestCase
             ->method('createAccountWithPasswordHash')
             ->with($this->customerMock, 'password hash')
             ->willReturn($this->customerMock);
+        $this->customerManagement->populateCustomerInfo($this->quoteMock);
+    }
+
+    public function testPopulateCustomerInfoForExistingCustomer()
+    {
+        $this->quoteMock->expects($this->once())
+            ->method('getCustomer')
+            ->willReturn($this->customerMock);
+        $this->customerMock->expects($this->atLeastOnce())
+            ->method('getId')
+            ->willReturn(1);
+        $this->customerMock->expects($this->atLeastOnce())
+            ->method('getDefaultBilling')
+            ->willReturn(100500);
+        $this->quoteMock->expects($this->atLeastOnce())
+            ->method('getBillingAddress')
+            ->willReturn($this->quoteAddressMock);
+        $this->quoteMock->expects($this->atLeastOnce())
+            ->method('getShippingAddress')
+            ->willReturn($this->quoteAddressMock);
+        $this->quoteAddressMock->expects($this->atLeastOnce())
+            ->method('getId')
+            ->willReturn(null);
+        $this->customerAddressRepositoryMock->expects($this->atLeastOnce())
+            ->method('getById')
+            ->with(100500)
+            ->willReturn($this->customerAddressMock);
+        $this->quoteAddressMock->expects($this->atLeastOnce())
+            ->method('importCustomerAddressData')
+            ->willReturnSelf();
         $this->customerManagement->populateCustomerInfo($this->quoteMock);
     }
 }


### PR DESCRIPTION
Backport MAGETWO-52856 from 2.2.0 to 2.1 - develop

### Description
Provide seamless experience on checkout with large amount of customer addresses.

### Fixed Issues (if relevant)
1. magento/magento2#9007: Get MAGETWO-52856 into Magento 2.1.x

### Manual testing scenarios
1. Log in as a customer
2. Create 581 addresses
3. Go to checkout

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
