### PR TITLE
fix #8846: avoid duplicated attribute option values

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
@@ -40,6 +40,17 @@ class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionMan
      */
     public function add($attributeCode, $option)
     {
+        /** @var \Magento\Eav\Api\Data\AttributeOptionInterface[] $currentOptions */
+        $currentOptions = $this->getItems($attributeCode);
+        if (is_array($currentOptions)) {
+            array_walk($currentOptions, function (&$attributeOption) {
+                /** @var \Magento\Eav\Api\Data\AttributeOptionInterface $attributeOption */
+                    $attributeOption = $attributeOption->getLabel();
+            });
+            if (in_array($option->getLabel(), $currentOptions)) {
+                return false;
+            }
+        }
         return $this->eavOptionManagement->add(
             \Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE,
             $attributeCode,


### PR DESCRIPTION
… #8846 


### Description
When adding an attribute option, check if its label exists for current attribute. If so, doesn't add the option and return false.

### Fixed Issues
1. magento/magento2#8846 Attribute option value uniqueness is not checked if created via REST Api

### Manual testing scenarios
Same testing described at issues #8846. Add an attribute option via API twice.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
