### PR TITLE
Fix #11729 - negative value in excel export [M2.2]

### DIFF
--- a/lib/internal/Magento/Framework/Convert/Excel.php
+++ b/lib/internal/Magento/Framework/Convert/Excel.php
@@ -147,6 +147,7 @@ class Excel
             }
             if (isset($value[0]) && in_array($value[0], ['=', '+', '-'])) {
                 $value = ' ' . $value;
+                $dataType = 'String';
             }
 
             $value = str_replace("\r\n", '&#10;', $value);


### PR DESCRIPTION
$dataType need to be set to 'String' instead 'Number' when value contain space (eg negative number with added space)

Fixed problem with negative values in exported XML file

### Description
Added correction of dataType for negative numbers

### Fixed Issues (if relevant)
1. magento/magento2#11729: Exported Excel with negative number can't be opened by MS Office

### Manual testing scenarios
1. Generate export with negative value
2. Open thru Microsoft Office XML handler with Microsoft Office Professional Plus 2013

### Contribution checklist
- not automated tests was provided