### PR TITLE
Fix getReservedOrderId() to use current store instead of default store

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote.php
@@ -167,7 +167,7 @@ class Quote extends AbstractDb
     {
         return $this->sequenceManager->getSequence(
             \Magento\Sales\Model\Order::ENTITY,
-            $quote->getStore()->getStoreId()
+            $quote->getStoreId()
         )
         ->getNextValue();
     }

--- a/app/code/Magento/Quote/Model/ResourceModel/Quote.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote.php
@@ -167,7 +167,7 @@ class Quote extends AbstractDb
     {
         return $this->sequenceManager->getSequence(
             \Magento\Sales\Model\Order::ENTITY,
-            $quote->getStore()->getGroup()->getDefaultStoreId()
+            $quote->getStore()->getStoreId()
         )
         ->getNextValue();
     }

--- a/app/code/Magento/Quote/Model/ResourceModel/Quote.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote.php
@@ -256,7 +256,7 @@ class Quote extends AbstractDb
      *
      * @param \Magento\Catalog\Model\Product $product
      *
-     * @deprecated 101.0.0
+     * @deprecated 101.0.1
      * @see \Magento\Quote\Model\ResourceModel\Quote::subtractProductFromQuotes
      *
      * @return $this

--- a/app/code/Magento/Quote/Model/ResourceModel/Quote.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote.php
@@ -211,7 +211,7 @@ class Quote extends AbstractDb
      * @param \Magento\Catalog\Model\Product $product
      * @return $this
      */
