### PR TITLE
MAGETWO-4711: Improve error reporting for products images import.

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2042,6 +2042,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
             $res = $this->_getUploader()->move($fileName, $renameFileOff);
             return $res['file'];
         } catch (\Exception $e) {
+            $this->_logger->critical($e);
             return '';
         }
     }

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -1194,6 +1194,70 @@ class ProductTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
         $this->assertArrayNotHasKey('PARAM2', $attributes);
     }
 
+    /**
+     * Test that errors occurred during importing images are logged.
+     *
+     * @param string $fileName
+     * @param bool $throwException
+     * @dataProvider uploadMediaFilesDataProvider
+     */
+    public function testUploadMediaFiles(string $fileName, bool $throwException)
+    {
+        $exception = new \Exception();
+        $expectedFileName = $fileName;
+        if ($throwException) {
+            $expectedFileName = '';
+            $this->_logger->expects($this->once())->method('critical')->with($exception);
+        }
+
+        $fileUploaderMock = $this
+            ->getMockBuilder(\Magento\CatalogImportExport\Model\Import\Uploader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fileUploaderMock
+            ->expects($this->once())
+            ->method('move')
+            ->willReturnCallback(
+                function ($name) use ($throwException, $exception) {
+                    if ($throwException) {
+                        throw $exception;
+                    }
+                    return ['file' => $name];
+                }
+            );
+
+        $this->setPropertyValue(
+            $this->importProduct,
+            '_fileUploader',
+            $fileUploaderMock
+        );
+
+        $actualFileName = $this->invokeMethod(
+            $this->importProduct,
+            'uploadMediaFiles',
+            [$fileName]
+        );
+
+        $this->assertEquals(
+            $expectedFileName,
+            $actualFileName
+        );
+    }
+
+    /**
+     * Data provider for testUploadMediaFiles.
+     *
+     * @return array
+     */
+    public function uploadMediaFilesDataProvider()
+    {
+        return [
+            ['test1.jpg', false],
+            ['test2.jpg', true],
+        ];
+    }
+
     public function getImagesFromRowDataProvider()
     {
         return [

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -26,7 +26,7 @@ use Magento\Framework\Registry;
 use Magento\Framework\Filesystem;
 use Magento\ImportExport\Model\Import;
 use Magento\Store\Model\Store;
-use Magento\UrlRewrite\Model\UrlRewrite;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class ProductTest
@@ -62,11 +62,20 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
      */
     protected $objectManager;
 
+    /**
+     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $logger;
+
     protected function setUp()
     {
         $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->_model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\CatalogImportExport\Model\Import\Product::class
+            \Magento\CatalogImportExport\Model\Import\Product::class,
+            ['logger' => $this->logger]
         );
         parent::setUp();
     }
@@ -660,6 +669,21 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
     }
 
     /**
+     * Test that errors occurred during importing images are logged.
+     *
+     * @magentoDataIsolation enabled
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture mediaImportImageFixture
+     * @magentoDataFixture mediaImportImageFixtureError
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testSaveMediaImageError()
+    {
+        $this->logger->expects(self::once())->method('critical');
+        $this->importDataForMediaTest('import_media.csv', 1);
+    }
+
+    /**
      * Copy fixture images into media import directory
      */
     public static function mediaImportImageFixture()
@@ -716,6 +740,30 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         $mediaDirectory->delete('import');
         $mediaDirectory->delete('catalog');
     }
+
+    /**
+     * Copy incorrect fixture image into media import directory.
+     */
+    public static function mediaImportImageFixtureError()
+    {
+        /** @var \Magento\Framework\Filesystem\Directory\Write $mediaDirectory */
+        $mediaDirectory = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Framework\Filesystem::class
+        )->getDirectoryWrite(
+            DirectoryList::MEDIA
+        );
+        $dirPath = $mediaDirectory->getAbsolutePath('import');
+        $items = [
+            [
+                'source' => __DIR__ . '/_files/magento_additional_image_error.jpg',
+                'dest' => $dirPath . '/magento_additional_image_two.jpg',
+            ],
+        ];
+        foreach ($items as $item) {
+            copy($item['source'], $item['dest']);
+        }
+    }
+
 
     /**
      * Export CSV string to array
@@ -1564,8 +1612,9 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
      * Import and check data from file
      *
      * @param string $fileName
+     * @param int $expectedErrors
      */
-    private function importDataForMediaTest($fileName)
+    private function importDataForMediaTest(string $fileName, int $expectedErrors = 0)
     {
         $filesystem = $this->objectManager->create(\Magento\Framework\Filesystem::class);
         $directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
@@ -1603,7 +1652,7 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         $this->assertTrue($errors->getErrorsCount() == 0);
 
         $this->_model->importData();
-        $this->assertTrue($this->_model->getErrorAggregator()->getErrorsCount() == 0);
+        $this->assertTrue($this->_model->getErrorAggregator()->getErrorsCount() == $expectedErrors);
     }
 
     /**


### PR DESCRIPTION
### Description
Errors occurred during importing images are logged.

### Fixed Issues (if relevant)
1.  magento/magento2#4711: Improve error reporting for products images import.

### Manual testing scenarios
1. Create a product, assign at least one image.
2. Go to System -> Export and export Products.
3. Delete the image assigned in Step 1.
4. Go to System -> Import and import Products.
5. Error message is displayed: "Imported resource (image) could not be downloaded from external resource due to timeout or access permissions..."
6. File /var/log/exception.log should contain more detailed information about occured error. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
