### PR TITLE
[TASK] Moved Customer Groups Menu Item from Other settings to Customers

### DIFF
--- a/app/code/Magento/Customer/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/menu.xml
@@ -10,6 +10,6 @@
         <add id="Magento_Customer::customer" title="Customers" translate="title" module="Magento_Customer" sortOrder="30" resource="Magento_Customer::customer"/>
         <add id="Magento_Customer::customer_manage" title="All Customers" translate="title" module="Magento_Customer" sortOrder="10" parent="Magento_Customer::customer" action="customer/index/" resource="Magento_Customer::manage"/>
         <add id="Magento_Customer::customer_online" title="Now Online" translate="title" module="Magento_Customer" sortOrder="30" parent="Magento_Customer::customer" action="customer/online/" resource="Magento_Customer::online"/>
-        <add id="Magento_Customer::customer_group" title="Customer Groups" translate="title" module="Magento_Customer" sortOrder="50" parent="Magento_Backend::other_settings" action="customer/group" resource="Magento_Customer::group"/>
+        <add id="Magento_Customer::customer_group" title="Customer Groups" translate="title" module="Magento_Customer" sortOrder="50" parent="Magento_Customer::customer" action="customer/group" resource="Magento_Customer::group"/>
     </menu>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Currently the Customer Groups are located in the Magento Admin under Stores > Other Settings > Customer Groups. But this is strange because in Magento 1 it was under Customers > Customer Groups

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Before changes:
![image](https://user-images.githubusercontent.com/6040343/31904925-cff551f2-b82c-11e7-92f4-43e0c58f5923.png)

After changes:
![image](https://user-images.githubusercontent.com/6040343/31904976-fbec770e-b82c-11e7-8954-cb08d8be3274.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
