### PR TITLE
7640: X-Magento-Tags header containing whitespaces causes exception

### DIFF
--- a/lib/internal/Magento/Framework/Config/Converter/Dom/Flat.php
+++ b/lib/internal/Magento/Framework/Config/Converter/Dom/Flat.php
@@ -102,9 +102,9 @@ class Flat
             }
         } else {
             if ($result) {
-                $result['value'] = $value;
+                $result['value'] = trim($value);
             } else {
-                $result = $value;
+                $result = trim($value);
             }
         }
         return $result;

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/converter/dom/flat/result.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/converter/dom/flat/result.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+// @codingStandardsIgnoreFile
 return [
     'root' => [
         'node_one' => [
@@ -11,14 +12,20 @@ return [
             'subnode' => [
                 ['attributeThree' => '30'],
                 ['attributeThree' => '40', 'attributeFour' => '40', 'value' => 'Value1'],
+                ['attributeThree' => '50', 'value' => 'value_from_new_line'],
+                ['attributeThree' => '60', 'value' => 'auto_formatted_by_ide_value_due_to_line_size_restriction']
             ],
             'books' => ['attributeFive' => '50'],
         ],
         'multipleNode' => [
             'one' => ['id' => 'one', 'name' => 'name1', 'value' => '1'],
             'two' => ['id' => 'two', 'name' => 'name2', 'value' => '2'],
+            'three' => ['id' => 'three', 'name' => 'name3', 'value' => 'value_from_new_line'],
+            'four' => ['id' => 'four', 'name' => 'name4', 'value' => 'auto_formatted_by_ide_value_due_to_line_size_restriction'],
         ],
         'someOtherVal' => '',
         'someDataVal' => '',
+        'valueFromNewLine' => 'value_from_new_line',
+        'autoFormattedValue' => 'auto_formatted_by_ide_value_due_to_line_size_restriction'
     ]
 ];

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/converter/dom/flat/source.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/converter/dom/flat/source.xml
@@ -9,6 +9,11 @@
     <node_one attributeOne = '10' attributeTwo = '20'>
         <subnode attributeThree = '30'></subnode>
         <subnode attributeThree = '40' attributeFour = '40' >Value1</subnode>
+        <subnode attributeThree = '50'>
+            value_from_new_line
+        </subnode>
+        <subnode attributeThree = '60'>auto_formatted_by_ide_value_due_to_line_size_restriction
+        </subnode>
         <books attributeFive = '50' />
     </node_one>
     <multipleNode id="one" name="name1">
@@ -19,4 +24,18 @@
     </multipleNode>
     <someOtherVal></someOtherVal>
     <someDataVal><![CDATA[]]></someDataVal>
+    <multipleNode id="three" name="name3">
+        <value>
+            value_from_new_line
+        </value>
+    </multipleNode>
+    <multipleNode id="four" name="name4">
+        <value>auto_formatted_by_ide_value_due_to_line_size_restriction
+        </value>
+    </multipleNode>
+    <valueFromNewLine>
+        value_from_new_line
+    </valueFromNewLine>
+    <autoFormattedValue>auto_formatted_by_ide_value_due_to_line_size_restriction
+    </autoFormattedValue>
 </root>


### PR DESCRIPTION
### Description
When the header X-Magento-Tags contains whitespaces, an Zend\Http\Header\Exception\InvalidArgumentException is being thrown when the full page cache is enabled. Block IDs can contain whitespaces due to reformatting in layout XML files, because of the 80 character line length limit.

### Fixed Issues (if relevant)
1. magento/magento2#7640: X-Magento-Tags header containing whitespaces causes exception

### Manual testing scenarios
1. Have layout files with block_id arguments that contain whitespaces (see image below)
![1fd0e096-b79e-11e6-9f12-1e300c0cd16c](https://user-images.githubusercontent.com/11520943/32049714-c279c9f0-ba56-11e7-8709-b822ab06c92d.png)
2. Enable full page cache
3. Reload a page
4. Check page reloaded correctly.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
