### PR TITLE
Fix Notice: freePackageValue is undefined

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Carrier/Tablerate.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Tablerate.php
@@ -113,8 +113,9 @@ class Tablerate extends \Magento\Shipping\Model\Carrier\AbstractCarrier implemen
 
         // Free shipping by qty
         $freeQty = 0;
+        $freePackageValue = 0;
+
         if ($request->getAllItems()) {
-            $freePackageValue = 0;
             foreach ($request->getAllItems() as $item) {
                 if ($item->getProduct()->isVirtual() || $item->getParentItem()) {
                     continue;


### PR DESCRIPTION
As visible from the code, freePackageValue can be undefined in some cases but accessed. `$request->getAllItems() == false` and `$request->getPackageQty() == $freeQty` is true and `!empty($rate) && $rate['price'] >= 0` is false This fixes this

