### PR TITLE
Check variable existence in prepareOptionIds(array) in EavAttribute.php

### DIFF
--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -174,7 +174,7 @@ class EavAttribute
     {
         if (isset($optionsArray['value']) && is_array($optionsArray['value'])) {
             foreach (array_keys($optionsArray['value']) as $optionId) {
-                if (isset($optionsArray['delete']) && $optionsArray['delete'][$optionId] == 1) {
+                if (isset($optionsArray['delete'][$optionId]) && $optionsArray['delete'][$optionId] == 1) {
                     unset($optionsArray['value'][$optionId]);
                 }
             }


### PR DESCRIPTION
### Description
The existence of $optionsArray['delete'] does not guarantee the existence of $optionsArray['delete'][$optionId]

### Fixed Issues (if relevant)
1. Php 500 Error when $optionsArray['delete'][$optionId] is not set
