### PR TITLE
Travis: surround variable TRAVIS_BRANCH with double-quotes instead of single-quotes

### DIFF
--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -71,7 +71,7 @@ case $TEST_SUITE in
             --output-file="$changed_files_ce" \
             --base-path="$TRAVIS_BUILD_DIR" \
             --repo='https://github.com/magento/magento2.git' \
-            --branch='$TRAVIS_BRANCH'
+            --branch="$TRAVIS_BRANCH"
         cat "$changed_files_ce" | sed 's/^/  + including /'
 
         cd ../../..


### PR DESCRIPTION
In dev/travis/before_script.sh, surround variable TRAVIS_BRANCH with double-quotes instead of single-quotes to get interpreted correctly:
<img width="851" alt="captura de pantalla 2017-10-24 a las 1 56 46" src="https://user-images.githubusercontent.com/17545750/31918751-a72f6d66-b85e-11e7-8945-955895fb8b6f.png">

This is a little demo of what Travis may be parsing:
![captura de pantalla 2017-10-24 a las 1 52 39](https://user-images.githubusercontent.com/17545750/31918788-cfc48b94-b85e-11e7-97ed-c218f9e0ca8a.png)

### Description
This may affect the way static test are executed, or over which files are performed.

### Fixed Issues (if relevant)
None AFAIK

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
