### PR TITLE
Fix #8820 #8171 [backport 2.3] check typeId on product save

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -326,6 +326,10 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      */
     protected function initializeProductData(array $productData, $createNew)
     {
+        if (empty($productData['type_id'])) {
+            unset($productData['type_id']);
+        }
+
         unset($productData['media_gallery']);
         if ($createNew) {
             $product = $this->productFactory->create();

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -327,7 +327,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     protected function initializeProductData(array $productData, $createNew)
     {
         if (empty($productData['type_id'])) {
-            unset($productData['type_id']);
+            $productData['type_id'] = \Magento\Catalog\Model\Product\Type::DEFAULT_TYPE;
         }
 
         unset($productData['media_gallery']);


### PR DESCRIPTION
… #8820 #8171 
When saving a product, check typeId control. If it's value isn't one of available, set the default one before saving.

### Description
Set the default product type before saving it on repository, for prevent error on create stockitem and the undesired attributes deleting on \Magento\Catalog\Model\Product\Type\AbstractType::_removeNotApplicableAttributes()

### Fixed Issues
1. magento/magento2#8820: WEBAPI: Unable to save Product when typeId and status is missing
2. magento/magento2#8171 Price not saved when creating product via REST API

### Manual testing scenarios
Same testing described at issues #8820 and #8171. Save product via API.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
