### PR TITLE
module downloadable overwrites result in checkout_allow_guest event

### DIFF
--- a/app/code/Magento/Downloadable/Observer/IsAllowedGuestCheckoutObserver.php
+++ b/app/code/Magento/Downloadable/Observer/IsAllowedGuestCheckoutObserver.php
@@ -40,18 +40,7 @@ class IsAllowedGuestCheckoutObserver implements ObserverInterface
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
-        $store = $observer->getEvent()->getStore();
         $result = $observer->getEvent()->getResult();
-
-        $result->setIsAllowed(true);
-
-        if (!$this->_scopeConfig->isSetFlag(
-            self::XML_PATH_DISABLE_GUEST_CHECKOUT,
-            ScopeInterface::SCOPE_STORE,
-            $store
-        )) {
-            return $this;
-        }
 
         /* @var $quote \Magento\Quote\Model\Quote */
         $quote = $observer->getEvent()->getQuote();


### PR DESCRIPTION
Module Downloadable overwrites other listener's changes to $result->isAllowed in checkout_allow_guest event.

When you listen to that event and set is_allowed to false it won't make a difference because the downloadable moduke sets it to true again afterwards.

Instead, the module should not set is_allowed to true, but only set is_allowed to false if a downloadable product is found in cart.

