### PR TITLE
Fix ModelInstance RegEx pattern for class names.

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
@@ -29,12 +29,12 @@ return [
         ],
     ],
     'renderer_attribute_with_invalid_value' => [
-        '<?xml version="1.0"?><config><option name="name_one" renderer="true12"><inputType name="name_one"/>' .
+        '<?xml version="1.0"?><config><option name="name_one" renderer="true-12"><inputType name="name_one"/>' .
         '</option></config>',
         [
-            "Element 'option', attribute 'renderer': [facet 'pattern'] The value 'true12' is not accepted by the " .
-            "pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
-            "Element 'option', attribute 'renderer': 'true12' is not a valid value of the atomic" .
+            "Element 'option', attribute 'renderer': [facet 'pattern'] The value 'true-12' is not accepted by the " .
+            "pattern '[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'option', attribute 'renderer': 'true-12' is not a valid value of the atomic" .
             " type 'modelName'.\nLine: 1\n"
         ],
     ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
@@ -20,11 +20,11 @@ return [
         ["Element 'type', attribute 'notallowed': The attribute 'notallowed' is not allowed.\nLine: 1\n"],
     ],
     'type_modelinstance_invalid_value' => [
-        '<?xml version="1.0"?><config><type name="some_name" modelInstance="123" /></config>',
+        '<?xml version="1.0"?><config><type name="some_name" modelInstance="true-123" /></config>',
         [
-            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value '123' is not accepted by the" .
-            " pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
-            "Element 'type', attribute 'modelInstance': '123' is not a valid value of the atomic type" .
+            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value 'true-123' is not accepted by the" .
+            " pattern '[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'type', attribute 'modelInstance': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
@@ -54,20 +54,20 @@ return [
         ["Element 'priceModel': The attribute 'instance' is required but missing.\nLine: 1\n"],
     ],
     'type_pricemodel_instance_invalid_value' => [
-        '<?xml version="1.0"?><config><type name="some_name"><priceModel instance="123123" /></type></config>',
+        '<?xml version="1.0"?><config><type name="some_name"><priceModel instance="true-123" /></type></config>',
         [
-            "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value '123123' is not accepted " .
-            "by the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
-            "Element 'priceModel', attribute 'instance': '123123' is not a valid value of the atomic type" .
+            "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value 'true-123' is not accepted " .
+            "by the pattern '[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'priceModel', attribute 'instance': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
     'type_indexermodel_instance_invalid_value' => [
-        '<?xml version="1.0"?><config><type name="some_name"><indexerModel instance="123" /></type></config>',
+        '<?xml version="1.0"?><config><type name="some_name"><indexerModel instance="true-123" /></type></config>',
         [
-            "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value '123' is not accepted by " .
-            "the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
-            "Element 'indexerModel', attribute 'instance': '123' is not a valid value of the atomic type" .
+            "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value 'true-123' is not accepted by " .
+            "the pattern '[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'indexerModel', attribute 'instance': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
@@ -80,11 +80,11 @@ return [
         ["Element 'stockIndexerModel': The attribute 'instance' is required but missing.\nLine: 1\n"],
     ],
     'stockindexermodel_instance_invalid_value' => [
-        '<?xml version="1.0"?><config><type name="some_name"><stockIndexerModel instance="1234"/></type></config>',
+        '<?xml version="1.0"?><config><type name="some_name"><stockIndexerModel instance="true-123"/></type></config>',
         [
-            "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value '1234' is not " .
-            "accepted by the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
-            "Element 'stockIndexerModel', attribute 'instance': '1234' is not a valid value of the atomic " .
+            "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value 'true-123' is not " .
+            "accepted by the pattern '[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'stockIndexerModel', attribute 'instance': 'true-123' is not a valid value of the atomic " .
             "type 'modelName'.\nLine: 1\n"
         ],
     ],

--- a/app/code/Magento/Catalog/etc/product_options.xsd
+++ b/app/code/Magento/Catalog/etc/product_options.xsd
@@ -61,11 +61,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [a-zA-Z_\\].
+                Model name can contain only [a-zA-Z0-9_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_\\]+" />
+            <xs:pattern value="[a-zA-Z0-9_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/Catalog/etc/product_types_base.xsd
+++ b/app/code/Magento/Catalog/etc/product_types_base.xsd
@@ -92,11 +92,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [a-zA-Z_\\].
+                Model name can contain only [a-zA-Z0-9_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_\\]+" />
+            <xs:pattern value="[a-zA-Z0-9_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Export/Config/_files/invalidExportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Export/Config/_files/invalidExportXmlArray.php
@@ -21,16 +21,16 @@ return [
     ],
     'attributes_with_type_modelName_and_invalid_value' => [
         '<?xml version="1.0"?><config><entity name="Name/one" model="model_one" '
-            . 'entityAttributeFilterType="model_one"/><entityType entity="Name/one" name="name_one" model="1"/>'
-            . ' <fileFormat name="name_one" model="model1"/></config>',
+            . 'entityAttributeFilterType="model_one"/><entityType entity="Name/one" name="name_one" model="true-123"/>'
+            . ' <fileFormat name="name_one" model="true-123"/></config>',
         [
-            "Element 'entityType', attribute 'model': [facet 'pattern'] The value '1' is not accepted by the " .
-            "pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'entityType', attribute 'model': '1' is not a valid value of the atomic type" .
+            "Element 'entityType', attribute 'model': [facet 'pattern'] The value 'true-123' is not accepted by the " .
+            "pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'entityType', attribute 'model': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n",
-            "Element 'fileFormat', attribute 'model': [facet 'pattern'] The value 'model1' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'fileFormat', attribute 'model': 'model1' is not a valid " .
+            "Element 'fileFormat', attribute 'model': [facet 'pattern'] The value 'true-123' is not " .
+            "accepted by the pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'fileFormat', attribute 'model': 'true-123' is not a valid " .
             "value of the atomic type 'modelName'.\nLine: 1\n"
         ],
     ],

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportMergedXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportMergedXmlArray.php
@@ -26,22 +26,22 @@ return [
         ["Element 'entity', attribute 'notallowed': The attribute 'notallowed' is not allowed.\nLine: 1\n"],
     ],
     'entity_model_with_invalid_value' => [
-        '<?xml version="1.0"?><config><entity name="test_name" label="test_label" model="afwer34" ' .
+        '<?xml version="1.0"?><config><entity name="test_name" label="test_label" model="true-123" ' .
         'behaviorModel="test" /></config>',
         [
-            "Element 'entity', attribute 'model': [facet 'pattern'] The value 'afwer34' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'entity', attribute 'model': 'afwer34' is not a valid value of the atomic type" .
+            "Element 'entity', attribute 'model': [facet 'pattern'] The value 'true-123' is not " .
+            "accepted by the pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'entity', attribute 'model': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
     'entity_behaviorModel_with_invalid_value' => [
-        '<?xml version="1.0"?><config><entity name="test_name" label="test_label" model="test" behaviorModel="666" />' .
+        '<?xml version="1.0"?><config><entity name="test_name" label="test_label" model="test" behaviorModel="true-123" />' .
         '</config>',
         [
-            "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value '666' is not accepted by " .
-            "the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'entity', attribute 'behaviorModel': '666' is not a valid value of the atomic type" .
+            "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value 'true-123' is not accepted by " .
+            "the pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'entity', attribute 'behaviorModel': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ]

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
@@ -16,20 +16,20 @@ return [
         ["Element 'entity': The attribute 'name' is required but missing.\nLine: 1\n"],
     ],
     'entity_with_invalid_model_value' => [
-        '<?xml version="1.0"?><config><entity name="some_name" model="12345"/></config>',
+        '<?xml version="1.0"?><config><entity name="some_name" model="true-123"/></config>',
         [
-            "Element 'entity', attribute 'model': [facet 'pattern'] The value '12345' is not accepted by " .
-            "the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'entity', attribute 'model': '12345' is not a valid value of the atomic type" .
+            "Element 'entity', attribute 'model': [facet 'pattern'] The value 'true-123' is not accepted by " .
+            "the pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'entity', attribute 'model': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
     'entity_with_invalid_behaviormodel_value' => [
-        '<?xml version="1.0"?><config><entity name="some_name" behaviorModel="=--09"/></config>',
+        '<?xml version="1.0"?><config><entity name="some_name" behaviorModel="true-123"/></config>',
         [
-            "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value '=--09' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'entity', attribute 'behaviorModel': '=--09' is not a valid value of the atomic type" .
+            "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value 'true-123' is not " .
+            "accepted by the pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'entity', attribute 'behaviorModel': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
@@ -46,11 +46,11 @@ return [
         ["Element 'entityType': The attribute 'model' is required but missing.\nLine: 1\n"],
     ],
     'entitytype_with_invalid_model_attribute_value' => [
-        '<?xml version="1.0"?><config><entityType entity="entity_name" name="some_name" model="test1"/></config>',
+        '<?xml version="1.0"?><config><entityType entity="entity_name" name="some_name" model="true-123"/></config>',
         [
-            "Element 'entityType', attribute 'model': [facet 'pattern'] The value 'test1' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
-            "Element 'entityType', attribute 'model': 'test1' is not a valid value of the atomic type" .
+            "Element 'entityType', attribute 'model': [facet 'pattern'] The value 'true-123' is not " .
+            "accepted by the pattern '[A-Za-z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'entityType', attribute 'model': 'true-123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],

--- a/app/code/Magento/ImportExport/etc/export.xsd
+++ b/app/code/Magento/ImportExport/etc/export.xsd
@@ -71,11 +71,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [A-Za-z_\\].
+                Model name can contain only [A-Za-z0-9_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z_\\]+" />
+            <xs:pattern value="[A-Za-z0-9_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/ImportExport/etc/import.xsd
+++ b/app/code/Magento/ImportExport/etc/import.xsd
@@ -61,11 +61,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [A-Za-z_\\].
+                Model name can contain only [A-Za-z0-9_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z_\\]+" />
+            <xs:pattern value="[A-Za-z0-9_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
@@ -82,7 +82,7 @@ class FormatTest extends \PHPUnit\Framework\TestCase
         return [
             ['en_US', ['decimalSymbol' => '.', 'groupSymbol' => ',']],
             ['de_DE', ['decimalSymbol' => ',', 'groupSymbol' => '.']],
-            ['de_CH', ['decimalSymbol' => '.', 'groupSymbol' => '\'']],
+            ['de_CH', ['decimalSymbol' => '.', 'groupSymbol' => '’']],
             ['uk_UA', ['decimalSymbol' => ',', 'groupSymbol' => ' ']]
         ];
     }


### PR DESCRIPTION
The updated XSD files forbid the usage of digits in the class or namespaces for the modelInstance value.

### Description
Changes `'[A-Za-z_\\]+'` for `'[A-Za-z0-9_\\]+'` to support namespaces with digits.

### Fixed Issues (if relevant)
1. [import.xsd doesn't allow numbers in vendor name and class name #4470](https://github.com/magento/magento2/issues/4470)
2. [Exception error on Module name when it has number(s) on product_options.xml - Regex issue #9985](https://github.com/magento/magento2/issues/9985)

### Manual testing scenarios
Create a module with a vendor name containing a digit. The following XML should be valid.
```
<!-- app/code/Interactiv4/TestProduct/etc/product_types.xml -->
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Catalog:etc/product_types.xsd">
    <type name="test" label="Test Product" modelInstance="Interactiv4\TestProduct\Model\Product\Type\Course" />
</config>
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)