### PR TITLE
#7065 Allow page.main.title block to decide if title should be translated

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
@@ -42,12 +42,14 @@
                 </arguments>
             </block>
         </referenceContainer>
-        <referenceBlock name="page.main.title">
-            <arguments>
-                <argument name="id" xsi:type="string">page-title-heading</argument>
-                <argument name="add_base_attribute_aria" xsi:type="string">page-title-heading toolbar-amount</argument>
-            </arguments>
-            <block class="Magento\Catalog\Block\Category\Rss\Link" name="rss.link" template="Magento_Catalog::category/rss.phtml"/>
-        </referenceBlock>
+        <referenceContainer name="columns.top">
+            <block class="Magento\Theme\Block\Html\RawTitle" name="page.main.title" template="Magento_Theme::html/title.phtml" before="-">
+                <arguments>
+                    <argument name="id" xsi:type="string">page-title-heading</argument>
+                    <argument name="add_base_attribute_aria" xsi:type="string">page-title-heading toolbar-amount</argument>
+                </arguments>
+                <block class="Magento\Catalog\Block\Category\Rss\Link" name="rss.link" template="Magento_Catalog::category/rss.phtml"/>
+            </block>
+        </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -17,12 +17,14 @@
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="checkout_page_head_components" template="Magento_Catalog::js/components.phtml"/>
         </referenceBlock>
-        <referenceBlock name="page.main.title">
-            <arguments>
-                <argument name="css_class" xsi:type="string">product</argument>
-                <argument name="add_base_attribute" xsi:type="string">itemprop="name"</argument>
-            </arguments>
-        </referenceBlock>
+        <referenceContainer name="columns.top">
+            <block class="Magento\Theme\Block\Html\RawTitle" name="page.main.title" template="Magento_Theme::html/title.phtml" before="-">
+                <arguments>
+                    <argument name="css_class" xsi:type="string">product</argument>
+                    <argument name="add_base_attribute" xsi:type="string">itemprop="name"</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
         <referenceBlock name="root">
             <arguments>
                 <argument name="add_attribute" xsi:type="string">itemscope itemtype="http://schema.org/Product"</argument>

