### PR TITLE
[Backport 2.2-develop] FIX show visual swatches in admin - product attribute

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
+++ b/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
@@ -3,6 +3,10 @@
  * See COPYING.txt for license details.
  */
 
+#swatch-visual-options-panel{
+    overflow: visible;
+}
+
 .swatch_sub-menu_container {
     position: absolute;
     z-index: 9999;


### PR DESCRIPTION
### Description
Backport of PR: FIX show visual swatches in admin - product attribute #11661

Visual swatch wasn't shown full menu, I only fix some CSS to show full menu. Now the menu is showed correctly.

### Fixed Issues (if relevant)
Values of Visual Swatch Attribute drop down is not work correct https://github.com/magento/magento2/issues/11534

### Manual testing scenarios

1. Go to Admin
2. Open Stores > Attributes > Product
3. Add New Attribute with Catalog Input Type for Store Owner: Visual Swatch
4. In Tab Manage Swatch (Values of Your Attribute) click Add Swatch button
5. Press to chose color or file
6. Now is fixed to rendered the menu with all items.


BEFORE:
<img width="1253" alt="screen shot 2017-10-24 at 08 50 41" src="https://user-images.githubusercontent.com/31536252/31928449-7848e588-b898-11e7-9154-51e2f4592848.png">

NOW:
![screen shot 2017-10-24 at 08 45 55](https://user-images.githubusercontent.com/31536252/31928367-3090724c-b898-11e7-8d3b-91932e3c34d4.png)


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
