### PR TITLE
[Backport 2.2-develop] Add option to keep Files in Rollback

### DIFF
--- a/lib/internal/Magento/Framework/Backup/AbstractBackup.php
+++ b/lib/internal/Magento/Framework/Backup/AbstractBackup.php
@@ -5,12 +5,15 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+
 /**
  * Class to work with archives
  *
  * @api
  */
-abstract class AbstractBackup implements BackupInterface
+abstract class AbstractBackup implements BackupInterface, SourceFileInterface
 {
     /**
      * Backup name
@@ -67,6 +70,11 @@ abstract class AbstractBackup implements BackupInterface
      * @var string
      */
     protected $_lastErrorMessage;
+
+    /**
+     * @var boolean
+     */
+    private $keepSourceFile = false;
 
     /**
      * Set Backup Extension
@@ -138,14 +146,14 @@ abstract class AbstractBackup implements BackupInterface
      * Set root directory of Magento installation
      *
      * @param string $rootDir
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return $this
      */
     public function setRootDir($rootDir)
     {
         if (!is_dir($rootDir)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Bad root directory')
+            throw new LocalizedException(
+                new Phrase('Bad root directory')
             );
         }
 
@@ -295,5 +303,25 @@ abstract class AbstractBackup implements BackupInterface
         $name = str_replace(' ', '_', $name);
 
         return $name;
+    }
+
+    /**
+     * Set if keep files of backup
+     *
+     * @param bool $keepSourceFile
+     * @return $this
+     */
+    public function setKeepSourceFile(bool $keepSourceFile)
+    {
+        $this->keepSourceFile = $keepSourceFile;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function keepSourceFile()
+    {
+        return $this->keepSourceFile;
     }
 }

--- a/lib/internal/Magento/Framework/Backup/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Backup/Archive/Tar.php
@@ -11,6 +11,10 @@
  */
 namespace Magento\Framework\Backup\Archive;
 
+use Magento\Framework\Backup\Filesystem\Iterator\Filter;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 class Tar extends \Magento\Framework\Archive\Tar
 {
     /**
@@ -35,12 +39,12 @@ class Tar extends \Magento\Framework\Archive\Tar
     {
         $path = $this->_getCurrentFile();
 
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::SELF_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::SELF_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter(
+        $iterator = new Filter(
             $filesystemIterator,
             $this->_skipFiles
         );

--- a/lib/internal/Magento/Framework/Backup/Db.php
+++ b/lib/internal/Magento/Framework/Backup/Db.php
@@ -45,7 +45,9 @@ class Db extends AbstractBackup
         foreach ($file as $statement) {
             $this->getResourceModel()->runCommand($statement);
         }
-        @unlink($source);
+        if ($this->keepSourceFile() === false) {
+            @unlink($source);
+        }
 
         $this->_lastOperationSucceed = true;
 

--- a/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
+++ b/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Framework\Backup\Db;
 
+use Magento\Framework\ObjectManagerInterface;
+
 /**
  * @api
  */
@@ -14,7 +16,7 @@ class BackupFactory
     /**
      * Object manager
      *
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     private $_objectManager;
 
@@ -29,12 +31,12 @@ class BackupFactory
     private $_backupDbInstanceName;
 
     /**
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      * @param string $backupInstanceName
      * @param string $backupDbInstanceName
      */
     public function __construct(
-        \Magento\Framework\ObjectManagerInterface $objectManager,
+        ObjectManagerInterface $objectManager,
         $backupInstanceName,
         $backupDbInstanceName
     ) {

--- a/lib/internal/Magento/Framework/Backup/Factory.php
+++ b/lib/internal/Magento/Framework/Backup/Factory.php
@@ -9,6 +9,10 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Phrase;
+
 /**
  * @api
  */
@@ -17,7 +21,7 @@ class Factory
     /**
      * Object manager
      *
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     private $_objectManager;
 
@@ -54,9 +58,9 @@ class Factory
     protected $_allowedTypes;
 
     /**
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      */
-    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager)
+    public function __construct(ObjectManagerInterface $objectManager)
     {
         $this->_objectManager = $objectManager;
         $this->_allowedTypes = [
@@ -73,13 +77,13 @@ class Factory
      *
      * @param string $type
      * @return BackupInterface
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function create($type)
     {
         if (!in_array($type, $this->_allowedTypes)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase(
+            throw new LocalizedException(
+                new Phrase(
                     'Current implementation not supported this type (%1) of backup.',
                     [$type]
                 )

--- a/lib/internal/Magento/Framework/Backup/Filesystem.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem.php
@@ -7,6 +7,14 @@
 namespace Magento\Framework\Backup;
 
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Backup\Archive\Tar;
+use Magento\Framework\Backup\Exception\NotEnoughFreeSpace;
+use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Filesystem\Helper;
+use Magento\Framework\Backup\Filesystem\Rollback\Fs;
+use Magento\Framework\Backup\Filesystem\Rollback\Ftp;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
 
 /**
  * Class to work with filesystem backups
@@ -58,19 +66,19 @@ class Filesystem extends AbstractBackup
     protected $_ftpPath;
 
     /**
-     * @var \Magento\Framework\Backup\Filesystem\Rollback\Ftp
+     * @var Ftp
      */
     protected $rollBackFtp;
 
     /**
-     * @var \Magento\Framework\Backup\Filesystem\Rollback\Fs
+     * @var Fs
      */
     protected $rollBackFs;
 
     /**
      * Implementation Rollback functionality for Filesystem
      *
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return bool
      */
     public function rollback()
@@ -90,7 +98,7 @@ class Filesystem extends AbstractBackup
     /**
      * Implementation Create Backup functionality for Filesystem
      *
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return boolean
      */
     public function create()
@@ -102,30 +110,30 @@ class Filesystem extends AbstractBackup
 
         $this->_checkBackupsDir();
 
-        $fsHelper = new \Magento\Framework\Backup\Filesystem\Helper();
+        $fsHelper = new Helper();
 
         $filesInfo = $fsHelper->getInfo(
             $this->getRootDir(),
-            \Magento\Framework\Backup\Filesystem\Helper::INFO_READABLE |
-            \Magento\Framework\Backup\Filesystem\Helper::INFO_SIZE,
+            Helper::INFO_READABLE |
+            Helper::INFO_SIZE,
             $this->getIgnorePaths()
         );
 
         if (!$filesInfo['readable']) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Not enough permissions to read files for backup')
+            throw new NotEnoughPermissions(
+                new Phrase('Not enough permissions to read files for backup')
             );
         }
         $this->validateAvailableDiscSpace($this->getBackupsDir(), $filesInfo['size']);
 
         $tarTmpPath = $this->_getTarTmpPath();
 
-        $tarPacker = new \Magento\Framework\Backup\Archive\Tar();
+        $tarPacker = new Tar();
         $tarPacker->setSkipFiles($this->getIgnorePaths())->pack($this->getRootDir(), $tarTmpPath, true);
 
         if (!is_file($tarTmpPath) || filesize($tarTmpPath) == 0) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Failed to create backup')
+            throw new LocalizedException(
+                new Phrase('Failed to create backup')
             );
         }
 
@@ -135,8 +143,8 @@ class Filesystem extends AbstractBackup
         $gzPacker->pack($tarTmpPath, $backupPath);
 
         if (!is_file($backupPath) || filesize($backupPath) == 0) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Failed to create backup')
+            throw new LocalizedException(
+                new Phrase('Failed to create backup')
             );
         }
 
@@ -152,15 +160,15 @@ class Filesystem extends AbstractBackup
      * @param string $backupDir
      * @param int $size
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function validateAvailableDiscSpace($backupDir, $size)
     {
         $freeSpace = disk_free_space($backupDir);
         $requiredSpace = 2 * $size;
         if ($requiredSpace > $freeSpace) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughFreeSpace(
-                new \Magento\Framework\Phrase(
+            throw new NotEnoughFreeSpace(
+                new Phrase(
                     'Warning: necessary space for backup is ' . (ceil($requiredSpace) / 1024)
                     . 'MB, but your free disc space is ' . (ceil($freeSpace) / 1024) . 'MB.'
                 )
@@ -269,7 +277,7 @@ class Filesystem extends AbstractBackup
      * Check backups directory existence and whether it's writeable
      *
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     protected function _checkBackupsDir()
     {
@@ -279,8 +287,8 @@ class Filesystem extends AbstractBackup
             $backupsDirParentDirectory = basename($backupsDir);
 
             if (!is_writeable($backupsDirParentDirectory)) {
-                throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                    new \Magento\Framework\Phrase('Cant create backups directory')
+                throw new NotEnoughPermissions(
+                    new Phrase('Cant create backups directory')
                 );
             }
 
@@ -289,8 +297,8 @@ class Filesystem extends AbstractBackup
         }
 
         if (!is_writable($backupsDir)) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Backups directory is not writeable')
+            throw new NotEnoughPermissions(
+                new Phrase('Backups directory is not writeable')
             );
         }
     }
@@ -307,14 +315,14 @@ class Filesystem extends AbstractBackup
     }
 
     /**
-     * @return \Magento\Framework\Backup\Filesystem\Rollback\Ftp
+     * @return Ftp
      * @deprecated 100.2.0
      */
     protected function getRollBackFtp()
     {
         if (!$this->rollBackFtp) {
             $this->rollBackFtp = ObjectManager::getInstance()->create(
-                \Magento\Framework\Backup\Filesystem\Rollback\Ftp::class,
+                Ftp::class,
                 ['snapshotObject' => $this]
             );
         }
@@ -323,14 +331,14 @@ class Filesystem extends AbstractBackup
     }
 
     /**
-     * @return \Magento\Framework\Backup\Filesystem\Rollback\Fs
+     * @return Fs
      * @deprecated 100.2.0
      */
     protected function getRollBackFs()
     {
         if (!$this->rollBackFs) {
             $this->rollBackFs = ObjectManager::getInstance()->create(
-                \Magento\Framework\Backup\Filesystem\Rollback\Fs::class,
+                Fs::class,
                 ['snapshotObject' => $this]
             );
         }

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Helper.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Helper.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Framework\Backup\Filesystem;
 
+use Magento\Framework\Backup\Filesystem\Iterator\Filter;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 /**
  * Filesystem helper
  *
@@ -56,12 +60,12 @@ class Helper
      */
     public function rm($path, $skipPaths = [], $removeRoot = false)
     {
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $skipPaths);
+        $iterator = new Filter($filesystemIterator, $skipPaths);
 
         foreach ($iterator as $item) {
             $item->isDir() ? @rmdir($item->__toString()) : @unlink($item->__toString());
@@ -99,12 +103,12 @@ class Helper
             $info['size'] = 0;
         }
 
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $skipFiles);
+        $iterator = new Filter($filesystemIterator, $skipFiles);
 
         foreach ($iterator as $item) {
             if ($item->isLink()) {

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/AbstractRollback.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/AbstractRollback.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\Backup\Filesystem\Rollback;
 
+use Magento\Framework\Backup\Filesystem;
+
 /**
  * Filesystem rollback workers abstract class
  *
@@ -15,16 +17,16 @@ abstract class AbstractRollback
     /**
      * Snapshot object
      *
-     * @var \Magento\Framework\Backup\Filesystem
+     * @var Filesystem
      */
     protected $_snapshot;
 
     /**
      * Default worker constructor
      *
-     * @param \Magento\Framework\Backup\Filesystem $snapshotObject
+     * @param Filesystem $snapshotObject
      */
-    public function __construct(\Magento\Framework\Backup\Filesystem $snapshotObject)
+    public function __construct(Filesystem $snapshotObject)
     {
         $this->_snapshot = $snapshotObject;
     }

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/Fs.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/Fs.php
@@ -6,6 +6,16 @@
 namespace Magento\Framework\Backup\Filesystem\Rollback;
 
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Archive;
+use Magento\Framework\Archive\Gz;
+use Magento\Framework\Archive\Helper\File;
+use Magento\Framework\Archive\Helper\File\Gz as HelperGz;
+use Magento\Framework\Archive\Tar;
+use Magento\Framework\Backup\Exception\CantLoadSnapshot;
+use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Filesystem\Helper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
 
 /**
  * Rollback worker for rolling back via local filesystem
@@ -15,7 +25,7 @@ use Magento\Framework\App\ObjectManager;
 class Fs extends AbstractRollback
 {
     /**
-     * @var \Magento\Framework\Backup\Filesystem\Helper
+     * @var Helper
      */
     private $fsHelper;
 
@@ -23,7 +33,7 @@ class Fs extends AbstractRollback
      * Files rollback implementation via local filesystem
      *
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      *
      * @see AbstractRollback::run()
      */
@@ -32,8 +42,8 @@ class Fs extends AbstractRollback
         $snapshotPath = $this->_snapshot->getBackupPath();
 
         if (!is_file($snapshotPath) || !is_readable($snapshotPath)) {
-            throw new \Magento\Framework\Backup\Exception\CantLoadSnapshot(
-                new \Magento\Framework\Phrase('Can\'t load snapshot archive')
+            throw new CantLoadSnapshot(
+                new Phrase('Can\'t load snapshot archive')
             );
         }
 
@@ -41,49 +51,53 @@ class Fs extends AbstractRollback
 
         $filesInfo = $fsHelper->getInfo(
             $this->_snapshot->getRootDir(),
-            \Magento\Framework\Backup\Filesystem\Helper::INFO_WRITABLE,
+            Helper::INFO_WRITABLE,
             $this->_snapshot->getIgnorePaths()
         );
 
         if (!$filesInfo['writable']) {
             if (!empty($filesInfo['writableMeta'])) {
-                throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                    new \Magento\Framework\Phrase(
+                throw new NotEnoughPermissions(
+                    new Phrase(
                         'You need write permissions for: %1',
                         [implode(', ', $filesInfo['writableMeta'])]
                     )
                 );
             }
 
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Unable to make rollback because not all files are writable')
+            throw new NotEnoughPermissions(
+                new Phrase('Unable to make rollback because not all files are writable')
             );
         }
 
-        $archiver = new \Magento\Framework\Archive();
+        $archiver = new Archive();
 
         /**
          * we need these fake initializations because all magento's files in filesystem will be deleted and autoloader
          * wont be able to load classes that we need for unpacking
          */
-        new \Magento\Framework\Archive\Tar();
-        new \Magento\Framework\Archive\Gz();
-        new \Magento\Framework\Archive\Helper\File('');
-        new \Magento\Framework\Archive\Helper\File\Gz('');
-        new \Magento\Framework\Exception\LocalizedException(new \Magento\Framework\Phrase('dummy'));
+        new Tar();
+        new Gz();
+        new File('');
+        new HelperGz('');
+        new LocalizedException(new Phrase('dummy'));
 
         $fsHelper->rm($this->_snapshot->getRootDir(), $this->_snapshot->getIgnorePaths());
         $archiver->unpack($snapshotPath, $this->_snapshot->getRootDir());
+
+        if ($this->_snapshot->keepSourceFile() === false) {
+            @unlink($snapshotPath);
+        }
     }
 
     /**
-     * @return \Magento\Framework\Backup\Filesystem\Helper
+     * @return Helper
      * @deprecated 100.2.0
      */
     private function getFsHelper()
     {
         if (!$this->fsHelper) {
-            $this->fsHelper = ObjectManager::getInstance()->get(\Magento\Framework\Backup\Filesystem\Helper::class);
+            $this->fsHelper = ObjectManager::getInstance()->get(Helper::class);
         }
 
         return $this->fsHelper;

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/Ftp.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/Ftp.php
@@ -5,7 +5,17 @@
  */
 namespace Magento\Framework\Backup\Filesystem\Rollback;
 
-use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\Archive;
+use Magento\Framework\Backup\Exception\CantLoadSnapshot;
+use Magento\Framework\Backup\Exception\FtpConnectionFailed;
+use Magento\Framework\Backup\Exception\FtpValidationFailed;
+use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Filesystem\Helper;
+use Magento\Framework\Backup\Filesystem\Iterator\Filter;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Rollback worker for rolling back via ftp
@@ -25,7 +35,7 @@ class Ftp extends AbstractRollback
      * Files rollback implementation via ftp
      *
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      *
      * @see AbstractRollback::run()
      */
@@ -34,8 +44,8 @@ class Ftp extends AbstractRollback
         $snapshotPath = $this->_snapshot->getBackupPath();
 
         if (!is_file($snapshotPath) || !is_readable($snapshotPath)) {
-            throw new \Magento\Framework\Backup\Exception\CantLoadSnapshot(
-                new \Magento\Framework\Phrase('Can\'t load snapshot archive')
+            throw new CantLoadSnapshot(
+                new Phrase('Can\'t load snapshot archive')
             );
         }
 
@@ -45,19 +55,22 @@ class Ftp extends AbstractRollback
         $tmpDir = $this->_createTmpDir();
         $this->_unpackSnapshot($tmpDir);
 
-        $fsHelper = new \Magento\Framework\Backup\Filesystem\Helper();
+        $fsHelper = new Helper();
 
         $this->_cleanupFtp();
         $this->_uploadBackupToFtp($tmpDir);
 
-        $fsHelper->rm($tmpDir, [], true);
+        if ($this->_snapshot->keepSourceFile() === false) {
+            $fsHelper->rm($tmpDir, [], true);
+            $this->_ftpClient->delete($snapshotPath);
+        }
     }
 
     /**
      * Initialize ftp client and connect to ftp
      *
      * @return void
-     * @throws \Magento\Framework\Backup\Exception\FtpConnectionFailed
+     * @throws FtpConnectionFailed
      */
     protected function _initFtpClient()
     {
@@ -65,8 +78,8 @@ class Ftp extends AbstractRollback
             $this->_ftpClient = new \Magento\Framework\System\Ftp();
             $this->_ftpClient->connect($this->_snapshot->getFtpConnectString());
         } catch (\Exception $e) {
-            throw new \Magento\Framework\Backup\Exception\FtpConnectionFailed(
-                new \Magento\Framework\Phrase($e->getMessage())
+            throw new FtpConnectionFailed(
+                new Phrase($e->getMessage())
             );
         }
     }
@@ -75,7 +88,7 @@ class Ftp extends AbstractRollback
      * Perform ftp validation. Check whether ftp account provided points to current magento installation
      *
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     protected function _validateFtp()
     {
@@ -86,8 +99,8 @@ class Ftp extends AbstractRollback
         @fclose($fh);
 
         if (!is_file($validationFilePath)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Unable to validate ftp account')
+            throw new LocalizedException(
+                new Phrase('Unable to validate ftp account')
             );
         }
 
@@ -98,8 +111,8 @@ class Ftp extends AbstractRollback
         @unlink($validationFilePath);
 
         if (!$fileExistsOnFtp) {
-            throw new \Magento\Framework\Backup\Exception\FtpValidationFailed(
-                new \Magento\Framework\Phrase('Failed to validate ftp account')
+            throw new FtpValidationFailed(
+                new Phrase('Failed to validate ftp account')
             );
         }
     }
@@ -114,13 +127,13 @@ class Ftp extends AbstractRollback
     {
         $snapshotPath = $this->_snapshot->getBackupPath();
 
-        $archiver = new \Magento\Framework\Archive();
+        $archiver = new Archive();
         $archiver->unpack($snapshotPath, $tmpDir);
     }
 
     /**
      * @return string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     protected function _createTmpDir()
     {
@@ -129,8 +142,8 @@ class Ftp extends AbstractRollback
         $result = @mkdir($tmpDir);
 
         if (false === $result) {
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Failed to create directory %1', [$tmpDir])
+            throw new NotEnoughPermissions(
+                new Phrase('Failed to create directory %1', [$tmpDir])
             );
         }
 
@@ -146,12 +159,12 @@ class Ftp extends AbstractRollback
     {
         $rootDir = $this->_snapshot->getRootDir();
 
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($rootDir),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($rootDir),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter(
+        $iterator = new Filter(
             $filesystemIterator,
             $this->_snapshot->getIgnorePaths()
         );
@@ -169,17 +182,17 @@ class Ftp extends AbstractRollback
      *
      * @param string $tmpDir
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     protected function _uploadBackupToFtp($tmpDir)
     {
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($tmpDir),
-            \RecursiveIteratorIterator::SELF_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($tmpDir),
+            RecursiveIteratorIterator::SELF_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter(
+        $iterator = new Filter(
             $filesystemIterator,
             $this->_snapshot->getIgnorePaths()
         );
@@ -197,8 +210,8 @@ class Ftp extends AbstractRollback
             } else {
                 $result = $this->_ftpClient->put($ftpPath, $item->__toString());
                 if (false === $result) {
-                    throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                        new \Magento\Framework\Phrase('Failed to upload file %1 to ftp', [$item->__toString()])
+                    throw new NotEnoughPermissions(
+                        new Phrase('Failed to upload file %1 to ftp', [$item->__toString()])
                     );
                 }
             }

--- a/lib/internal/Magento/Framework/Backup/SourceFileInterface.php
+++ b/lib/internal/Magento/Framework/Backup/SourceFileInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Interface for work with archives
+ *
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+
+namespace Magento\Framework\Backup;
+
+interface SourceFileInterface
+{
+
+    /**
+     * Check if keep files of backup
+     *
+     * @return bool
+     */
+    public function keepSourceFile();
+
+    /**
+     * Set if keep files of backup
+     *
+     * @param bool $keepSourceFile
+     * @return $this
+     */
+    public function setKeepSourceFile(bool $keepSourceFile);
+}

--- a/lib/internal/Magento/Framework/Setup/BackupRollback.php
+++ b/lib/internal/Magento/Framework/Setup/BackupRollback.php
@@ -6,14 +6,15 @@
 
 namespace Magento\Framework\Setup;
 
+use Magento\Backup\Model\ResourceModel\Db as ResourceModelDb;
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Backup\Factory;
+use Magento\Framework\Backup\Db;
 use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Factory;
 use Magento\Framework\Backup\Filesystem;
 use Magento\Framework\Backup\Filesystem\Helper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\Driver\File;
-use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Phrase;
 
@@ -106,8 +107,8 @@ class BackupRollback
      */
     public function codeBackup($time, $type = Factory::TYPE_FILESYSTEM)
     {
-        /** @var \Magento\Framework\Backup\Filesystem $fsBackup */
-        $fsBackup = $this->objectManager->create(\Magento\Framework\Backup\Filesystem::class);
+        /** @var Filesystem $fsBackup */
+        $fsBackup = $this->objectManager->create(Filesystem::class);
         $fsBackup->setRootDir($this->directoryList->getRoot());
         if ($type === Factory::TYPE_FILESYSTEM) {
             $fsBackup->addIgnorePaths($this->getCodeBackupIgnorePaths());
@@ -129,7 +130,7 @@ class BackupRollback
         $this->log->log($granularType . ' backup is starting...');
         $fsBackup->create();
         $this->log->log(
-            $granularType. ' backup filename: ' . $fsBackup->getBackupFilename()
+            $granularType . ' backup filename: ' . $fsBackup->getBackupFilename()
             . ' (The archive can be uncompressed with 7-Zip on Windows systems)'
         );
         $this->log->log($granularType . ' backup path: ' . $fsBackup->getBackupPath());
@@ -142,10 +143,11 @@ class BackupRollback
      *
      * @param string $rollbackFile
      * @param string $type
+     * @param boolean $keepSourceFile
      * @return void
      * @throws LocalizedException
      */
-    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM)
+    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM, $keepSourceFile = false)
     {
         if (preg_match('/[0-9]_(filesystem)_(code|media)\.(tgz)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -153,8 +155,8 @@ class BackupRollback
         if (!$this->file->isExists($this->backupsDir . '/' . $rollbackFile)) {
             throw new LocalizedException(new Phrase('The rollback file does not exist.'));
         }
-        /** @var \Magento\Framework\Backup\Filesystem $fsRollback */
-        $fsRollback = $this->objectManager->create(\Magento\Framework\Backup\Filesystem::class);
+        /** @var Filesystem $fsRollback */
+        $fsRollback = $this->objectManager->create(Filesystem::class);
         if ($type === Factory::TYPE_FILESYSTEM) {
             $ignorePaths = $this->getCodeBackupIgnorePaths();
             $granularType = 'Code';
@@ -180,6 +182,7 @@ class BackupRollback
         $fsRollback->addIgnorePaths($ignorePaths);
         $fsRollback->setBackupsDir($this->backupsDir);
         $fsRollback->setBackupExtension('tgz');
+        $fsRollback->setKeepSourceFile($keepSourceFile);
         $time = explode('_', $rollbackFile);
         $fsRollback->setTime($time[0]);
         $this->log->log($granularType . ' rollback is starting ...');
@@ -197,8 +200,8 @@ class BackupRollback
      */
     public function dbBackup($time)
     {
-        /** @var \Magento\Framework\Backup\Db $dbBackup */
-        $dbBackup = $this->objectManager->create(\Magento\Framework\Backup\Db::class);
+        /** @var Db $dbBackup */
+        $dbBackup = $this->objectManager->create(Db::class);
         $dbBackup->setRootDir($this->directoryList->getRoot());
         if (!$this->file->isExists($this->backupsDir)) {
             $this->file->createDirectory($this->backupsDir);
@@ -219,9 +222,10 @@ class BackupRollback
      *
      * @param string $rollbackFile
      * @return void
+     * @param boolean $keepSourceFile
      * @throws LocalizedException
      */
-    public function dbRollback($rollbackFile)
+    public function dbRollback($rollbackFile, $keepSourceFile = false)
     {
         if (preg_match('/[0-9]_(db)(.*?).(sql)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -229,8 +233,8 @@ class BackupRollback
         if (!$this->file->isExists($this->backupsDir . '/' . $rollbackFile)) {
             throw new LocalizedException(new Phrase('The rollback file does not exist.'));
         }
-        /** @var \Magento\Framework\Backup\Db $dbRollback */
-        $dbRollback = $this->objectManager->create(\Magento\Framework\Backup\Db::class);
+        /** @var Db $dbRollback */
+        $dbRollback = $this->objectManager->create(Db::class);
         $dbRollback->setRootDir($this->directoryList->getRoot());
         $dbRollback->setBackupsDir($this->backupsDir);
         $dbRollback->setBackupExtension('sql');
@@ -241,7 +245,8 @@ class BackupRollback
         }
         $dbRollback->setTime($time[0]);
         $this->log->log('DB rollback is starting...');
-        $dbRollback->setResourceModel($this->objectManager->create(\Magento\Backup\Model\ResourceModel\Db::class));
+        $dbRollback->setKeepSourceFile($keepSourceFile);
+        $dbRollback->setResourceModel($this->objectManager->create(ResourceModelDb::class));
         $dbRollback->rollback();
         $this->log->log('DB rollback filename: ' . $dbRollback->getBackupFilename());
         $this->log->log('DB rollback path: ' . $dbRollback->getBackupPath());
@@ -325,8 +330,8 @@ class BackupRollback
      */
     public function getDBDiskSpace()
     {
-        /** @var \Magento\Framework\Backup\Db $dbBackup */
-        $dbBackup = $this->objectManager->create(\Magento\Framework\Backup\Db::class);
+        /** @var Db $dbBackup */
+        $dbBackup = $this->objectManager->create(Db::class);
         return $dbBackup->getDBSize();
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -129,7 +129,7 @@ class RollbackCommand extends AbstractSetupCommand
             }
 
             $questionKeep = new ConfirmationQuestion(
-                '<info>you want to keep the backups?[y/N]<info>',
+                '<info>Do you want to keep the backups?[y/N]<info>',
                 false
             );
             $keepSourceFile = $helper->ask($input, $output, $questionKeep);
@@ -161,7 +161,11 @@ class RollbackCommand extends AbstractSetupCommand
         $inputOptionProvided = false;
         $rollbackHandler = $this->backupRollbackFactory->create($output);
         if ($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE), $keepSourceFile);
+            $rollbackHandler->codeRollback(
+                $input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE),
+                Factory::TYPE_FILESYSTEM,
+                $keepSourceFile
+            );
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)) {

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -127,7 +127,14 @@ class RollbackCommand extends AbstractSetupCommand
             if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {
                 return \Magento\Framework\Console\Cli::RETURN_FAILURE;
             }
-            $this->doRollback($input, $output);
+
+            $questionKeep = new ConfirmationQuestion(
+                '<info>you want to keep the backups?[y/N]<info>',
+                false
+            );
+            $keepSourceFile = $helper->ask($input, $output, $questionKeep);
+
+            $this->doRollback($input, $output, $keepSourceFile);
             $output->writeln('<info>Please set file permission of bin/magento to executable</info>');
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
@@ -145,24 +152,29 @@ class RollbackCommand extends AbstractSetupCommand
      *
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @param boolean $keepSourceFile
      * @return void
      * @throws \InvalidArgumentException
      */
-    private function doRollback(InputInterface $input, OutputInterface $output)
+    private function doRollback(InputInterface $input, OutputInterface $output, $keepSourceFile)
     {
         $inputOptionProvided = false;
         $rollbackHandler = $this->backupRollbackFactory->create($output);
         if ($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE));
+            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE), $keepSourceFile);
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA);
+            $rollbackHandler->codeRollback(
+                $input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE),
+                Factory::TYPE_MEDIA,
+                $keepSourceFile
+            );
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE)) {
             $this->setAreaCode();
-            $rollbackHandler->dbRollback($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE));
+            $rollbackHandler->dbRollback($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE), $keepSourceFile);
             $inputOptionProvided = true;
         }
         if (!$inputOptionProvided) {

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/RollbackCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/RollbackCommandTest.php
@@ -165,7 +165,7 @@ class RollbackCommandTest extends \PHPUnit\Framework\TestCase
             ->method('isAvailable')
             ->will($this->returnValue(true));
         $this->question
-            ->expects($this->once())
+            ->expects($this->atLeast(2))
             ->method('ask')
             ->will($this->returnValue(false));
         $this->helperSet


### PR DESCRIPTION
Add option to keep files in rollback and improve Readability and PSR of Backup Library
### Description
Ask to user when launch command: `bin/magento setup:rollback` if he wants keep files to future rollbacks. Also I changed variable name protected with underscore to acomplish PSR and I imported all classes to use in class.

### Fixed Issues (if relevant)
1. magento/magento2#6460: [2.1.1 CE] Rollback/Restore deletes database (--db) backup file in ${webroot}/var/backups.

### Manual testing scenarios
1. create backup  e.g: `bin/magento setup:backup --media`
2. rollback backup e.g: `bin/magento setup:rollback -m 1508950479_filesystem_media.tgz`
3. Answer `y` to question: `you want to keep the backups?[y/N]`
4. Check that your backup was kept in `var/backups`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
