### PR TITLE
Allow coupon code with special charater to be applied to order in checkout

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/resource-url-manager.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/resource-url-manager.js
@@ -75,8 +75,8 @@ define([
                             quoteId: quoteId
                         } : {},
                     urls = {
-                        'guest': '/guest-carts/' + quoteId + '/coupons/' + couponCode,
-                        'customer': '/carts/mine/coupons/' + couponCode
+                        'guest': '/guest-carts/' + quoteId + '/coupons/' + encodeURIComponent(couponCode),
+                        'customer': '/carts/mine/coupons/' + encodeURIComponent(couponCode)
                     };
 
                 return this.getUrl(urls, params);


### PR DESCRIPTION
Fixes issue where coupon with special char (ex: %) could not be applied to quote in checkout, payment step

### Description
Encoding of coupon code prior to requesting it to be applied

### Fixed Issues (if relevant)
1. magento/magento2#9763: When go checkout,Cart Price Rules 25%test coupon code can go wrong

### Manual testing scenarios
1. In the admin, create a shopping cart price rule, and set it to use a coupon code, specify the coupon code to be 25%off. Set very broad conditions - preferably none - select all websites and all user groups.
2. In the frontend, add a product to cart
3. Proceed to checkout, type in address and select shipping method. It makes no difference if you're logged in as a customer or not
4. Proceed to the payment method step and apply the coupon code 25%off. The coupon code will be applied correctly

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
