### PR TITLE
MAGETWO-11669: API salesRefundInvoiceV1 does no save invoice ID on credit memo

### DIFF
--- a/app/code/Magento/Sales/Model/RefundInvoice.php
+++ b/app/code/Magento/Sales/Model/RefundInvoice.php
@@ -175,6 +175,7 @@ class RefundInvoice implements RefundInvoiceInterface
                     $invoice->getBaseTotalRefunded() + $creditmemo->getBaseGrandTotal()
                 );
             }
+            $creditmemo->setInvoiceId($invoice->getId());
             $this->invoiceRepository->save($invoice);
             $order = $this->orderRepository->save($order);
             $creditmemo = $this->creditmemoRepository->save($creditmemo);

--- a/app/code/Magento/Sales/Test/Unit/Model/RefundInvoiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/RefundInvoiceTest.php
@@ -100,7 +100,7 @@ class RefundInvoiceTest extends \PHPUnit\Framework\TestCase
     private $orderMock;
 
     /**
-     * @var OrderInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var InvoiceInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $invoiceMock;
 
@@ -186,6 +186,7 @@ class RefundInvoiceTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
 
         $this->invoiceMock = $this->getMockBuilder(InvoiceInterface::class)
+            ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -239,6 +240,9 @@ class RefundInvoiceTest extends \PHPUnit\Framework\TestCase
         $this->invoiceRepositoryMock->expects($this->once())
             ->method('get')
             ->willReturn($this->invoiceMock);
+        $this->invoiceMock->expects($this->once())
+            ->method('getId')
+            ->willReturn($invoiceId);
         $this->orderRepositoryMock->expects($this->once())
             ->method('get')
             ->willReturn($this->orderMock);


### PR DESCRIPTION
### Description
Fix for API salesRefundInvoiceV1 does no save invoice ID on credit memo.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11669: API salesRefundInvoiceV1 does no save invoice ID on credit memo

### Manual testing scenarios
1. Place an order with an online payment method (PayPal).
2. Create an online invoice for the order.
3. Use API method salesRefundInvoiceV1 to create a refund for the invoice.
4. Check newly added row in sales_creditmemo table in Your Magento database. Field 'invoice_id' should content id of invoice credit memo was created for.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
