### PR TITLE
Clean unreachable code in creditmemo model

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo.php
@@ -412,23 +412,6 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
     public function canVoid()
     {
         return false;
-        $canVoid = false;
-        if ($this->getState() == self::STATE_REFUNDED) {
-            $canVoid = $this->getCanVoidFlag();
-            /**
-             * If we not retrieve negative answer from payment yet
-             */
-            if (is_null($canVoid)) {
-                $canVoid = $this->getOrder()->getPayment()->canVoid();
-                if ($canVoid === false) {
-                    $this->setCanVoidFlag(false);
-                    $this->_saveBeforeDestruct = true;
-                }
-            } else {
-                $canVoid = (bool)$canVoid;
-            }
-        }
-        return $canVoid;
     }
 
     /**


### PR DESCRIPTION
### Description
Remove unreachable code in app/code/Magento/Sales/Model/Order/Creditmemo.php, canVoid() method. It is easy to see that is unreachable:
![captura de pantalla 2017-10-24 a las 1 12 43](https://user-images.githubusercontent.com/17545750/31917607-a26854ba-b858-11e7-8a01-31b7b5818f2c.png)

### Fixed Issues (if relevant)
None

### Manual testing scenarios
None

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
