### PR TITLE
#7778: Date of Birth attribute gets weird format on page reload

### DIFF
--- a/app/code/Magento/Customer/Block/Widget/Dob.php
+++ b/app/code/Magento/Customer/Block/Widget/Dob.php
@@ -94,6 +94,7 @@ class Dob extends AbstractWidget
     public function setDate($date)
     {
         $this->setTime($date ? strtotime($date) : false);
+        $date = $this->applyInputFilter($date);
         $this->setValue($this->applyOutputFilter($date));
         return $this;
     }
@@ -116,6 +117,20 @@ class Dob extends AbstractWidget
             return $filter;
         }
         return false;
+    }
+
+    /**
+     * Apply input filter to value
+     * @param $value
+     * @return string
+     */
+    protected function applyInputFilter($value)
+    {
+        $filter = $this->getFormFilter();
+        if ($filter) {
+            $value = $filter->inputFilter($value);
+        }
+        return $value;
     }
 
     /**


### PR DESCRIPTION
Bugfix for #7778 and #11721

### Description
This PR fixes issue with displaying date of birth on registration page in a case if there was some validation error triggered in backend. The main problem why it displays incorrectly is applying ONLY output filter to "DoB" value when the form input field are displayed. However when the form submitted correctly Magento applies both Input and Output filter.

\Magento\Customer\Block\Widget\Dob used in 2 templates: Magento/Customer/view/frontend/templates/form/register.phtml
Magento/Customer/view/frontend/templates/form/edit.phtml

### Fixed Issues
1. magento/magento2#7778: Date of Birth attribute gets weird format on page reload
2. magento/magento2#11721: duplicate of #7778 

### Manual testing scenarios
1. Go to Account Creation Page
2. Fill In all required fields including Date of Birth, insert already existed email in form.
3. Observe the result

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
