### PR TITLE
[BACKPORT 2.2] [TASK] Removed Typo in Paypal TestCase didgit => digit

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/OnePageCheckoutTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/OnePageCheckoutTest.xml
@@ -76,7 +76,7 @@
             <data name="isVaultPresent" xsi:type="boolean">false</data>
             <data name="configData" xsi:type="string">payflowpro</data>
             <data name="paymentInfo" xsi:type="array">
-                <item name="AVS Street Match" xsi:type="string">#Y: Yes. Matched Address and five-didgit ZIP</item>
+                <item name="AVS Street Match" xsi:type="string">#Y: Yes. Matched Address and five-digit ZIP</item>
             </data>
             <data name="status" xsi:type="string">Processing</data>
             <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
@@ -113,7 +113,7 @@
             <data name="payment/method" xsi:type="string">payflowpro</data>
             <data name="creditCard/dataset" xsi:type="string">visa_default</data>
             <data name="paymentInfo" xsi:type="array">
-                <item name="AVS zip" xsi:type="string">#Y: Yes. Matched Address and five-didgit ZIP</item>
+                <item name="AVS zip" xsi:type="string">#Y: Yes. Matched Address and five-digit ZIP</item>
             </data>
             <data name="configData" xsi:type="string">payflowpro, payflowpro_use_avs_zip</data>
             <data name="status" xsi:type="string">Processing</data>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
backported  #11659

### Description
<!--- Provide a description of the changes proposed in the pull request -->
There was a typo in the Paypal TestCase dev/tests/functional/tests/app/Magento/Paypal/Test/TestCase/OnePageCheckoutTest.xml

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#7591: PayPal module, "didgit" misspelling


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
