### PR TITLE
[Backport 2.2-develop] Fix label to avoid wrapping poorly,now break by word

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -1383,7 +1383,6 @@
             line-height: 1.33;
             vertical-align: middle;
             white-space: normal;
-            word-break: break-all;
 
             &[data-config-scope] {
                 position: relative;


### PR DESCRIPTION
### Description
Backport to 2.2 of PR: " Fix: field labels wrapping poorly #11727 "
Some long labels break by letter, that was a UX problem to some users and confusiing. I've edited a styless-old.less to fix it.

### Fixed Issues (if relevant)
Admin: field labels wrapping poorly #7099

### Manual testing scenarios

1. Go to any page that has long input field labels, such as when adding a new product attribute (also depends of your resolution)
2. Now the labels break by word instead by letter.

BEFORE:
![screen shot 2017-10-25 at 15 56 23](https://user-images.githubusercontent.com/31536252/32002838-ba14e11e-b99d-11e7-8995-15c4fefeab9d.png)
NOW:
![screen shot 2017-10-25 at 16 02 35](https://user-images.githubusercontent.com/31536252/32002944-fbd53784-b99d-11e7-9af5-7161fbbde0cb.png)




### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
