### PR TITLE
Commit for resolve Minimum order amount with multiple currency issues in notice messages

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
+++ b/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
@@ -23,18 +23,28 @@ class ValidationMessage
     private $currency;
 
     /**
+     * @var \Magento\Framework\Pricing\Helper\Data
+     */
+    private $priceHelper;
+
+
+    /**
+     * ValidationMessage constructor.
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\Locale\CurrencyInterface $currency
+     * @param \Magento\Framework\Pricing\Helper\Data $priceHelper
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\Locale\CurrencyInterface $currency
+        \Magento\Framework\Locale\CurrencyInterface $currency,
+        \Magento\Framework\Pricing\Helper\Data $priceHelper
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
         $this->currency = $currency;
+        $this->priceHelper = $priceHelper;
     }
 
     /**
@@ -50,13 +60,11 @@ class ValidationMessage
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
         if (!$message) {
-            $currencyCode = $this->storeManager->getStore()->getCurrentCurrencyCode();
-            $minimumAmount = $this->currency->getCurrency($currencyCode)->toCurrency(
-                $this->scopeConfig->getValue(
-                    'sales/minimum_order/amount',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            );
+            $minimumAmount =  $this->priceHelper->currency($this->scopeConfig->getValue(
+                'sales/minimum_order/amount',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            ), true, false);
+
             $message = __('Minimum order amount is %1', $minimumAmount);
         } else {
             //Added in order to address the issue: https://github.com/magento/magento2/issues/8287


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
This is about notice message of min order amount on cart page.When we have set min order amount and on cart page someone change currency, user see same amount and only currency symbol changed. It should recalculate amount also. 

### Description
Instead of currency convert, we use price helper then it gives us re calculated price amount in notice message.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Preconditions
1. - Any Product must be created and enabled in frontend with the price greater then 0 or less then 1000  

Steps to reproduce 

1. - Enable Minimum Order Amount 
Login to [Magento Admin Panel]/ Stores -> Configuration -> Sales -> Sales -> Minimum Order Amount and do the following

  - Set Enable "Yes"
  - Enter Amount for example 1000
  - Leave Description Message text blank 
  - Leave Error to Show in Shopping Cart blank 
  - Save the Configurations by clicking on "Save Config" button on top right corner

2. - Now setup Multiple currencies for that follow below steps 

Go to section Stores -> Configuration->General->Currency Setup

Now select multiple currencies from Allowed Currencies by pressing ctrl key 
select Brazilian Real, Indian Rupee, Japanese Yen, Russian Ruble, US Dollar

3. - Import Currency Rates 
Go to Stores -> Under Currency Title click on Currency Rates. 
Select any of service and click on import rates it will import live currency rates. 


4. - Go to Frontend Add any product in shopping cart add any product 1 qty which has price less then 1000. 

5. - Go to cart page "View and Edit Cart" link which you can see on Minicart Popup or by browsing url [Magento base url]/heckout/cart/

6. - You can see the default message on "Minimum order amount is $1,000.00" 

7. - Now change the currencies from header upper right corner. You can see Minimum order amount is $1,000.00 in any currency you selected 

Expected result

1000 must be changed according to the live currency rates in case of multi currency.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
