### PR TITLE
[Backport 2.1-develop] Add option to keep Files in Rollback

### DIFF
--- a/lib/internal/Magento/Framework/Backup/AbstractBackup.php
+++ b/lib/internal/Magento/Framework/Backup/AbstractBackup.php
@@ -319,6 +319,11 @@ abstract class AbstractBackup implements BackupInterface
         return $this;
     }
 
+    /**
+     * Get if keep files of backup
+     *
+     * @return boolean
+     */
     public function keepSourceFile()
     {
         return $this->keepSourceFile;

--- a/lib/internal/Magento/Framework/Backup/AbstractBackup.php
+++ b/lib/internal/Magento/Framework/Backup/AbstractBackup.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+
 /**
  * Class to work with archives
  *
@@ -67,6 +70,12 @@ abstract class AbstractBackup implements BackupInterface
      * @var string
      */
     protected $_lastErrorMessage;
+
+    /**
+     *
+     * @var boolean
+     */
+    protected $keepSourceFile = false;
 
     /**
      * Set Backup Extension
@@ -138,14 +147,14 @@ abstract class AbstractBackup implements BackupInterface
      * Set root directory of Magento installation
      *
      * @param string $rootDir
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return $this
      */
     public function setRootDir($rootDir)
     {
         if (!is_dir($rootDir)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Bad root directory')
+            throw new LocalizedException(
+                new Phrase('Bad root directory')
             );
         }
 
@@ -295,5 +304,22 @@ abstract class AbstractBackup implements BackupInterface
         $name = str_replace(' ', '_', $name);
 
         return $name;
+    }
+
+    /**
+     * Set if keep files of backup
+     *
+     * @param boolean $keepSourceFile
+     * @return $this
+     */
+    public function setKeepSourceFile($keepSourceFile)
+    {
+        $this->keepSourceFile = $keepSourceFile;
+        return $this;
+    }
+
+    public function keepSourceFile()
+    {
+        return $this->keepSourceFile;
     }
 }

--- a/lib/internal/Magento/Framework/Backup/AbstractBackup.php
+++ b/lib/internal/Magento/Framework/Backup/AbstractBackup.php
@@ -72,6 +72,7 @@ abstract class AbstractBackup implements BackupInterface
     protected $_lastErrorMessage;
 
     /**
+     * Keep Source files in Backup
      *
      * @var boolean
      */

--- a/lib/internal/Magento/Framework/Backup/BackupInterface.php
+++ b/lib/internal/Magento/Framework/Backup/BackupInterface.php
@@ -65,4 +65,19 @@ interface BackupInterface
      * @return $this
      */
     public function setBackupsDir($backupsDir);
+
+    /**
+     * Check if keep files of backup
+     *
+     * @return boolean
+     */
+    public function keepSourceFile();
+
+    /**
+     * Set if keep files of backup
+     *
+     * @param boolean $keepSourceFile
+     * @return $this
+     */
+    public function setKeepSourceFile($keepSourceFile);
 }

--- a/lib/internal/Magento/Framework/Backup/Db.php
+++ b/lib/internal/Magento/Framework/Backup/Db.php
@@ -47,7 +47,7 @@ class Db extends AbstractBackup
         foreach ($file as $statement) {
             $this->getResourceModel()->runCommand($statement);
         }