-    public function substractProductFromQuotes($product)
+    public function subtractProductFromQuotes($product)
     {
         $productId = (int)$product->getId();
         if (!$productId) {
@@ -249,6 +249,21 @@ class Quote extends AbstractDb
         $connection->query($updateQuery);
 
         return $this;
+    }
+
+    /**
+     * Subtract product from all quotes quantities
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     *
+     * @deprecated 101.0.0
+     * @see \Magento\Quote\Model\ResourceModel\Quote::subtractProductFromQuotes
+     *
+     * @return $this
+     */
+    public function substractProductFromQuotes($product)
+    {
+        return $this->subtractProductFromQuotes($product);
     }
 
     /**

--- a/app/code/Magento/Quote/Test/Unit/Model/ResourceModel/QuoteTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ResourceModel/QuoteTest.php
@@ -24,11 +24,6 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
     private $sequenceMock;
 
     /**
-     * @var \Magento\Sales\Model\Order|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $storeMock;
-
-    /**
      * @var \Magento\Quote\Model\ResourceModel\Quote
      */
     private $quote;
@@ -56,9 +51,6 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
         $this->sequenceMock = $this->getMockBuilder(\Magento\Framework\DB\Sequence\SequenceInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->storeMock = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->quote = new \Magento\Quote\Model\ResourceModel\Quote(
             $context,
             $snapshot,
@@ -71,24 +63,23 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
     /**
      * @param $entityType
      * @param $storeId
+     * @param $reservedOrderId
      * @dataProvider getReservedOrderIdDataProvider
      */
-    public function testGetReservedOrderId($entityType, $storeId)
+    public function testGetReservedOrderId($entityType, $storeId, $reservedOrderId)
     {
         $this->sequenceManagerMock->expects($this->once())
             ->method('getSequence')
-            ->with(\Magento\Sales\Model\Order::ENTITY, $storeId)
+            ->with($entityType, $storeId)
             ->willReturn($this->sequenceMock);
         $this->quoteMock->expects($this->once())
-            ->method('getStore')
-            ->willReturn($this->storeMock);
-        $this->storeMock->expects($this->once())
             ->method('getStoreId')
             ->willReturn($storeId);
         $this->sequenceMock->expects($this->once())
-            ->method('getNextValue');
+            ->method('getNextValue')
+            ->willReturn($reservedOrderId);
 
-        $this->quote->getReservedOrderId($this->quoteMock);
+        $this->assertEquals($reservedOrderId, $this->quote->getReservedOrderId($this->quoteMock));
     }
 
     /**
@@ -97,9 +88,9 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
     public function getReservedOrderIdDataProvider(): array
     {
         return [
-            [\Magento\Sales\Model\Order::ENTITY, 1],
-            [\Magento\Sales\Model\Order::ENTITY, 2],
-            [\Magento\Sales\Model\Order::ENTITY, 3]
+            [\Magento\Sales\Model\Order::ENTITY, 1, '1000000001'],
+            [\Magento\Sales\Model\Order::ENTITY, 2, '2000000001'],
+            [\Magento\Sales\Model\Order::ENTITY, 3, '3000000001']
         ];
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/ResourceModel/QuoteTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ResourceModel/QuoteTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Test\Unit\Model\ResourceModel;
+
+class QuoteTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Quote\Model\Quote|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $quoteMock;
+
+    /**
+     * @var \Magento\SalesSequence\Model\Manager|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $sequenceManagerMock;
+
+    /**
+     * @var \Magento\Framework\DB\Sequence\SequenceInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $sequenceMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeMock;
+
+    /**
+     * @var \Magento\Quote\Model\ResourceModel\Quote
+     */
+    private $quote;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $context = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\Db\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $snapshot = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\Db\VersionControl\Snapshot::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $entityRelationComposite = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\Db\VersionControl\RelationComposite::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->quoteMock = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->sequenceManagerMock = $this->getMockBuilder(\Magento\SalesSequence\Model\Manager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->sequenceMock = $this->getMockBuilder(\Magento\Framework\DB\Sequence\SequenceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->storeMock = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->quote = new \Magento\Quote\Model\ResourceModel\Quote(
+            $context,
+            $snapshot,
+            $entityRelationComposite,
+            $this->sequenceManagerMock,
+            null
+        );
+    }
+
+    /**
+     * @param $entityType
+     * @param $storeId
+     * @dataProvider getReservedOrderIdDataProvider
+     */
+    public function testGetReservedOrderId($entityType, $storeId)
+    {
+        $this->sequenceManagerMock->expects($this->once())
+            ->method('getSequence')
+            ->with(\Magento\Sales\Model\Order::ENTITY, $storeId)
+            ->willReturn($this->sequenceMock);
+        $this->quoteMock->expects($this->once())
+            ->method('getStore')
+            ->willReturn($this->storeMock);
+        $this->storeMock->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn($storeId);
+        $this->sequenceMock->expects($this->once())
+            ->method('getNextValue');
+
+        $this->quote->getReservedOrderId($this->quoteMock);
+    }
+
+    /**
+     * @return array
+     */
+    public function getReservedOrderIdDataProvider(): array
+    {
+        return [
+            [\Magento\Sales\Model\Order::ENTITY, 1],
+            [\Magento\Sales\Model\Order::ENTITY, 2],
+            [\Magento\Sales\Model\Order::ENTITY, 3]
+        ];
+    }
+}

--- a/app/code/Magento/Quote/Test/Unit/Model/ResourceModel/QuoteTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ResourceModel/QuoteTest.php
@@ -6,20 +6,27 @@
 
 namespace Magento\Quote\Test\Unit\Model\ResourceModel;
 
+use Magento\Framework\DB\Sequence\SequenceInterface;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Framework\Model\ResourceModel\Db\VersionControl\RelationComposite;
+use Magento\Framework\Model\ResourceModel\Db\VersionControl\Snapshot;
+use Magento\Quote\Model\Quote;
+use Magento\SalesSequence\Model\Manager;
+
 class QuoteTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Quote\Model\Quote|\PHPUnit_Framework_MockObject_MockObject
+     * @var Quote|\PHPUnit_Framework_MockObject_MockObject
      */
     private $quoteMock;
 
     /**
-     * @var \Magento\SalesSequence\Model\Manager|\PHPUnit_Framework_MockObject_MockObject
+     * @var Manager|\PHPUnit_Framework_MockObject_MockObject
      */
     private $sequenceManagerMock;
 
     /**
-     * @var \Magento\Framework\DB\Sequence\SequenceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SequenceInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $sequenceMock;
 
@@ -33,28 +40,28 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        $context = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\Db\Context::class)
+        $context = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $snapshot = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\Db\VersionControl\Snapshot::class)
+        $snapshot = $this->getMockBuilder(Snapshot::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $entityRelationComposite = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\Db\VersionControl\RelationComposite::class)
+        $relationComposite = $this->getMockBuilder(RelationComposite::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->quoteMock = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
+        $this->quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->sequenceManagerMock = $this->getMockBuilder(\Magento\SalesSequence\Model\Manager::class)
+        $this->sequenceManagerMock = $this->getMockBuilder(Manager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->sequenceMock = $this->getMockBuilder(\Magento\Framework\DB\Sequence\SequenceInterface::class)
+        $this->sequenceMock = $this->getMockBuilder(SequenceInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->quote = new \Magento\Quote\Model\ResourceModel\Quote(
             $context,
             $snapshot,
-            $entityRelationComposite,
+            $relationComposite,
             $this->sequenceManagerMock,
             null
         );

--- a/app/code/Magento/Sales/Observer/Backend/SubtractQtyFromQuotesObserver.php
+++ b/app/code/Magento/Sales/Observer/Backend/SubtractQtyFromQuotesObserver.php
@@ -31,6 +31,6 @@ class SubtractQtyFromQuotesObserver implements ObserverInterface
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         $product = $observer->getEvent()->getProduct();
-        $this->_quote->substractProductFromQuotes($product);
+        $this->_quote->subtractProductFromQuotes($product);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Observer/Backend/SubtractQtyFromQuotesObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/Backend/SubtractQtyFromQuotesObserverTest.php
@@ -15,12 +15,12 @@ class SubtractQtyFromQuotesObserverTest extends \PHPUnit\Framework\TestCase
     protected $_model;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Quote\Model\ResourceModel\Quote|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $_quoteMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Event\Observer|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $_observerMock;
 
@@ -48,7 +48,7 @@ class SubtractQtyFromQuotesObserverTest extends \PHPUnit\Framework\TestCase
             ['getId', 'getStatus', '__wakeup']
         );
         $this->_eventMock->expects($this->once())->method('getProduct')->will($this->returnValue($productMock));
-        $this->_quoteMock->expects($this->once())->method('substractProductFromQuotes')->with($productMock);
+        $this->_quoteMock->expects($this->once())->method('subtractProductFromQuotes')->with($productMock);
         $this->_model->execute($this->_observerMock);
     }
 }


### PR DESCRIPTION
### Description
Fix getReservedOrderId() to use current store instead of default store. When placing orders from a new store view under the same website, it would use the reserved order id from the default store view. 

In the image below, you'll the first 2 created orders without the fix. The last order(`2000000001`) is after the fix and you'll see the increment id corresponds to the store view.
![image](https://user-images.githubusercontent.com/1165302/31959901-53e4e918-b8f6-11e7-8f01-c95e7139fd49.png)

I also saw a typo in `Quote::substractProductFromQuotes()` and refactored the method. I created a placeholder for the old method and deprecated it.

So this problem is fixed this way, but I'm wondering why it was implemented like this in the first place. Does this have implications for Single Store Mode? I'd say it wouldn't, but I think it's good to be sure. Please let me know :)

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9055

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Setup a clean install of Magento
2. Add a second store view to the default website
3. Place an order on the second store view

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
