### PR TITLE
[TASK] Incorrect minimum memory_limit references have been updated fr…

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -36,7 +36,7 @@
 ############################################
 ## adjust memory limit
 
-    php_value memory_limit 768M
+    php_value memory_limit 756M
     php_value max_execution_time 18000
 
 ############################################
@@ -59,7 +59,7 @@
 ############################################
 ## adjust memory limit
 
-    php_value memory_limit 768M
+    php_value memory_limit 756M
     php_value max_execution_time 18000
 
 ############################################

--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -35,7 +35,7 @@
 ############################################
 ## adjust memory limit
 
-    php_value memory_limit 768M
+    php_value memory_limit 756M
     php_value max_execution_time 18000
 
 ############################################

--- a/.user.ini
+++ b/.user.ini
@@ -1,4 +1,4 @@
-memory_limit = 768M
+memory_limit = 756M
 max_execution_time = 18000
 session.auto_start = off
 suhosin.session.cryptua = off

--- a/app/code/Magento/SampleData/Console/Command/SampleDataDeployCommand.php
+++ b/app/code/Magento/SampleData/Console/Command/SampleDataDeployCommand.php
@@ -136,8 +136,8 @@ class SampleDataDeployCommand extends Command
         if (function_exists('ini_set')) {
             @ini_set('display_errors', 1);
             $memoryLimit = trim(ini_get('memory_limit'));
-            if ($memoryLimit != -1 && $this->getMemoryInBytes($memoryLimit) < 768 * 1024 * 1024) {
-                @ini_set('memory_limit', '768M');
+            if ($memoryLimit != -1 && $this->getMemoryInBytes($memoryLimit) < 756 * 1024 * 1024) {
+                @ini_set('memory_limit', '756M');
             }
         }
     }

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -41,7 +41,7 @@ location ~* ^/setup($|/) {
         fastcgi_pass   fastcgi_backend;
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-        fastcgi_param  PHP_VALUE "memory_limit=768M \n max_execution_time=600";
+        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
         fastcgi_read_timeout 600s;
         fastcgi_connect_timeout 600s;
 
@@ -168,7 +168,7 @@ location ~ (index|get|static|report|404|503)\.php$ {
     fastcgi_buffers 1024 4k;
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-    fastcgi_param  PHP_VALUE "memory_limit=768M \n max_execution_time=18000";
+    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
 

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -37,7 +37,7 @@
 ############################################
 ## Adjust memory limit
 
-    php_value memory_limit 768M
+    php_value memory_limit 756M
     php_value max_execution_time 18000
 
 ############################################
@@ -60,7 +60,7 @@
 ############################################
 ## Adjust memory limit
 
-    php_value memory_limit 768M
+    php_value memory_limit 756M
     php_value max_execution_time 18000
 
 ############################################

--- a/pub/.user.ini
+++ b/pub/.user.ini
@@ -1,4 +1,4 @@
-memory_limit = 768M
+memory_limit = 756M
 max_execution_time = 18000
 session.auto_start = off
 suhosin.session.cryptua = off


### PR DESCRIPTION
…om 768M to 756M

Same as #11734

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The Magento DevDocs recommend to set the memory_limit to 1G or at least 2G for debugging.
http://devdocs.magento.com/guides/v2.2/install-gde/trouble/php/tshoot_php-set.html

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11322: User.ini files specify 768M - Docs recommend at least 1G

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