-        if ($this->keepSourceFile()) {
+        if (!$this->keepSourceFile()) {
             @unlink($source);
         }
 

--- a/lib/internal/Magento/Framework/Backup/Db.php
+++ b/lib/internal/Magento/Framework/Backup/Db.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Archive;
+use Magento\Framework\Backup\Filesystem\Iterator\File;
+
 /**
  * Class to work with database backups
  *
@@ -37,14 +40,16 @@ class Db extends AbstractBackup
 
         $this->_lastOperationSucceed = false;
 
-        $archiveManager = new \Magento\Framework\Archive();
+        $archiveManager = new Archive();
         $source = $archiveManager->unpack($this->getBackupPath(), $this->getBackupsDir());
 
-        $file = new \Magento\Framework\Backup\Filesystem\Iterator\File($source);
+        $file = new File($source);
         foreach ($file as $statement) {
             $this->getResourceModel()->runCommand($statement);
         }
-        @unlink($source);
+        if ($this->keepSourceFile()) {
+            @unlink($source);
+        }
 
         $this->_lastOperationSucceed = true;
 
@@ -57,7 +62,7 @@ class Db extends AbstractBackup
      * @param string $line
      * @return bool
      */
-    protected function _isLineLastInCommand($line)
+    protected function isLineLastInCommand($line)
     {
         $cleanLine = trim($line);
         $lineLength = strlen($cleanLine);

--- a/lib/internal/Magento/Framework/Backup/Db/BackupDbInterface.php
+++ b/lib/internal/Magento/Framework/Backup/Db/BackupDbInterface.php
@@ -13,7 +13,7 @@ interface BackupDbInterface
      * @param BackupInterface $backup
      * @return void
      */
-    public function createBackup(\Magento\Framework\Backup\Db\BackupInterface $backup);
+    public function createBackup(BackupInterface $backup);
 
     /**
      * Get database backup size

--- a/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
+++ b/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
@@ -8,35 +8,37 @@
 
 namespace Magento\Framework\Backup\Db;
 
+use Magento\Framework\ObjectManagerInterface;
+
 class BackupFactory
 {
     /**
      * Object manager
      *
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
-    private $_objectManager;
+    private $objectManager;
 
     /**
      * @var string
      */
-    private $_backupInstanceName;
+    private $backupInstanceName;
 
     /**
      * @var string
      */
-    private $_backupDbInstanceName;
+    private $backupDbInstanceName;
 
     /**
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      * @param string $backupInstanceName
      * @param string $backupDbInstanceName
      */
-    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager, $backupInstanceName, $backupDbInstanceName)
+    public function __construct(ObjectManagerInterface $objectManager, $backupInstanceName, $backupDbInstanceName)
     {
-        $this->_objectManager = $objectManager;
-        $this->_backupInstanceName = $backupInstanceName;
-        $this->_backupDbInstanceName = $backupDbInstanceName;
+        $this->objectManager = $objectManager;
+        $this->backupInstanceName = $backupInstanceName;
+        $this->backupDbInstanceName = $backupDbInstanceName;
     }
 
     /**
@@ -47,7 +49,7 @@ class BackupFactory
      */
     public function createBackupModel(array $arguments = [])
     {
-        return $this->_objectManager->create($this->_backupInstanceName, $arguments);
+        return $this->objectManager->create($this->backupInstanceName, $arguments);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Backup/Factory.php
+++ b/lib/internal/Magento/Framework/Backup/Factory.php
@@ -10,6 +10,9 @@
 
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+
 class Factory
 {
     /**
@@ -17,7 +20,7 @@ class Factory
      *
      * @var \Magento\Framework\ObjectManagerInterface
      */
-    private $_objectManager;
+    private $objectManager;
 
     /**
      * Backup type constant for database backup
@@ -56,7 +59,7 @@ class Factory
      */
     public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager)
     {
-        $this->_objectManager = $objectManager;
+        $this->objectManager = $objectManager;
         $this->_allowedTypes = [
             self::TYPE_DB,
             self::TYPE_FILESYSTEM,
@@ -71,19 +74,19 @@ class Factory
      *
      * @param string $type
      * @return BackupInterface
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function create($type)
     {
         if (!in_array($type, $this->_allowedTypes)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase(
+            throw new LocalizedException(
+                new Phrase(
                     'Current implementation not supported this type (%1) of backup.',
                     [$type]
                 )
             );
         }
         $class = 'Magento\Framework\Backup\\' . ucfirst($type);
-        return $this->_objectManager->create($class);
+        return $this->objectManager->create($class);
     }
 }

--- a/lib/internal/Magento/Framework/Backup/Filesystem.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem.php
@@ -7,7 +7,16 @@
 // @codingStandardsIgnoreFile
 
 namespace Magento\Framework\Backup;
-use Magento\Framework\Filesystem\DriverInterface;
+
+use Magento\Framework\Archive\Gz;
+use Magento\Framework\Backup\Archive\Tar;
+use Magento\Framework\Backup\Exception\NotEnoughFreeSpace;
+use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Filesystem\Helper;
+use Magento\Framework\Backup\Filesystem\Rollback\Fs;
+use Magento\Framework\Backup\Filesystem\Rollback\Ftp;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
 
 /**
  * Class to work with filesystem backups
@@ -61,7 +70,7 @@ class Filesystem extends AbstractBackup
     /**
      * Implementation Rollback functionality for Filesystem
      *
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return bool
      */
     public function rollback()
@@ -71,9 +80,9 @@ class Filesystem extends AbstractBackup
         set_time_limit(0);
         ignore_user_abort(true);
 
-        $rollbackWorker = $this->_useFtp ? new \Magento\Framework\Backup\Filesystem\Rollback\Ftp(
+        $rollbackWorker = $this->_useFtp ? new Ftp(
             $this
-        ) : new \Magento\Framework\Backup\Filesystem\Rollback\Fs(
+        ) : new Fs(
             $this
         );
         $rollbackWorker->run();
@@ -85,7 +94,7 @@ class Filesystem extends AbstractBackup
     /**
      * Implementation Create Backup functionality for Filesystem
      *
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return boolean
      */
     public function create()
@@ -97,40 +106,40 @@ class Filesystem extends AbstractBackup
 
         $this->_checkBackupsDir();
 
-        $fsHelper = new \Magento\Framework\Backup\Filesystem\Helper();
+        $fsHelper = new Helper();
 
         $filesInfo = $fsHelper->getInfo(
             $this->getRootDir(),
-            \Magento\Framework\Backup\Filesystem\Helper::INFO_READABLE | \Magento\Framework\Backup\Filesystem\Helper::INFO_SIZE,
+            Helper::INFO_READABLE | Helper::INFO_SIZE,
             $this->getIgnorePaths()
         );
 
         if (!$filesInfo['readable']) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Not enough permissions to read files for backup')
+            throw new NotEnoughPermissions(
+                new Phrase('Not enough permissions to read files for backup')
             );
         }
         $this->validateAvailableDiscSpace($this->getBackupsDir(), $filesInfo['size']);
 
         $tarTmpPath = $this->_getTarTmpPath();
 
-        $tarPacker = new \Magento\Framework\Backup\Archive\Tar();
+        $tarPacker = new Tar();
         $tarPacker->setSkipFiles($this->getIgnorePaths())->pack($this->getRootDir(), $tarTmpPath, true);
 
         if (!is_file($tarTmpPath) || filesize($tarTmpPath) == 0) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Failed to create backup')
+            throw new LocalizedException(
+                new Phrase('Failed to create backup')
             );
         }
 
         $backupPath = $this->getBackupPath();
 
-        $gzPacker = new \Magento\Framework\Archive\Gz();
+        $gzPacker = new Gz();
         $gzPacker->pack($tarTmpPath, $backupPath);
 
         if (!is_file($backupPath) || filesize($backupPath) == 0) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Failed to create backup')
+            throw new LocalizedException(
+                new Phrase('Failed to create backup')
             );
         }
 
@@ -146,17 +155,17 @@ class Filesystem extends AbstractBackup
      * @param string $backupDir
      * @param int $size
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function validateAvailableDiscSpace($backupDir, $size)
     {
         $freeSpace = disk_free_space($backupDir);
         $requiredSpace = 2 * $size;
         if ($requiredSpace > $freeSpace) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughFreeSpace(
-                new \Magento\Framework\Phrase(
-                'Warning: necessary space for backup is ' . (ceil($requiredSpace)/1024)
-                . 'MB, but your free disc space is ' . (ceil($freeSpace)/1024) . 'MB.'
+            throw new NotEnoughFreeSpace(
+                new Phrase(
+                'Warning: necessary space for backup is ' . (ceil($requiredSpace) / 1024)
+                . 'MB, but your free disc space is ' . (ceil($freeSpace) / 1024) . 'MB.'
                 )
             );
         }
@@ -173,7 +182,7 @@ class Filesystem extends AbstractBackup
      */
     public function setUseFtp($host, $username, $password, $path)
     {
-        $this->_useFtp = true;
+        $this->_useFtp  = true;
         $this->_ftpHost = $host;
         $this->_ftpUser = $username;
         $this->_ftpPass = $password;
@@ -263,7 +272,7 @@ class Filesystem extends AbstractBackup
      * Check backups directory existence and whether it's writeable
      *
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     protected function _checkBackupsDir()
     {
@@ -273,8 +282,8 @@ class Filesystem extends AbstractBackup
             $backupsDirParentDirectory = basename($backupsDir);
 
             if (!is_writeable($backupsDirParentDirectory)) {
-                throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                    new \Magento\Framework\Phrase('Cant create backups directory')
+                throw new NotEnoughPermissions(
+                    new Phrase('Cant create backups directory')
                 );
             }
 
@@ -283,8 +292,8 @@ class Filesystem extends AbstractBackup
         }
 
         if (!is_writable($backupsDir)) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Backups directory is not writeable')
+            throw new NotEnoughPermissions(
+                new Phrase('Backups directory is not writeable')
             );
         }
     }

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Helper.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Helper.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Framework\Backup\Filesystem;
 
+use Magento\Framework\Backup\Filesystem\Iterator\Filter;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 /**
  * Filesystem helper
  *
@@ -56,12 +60,12 @@ class Helper
      */
     public function rm($path, $skipPaths = [], $removeRoot = false)
     {
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $skipPaths);
+        $iterator = new Filter($filesystemIterator, $skipPaths);
 
         foreach ($iterator as $item) {
             $item->isDir() ? @rmdir($item->__toString()) : @unlink($item->__toString());
@@ -97,12 +101,12 @@ class Helper
             $info['size'] = 0;
         }
 
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $skipFiles);
+        $iterator = new Filter($filesystemIterator, $skipFiles);
 
         foreach ($iterator as $item) {
             if ($item->isLink()) {

--- a/lib/internal/Magento/Framework/Backup/Media.php
+++ b/lib/internal/Magento/Framework/Backup/Media.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\Backup;
 
-
 /**
  * Class to work media folder and database backups
  *

--- a/lib/internal/Magento/Framework/Backup/Snapshot.php
+++ b/lib/internal/Magento/Framework/Backup/Snapshot.php
@@ -41,7 +41,7 @@ class Snapshot extends Filesystem
      */
     public function __construct(AppFilesystem $filesystem, Factory $backupFactory)
     {
-        $this->_filesystem = $filesystem;
+        $this->_filesystem    = $filesystem;
         $this->_backupFactory = $backupFactory;
     }
 

--- a/lib/internal/Magento/Framework/Setup/BackupRollback.php
+++ b/lib/internal/Magento/Framework/Setup/BackupRollback.php
@@ -7,13 +7,12 @@
 namespace Magento\Framework\Setup;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Backup\Factory;
 use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Factory;
 use Magento\Framework\Backup\Filesystem;
 use Magento\Framework\Backup\Filesystem\Helper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\Driver\File;
-use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Phrase;
 
@@ -129,7 +128,7 @@ class BackupRollback
         $this->log->log($granularType . ' backup is starting...');
         $fsBackup->create();
         $this->log->log(
-            $granularType. ' backup filename: ' . $fsBackup->getBackupFilename()
+            $granularType . ' backup filename: ' . $fsBackup->getBackupFilename()
             . ' (The archive can be uncompressed with 7-Zip on Windows systems)'
         );
         $this->log->log($granularType . ' backup path: ' . $fsBackup->getBackupPath());
@@ -142,10 +141,11 @@ class BackupRollback
      *
      * @param string $rollbackFile
      * @param string $type
+     * @param boolean $keepSourceFile
      * @return void
      * @throws LocalizedException
      */
-    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM)
+    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM, $keepSourceFile)
     {
         if (preg_match('/[0-9]_(filesystem)_(code|media)\.(tgz)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -183,6 +183,7 @@ class BackupRollback
         $time = explode('_', $rollbackFile);
         $fsRollback->setTime($time[0]);
         $this->log->log($granularType . ' rollback is starting ...');
+        $fsRollback->setKeepSourceFile($keepSourceFile);
         $fsRollback->rollback();
         $this->log->log($granularType . ' rollback filename: ' . $fsRollback->getBackupFilename());
         $this->log->log($granularType . ' rollback file path: ' . $fsRollback->getBackupPath());
@@ -218,10 +219,11 @@ class BackupRollback
      * Roll back database
      *
      * @param string $rollbackFile
+     * @param boolean $keepDbFile
      * @return void
      * @throws LocalizedException
      */
-    public function dbRollback($rollbackFile)
+    public function dbRollback($rollbackFile, $keepDbFile)
     {
         if (preg_match('/[0-9]_(db)(.*?).(sql)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -242,6 +244,7 @@ class BackupRollback
         $dbRollback->setTime($time[0]);
         $this->log->log('DB rollback is starting...');
         $dbRollback->setResourceModel($this->objectManager->create('Magento\Backup\Model\ResourceModel\Db'));
+        $dbRollback->setKeepSourceFile($keepDbFile);
         $dbRollback->rollback();
         $this->log->log('DB rollback filename: ' . $dbRollback->getBackupFilename());
         $this->log->log('DB rollback path: ' . $dbRollback->getBackupPath());

--- a/lib/internal/Magento/Framework/Setup/BackupRollback.php
+++ b/lib/internal/Magento/Framework/Setup/BackupRollback.php
@@ -145,7 +145,7 @@ class BackupRollback
      * @return void
      * @throws LocalizedException
      */
-    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM, $keepSourceFile)
+    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM, $keepSourceFile = false)
     {
         if (preg_match('/[0-9]_(filesystem)_(code|media)\.(tgz)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -223,7 +223,7 @@ class BackupRollback
      * @return void
      * @throws LocalizedException
      */
-    public function dbRollback($rollbackFile, $keepDbFile)
+    public function dbRollback($rollbackFile, $keepDbFile = false)
     {
         if (preg_match('/[0-9]_(db)(.*?).(sql)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -127,9 +127,15 @@ class RollbackCommand extends AbstractSetupCommand
             if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {
                 return \Magento\Framework\Console\Cli::RETURN_FAILURE;
             }
-            $this->doRollback($input, $output);
-            $output->writeln('<info>Please set file permission of bin/magento to executable</info>');
 
+            $questionKeep = new ConfirmationQuestion(
+                '<info>you want to keep the backups?[y/N]<info>',
+                false
+            );
+            $keep = $helper->ask($input, $output, $questionKeep);
+
+            $this->doRollback($input, $output, $keep);
+            $output->writeln('<info>Please set file permission of bin/magento to executable</info>');
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             // we must have an exit code higher than zero to indicate something was wrong
@@ -146,24 +152,25 @@ class RollbackCommand extends AbstractSetupCommand
      *
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @param boolean $keep
      * @return void
      * @throws \InvalidArgumentException
      */
-    private function doRollback(InputInterface $input, OutputInterface $output)
+    private function doRollback(InputInterface $input, OutputInterface $output, $keep)
     {
         $inputOptionProvided = false;
         $rollbackHandler = $this->backupRollbackFactory->create($output);
         if ($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE));
+            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE), $keep);
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA);
+            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA, $keep);
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE)) {
             $this->setAreaCode();
-            $rollbackHandler->dbRollback($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE));
+            $rollbackHandler->dbRollback($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE), $keep);
             $inputOptionProvided = true;
         }
         if (!$inputOptionProvided) {

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -165,8 +165,11 @@ class RollbackCommand extends AbstractSetupCommand
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA,
-                $keep);
+            $rollbackHandler->codeRollback(
+                $input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE),
+                Factory::TYPE_MEDIA,
+                $keep
+            );
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE)) {

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -165,7 +165,8 @@ class RollbackCommand extends AbstractSetupCommand
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA, $keep);
+            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA,
+                $keep);
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE)) {

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/RollbackCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/RollbackCommandTest.php
@@ -177,7 +177,7 @@ class RollbackCommandTest extends \PHPUnit_Framework_TestCase
             ->method('isAvailable')
             ->will($this->returnValue(true));
         $this->question
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('ask')
             ->will($this->returnValue(false));
         $this->helperSet


### PR DESCRIPTION
Add option to keep files in rollback and improve Readability and PSR of Backup Library
### Description
Ask to user when launch command: `bin/magento setup:rollback` if he wants keep files to future rollbacks. Also I changed variable name protected with underscore to acomplish PSR and I imported all classes to use in class.

### Fixed Issues (if relevant)
1. magento/magento2#6460: [2.1.1 CE] Rollback/Restore deletes database (--db) backup file in ${webroot}/var/backups.

### Manual testing scenarios
1. create backup  e.g: `bin/magento setup:backup --media`
2. rollback backup e.g: `bin/magento setup:rollback -m 1508950479_filesystem_media.tgz`
3. Answer `y` to question: `you want to keep the backups?[y/N]`
4. Check that your backup was kept in `var/backups`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
