### PR TITLE
Minification erroneously removes // from JavaScript strings

### DIFF
--- a/lib/internal/Magento/Framework/View/Test/Unit/Template/Html/MinifierTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Template/Html/MinifierTest.php
@@ -144,6 +144,7 @@ class MinifierTest extends \PHPUnit\Framework\TestCase
             testFunctionCall(function () {
                 return {
                     'someProperty': test,
+                    'someOtherProperty': '<?php echo \$block->getUrl('test/path/path'); ?>//',
                     'someMethod': function () {
                         alert(<?php echo \$block->getJsAlert() ?>);
                     }
@@ -173,6 +174,7 @@ TEXT;
             testFunctionCall(function () {
                 return {
                     'someProperty': test,
+                    'someOtherProperty': '<?php echo \$block->getUrl('test/path/path'); ?>//',
                     'someMethod': function () {
                         alert(<?php echo \$block->getJsAlert() ?>);
                     }


### PR DESCRIPTION
This pull request adds a failing unit test to identify and test for the resolution of a bug in the phtml template minification process. 

### Description
When the minifier encounters a // in the middle of JavaScript, even when in a string, the minification will ignore it and everything afterwards.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
