### PR TITLE
[Backport 2.1-develop] Remove hardcoding for Magento_Backend::admin in ACL tree

### DIFF
--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Activate/Permissions/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Activate/Permissions/Tab/Webapi.php
@@ -148,7 +148,11 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
     public function getResourcesTreeJson()
     {
         $resources = $this->_resourceProvider->getAclResources();
-        $aclResourcesTree = $this->_integrationData->mapResources($resources[1]['children']);
+        $configResource = array_filter($resources, function ($node) {
+            return isset($node['id']) && $node['id'] == 'Magento_Backend::admin';
+        });
+        $configResource = reset($configResource);
+        $aclResourcesTree = $this->_integrationData->mapResources($configResource['children']);
 
         return $this->encoder->encode($aclResourcesTree);
     }
@@ -167,7 +171,11 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
         $selectedResources = $this->_selectedResources;
         if ($this->isEverythingAllowed()) {
             $resources = $this->_resourceProvider->getAclResources();
-            $selectedResources = $this->_getAllResourceIds($resources[1]['children']);
+            $configResource = array_filter($resources, function ($node) {
+                return isset($node['id']) && $node['id'] == 'Magento_Backend::admin';
+            });
+            $configResource = reset($configResource);
+            $selectedResources = $this->_getAllResourceIds($configResource['children']);
         }
         return $this->encoder->encode($selectedResources);
     }

--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
@@ -141,7 +141,7 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
 
     /**
      * Retrieve saved resource
-     * 
+     *
      * @return array|bool
      */
     protected function retrieveFormResources()
@@ -176,8 +176,12 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
     public function getTree()
     {
         $resources = $this->aclResourceProvider->getAclResources();
+        $configResource = array_filter($resources, function ($node) {
+            return isset($node['id']) && $node['id'] == 'Magento_Backend::admin';
+        });
+        $configResource = reset($configResource);
         $rootArray = $this->integrationData->mapResources(
-            isset($resources[1]['children']) ? $resources[1]['children'] : []
+            isset($configResource['children']) ? $configResource['children'] : []
         );
         return $rootArray;
     }

--- a/app/code/Magento/Integration/Test/Unit/Block/Adminhtml/Integration/Edit/Tab/WebapiTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Block/Adminhtml/Integration/Edit/Tab/WebapiTest.php
@@ -155,7 +155,7 @@ class WebapiTest extends \PHPUnit_Framework_TestCase
     {
         $this->webapiBlock = $this->getWebapiBlock();
         $resources = [
-            1 => [ 'children' => [1, 2, 3] ]
+            1 => [ 'id' => 'Magento_Backend::admin', 'children' => [1, 2, 3] ]
         ];
         $this->aclResourceProvider->expects($this->once())
             ->method('getAclResources')

--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -199,8 +199,12 @@ class Edit extends \Magento\Backend\Block\Widget\Form implements \Magento\Backen
     public function getTree()
     {
         $resources = $this->_aclResourceProvider->getAclResources();
+        $configResource = array_filter($resources, function ($node) {
+            return isset($node['id']) && $node['id'] == 'Magento_Backend::admin';
+        });
+        $configResource = reset($configResource);
         $rootArray = $this->_integrationData->mapResources(
-            isset($resources[1]['children']) ? $resources[1]['children'] : []
+            isset($configResource['children']) ? $configResource['children'] : []
         );
         return $rootArray;
     }


### PR DESCRIPTION
This backports a removal of the hardcoding the array index of
Magento_Backend::admin in the resources ACL tree

Original commit 66d19602e9627b2c446dd5445ff62bfbc2eea2b6