### PR TITLE
6802: Magento\Search\Helper\getSuggestUrl() not used in search template.

### DIFF
--- a/app/code/Magento/Search/Helper/Data.php
+++ b/app/code/Magento/Search/Helper/Data.php
@@ -124,7 +124,7 @@ class Data extends AbstractHelper
     {
         return $this->_getUrl(
             'search/ajax/suggest',
-            ['_secure' => $this->storeManager->getStore()->isCurrentlySecure()]
+            ['_secure' => $this->_getRequest()->isSecure()]
         );
     }
 

--- a/app/code/Magento/Search/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Search/Test/Unit/Helper/DataTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Search\Test\Unit\Helper;
 
 /**
@@ -43,6 +44,11 @@ class DataTest extends \PHPUnit\Framework\TestCase
      */
     protected $storeManagerMock;
 
+    /**
+     * @var \Magento\Framework\UrlInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $urlBuilderMock;
+
     protected function setUp()
     {
         $this->stringMock = $this->createMock(\Magento\Framework\Stdlib\StringUtils::class);
@@ -53,9 +59,14 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->setMethods([])
             ->getMock();
+        $this->urlBuilderMock = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
+            ->setMethods(['getUrl'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
         $this->contextMock = $this->createMock(\Magento\Framework\App\Helper\Context::class);
         $this->contextMock->expects($this->any())->method('getScopeConfig')->willReturn($this->scopeConfigMock);
         $this->contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
+        $this->contextMock->expects($this->any())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
 
         $this->model = new \Magento\Search\Helper\Data(
             $this->contextMock,
@@ -124,6 +135,41 @@ class DataTest extends \PHPUnit\Framework\TestCase
             [['test'], 100, ''],
             ['test', 100, 'test'],
             ['testtest', 7, 'testtes'],
+        ];
+    }
+
+    /**
+     * Test getSuggestUrl() take into consideration type of request(secure, non-secure).
+     *
+     * @dataProvider getSuggestUrlDataProvider
+     * @param bool $isSecure
+     * @return void
+     */
+    public function testGetSuggestUrl(bool $isSecure)
+    {
+        $this->requestMock->expects(self::once())
+            ->method('isSecure')
+            ->willReturn($isSecure);
+        $this->urlBuilderMock->expects(self::once())
+            ->method('getUrl')
+            ->with(self::identicalTo('search/ajax/suggest'), self::identicalTo(['_secure' => $isSecure]));
+        $this->model->getSuggestUrl();
+    }
+
+    /**
+     * Provide test data for testGetSuggestUrl() test.
+     *
+     * @return array
+     */
+    public function getSuggestUrlDataProvider()
+    {
+        return [
+            'non-secure' => [
+                'isSecure' => false,
+            ],
+            'secure' => [
+                'secure' => true,
+            ],
         ];
     }
 }

--- a/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
@@ -9,7 +9,7 @@
 <?php
 /** @var $block \Magento\Framework\View\Element\Template */
 /** @var $helper \Magento\Search\Helper\Data */
-$helper = $this->helper('Magento\Search\Helper\Data');
+$helper = $this->helper(\Magento\Search\Helper\Data::class);
 ?>
 <div class="block block-search">
     <div class="block block-title"><strong><?= /* @escapeNotVerified */ __('Search') ?></strong></div>
@@ -23,7 +23,7 @@ $helper = $this->helper('Magento\Search\Helper\Data');
                     <input id="search"
                            data-mage-init='{"quickSearch":{
                                 "formSelector":"#search_mini_form",
-                                "url":"<?= /* @escapeNotVerified */ $block->getUrl('search/ajax/suggest', ['_secure' => $block->getRequest()->isSecure()]) ?>",
+                                "url":"<?= /* @escapeNotVerified */ $helper->getSuggestUrl()?>",
                                 "destinationSelector":"#search_autocomplete"}
                            }'
                            type="text"


### PR DESCRIPTION
### Description
Magento\Search\Helper\Data::getSuggestUrl() now used in form.mini.phtml instead of direct call on $block->getUrl().

### Fixed Issues (if relevant)
1. magento/magento2#6802: Magento\Search\Helper\getSuggestUrl() not used in search template

### Manual testing scenarios
1. Create a plugin for Magento\Search\Helper\Data::getSuggestUrl() with method afterGetSuggestUrl() to add custom autosuggest feature(or use just return 'some-test-url-which-leads-nowhere').
2. Type something in the search box.
3. the custom URL should be used(check console, if you use 'some-test-url-which-leads-nowhere'. You should see 404 error with your test url with query params).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
