### PR TITLE
GitHub 11380

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/billing/method/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/billing/method/form.phtml
@@ -55,9 +55,7 @@
             'Magento_Sales/order/create/form'
         ], function(mage) {
             mage.apply();
-        <?php if ($_methodsCount != 1) : ?>
             order.setPaymentMethod('<?= $block->escapeHtml($block->getSelectedMethodCode()); ?>');
-        <?php endif; ?>
         });
     </script>
 <?php else : ?>

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Billing/Method/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Billing/Method/FormTest.php
@@ -45,6 +45,8 @@ class FormTest extends \PHPUnit\Framework\TestCase
         $block = $this->layout->createBlock(Form::class, 'order_billing_method');
         $block->setTemplate('Magento_Sales::order/create/billing/method/form.phtml');
 
-        $this->assertContains('mage.apply()', $block->toHtml());
+        $html = $block->toHtml();
+        $this->assertContains('mage.apply()', $html);
+        $this->assertContains("order.setPaymentMethod('" . $block->escapeHtml($block->getSelectedMethodCode()) . "')", $html);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Billing/Method/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Billing/Method/FormTest.php
@@ -47,6 +47,9 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         $html = $block->toHtml();
         $this->assertContains('mage.apply()', $html);
-        $this->assertContains("order.setPaymentMethod('" . $block->escapeHtml($block->getSelectedMethodCode()) . "')", $html);
+        $this->assertContains(
+            "order.setPaymentMethod('" . $block->escapeHtml($block->getSelectedMethodCode()) . "')",
+            $html
+        );
     }
 }


### PR DESCRIPTION
### Description
Payment Method Issue in Admin

### Fixed Issues
1. magento/magento2#11380: Payment Method Issue in Admin

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Enable only one payment method, that has a form (for example: Purchase Order);
2. Place order in admin area
3. Payment form with input field should be appear
![payment_form](https://user-images.githubusercontent.com/23723146/31937627-c40b68b8-b8bd-11e7-8148-f53cb20369ca.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
