### PR TITLE
magento/magento2#80428 Coupon codes not showing in invoice #10168

### DIFF
--- a/app/code/Magento/Sales/etc/fieldset.xml
+++ b/app/code/Magento/Sales/etc/fieldset.xml
@@ -488,6 +488,7 @@
             </field>
             <field name="discount_description">
                 <aspect name="to_invoice" />
+                <aspect name="to_cm"/>
             </field>
             <field name="shipping_amount">
                 <aspect name="to_quote_address_shipping" />

--- a/app/code/Magento/Sales/etc/fieldset.xml
+++ b/app/code/Magento/Sales/etc/fieldset.xml
@@ -486,6 +486,10 @@
                 <aspect name="to_quote_address_shipping" />
                 <aspect name="to_cm"/>
             </field>
+            <field name="discount_description">
+                <aspect name="to_invoice" />
+                <aspect name="to_cm"/>
+            </field>
             <field name="shipping_amount">
                 <aspect name="to_quote_address_shipping" />
                 <aspect name="to_cm"/>

--- a/app/code/Magento/Sales/etc/fieldset.xml
+++ b/app/code/Magento/Sales/etc/fieldset.xml
@@ -486,6 +486,9 @@
                 <aspect name="to_quote_address_shipping" />
                 <aspect name="to_cm"/>
             </field>
+            <field name="discount_description">
+                <aspect name="to_invoice" />
+            </field>
             <field name="shipping_amount">
                 <aspect name="to_quote_address_shipping" />
                 <aspect name="to_cm"/>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10168: Coupon codes not showing in invoice
2. If order has coupon code then in a total section previously shows only Discount label without a coupon code.
3. It was creating an Issue because in fieldset.xml `discount_description` field was missing. So I added this field tag in fieldset.xml

          <field name="discount_description">
                <aspect name="to_invoice" />
            </field>

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. I placed one order with coupon code and checked and It is working fine. Please see my screenshot
2. Also, checked invoice.pdf and It is displaying coupon code. (Attached PDF
[invoice2017-10-25_14-22-42.pdf](https://github.com/magento/magento2/files/1414973/invoice2017-10-25_14-22-42.pdf)
)
![000000001 invoices operations sales magento admin](https://user-images.githubusercontent.com/17308601/32005033-8f562c2a-b9a3-11e7-88bf-feec66c71eec.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
