### PR TITLE
[BUGFIX] Solved error while upgrading from 2.1 to 2.2

### DIFF
--- a/app/code/Magento/Tax/Setup/UpgradeData.php
+++ b/app/code/Magento/Tax/Setup/UpgradeData.php
@@ -81,7 +81,7 @@ class UpgradeData implements UpgradeDataInterface
                 false
             );
         }
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+        if (version_compare($context->getVersion(), '2.0.3', '<')) {
             //Update the tax_region_id
             $taxRateList = $this->taxRateRepository->getList($this->searchCriteriaFactory->create());
             /** @var \Magento\Tax\Api\Data\TaxRateInterface $taxRateData */

--- a/app/code/Magento/Tax/Setup/UpgradeData.php
+++ b/app/code/Magento/Tax/Setup/UpgradeData.php
@@ -91,6 +91,9 @@ class UpgradeData implements UpgradeDataInterface
                     /** @var \Magento\Directory\Model\Region $region */
                     $region = $this->directoryRegionFactory->create();
                     $region->loadByCode($regionCode, $taxRateData->getTaxCountryId());
+                    if ($taxRateData->getTaxPostcode() === null) {
+                        $taxRateData->setTaxPostcode('*');
+                    }
                     $taxRateData->setTaxRegionId($region->getRegionId());
                     $this->taxRateRepository->save($taxRateData);
                 }

--- a/app/code/Magento/Tax/etc/module.xml
+++ b/app/code/Magento/Tax/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Tax" setup_version="2.0.2">
+    <module name="Magento_Tax" setup_version="2.0.3">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
Given error while running setup:upgrade:

	`postcode is a required field`

Problem is solved by setting tax_postcode to * if it was NULL

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you try to upgrade from 2.1 to 2.2 and you have the following two tax rates in your 2.1 installation:

**Rate 1:**
- tax_calculation_rate_id = 1
- tax_country_id = US
- tax_region_id = 43
- tax_postcode = NULL
- code = US-CA-*-Rate 1
- rate = 8.25
- zip_is_range = NULL
- zip_from = NULL
- zip_to = NULL

**Rate 2:**
- tax_calculation_rate_id = 5
- tax_country_id = US
- tax_region_id = 12
- tax_postcode = NULL
- code = US-NY-*-Rate 1
- rate = 8.3750
- zip_is_range = NULL
- zip_from = NULL
- zip_to = NULL

Insert query for these rates is:

```INSERT INTO `tax_calculation_rate` (`tax_calculation_rate_id`, `tax_country_id`, `tax_region_id`, `tax_postcode`, `code`, `rate`, `zip_is_range`, `zip_from`, `zip_to`) VALUES
(1, 'US', 12, NULL, 'US-CA-*-Rate 1', 8.2500, NULL, NULL, NULL),
(5, 'US', 43, NULL, 'US-NY-*-Rate 1', 8.3750, NULL, NULL, NULL)```


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11095: Magento_Tax "postcode is a required field" when upgrading from 2.1.9 to 2.2

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Insert or change rules so they are the same as the above rates
2. Set setup_module version Magento_Tax from 2.0.2 to 2.0.1 (this will simulate an upgrade from M2.1 to M2.2 for the Magento_Tax module)
3. Run setup:upgrade and the error is given

Apply changes and the data will be changed automatically and this manual query is no longer needed:

`UPDATE tax_calculation_rate SET tax_postcode = '*' WHERE tax_postcode IS NULL`

tax_calculation_rate table before:
![image](https://user-images.githubusercontent.com/6040343/31902035-b6a1cc66-b823-11e7-9f37-c18e12d22578.png)

tax_calculation_rate table after:
![image](https://user-images.githubusercontent.com/6040343/31902057-c8fe1644-b823-11e7-9527-c4646bed0a93.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
