### PR TITLE
Magento sets ISO invalid language code [2.3-develop Backport]

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -173,7 +173,7 @@ class Config
         $this->setElementAttribute(
             self::ELEMENT_TYPE_HTML,
             self::HTML_ATTRIBUTE_LANG,
-            str_replace('_', '-', $this->localeResolver->getLocale())
+            strstr($this->localeResolver->getLocale(), '_', true)
         );
     }
 


### PR DESCRIPTION
### Description
Magento HTML Language code is invalid.

### Fixed Issues
1. https://github.com/magento/magento2/issues/11540

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
