### PR TITLE
Removed duplicated rows from the integration PHPUnit config

### DIFF
--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -54,8 +54,6 @@
         <!-- Memory usage and estimated leaks thresholds -->
         <!--<const name="TESTS_MEM_USAGE_LIMIT" value="1024M"/>-->
         <const name="TESTS_MEM_LEAK_LIMIT" value=""/>
-        <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
-        <!--<const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>-->
         <!-- Path to Percona Toolkit bin directory -->
         <!--<const name="PERCONA_TOOLKIT_BIN_DIR" value=""/>-->
         <!-- CSV Profiler Output file -->


### PR DESCRIPTION
### Description
The commented lines in the `phpunit.xml.dist` are redundant since we have the same lines in the same section but uncommented. 


