### PR TITLE
testGetIgnoresFirstSlash method in ObjectManagerTest has lost its purpose (dummy test)

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/ObjectManagerTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/ObjectManagerTest.php
@@ -400,7 +400,7 @@ class ObjectManagerTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertSame(
             $this->_object->get(\Magento\Test\Di\Child::class),
-            $this->_object->get(\Magento\Test\Di\Child::class)
+            $this->_object->get('\\' . \Magento\Test\Di\Child::class)
         );
     }
 }


### PR DESCRIPTION
Once upon a time, long long time ago, in the beginning of times, there was a test method inside a unit test class with a purpose. Nowadays, it has become a dummy test, because of some refactoring.

`\Magento\Framework\ObjectManager\Test\Unit\ObjectManagerTest::testGetIgnoresFirstSlash` is that method, intended to check if same object was returned when calling `ObjectManager::get('\Classname')` and `ObjectManager::get('Classname')`:
<img width="887" alt="captura de pantalla 2017-10-24 a las 1 28 39" src="https://user-images.githubusercontent.com/17545750/31918253-0f8b4d60-b85c-11e7-9541-a235b0cab374.png">

Now, it really doesn't check anything, because the two calls are the same:
<img width="447" alt="captura de pantalla 2017-10-24 a las 1 23 35" src="https://user-images.githubusercontent.com/17545750/31918285-32f2fd84-b85c-11e7-8587-20dfaa4733f5.png">

### Description
Proposed change will make this test useful again, as when it was born:
<img width="471" alt="captura de pantalla 2017-10-24 a las 1 41 59" src="https://user-images.githubusercontent.com/17545750/31918372-8db1dc40-b85c-11e7-8fcd-940016da0ddd.png">

### Fixed Issues (if relevant)
None.

### Manual testing scenarios
1. Run unit tests over this class.
2. They should pass with the changes.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
