### PR TITLE
[Backport 2.2-develop] Fix datetime type product that show current date when is empty in grids 

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -39,7 +39,7 @@ define([
         getLabel: function (value, format) {
             var date = moment(this._super());
 
-            date = date.isValid() ?
+            date = date.isValid() && value[this.index]?
                 date.format(format || this.dateFormat) :
                 '';
 

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -39,7 +39,7 @@ define([
         getLabel: function (value, format) {
             var date = moment(this._super());
 
-            date = date.isValid() && value[this.index]?
+            date = date.isValid() && value[this.index] ?
                 date.format(format || this.dateFormat) :
                 '';
 


### PR DESCRIPTION
### Description
Backport of PR: Fix datetime type product that show current date when is empty in grids #11636

In the product grid, when a date attribute is listed and the value was empty, the current date was displayed. This was very confusing because I did not know if the value was assigned or not. Now you can see empty cells when is unassigned.

### Fixed Issues (if relevant)
datetime type product attribute showing current date #9869

### Manual testing scenarios

1. Create a date type product attribute
2. assign that product to the required attribute set
3. you can edit the attribute value in the product edit.
4. create a new product and simply not assign any value to this attribute.
5. save product
6. Now you dont see the current date if is unset.

NOW:
<img width="1082" alt="screen shot 2017-10-24 at 08 55 38" src="https://user-images.githubusercontent.com/31536252/31928657-377b3730-b899-11e7-9870-bebf57987ed4.png">


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds on Travis CI are green)