### PR TITLE
Add a health check to the NGINX configuration sample

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -162,7 +162,7 @@ location /media/import/ {
 }
 
 # PHP entry point for main application
-location ~ (index|get|static|report|404|503)\.php$ {
+location ~ (index|get|static|report|404|503|health_check)\.php$ {
     try_files $uri =404;
     fastcgi_pass   fastcgi_backend;
     fastcgi_buffers 1024 4k;


### PR DESCRIPTION
With the release of the 2.2 version of Magento Varnish has been configured 
to determine the state of the upstream HTTP proxy with a HTTP probe. This
probe polls a script called "health_check.php", located in the pub folder.

Unfortunately in the sample configuration, this script is not whitelisted as a PHP
executable script, and thus fails to get executed as expected. Varnish then marks
the host as down, refusing to serve any traffic.

This commit adds the health_check script to the executable PHP block, allowing
the varnish proxy to correctly determine the health of the application.

Fixes #11157