### PR TITLE
#7915: customer objects are equal to eachother after observing event customer_save_after_data_object

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
@@ -246,7 +246,7 @@ class CustomerRepository implements \Magento\Customer\Api\CustomerRepositoryInte
         $savedCustomer = $this->get($customer->getEmail(), $customer->getWebsiteId());
         $this->eventManager->dispatch(
             'customer_save_after_data_object',
-            ['customer_data_object' => $savedCustomer, 'orig_customer_data_object' => $customer]
+            ['customer_data_object' => $savedCustomer, 'orig_customer_data_object' => $prevCustomerData]
         );
         return $savedCustomer;
     }

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
@@ -241,6 +241,8 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
                 'save',
             ]);
 
+        $origCustomer = $this->customer;
+
         $this->customer->expects($this->atLeastOnce())
             ->method('__toArray')
             ->willReturn(['default_billing', 'default_shipping']);
@@ -417,7 +419,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(
                 'customer_save_after_data_object',
-                ['customer_data_object' => $this->customer, 'orig_customer_data_object' => $customerAttributesMetaData]
+                ['customer_data_object' => $this->customer, 'orig_customer_data_object' => $origCustomer]
             );
 
         $this->model->save($this->customer);
@@ -474,6 +476,8 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
                 'getId'
             ]
         );
+
+        $origCustomer = $this->customer;
 
         $this->customer->expects($this->atLeastOnce())
             ->method('__toArray')
@@ -642,7 +646,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(
                 'customer_save_after_data_object',
-                ['customer_data_object' => $this->customer, 'orig_customer_data_object' => $customerAttributesMetaData]
+                ['customer_data_object' => $this->customer, 'orig_customer_data_object' => $origCustomer]
             );
 
         $this->model->save($this->customer, $passwordHash);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
1. magento/magento2#7915: customer objects are equal to eachother after observing event customer_save_after_data_object customer objects are equal to eachother after observing event customer_save_after_data_object.

### Manual testing scenarios
1. Log in with existing user in frontend.
2. Change first name of customer to 'test35'.
3. Observe the event 'customer_save_after_data_object'. Two objects are given called : 'orig_customer_data_object' & 'customer_data_object'.
5. Those two objects are identical to each other. First name in both objects is equal to 'test35'

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
