### PR TITLE
Fix #8820 #8171 [backport 2.2] check typeId on product save

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -7,7 +7,6 @@
 namespace Magento\Catalog\Model;
 
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Api\ProductTypeListInterface;
 use Magento\Catalog\Model\Product\Gallery\MimeTypeExtensionMap;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Api\Data\ImageContentInterface;
@@ -152,18 +151,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     private $serializer;
 
     /**
-     * @var ProductTypeListInterface
-     */
-    protected $productTypeList;
-
-    /**
-     * Available product types
-     *
-     * @var array
-     */
-    protected $availableProductTypes;
-
-    /**
      * ProductRepository constructor.
      * @param ProductFactory $productFactory
      * @param \Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper $initializationHelper
@@ -185,7 +172,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      * @param MimeTypeExtensionMap $mimeTypeExtensionMap
      * @param ImageProcessorInterface $imageProcessor
      * @param \Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface $extensionAttributesJoinProcessor
-     * @param ProductTypeListInterface $productTypeList
      * @param CollectionProcessorInterface $collectionProcessor [optional]
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param int $cacheLimit [optional]
@@ -213,7 +199,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         MimeTypeExtensionMap $mimeTypeExtensionMap,
         ImageProcessorInterface $imageProcessor,
         \Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface $extensionAttributesJoinProcessor,
-        ProductTypeListInterface $productTypeList,
         CollectionProcessorInterface $collectionProcessor = null,
         \Magento\Framework\Serialize\Serializer\Json $serializer = null,
         $cacheLimit = 1000
@@ -239,7 +224,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         $this->cacheLimit = (int)$cacheLimit;
-        $this->productTypeList = $productTypeList;
     }
 
     /**
@@ -342,9 +326,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      */
     protected function initializeProductData(array $productData, $createNew)
     {
-        if (isset($productData['type_id'])
-            && !in_array($productData['type_id'], $this->getAvailableProductTypes())
-        ) {
+        if (empty($productData['type_id'])) {
             unset($productData['type_id']);
         }
 
@@ -436,27 +418,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             ]
         );
         return $this;
-    }
-
-    /**
-     * Get an array with the available product type ids
-     *
-     * @return string[]
-     */
-    protected function getAvailableProductTypes()
-    {
-        if (!isset($this->availableProductTypes)) {
-            $productTypeList = $this->productTypeList->getProductTypes();
-            array_walk(
-                $productTypeList,
-                function (&$productType) {
-                    /** @var \Magento\Catalog\Api\Data\ProductTypeInterface $productType */
-                    $productType = $productType->getName();
-                }
-            );
-            $this->availableProductTypes = $productTypeList;
-        }
-        return $this->availableProductTypes;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -327,7 +327,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     protected function initializeProductData(array $productData, $createNew)
     {
         if (empty($productData['type_id'])) {
-            unset($productData['type_id']);
+            $productData['type_id'] = \Magento\Catalog\Model\Product\Type::DEFAULT_TYPE;
         }
 
         unset($productData['media_gallery']);


### PR DESCRIPTION
… #8820 #8171 
When saving a product, check typeId control. If it's value isn't one of available, set the default one before saving.

### Description
Set the default product type before saving it on repository, for prevent error on create stockitem and the undesired attributes deleting on \Magento\Catalog\Model\Product\Type\AbstractType::_removeNotApplicableAttributes()

### Fixed Issues
1. magento/magento2#8820: WEBAPI: Unable to save Product when typeId and status is missing
2. magento/magento2#8171 Price not saved when creating product via REST API

### Manual testing scenarios
Same testing described at issues #8820 and #8171. Save product via API.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