--- a/app/code/Magento/Theme/Block/Html/RawTitle.php
+++ b/app/code/Magento/Theme/Block/Html/RawTitle.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Theme\Block\Html;
+
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Html page raw title block
+ *
+ * @method $this setTitleId($titleId)
+ * @method $this setTitleClass($titleClass)
+ * @method string getTitleId()
+ * @method string getTitleClass()
+ */
+class RawTitle extends Template
+{
+    /**
+     * Own page title to display on the page
+     *
+     * @var string
+     */
+    private $pageTitle;
+
+    /**
+     * Provide own page title or pick it from Head Block
+     *
+     * @return string
+     */
+    public function getPageTitle()
+    {
+        if (!empty($this->pageTitle)) {
+            return $this->pageTitle;
+        }
+        return $this->pageConfig->getTitle()->getShort();
+    }
+
+    /**
+     * Provide own page content heading
+     *
+     * @return string
+     */
+    public function getPageHeading()
+    {
+        if (!empty($this->pageTitle)) {
+            return $this->pageTitle;
+        }
+        return $this->pageConfig->getTitle()->getShortHeading();
+    }
+
+    /**
+     * Set own page title
+     *
+     * @param string $pageTitle
+     * @return void
+     */
+    public function setPageTitle($pageTitle)
+    {
+        $this->pageTitle = $pageTitle;
+    }
+}

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/RawTitleTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/RawTitleTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Theme\Test\Unit\Block\Html;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+class RawTitleTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ObjectManagerHelper
+     */
+    protected $objectManagerHelper;
+
+    /**
+     * @var \Magento\Framework\View\Page\Config|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pageConfigMock;
+
+    /**
+     * @var \Magento\Framework\View\Page\Title|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pageTitleMock;
+
+    /**
+     * @var \Magento\Theme\Block\Html\RawTitle
+     */
+    protected $rawHtmlTitle;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->pageConfigMock = $this->createMock(\Magento\Framework\View\Page\Config::class);
+        $this->pageTitleMock = $this->createMock(\Magento\Framework\View\Page\Title::class);
+
+        $context = $this->objectManagerHelper->getObject(
+            \Magento\Framework\View\Element\Template\Context::class,
+            ['pageConfig' => $this->pageConfigMock]
+        );
+
+        $this->rawHtmlTitle = $this->objectManagerHelper->getObject(
+            \Magento\Theme\Block\Html\RawTitle::class,
+            ['context' => $context]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetPageTitleWithSetPageTitle()
+    {
+        $title = 'some title';
+
+        $this->rawHtmlTitle->setPageTitle($title);
+        $this->pageConfigMock->expects($this->never())
+            ->method('getTitle');
+
+        $this->assertEquals($title, $this->rawHtmlTitle->getPageTitle());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetPageTitle()
+    {
+        $title = 'some title';
+
+        $this->pageTitleMock->expects($this->once())
+            ->method('getShort')
+            ->willReturn($title);
+        $this->pageConfigMock->expects($this->once())
+            ->method('getTitle')
+            ->willReturn($this->pageTitleMock);
+
+        $this->assertEquals($title, $this->rawHtmlTitle->getPageTitle());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetPageHeadingWithSetPageTitle()
+    {
+        $title = 'some title';
+
+        $this->rawHtmlTitle->setPageTitle($title);
+        $this->pageConfigMock->expects($this->never())
+            ->method('getTitle');
+
+        $this->assertEquals($title, $this->rawHtmlTitle->getPageHeading());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetPageHeading()
+    {
+        $title = 'some title';
+
+        $this->pageTitleMock->expects($this->once())
+            ->method('getShortHeading')
+            ->willReturn($title);
+        $this->pageConfigMock->expects($this->once())
+            ->method('getTitle')
+            ->willReturn($this->pageTitleMock);
+
+        $this->assertEquals($title, $this->rawHtmlTitle->getPageHeading());
+    }
+}

--- a/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
@@ -7,12 +7,12 @@
 // @codingStandardsIgnoreFile
 
 /**
- * @var $block \Magento\Theme\Block\Html\Title
+ * @var $block \Magento\Theme\Block\Html\Title|\Magento\Theme\Block\Html\RawTitle
  */
 $cssClass = $block->getCssClass() ? ' ' . $block->getCssClass() : '';
 $title = '';
 if (trim($block->getPageHeading())) {
-    $title = '<span class="base" data-ui-id="page-title-wrapper" ' .  $block->getAddBaseAttribute() . '>'
+    $title = '<span class="base" data-ui-id="page-title-wrapper" ' . $block->getAddBaseAttribute() . '>'
         . $block->escapeHtml($block->getPageHeading()) . '</span>';
 }
 ?>


### PR DESCRIPTION
Related to https://github.com/magento/magento2/issues/7065.

Layout block with name 'page.main.title', related with block `\Magento\Theme\Block\Html\Title`, always translates title before being returned. Unfortunately, category and product pages get their titles translated when they shouldn't (if wanted so, a different value should be defined for category / product at store view level in admin).

### Description
This may be the desired behaviour for most parts of the system, but 'page.main.title' always translates the title. Because of that, that block is now capable to handle the boolean argument `translate_title`, injected in constructor and defined via layout xml, to decide whether it has to translate the title or not.

As it used to translate all titles before, impact has been minified making `\Magento\Theme\Block\Html\Title` translate all titles by default, unless it has been told to do the opposite. This is the case of category and product pages by now, but there could be other pages interested in title not being translated.

I'm aware that arguments translation and be done via `translate` attribute, like in `Magento/Catalog/view/frontend/layout/catalog_product_compare_index.xml`:
```
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <body>
        <referenceBlock name="page.main.title">
            <action method="setPageTitle">
                <argument translate="true" name="page_title" xsi:type="string">Compare Products</argument>
            </action>
        </referenceBlock>
        <referenceContainer name="content">
            <block class="Magento\Catalog\Block\Product\Compare\ListCompare" name="catalog.compare.list" template="Magento_Catalog::product/compare/list.phtml" cacheable="false"/>
        </referenceContainer>
    </body>
</page>
```

But this only works for static values, that get translated when layout files are parsed and layout is generated. For products and categories, this value is set afterwards in _prepareLayout method.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#7065: page.main.title is translating title

### Manual testing scenarios
1. As proposed in https://github.com/magento/magento2/issues/7065, I created a product with name 'Save'
2. I have installed translation packages for es_ES, and configured store to use that locale.
3. The result was the product name translated in product page view (Save => Guardar):
![captura de pantalla 2017-10-25 a las 2 31 28](https://user-images.githubusercontent.com/17545750/31976302-01ab8d6e-b937-11e7-854e-f79a0003f7b7.png)
4. After applying this changes, product name does not get translated anymore:
![captura de pantalla 2017-10-25 a las 3 08 54](https://user-images.githubusercontent.com/17545750/31976321-2a983dee-b937-11e7-897a-b9363fcb3d60.png)

Also checked home page, and it still gets it title translated.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
