### PR TITLE
magento/magento2#9851 Duplicating Configurable Product With Related Products not working

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -39,7 +39,8 @@ class SaveHandler
         MetadataPool $metadataPool,
         Link $linkResource,
         ProductLinkRepositoryInterface $productLinkRepository
-    ) {
+    )
+    {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
         $this->productLinkRepository = $productLinkRepository;
@@ -53,11 +54,14 @@ class SaveHandler
      */
     public function execute($entityType, $entity)
     {
+        /** @var \Magento\Catalog\Api\Data\ProductInterface $entity */
         $link = $entity->getData($this->metadataPool->getMetadata($entityType)->getLinkField());
-        if ($this->linkResource->hasProductLinks($link)) {
-            /** @var \Magento\Catalog\Api\Data\ProductInterface $entity*/
-            foreach ($this->productLinkRepository->getList($entity) as $link) {
-                $this->productLinkRepository->delete($link);
+        if (!$entity->getIsDuplicate()) {
+            if ($this->linkResource->hasProductLinks($link)) {
+                /** @var \Magento\Catalog\Api\Data\ProductInterface $entity */
+                foreach ($this->productLinkRepository->getList($entity) as $link) {
+                    $this->productLinkRepository->delete($link);
+                }
             }
         }
         $productLinks = $entity->getProductLinks();


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9851: Duplicating Configurable Product With Related Products Not Working Magento 2.1.7
2. Previously while duplicating product It is deleting the old relationship between product and related product but in an actual manner duplicate product is not created so It is throwing the error so I added one condition to filter with only original product not duplicate(Because in duplicate product 1 flag is available like IsDuplicate=true).

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Tested with configurable product with related product
2. Tested with different product type and cross-sell, upsell 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
