### PR TITLE
MAGETWO-77673: <![CDATA[]]>in system.xml translate phrase not work, if comment starts from new line[port from 2.2-develop]

### DIFF
--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Xml.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Xml.php
@@ -65,7 +65,7 @@ class Xml extends AbstractAdapter
     {
         $nodesDelimiter = strpos($attributes['translate'], ' ') === false ? ',' : ' ';
         foreach (explode($nodesDelimiter, $attributes['translate']) as $value) {
-            $phrase = (string)$element->{$value};
+            $phrase = trim((string)$element->{$value});
             if ($phrase) {
                 $this->_addPhrase($phrase);
             }

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/XmlTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/XmlTest.php
@@ -53,6 +53,7 @@ class XmlTest extends \PHPUnit\Framework\TestCase
                     ['phrase' => 'Phrase 2', 'file' => $default, 'line' => '', 'quote' => ''],
                     ['phrase' => 'Phrase 3', 'file' => $default, 'line' => '', 'quote' => ''],
                     ['phrase' => 'Phrase 1', 'file' => $default, 'line' => '', 'quote' => ''],
+                    ['phrase' => 'Comment from new line.', 'file' => $default, 'line' => '', 'quote' => ''],
                 ],
             ],
             [

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/default.xml
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/default.xml
@@ -15,4 +15,9 @@
     <node2>
         <title translate="true">Phrase 1</title>
     </node2>
+    <node3 translate="comment">
+        <comment>
+            <![CDATA[Comment from new line.]]>
+        </comment>
+    </node3>
 </layout>


### PR DESCRIPTION
### Description
Fix for `<![CDATA[]]>` in system.xml translate phrase not work, if comment has spaces after opening tag, or before closing one(for instance: comment starts on new line). Ex:
```
<comment>
<![CDATA[Some comment]]>
</comment>
```
### Fixed Issues (if relevant)
1. magento/magento2#7767: <![CDATA[]]>in system.xml translate phrase not work

### Manual testing scenarios
1. Create a module which has system.xml
2. In the system.xml:
```
<?xml version="1.0"?>
<!--
/**
 * Copyright © Magento, Inc. All rights reserved.
 * See COPYING.txt for license details.
 */
-->
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
    <system>
        <tab id="foo_bar" translate="label" sortOrder="200">
            <label>Foo/Bar</label>
        </tab>
        <section id="foo_bar" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
            <class>separator-top</class>
            <label>Foo/Bar</label>
            <tab>foo_bar</tab>
            <resource>Magento_Catalog::config_catalog</resource>
            <group id="test" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                <field id="test" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                    <label>Test phrases</label>
                    <comment>
                        <![CDATA[Some test comment here.]]>
                    </comment>
                </field>
            </group>
        </section>
    </system>
</config>

```
3. Use the command to collect the phrases:
bin/magento i18n:collect-phrases -o "/path_to_your_module/i18n/en_US.csv"  path_to_your_module/dir
4. Make some changes to translation in generated en_US.csv ex:
"Some test comment here. **add something new here** "
5. Clean cache.
6. Navigate to admin>stores>configuration>Foo/Bar/>Foo/Bar/
7. Check comment for field "Test phrases". It should has **add something new here** modification You have made in en_US.csv.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
