### PR TITLE
magento/magento2#80862 Custom Product Attribute changes backend_type property

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -78,7 +78,8 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
         \Magento\Framework\Filter\FilterManager $filterManager,
         \Magento\Catalog\Helper\Product $productHelper,
         \Magento\Framework\View\LayoutFactory $layoutFactory
-    ) {
+    )
+    {
         parent::__construct($context, $attributeLabelCache, $coreRegistry, $resultPageFactory);
         $this->buildFactory = $buildFactory;
         $this->filterManager = $filterManager;
@@ -194,8 +195,8 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             }
 
             $data += ['is_filterable' => 0, 'is_filterable_in_search' => 0, 'apply_to' => []];
-
-            if (is_null($model->getIsUserDefined()) || $model->getIsUserDefined() != 0) {
+            
+            if (is_null($model->getBackendType()) && $model->getIsUserDefined()) {
                 $data['backend_type'] = $model->getBackendTypeByInput($data['frontend_input']);
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9219: Custom Product Attribute changes 'backend_type' when 'is_user_defined = 1' and get updated/saved in Admin Backend
2. User define product attribute backend type change from backend save.
3. So if we have backend type as varchar(on Installer script) with its value in a string and after creating attribute when we update its property from backend then it changes backend type to integer. so we cannot save its attribute value on a product level

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Created Installer script with backendtype as varchar and change its property from backend and after saving attribute still, I have backendtype as varchar

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
