### PR TITLE
Allows modules with underscores in name to add blocks to layout via XML

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -138,7 +138,7 @@
 
     <xs:simpleType name="blockClassType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z][a-zA-Z\d]*(\\[A-Z][a-zA-Z\d]*)*"/>
+            <xs:pattern value="[A-Z][_a-zA-Z\d]*(\\[A-Z][_a-zA-Z\d]*)*"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Allow modules with underscores in the name to add blocks to the layout using XML.

### Description
Magento 2 allows module names to include the underscore character (Vendor_Module_Name, which is app/code/Vendor/Module_Name) but doesn't then allow the module to add a block to the layout via XML.

This only occurs in developer mode and produces the following error:

```
1 exception(s):
Exception #0 (Magento\Framework\Config\Dom\ValidationException): Element 'block', attribute 'class': [facet 'pattern'] The value 'Vendor\Module_Name\Block\OpenGraph' is not accepted by the pattern '[A-Z][a-zA-Z\d]*(\\[A-Z][a-zA-Z\d]*)*'.
Line: 632

Element 'block', attribute 'class': 'Vendor\Module_Name\Block\OpenGraph' is not a valid value of the atomic type 'blockClassType'.
Line: 632


Exception #0 (Magento\Framework\Config\Dom\ValidationException): Element 'block', attribute 'class': [facet 'pattern'] The value 'Vendor\Module_Name\Block\OpenGraph' is not accepted by the pattern '[A-Z][a-zA-Z\d]*(\\[A-Z][a-zA-Z\d]*)*'.
Line: 632

Element 'block', attribute 'class': 'Vendor\Module_Name\Block\OpenGraph' is not a valid value of the atomic type 'blockClassType'.
Line: 632
```
The facet pattern is defined in lib/internal/Magento/Framework/View/Layout/etc/elements.xsd:

```
<xs:simpleType name="blockClassType">
    <xs:restriction base="xs:string">
        <xs:pattern value="[A-Z][a-zA-Z\d]*(\\[A-Z][a-zA-Z\d]*)*"/>
    </xs:restriction>
</xs:simpleType>
```
This pattern does not allow the underscore character to appear in the block class type attribute. I have fixed this by changing the pattern to:

`<xs:pattern value="[A-Z][a-zA-Z\d]*(\\[A-Z][_a-zA-Z\d]*)*"/>`

This allows an underscore to be used in the module name. This could be further to changed to allow an underscore to be used in the vendor name by changing it to:

`<xs:pattern value="[A-Z][_a-zA-Z\d]*(\\[A-Z][_a-zA-Z\d]*)*"/>`

### Manual testing scenarios
1. Enable developer mode using php bin/magento deploy:mode:set developer
2. Create a module at app/code/Vendor/Some_Module
3. Add a frontend layout XML file to the module and include a block from the module
4. Flush the cache and view the frontend
