### PR TITLE
[BUGFIX] Solved problem with incorrect store urls in footer and heade…

### DIFF
--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -654,7 +654,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
     {
         if (empty($this->templateFilter)) {
             $this->templateFilter = $this->getFilterFactory()->create();
-            $this->templateFilter->setUseAbsoluteLinks($this->getUseAbsoluteLinks())
+            $this->templateFilter->setUseAbsoluteLinks(true)
                 ->setStoreId($this->getDesignConfig()->getStore())
                 ->setUrlModel($this->urlModel);
         }

--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -375,7 +375,6 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
             );
         }
 
-        $this->setUseAbsoluteLinks(true);
         $text = $this->getProcessedTemplate($this->_getVars());
 
         if ($isDesignApplied) {


### PR DESCRIPTION
…r of emails

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Always use Use Absolute Links in email templates.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9369: Store URLs incorrect in email templates

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a custom footer or header email template
2. Add {{store url="test"}} to this template
3. Configure so it is used as header or footer in the email
Design > Design > Configuration > Edit your Theme > Transactional Emails > Header or Footer
4. Place a Guest Order
5. The Url will be displayed in the email as `http://www.example.com/test/index/index`
6. Apply changes
7. Re-sent email through the Admin Interface
8. The Url will now be displayed in the email as `http://www.example.com/test`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
