### PR TITLE
Fix #10438: Potential error on order edit page when address has extension attributes

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -10,9 +10,12 @@ namespace Magento\Sales\Model\AdminOrder;
 
 use Magento\Customer\Api\AddressMetadataInterface;
 use Magento\Customer\Model\Metadata\Form as CustomerForm;
+use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\App\ObjectManager;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Item;
+use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Sales\Model\Order;
 
 /**
  * Order create model
@@ -236,6 +239,11 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
     private $serializer;
 
     /**
+     * @var ExtensibleDataObjectConverter
+     */
+    private $dataObjectConverter;
+
+    /**
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param \Magento\Framework\Registry $coreRegistry
@@ -265,6 +273,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
      * @param \Magento\Quote\Model\QuoteFactory $quoteFactory
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param ExtensibleDataObjectConverter|null $dataObjectConverter
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -296,7 +305,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         \Magento\Sales\Api\OrderManagementInterface $orderManagement,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
         array $data = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+        ExtensibleDataObjectConverter $dataObjectConverter = null
     ) {
         $this->_objectManager = $objectManager;
         $this->_eventManager = $eventManager;
@@ -328,6 +338,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         $this->serializer = $serializer ?: ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($data);
+        $this->dataObjectConverter = $dataObjectConverter ?: ObjectManager::getInstance()
+            ->get(ExtensibleDataObjectConverter::class);
     }
 
     /**
@@ -514,9 +526,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
 
         $shippingAddress = $order->getShippingAddress();
         if ($shippingAddress) {
-            $addressDiff = array_diff_assoc($shippingAddress->getData(), $order->getBillingAddress()->getData());
-            unset($addressDiff['address_type'], $addressDiff['entity_id']);
-            $shippingAddress->setSameAsBilling(empty($addressDiff));
+            $shippingAddress->setSameAsBilling($this->isAddressesAreEqual($order));
         }
 
         $this->_initBillingAddressFromOrder($order);
@@ -2009,5 +2019,27 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         }
 
         return $email;
+    }
+
+    /**
+     * Checks id shipping and billing addresses are equal.
+     *
+     * @param Order $order
+     * @return bool
+     */
+    private function isAddressesAreEqual(Order $order)
+    {
+        $shippingAddress = $order->getShippingAddress();
+        $billingAddress = $order->getBillingAddress();
+        $shippingData = $this->dataObjectConverter->toFlatArray($shippingAddress, [], OrderAddressInterface::class);
+        $billingData = $this->dataObjectConverter->toFlatArray($billingAddress, [], OrderAddressInterface::class);
+        unset(
+            $shippingData['address_type'],
+            $shippingData['entity_id'],
+            $billingData['address_type'],
+            $billingData['entity_id']
+        );
+
+        return $shippingData == $billingData;
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
@@ -8,8 +8,25 @@
 
 namespace Magento\Sales\Test\Unit\Model\AdminOrder;
 
+use Magento\Backend\Model\Session\Quote as SessionQuote;
+use Magento\Customer\Api\Data\AttributeMetadataInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Api\Data\CustomerInterfaceFactory;
+use Magento\Customer\Api\Data\GroupInterface;
+use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Customer\Model\Customer\Mapper;
+use Magento\Customer\Model\Metadata\Form;
+use Magento\Customer\Model\Metadata\FormFactory;
+use Magento\Framework\Api\DataObjectHelper;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\Quote\Item\Updater;
+use Magento\Sales\Model\AdminOrder\Create;
 use Magento\Sales\Model\AdminOrder\Product;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -19,161 +36,74 @@ class CreateTest extends \PHPUnit\Framework\TestCase
 {
     const CUSTOMER_ID = 1;
 
-    /** @var \Magento\Sales\Model\AdminOrder\Create */
-    protected $adminOrderCreate;
-
-    /** @var \Magento\Backend\Model\Session\Quote|\PHPUnit_Framework_MockObject_MockObject */
-    protected $sessionQuoteMock;
-
-    /** @var \Magento\Customer\Model\Metadata\FormFactory|\PHPUnit_Framework_MockObject_MockObject */
-    protected $formFactoryMock;
-
-    /** @var \Magento\Customer\Api\Data\CustomerInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject */
-    protected $customerFactoryMock;
-
-    /** @var \Magento\Quote\Model\Quote\Item\Updater|\PHPUnit_Framework_MockObject_MockObject */
-    protected $itemUpdater;
-
-    /** @var \Magento\Customer\Model\Customer\Mapper|\PHPUnit_Framework_MockObject_MockObject */
-    protected $customerMapper;
+    /**
+     * @var Create
+     */
+    private $adminOrderCreate;
 
     /**
-     * @var Product\Quote\Initializer|\PHPUnit_Framework_MockObject_MockObject
+     * @var SessionQuote|MockObject
      */
-    protected $quoteInitializerMock;
+    private $sessionQuote;
 
     /**
-     * @var \Magento\Customer\Api\CustomerRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var FormFactory|MockObject
      */
-    protected $customerRepositoryMock;
+    private $formFactory;
 
     /**
-     * @var \Magento\Customer\Api\AddressRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CustomerInterfaceFactory|MockObject
      */
-    protected $addressRepositoryMock;
+    private $customerFactory;
 
     /**
-     * @var \Magento\Customer\Api\Data\AddressInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var Updater|MockObject
      */
-    protected $addressFactoryMock;
+    private $itemUpdater;
 
     /**
-     * @var \Magento\Customer\Api\GroupRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var Mapper|MockObject
      */
-    protected $groupRepositoryMock;
+    private $customerMapper;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var GroupRepositoryInterface|MockObject
      */
-    protected $scopeConfigMock;
+    private $groupRepository;
 
     /**
-     * @var \Magento\Sales\Model\AdminOrder\EmailSender|\PHPUnit_Framework_MockObject_MockObject
+     * @var DataObjectHelper|MockObject
      */
-    protected $emailSenderMock;
+    private $dataObjectHelper;
 
-    /**
-     * @var \Magento\Customer\Api\AccountManagementInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $accountManagementMock;
-
-    /**
-     * @var \Magento\Framework\Api\DataObjectHelper|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $dataObjectHelper;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $objectFactory;
-
-    /**
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
-     */
     protected function setUp()
     {
-        $objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
-        $eventManagerMock = $this->createMock(\Magento\Framework\Event\ManagerInterface::class);
-        $registryMock = $this->createMock(\Magento\Framework\Registry::class);
-        $configMock = $this->createMock(\Magento\Sales\Model\Config::class);
-        $this->sessionQuoteMock = $this->createMock(\Magento\Backend\Model\Session\Quote::class);
-        $loggerMock = $this->createMock(\Psr\Log\LoggerInterface::class);
-        $copyMock = $this->createMock(\Magento\Framework\DataObject\Copy::class);
-        $messageManagerMock = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
-        $this->formFactoryMock = $this->createPartialMock(\Magento\Customer\Model\Metadata\FormFactory::class, ['create']);
-        $this->customerFactoryMock = $this->createPartialMock(\Magento\Customer\Api\Data\CustomerInterfaceFactory::class, ['create']);
+        $this->sessionQuote = $this->createMock(SessionQuote::class);
+        $this->formFactory = $this->createPartialMock(FormFactory::class, ['create']);
+        $this->customerFactory = $this->createPartialMock(CustomerInterfaceFactory::class, ['create']);
 
-        $this->itemUpdater = $this->createMock(\Magento\Quote\Model\Quote\Item\Updater::class);
+        $this->itemUpdater = $this->createMock(Updater::class);
 
-        $this->objectFactory = $this->getMockBuilder(\Magento\Framework\DataObject\Factory::class)
+        $this->customerMapper = $this->getMockBuilder(Mapper::class)
+            ->setMethods(['toFlatArray'])
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
             ->getMock();
 
-        $this->customerMapper = $this->getMockBuilder(
-            \Magento\Customer\Model\Customer\Mapper::class
-        )->setMethods(['toFlatArray'])->disableOriginalConstructor()->getMock();
-
-        $this->quoteInitializerMock = $this->createMock(\Magento\Sales\Model\AdminOrder\Product\Quote\Initializer::class);
-        $this->customerRepositoryMock = $this->getMockForAbstractClass(
-            \Magento\Customer\Api\CustomerRepositoryInterface::class,
-            [],
-            '',
-            false
-        );
-        $this->addressRepositoryMock = $this->getMockForAbstractClass(
-            \Magento\Customer\Api\AddressRepositoryInterface::class,
-            [],
-            '',
-            false
-        );
-        $this->addressFactoryMock = $this->createMock(\Magento\Customer\Api\Data\AddressInterfaceFactory::class);
-        $this->groupRepositoryMock = $this->getMockForAbstractClass(
-            \Magento\Customer\Api\GroupRepositoryInterface::class,
-            [],
-            '',
-            false
-        );
-        $this->scopeConfigMock = $this->getMockForAbstractClass(
-            \Magento\Framework\App\Config\ScopeConfigInterface::class,
-            [],
-            '',
-            false
-        );
-        $this->emailSenderMock = $this->createMock(\Magento\Sales\Model\AdminOrder\EmailSender::class);
-        $this->accountManagementMock = $this->getMockForAbstractClass(
-            \Magento\Customer\Api\AccountManagementInterface::class,
-            [],
-            '',
-            false
-        );
-        $this->dataObjectHelper = $this->getMockBuilder(\Magento\Framework\Api\DataObjectHelper::class)
+        $this->groupRepository = $this->getMockForAbstractClass(GroupRepositoryInterface::class);
+        $this->dataObjectHelper = $this->getMockBuilder(DataObjectHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $objectManagerHelper = new ObjectManagerHelper($this);
         $this->adminOrderCreate = $objectManagerHelper->getObject(
-            \Magento\Sales\Model\AdminOrder\Create::class,
+            Create::class,
             [
-                'objectManager' => $objectManagerMock,
-                'eventManager' => $eventManagerMock,
-                'coreRegistry' => $registryMock,
-                'salesConfig' => $configMock,
-                'quoteSession' => $this->sessionQuoteMock,
-                'logger' => $loggerMock,
-                'objectCopyService' => $copyMock,
-                'messageManager' => $messageManagerMock,
-                'quoteInitializer' => $this->quoteInitializerMock,
-                'customerRepository' => $this->customerRepositoryMock,
-                'addressRepository' => $this->addressRepositoryMock,
-                'addressFactory' => $this->addressFactoryMock,
-                'metadataFormFactory' => $this->formFactoryMock,
-                'customerFactory' => $this->customerFactoryMock,
-                'groupRepository' => $this->groupRepositoryMock,
+                'quoteSession' => $this->sessionQuote,
+                'metadataFormFactory' => $this->formFactory,
+                'customerFactory' => $this->customerFactory,
+                'groupRepository' => $this->groupRepository,
                 'quoteItemUpdater' => $this->itemUpdater,
                 'customerMapper' => $this->customerMapper,
-                'objectFactory' => $this->objectFactory,
-                'accountManagement' => $this->accountManagementMock,
                 'dataObjectHelper' => $this->dataObjectHelper,
             ]
         );
@@ -188,64 +118,60 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         ];
         $attributeMocks = [];
 
-        foreach ($attributes as $attribute) {
-            $attributeMock = $this->createMock(\Magento\Customer\Api\Data\AttributeMetadataInterface::class);
+        foreach ($attributes as $value) {
+            $attribute = $this->createMock(AttributeMetadataInterface::class);
+            $attribute->method('getAttributeCode')
+                ->willReturn($value[0]);
 
-            $attributeMock->expects($this->any())->method('getAttributeCode')->will($this->returnValue($attribute[0]));
-
-            $attributeMocks[] = $attributeMock;
+            $attributeMocks[] = $attribute;
         }
 
-        $customerGroupMock = $this->getMockForAbstractClass(
-            \Magento\Customer\Api\Data\GroupInterface::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['getTaxClassId']
-        );
-        $customerGroupMock->expects($this->once())->method('getTaxClassId')->will($this->returnValue($taxClassId));
-        $customerFormMock = $this->createMock(\Magento\Customer\Model\Metadata\Form::class);
-        $customerFormMock->expects($this->any())
-            ->method('getAttributes')
-            ->will($this->returnValue([$attributeMocks[1]]));
-        $customerFormMock->expects($this->any())->method('extractData')->will($this->returnValue([]));
-        $customerFormMock->expects($this->any())->method('restoreData')->will($this->returnValue(['group_id' => 1]));
+        $customerGroup = $this->getMockForAbstractClass(GroupInterface::class);
+        $customerGroup->method('getTaxClassId')
+            ->willReturn($taxClassId);
+        $customerForm = $this->createMock(Form::class);
+        $customerForm->method('getAttributes')
+            ->willReturn([$attributeMocks[1]]);
+        $customerForm
+            ->method('extractData')
+            ->willReturn([]);
+        $customerForm
+            ->method('restoreData')
+            ->willReturn(['group_id' => 1]);
 
-        $customerFormMock->expects($this->any())
-            ->method('prepareRequest')
-            ->will($this->returnValue($this->createMock(\Magento\Framework\App\RequestInterface::class)));
+        $customerForm->method('prepareRequest')
+            ->willReturn($this->createMock(RequestInterface::class));
 
-        $customerMock = $this->createMock(\Magento\Customer\Api\Data\CustomerInterface::class);
-        $this->customerMapper->expects($this->atLeastOnce())
+        $customer = $this->createMock(CustomerInterface::class);
+        $this->customerMapper->expects(self::atLeastOnce())
             ->method('toFlatArray')
             ->willReturn(['group_id' => 1]);
 
-        $quoteMock = $this->createMock(\Magento\Quote\Model\Quote::class);
-        $quoteMock->expects($this->any())->method('getCustomer')->will($this->returnValue($customerMock));
-        $quoteMock->expects($this->once())
-            ->method('addData')
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getCustomer')->willReturn($customer);
+        $quote->method('addData')
             ->with(
             [
                 'customer_group_id' => $attributes[1][1],
                 'customer_tax_class_id' => $taxClassId
             ]
         );
-        $this->dataObjectHelper->expects($this->once())
-            ->method('populateWithArray')
+        $this->dataObjectHelper->method('populateWithArray')
             ->with(
-                $customerMock,
-                ['group_id' => 1], \Magento\Customer\Api\Data\CustomerInterface::class
+                $customer,
+                ['group_id' => 1], CustomerInterface::class
             );
 
-        $this->formFactoryMock->expects($this->any())->method('create')->will($this->returnValue($customerFormMock));
-        $this->sessionQuoteMock->expects($this->any())->method('getQuote')->will($this->returnValue($quoteMock));
-        $this->customerFactoryMock->expects($this->any())->method('create')->will($this->returnValue($customerMock));
+        $this->formFactory->method('create')
+            ->willReturn($customerForm);
+        $this->sessionQuote
+            ->method('getQuote')
+            ->willReturn($quote);
+        $this->customerFactory->method('create')
+            ->willReturn($customer);
 
-        $this->groupRepositoryMock->expects($this->once())
-            ->method('getById')
-            ->will($this->returnValue($customerGroupMock));
+        $this->groupRepository->method('getById')
+            ->willReturn($customerGroup);
 
         $this->adminOrderCreate->setAccountData(['group_id' => 1]);
     }
@@ -253,7 +179,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     public function testUpdateQuoteItemsNotArray()
     {
         $object = $this->adminOrderCreate->updateQuoteItems('string');
-        $this->assertEquals($this->adminOrderCreate, $object);
+        self::assertEquals($this->adminOrderCreate, $object);
     }
 
     public function testUpdateQuoteItemsEmptyConfiguredOption()
@@ -266,22 +192,21 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $itemMock = $this->createMock(\Magento\Quote\Model\Quote\Item::class);
+        $item = $this->createMock(Item::class);
 
-        $quoteMock = $this->createMock(\Magento\Quote\Model\Quote::class);
-        $quoteMock->expects($this->once())
-            ->method('getItemById')
-            ->will($this->returnValue($itemMock));
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getItemById')
+            ->willReturn($item);
 
-        $this->sessionQuoteMock->expects($this->any())->method('getQuote')->will($this->returnValue($quoteMock));
-        $this->itemUpdater->expects($this->once())
-            ->method('update')
-            ->with($this->equalTo($itemMock), $this->equalTo($items[1]))
-            ->will($this->returnSelf());
+        $this->sessionQuote->method('getQuote')
+            ->willReturn($quote);
+        $this->itemUpdater->method('update')
+            ->with(self::equalTo($item), self::equalTo($items[1]))
+            ->willReturnSelf();
 
         $this->adminOrderCreate->setRecollect(false);
         $object = $this->adminOrderCreate->updateQuoteItems($items);
-        $this->assertEquals($this->adminOrderCreate, $object);
+        self::assertEquals($this->adminOrderCreate, $object);
     }
 
     public function testUpdateQuoteItemsWithConfiguredOption()
@@ -295,43 +220,50 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $itemMock = $this->createMock(\Magento\Quote\Model\Quote\Item::class);
-        $itemMock->expects($this->once())
-            ->method('getQty')
-            ->will($this->returnValue($qty));
+        $item = $this->createMock(Item::class);
+        $item->method('getQty')
+            ->willReturn($qty);
 
-        $quoteMock = $this->createMock(\Magento\Quote\Model\Quote::class);
-        $quoteMock->expects($this->once())
-            ->method('updateItem')
-            ->will($this->returnValue($itemMock));
+        $quote = $this->createMock(Quote::class);
+        $quote->method('updateItem')
+            ->willReturn($item);
 
-        $this->sessionQuoteMock->expects($this->any())->method('getQuote')->will($this->returnValue($quoteMock));
+        $this->sessionQuote
+            ->method('getQuote')
+            ->willReturn($quote);
 
         $expectedInfo = $items[1];
         $expectedInfo['qty'] = $qty;
-        $this->itemUpdater->expects($this->once())
-            ->method('update')
-            ->with($this->equalTo($itemMock), $this->equalTo($expectedInfo));
+        $this->itemUpdater->method('update')
+            ->with(self::equalTo($item), self::equalTo($expectedInfo));
 
         $this->adminOrderCreate->setRecollect(false);
         $object = $this->adminOrderCreate->updateQuoteItems($items);
-        $this->assertEquals($this->adminOrderCreate, $object);
+        self::assertEquals($this->adminOrderCreate, $object);
     }
 
     public function testApplyCoupon()
     {
-        $couponCode = '';
-        $quoteMock = $this->createPartialMock(\Magento\Quote\Model\Quote::class, ['getShippingAddress', 'setCouponCode']);
-        $this->sessionQuoteMock->expects($this->once())->method('getQuote')->willReturn($quoteMock);
+        $couponCode = '123';
+        $quote = $this->createPartialMock(Quote::class, ['getShippingAddress', 'setCouponCode']);
+        $this->sessionQuote->method('getQuote')
+            ->willReturn($quote);
 
-        $addressMock = $this->createPartialMock(\Magento\Quote\Model\Quote\Address::class, ['setCollectShippingRates', 'setFreeShipping']);
-        $quoteMock->expects($this->exactly(2))->method('getShippingAddress')->willReturn($addressMock);
-        $quoteMock->expects($this->once())->method('setCouponCode')->with($couponCode)->willReturnSelf();
+        $address = $this->createPartialMock(Address::class, ['setCollectShippingRates', 'setFreeShipping']);
+        $quote->method('getShippingAddress')
+            ->willReturn($address);
+        $quote->method('setCouponCode')
+            ->with($couponCode)
+            ->willReturnSelf();
 
-        $addressMock->expects($this->once())->method('setCollectShippingRates')->with(true)->willReturnSelf();
-        $addressMock->expects($this->once())->method('setFreeShipping')->with(0)->willReturnSelf();
+        $address->method('setCollectShippingRates')
+            ->with(true)
+            ->willReturnSelf();
+        $address->method('setFreeShipping')
+            ->with(0)
+            ->willReturnSelf();
 
         $object = $this->adminOrderCreate->applyCoupon($couponCode);
-        $this->assertEquals($this->adminOrderCreate, $object);
+        self::assertEquals($this->adminOrderCreate, $object);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/AdminOrder/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/AdminOrder/CreateTest.php
@@ -5,10 +5,20 @@
  */
 namespace Magento\Sales\Model\AdminOrder;
 
-use Magento\Sales\Api\OrderManagementInterface;
-use Magento\TestFramework\Helper\Bootstrap;
-use Magento\Sales\Model\Order;
+use Magento\Backend\Model\Session\Quote as SessionQuote;
+use Magento\Customer\Api\AddressRepositoryInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\CustomerRegistry;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Registry;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\Data\OrderAddressExtensionInterface;
+use Magento\Sales\Api\Data\OrderAddressExtensionInterfaceFactory;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Model\Order;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -18,21 +28,25 @@ use Magento\Framework\Registry;
 class CreateTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Sales\Model\AdminOrder\Create
+     * @var Create
      */
-    protected $_model;
+    private $model;
 
-    /** @var \Magento\Framework\Message\ManagerInterface */
-    protected $_messageManager;
+    /**
+     * @var ManagerInterface
+     */
+    private $messageManager;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
 
     protected function setUp()
     {
-        parent::setUp();
-        $this->_messageManager = Bootstrap::getObjectManager()->get(\Magento\Framework\Message\ManagerInterface::class);
-        $this->_model = Bootstrap::getObjectManager()->create(
-            \Magento\Sales\Model\AdminOrder\Create::class,
-            ['messageManager' => $this->_messageManager]
-        );
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->messageManager = $this->objectManager->get(ManagerInterface::class);
+        $this->model =$this->objectManager->create(Create::class, ['messageManager' => $this->messageManager]);
     }
 
     /**
@@ -41,17 +55,15 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testInitFromOrderShippingAddressSameAsBillingWhenEmpty()
     {
-        /** @var $order \Magento\Sales\Model\Order */
-        $order = Bootstrap::getObjectManager()->create(\Magento\Sales\Model\Order::class);
+        /** @var $order Order */
+        $order = $this->objectManager->create(Order::class);
         $order->loadByIncrementId('100000001');
-        $this->assertNull($order->getShippingAddress());
+        self::assertNull($order->getShippingAddress());
 
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = Bootstrap::getObjectManager();
-        $objectManager->get(\Magento\Framework\Registry::class)->unregister('rule_data');
-        $this->_model->initFromOrder($order);
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+        $this->model->initFromOrder($order);
 
-        $this->assertNull($order->getShippingAddress());
+        self::assertNull($order->getShippingAddress());
     }
 
     /**
@@ -64,45 +76,45 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     public function testInitFromOrderAndCreateOrderFromQuoteWithAdditionalOptions()
     {
         /** @var $serializer \Magento\Framework\Serialize\Serializer\Json */
-        $serializer = Bootstrap::getObjectManager()->create(\Magento\Framework\Serialize\Serializer\Json::class);
+        $serializer = $this->objectManager->create(\Magento\Framework\Serialize\Serializer\Json::class);
 
-        /** @var $order \Magento\Sales\Model\Order */
-        $order = Bootstrap::getObjectManager()->create(\Magento\Sales\Model\Order::class);
+        /** @var $order Order */
+        $order = $this->objectManager->create(Order::class);
         $order->loadByIncrementId('100000001');
 
         /** @var $orderCreate \Magento\Sales\Model\AdminOrder\Create */
-        $orderCreate = $this->_model->initFromOrder($order);
+        $orderCreate = $this->model->initFromOrder($order);
 
         $quoteItems = $orderCreate->getQuote()->getItemsCollection();
 
-        $this->assertEquals(1, $quoteItems->count());
+        self::assertEquals(1, $quoteItems->count());
 
         $quoteItem = $quoteItems->getFirstItem();
         $quoteItemOptions = $quoteItem->getOptionsByCode();
 
-        $this->assertEquals(
+        self::assertEquals(
             $serializer->serialize(['additional_option_key' => 'additional_option_value']),
             $quoteItemOptions['additional_options']->getValue()
         );
 
-        $session = Bootstrap::getObjectManager()->get(\Magento\Backend\Model\Session\Quote::class);
+        $session = $this->objectManager->get(SessionQuote::class);
         $session->setCustomerId(1);
 
-        $customer = Bootstrap::getObjectManager()->create(\Magento\Customer\Model\Customer::class);
+        $customer = $this->objectManager->create(Customer::class);
         $customer->load(1)->setDefaultBilling(null)->setDefaultShipping(null)->save();
 
-        $rate = Bootstrap::getObjectManager()->create(\Magento\Quote\Model\Quote\Address\Rate::class);
+        $rate = $this->objectManager->create(Quote\Address\Rate::class);
         $rate->setCode('freeshipping_freeshipping');
 
-        $this->_model->getQuote()->getShippingAddress()->addShippingRate($rate);
-        $this->_model->getQuote()->getShippingAddress()->setCountryId('EE');
-        $this->_model->setShippingAsBilling(0);
-        $this->_model->setPaymentData(['method' => 'checkmo']);
+        $this->model->getQuote()->getShippingAddress()->addShippingRate($rate);
+        $this->model->getQuote()->getShippingAddress()->setCountryId('EE');
+        $this->model->setShippingAsBilling(0);
+        $this->model->setPaymentData(['method' => 'checkmo']);
 
-        $newOrder = $this->_model->createOrder();
+        $newOrder = $this->model->createOrder();
         $newOrderItems = $newOrder->getItemsCollection();
 
-        $this->assertEquals(1, $newOrderItems->count());
+        self::assertEquals(1, $newOrderItems->count());
 
         $order->loadByIncrementId('100000001');
         $this->assertEquals($newOrder->getRealOrderId(), $order->getRelationChildRealId());
@@ -110,7 +122,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
 
         $newOrderItem = $newOrderItems->getFirstItem();
 
-        $this->assertEquals(
+        self::assertEquals(
             ['additional_option_key' => 'additional_option_value'],
             $newOrderItem->getProductOptionByCode('additional_options')
         );
@@ -123,18 +135,28 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testInitFromOrderShippingAddressSameAsBillingWhenSame()
     {
-        /** @var $order \Magento\Sales\Model\Order */
-        $order = Bootstrap::getObjectManager()->create(\Magento\Sales\Model\Order::class);
+        /** @var $order Order */
+        $order = $this->objectManager->create(Order::class);
         $order->loadByIncrementId('100000001');
 
-        $this->assertNull($order->getShippingAddress()->getSameAsBilling());
+        self::assertNull($order->getShippingAddress()->getSameAsBilling());
 
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = Bootstrap::getObjectManager();
-        $objectManager->get(\Magento\Framework\Registry::class)->unregister('rule_data');
-        $this->_model->initFromOrder($order);
+        /** @var OrderAddressExtensionInterface $shippingExtAttributes */
+        $shippingExtAttributes = $this->objectManager->get(OrderAddressExtensionInterfaceFactory::class)
+            ->create();
 
-        $this->assertTrue($order->getShippingAddress()->getSameAsBilling());
+        $billingExtAttributes = clone $shippingExtAttributes;
+
+        $shippingExtAttributes->setData('tmp', false);
+        $billingExtAttributes->setData('tmp', true);
+
+        $order->getShippingAddress()->setExtensionAttributes($shippingExtAttributes);
+        $order->getBillingAddress()->setExtensionAttributes($billingExtAttributes);
+
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+        $this->model->initFromOrder($order);
+
+        self::assertTrue($order->getShippingAddress()->getSameAsBilling());
     }
 
     /**
@@ -144,19 +166,16 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testInitFromOrderShippingAddressSameAsBillingWhenDifferent()
     {
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = Bootstrap::getObjectManager();
-
-        /** @var $order \Magento\Sales\Model\Order */
-        $order = $objectManager->create(\Magento\Sales\Model\Order::class);
+        /** @var $order Order */
+        $order = $this->objectManager->create(Order::class);
         $order->loadByIncrementId('100000002');
 
-        $this->assertNull($order->getShippingAddress()->getSameAsBilling());
+        self::assertNull($order->getShippingAddress()->getSameAsBilling());
 
-        $objectManager->get(\Magento\Framework\Registry::class)->unregister('rule_data');
-        $this->_model->initFromOrder($order);
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+        $this->model->initFromOrder($order);
 
-        $this->assertFalse($order->getShippingAddress()->getSameAsBilling());
+        self::assertFalse($order->getShippingAddress()->getSameAsBilling());
     }
 
     /**
@@ -164,26 +183,23 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testInitFromOrderCcInformationDeleted()
     {
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = Bootstrap::getObjectManager();
-
-        /** @var $order \Magento\Sales\Model\Order */
-        $order = $objectManager->create(\Magento\Sales\Model\Order::class);
+        /** @var $order Order */
+        $order = $this->objectManager->create(Order::class);
         $order->loadByIncrementId('100000001');
 
         $payment = $order->getPayment();
-        $this->assertEquals('5', $payment->getCcExpMonth());
-        $this->assertEquals('2016', $payment->getCcExpYear());
-        $this->assertEquals('AE', $payment->getCcType());
-        $this->assertEquals('0005', $payment->getCcLast4());
+        self::assertEquals('5', $payment->getCcExpMonth());
+        self::assertEquals('2016', $payment->getCcExpYear());
+        self::assertEquals('AE', $payment->getCcType());
+        self::assertEquals('0005', $payment->getCcLast4());
 
-        $objectManager->get(\Magento\Framework\Registry::class)->unregister('rule_data');
-        $payment = $this->_model->initFromOrder($order)->getQuote()->getPayment();
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+        $payment = $this->model->initFromOrder($order)->getQuote()->getPayment();
 
-        $this->assertNull($payment->getCcExpMonth());
-        $this->assertNull($payment->getCcExpYear());
-        $this->assertNull($payment->getCcType());
-        $this->assertNull($payment->getCcLast4());
+        self::assertNull($payment->getCcExpMonth());
+        self::assertNull($payment->getCcExpYear());
+        self::assertNull($payment->getCcType());
+        self::assertNull($payment->getCcLast4());
     }
 
     /**
@@ -191,25 +207,23 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testInitFromOrderWithEmptyPaymentDetails()
     {
-        /** @var $objectManager \Magento\TestFramework\ObjectManager */
-        $objectManager = Bootstrap::getObjectManager();
-        /** @var $order \Magento\Sales\Model\Order */
-        $order = $objectManager->create(Order::class);
+        /** @var $order Order */
+        $order = $this->objectManager->create(Order::class);
         $order->loadByIncrementId('100000001');
 
-        $objectManager->get(Registry::class)
+        $this->objectManager->get(Registry::class)
             ->unregister('rule_data');
 
-        $initOrder = $this->_model->initFromOrder($order);
+        $initOrder = $this->model->initFromOrder($order);
         $payment = $initOrder->getQuote()->getPayment();
 
-        static::assertEquals($initOrder->getQuote()->getId(), $payment->getData('quote_id'));
+        self::assertEquals($initOrder->getQuote()->getId(), $payment->getData('quote_id'));
         $payment->unsetData('quote_id');
 
-        static::assertEmpty($payment->getMethod());
-        static::assertEmpty($payment->getAdditionalInformation());
-        static::assertEmpty($payment->getAdditionalData());
-        static::assertEmpty($payment->getData());
+        self::assertEmpty($payment->getMethod());
+        self::assertEmpty($payment->getAdditionalInformation());
+        self::assertEmpty($payment->getAdditionalData());
+        self::assertEmpty($payment->getData());
     }
 
     /**
@@ -217,11 +231,11 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCustomerWishlistNoCustomerId()
     {
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->create(SessionQuote::class);
         $session->setCustomerId(null);
-        $this->assertFalse(
-            $this->_model->getCustomerWishlist(true),
+        self::assertFalse(
+            $this->model->getCustomerWishlist(true),
             'If customer ID is not set to session, false is expected to be returned.'
         );
     }
@@ -236,24 +250,24 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     {
         $customerIdFromFixture = 1;
         $productIdFromFixture = 1;
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->create(SessionQuote::class);
         $session->setCustomerId($customerIdFromFixture);
 
         /** Test new wishlist creation for the customer specified above */
         /** @var \Magento\Wishlist\Model\Wishlist $wishlist */
-        $wishlist = $this->_model->getCustomerWishlist(true);
-        $this->assertInstanceOf(
+        $wishlist = $this->model->getCustomerWishlist(true);
+        self::assertInstanceOf(
             \Magento\Wishlist\Model\Wishlist::class,
             $wishlist,
             'New Wish List is expected to be created if existing Customer does not have one yet.'
         );
-        $this->assertEquals(0, $wishlist->getItemsCount(), 'New Wish List must be empty just after creation.');
+        self::assertEquals(0, $wishlist->getItemsCount(), 'New Wish List must be empty just after creation.');
 
         /** Add new item to wishlist and try to get it using getCustomerWishlist once again */
         $wishlist->addNewItem($productIdFromFixture)->save();
-        $updatedWishlist = $this->_model->getCustomerWishlist(true);
-        $this->assertEquals(
+        $updatedWishlist = $this->model->getCustomerWishlist(true);
+        self::assertEquals(
             1,
             $updatedWishlist->getItemsCount(),
             'Wish List must contain a Product which was added to it earlier.'
@@ -261,14 +275,14 @@ class CreateTest extends \PHPUnit\Framework\TestCase
 
         /** Try to load wishlist from cache in the class after it is deleted from DB */
         $wishlist->delete();
-        $this->assertSame(
+        self::assertSame(
             $updatedWishlist,
-            $this->_model->getCustomerWishlist(false),
+            $this->model->getCustomerWishlist(false),
             'Wish List cached in class variable is expected to be returned.'
         );
-        $this->assertNotSame(
+        self::assertNotSame(
             $updatedWishlist,
-            $this->_model->getCustomerWishlist(true),
+            $this->model->getCustomerWishlist(true),
             'New Wish List is expected to be created when cache is forced to be refreshed.'
         );
     }
@@ -278,12 +292,12 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetBillingAddress()
     {
-        $addressData = $this->_getValidAddressData();
+        $addressData = $this->getValidAddressData();
         /** Validate data before creating address object */
-        $this->_model->setIsValidate(true)->setBillingAddress($addressData);
-        $this->assertInstanceOf(
-            \Magento\Quote\Model\Quote\Address::class,
-            $this->_model->getBillingAddress(),
+        $this->model->setIsValidate(true)->setBillingAddress($addressData);
+        self::assertInstanceOf(
+            Quote\Address::class,
+            $this->model->getBillingAddress(),
             'Billing address object was not created.'
         );
 
@@ -291,7 +305,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $addressData,
             [
                 'address_type' => 'billing',
-                'quote_id' => $this->_model->getQuote()->getId(),
+                'quote_id' => $this->model->getQuote()->getId(),
                 'street' => "Line1\nLine2",
                 'save_in_address_book' => 0,
                 'region' => '',
@@ -299,10 +313,10 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $result = $this->_model->getBillingAddress()->getData();
+        $result = $this->model->getBillingAddress()->getData();
         foreach ($expectedAddressData as $key => $value) {
-            $this->assertArrayHasKey($key, $result);
-            $this->assertEquals($value, $result[$key]);
+            self::assertArrayHasKey($key, $result);
+            self::assertEquals($value, $result[$key]);
         }
     }
 
@@ -314,32 +328,32 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     public function testSetBillingAddressValidationErrors()
     {
         $customerIdFromFixture = 1;
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->create(SessionQuote::class);
         $session->setCustomerId($customerIdFromFixture);
-        $invalidAddressData = array_merge($this->_getValidAddressData(), ['firstname' => '', 'lastname' => '']);
+        $invalidAddressData = array_merge($this->getValidAddressData(), ['firstname' => '', 'lastname' => '']);
         /**
          * Note that validation errors are collected during setBillingAddress() call in the internal class variable,
          * but they are not set to message manager at this step.
          * They are set to message manager only during createOrder() call.
          */
-        $this->_model->setIsValidate(true)->setBillingAddress($invalidAddressData);
+        $this->model->setIsValidate(true)->setBillingAddress($invalidAddressData);
         try {
-            $this->_model->createOrder();
+            $this->model->createOrder();
             $this->fail('Validation errors are expected to lead to exception during createOrder() call.');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             /** createOrder is expected to throw exception with empty message when validation error occurs */
         }
         $errorMessages = [];
         /** @var $validationError \Magento\Framework\Message\Error */
-        foreach ($this->_messageManager->getMessages()->getItems() as $validationError) {
+        foreach ($this->messageManager->getMessages()->getItems() as $validationError) {
             $errorMessages[] = $validationError->getText();
         }
-        $this->assertTrue(
+        self::assertTrue(
             in_array('Billing Address: "First Name" is a required value.', $errorMessages),
             'Expected validation message is absent.'
         );
-        $this->assertTrue(
+        self::assertTrue(
             in_array('Billing Address: "Last Name" is a required value.', $errorMessages),
             'Expected validation message is absent.'
         );
@@ -361,9 +375,9 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $orderData = [
             'currency' => 'USD',
             'account' => ['group_id' => '1', 'email' => $customerEmail],
-            'billing_address' => array_merge($this->_getValidAddressData(), ['save_in_address_book' => '1']),
+            'billing_address' => array_merge($this->getValidAddressData(), ['save_in_address_book' => '1']),
             'shipping_address' => array_merge(
-                $this->_getValidAddressData(),
+                $this->getValidAddressData(),
                 ['save_in_address_book' => '1', 'firstname' => $firstNameForShippingAddress]
             ),
             'shipping_method' => $shippingMethod,
@@ -372,7 +386,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         ];
         $paymentData = ['method' => $paymentMethod];
 
-        $this->_preparePreconditionsForCreateOrder(
+        $this->preparePreconditionsForCreateOrder(
             $productIdFromFixture,
             $customerEmail,
             $shippingMethod,
@@ -381,12 +395,12 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $orderData,
             $paymentMethod
         );
-        $order = $this->_model->createOrder();
-        $this->_verifyCreatedOrder($order, $shippingMethod);
-        /** @var \Magento\Customer\Model\Customer $customer */
-        $customer = Bootstrap::getObjectManager()->create(\Magento\Customer\Model\Customer::class);
+        $order = $this->model->createOrder();
+        $this->verifyCreatedOrder($order, $shippingMethod);
+        /** @var Customer $customer */
+        $customer = $this->objectManager->create(Customer::class);
         $customer->load($order->getCustomerId());
-        $this->assertEquals(
+        self::assertEquals(
             $firstNameForShippingAddress,
             $customer->getPrimaryShippingAddress()->getFirstname(),
             'Shipping address is saved incorrectly.'
@@ -408,14 +422,14 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $orderData = [
             'currency' => 'USD',
             'account' => ['group_id' => '1', 'email' => $customerEmail],
-            'billing_address' => array_merge($this->_getValidAddressData(), ['save_in_address_book' => '1']),
+            'billing_address' => array_merge($this->getValidAddressData(), ['save_in_address_book' => '1']),
             'shipping_method' => $shippingMethod,
             'comment' => ['customer_note' => ''],
             'send_confirmation' => false,
         ];
         $paymentData = ['method' => $paymentMethod];
 
-        $this->_preparePreconditionsForCreateOrder(
+        $this->preparePreconditionsForCreateOrder(
             $productIdFromFixture,
             $customerEmail,
             $shippingMethod,
@@ -424,12 +438,12 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $orderData,
             $paymentMethod
         );
-        $order = $this->_model->createOrder();
+        $order = $this->model->createOrder();
         //Check, order considering decimal qty in product.
         foreach ($order->getItems() as $orderItem) {
             self::assertTrue($orderItem->getIsQtyDecimal());
         }
-        $this->_verifyCreatedOrder($order, $shippingMethod);
+        $this->verifyCreatedOrder($order, $shippingMethod);
     }
 
     /**
@@ -454,14 +468,14 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $orderData = [
             'currency' => 'USD',
             'account' => ['group_id' => '1', 'email' => $customerEmail],
-            'billing_address' => array_merge($this->_getValidAddressData(), ['save_in_address_book' => '1']),
+            'billing_address' => array_merge($this->getValidAddressData(), ['save_in_address_book' => '1']),
             'shipping_method' => $shippingMethod,
             'comment' => ['customer_note' => ''],
             'send_confirmation' => false,
         ];
         $paymentData = ['method' => $paymentMethod];
 
-        $this->_preparePreconditionsForCreateOrder(
+        $this->preparePreconditionsForCreateOrder(
             $productIdFromFixture,
             $customerEmail,
             $shippingMethod,
@@ -475,17 +489,17 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $orderManagement = $this->getMockForAbstractClass(OrderManagementInterface::class);
         $orderManagement->method('place')
             ->willThrowException(new \Exception('Can\'t place order'));
-        Bootstrap::getObjectManager()->addSharedInstance($orderManagement, OrderManagementInterface::class);
+        $this->objectManager->addSharedInstance($orderManagement, OrderManagementInterface::class);
         try {
-            $this->_model->createOrder();
+            $this->model->createOrder();
         } catch (\Exception $e) {
-            Bootstrap::getObjectManager()->removeSharedInstance(OrderManagementInterface::class);
+            $this->objectManager->removeSharedInstance(OrderManagementInterface::class);
         }
 
-        $customerEmail = $customerEmailSecondAttempt ? :$this->_model->getQuote()->getCustomer()->getEmail();
+        $customerEmail = $customerEmailSecondAttempt ? :$this->model->getQuote()->getCustomer()->getEmail();
         $orderData['account']['email'] = $customerEmailSecondAttempt;
 
-        $this->_preparePreconditionsForCreateOrder(
+        $this->preparePreconditionsForCreateOrder(
             $productIdFromFixture,
             $customerEmail,
             $shippingMethod,
@@ -495,8 +509,8 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $paymentMethod
         );
 
-        $order = $this->_model->createOrder();
-        $this->_verifyCreatedOrder($order, $shippingMethod);
+        $order = $this->model->createOrder();
+        $this->verifyCreatedOrder($order, $shippingMethod);
     }
 
     /**
@@ -537,9 +551,9 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $firstNameForShippingAddress = 'FirstNameForShipping';
         $orderData = [
             'currency' => 'USD',
-            'billing_address' => array_merge($this->_getValidAddressData(), ['save_in_address_book' => '1']),
+            'billing_address' => array_merge($this->getValidAddressData(), ['save_in_address_book' => '1']),
             'shipping_address' => array_merge(
-                $this->_getValidAddressData(),
+                $this->getValidAddressData(),
                 ['save_in_address_book' => '1', 'firstname' => $firstNameForShippingAddress]
             ),
             'shipping_method' => $shippingMethod,
@@ -548,7 +562,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         ];
         $paymentData = ['method' => $paymentMethod];
 
-        $this->_preparePreconditionsForCreateOrder(
+        $this->preparePreconditionsForCreateOrder(
             $productIdFromFixture,
             $customerEmailFromFixture,
             $shippingMethod,
@@ -558,12 +572,15 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $paymentMethod,
             $customerIdFromFixture
         );
-        $order = $this->_model->createOrder();
-        $this->_verifyCreatedOrder($order, $shippingMethod);
-        $this->getCustomerRegistry()->remove($order->getCustomerId());
-        $customer = $this->getCustomerById($order->getCustomerId());
-        $address = $this->getAddressById($customer->getDefaultShipping());
-        $this->assertEquals(
+        $order = $this->model->createOrder();
+        $this->verifyCreatedOrder($order, $shippingMethod);
+        $this->objectManager->get(CustomerRegistry::class)
+            ->remove($order->getCustomerId());
+        $customer = $this->objectManager->get(CustomerRepositoryInterface::class)
+            ->getById($order->getCustomerId());
+        $address = $this->objectManager->get(AddressRepositoryInterface::class)
+            ->getById($customer->getDefaultShipping());
+        self::assertEquals(
             $firstNameForShippingAddress,
             $address->getFirstname(),
             'Shipping address is saved incorrectly.'
@@ -586,14 +603,14 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $shippingAddressAsBilling = 1;
         $orderData = [
             'currency' => 'USD',
-            'billing_address' => array_merge($this->_getValidAddressData(), ['save_in_address_book' => '1']),
+            'billing_address' => array_merge($this->getValidAddressData(), ['save_in_address_book' => '1']),
             'shipping_method' => $shippingMethod,
             'comment' => ['customer_note' => ''],
             'send_confirmation' => false,
         ];
         $paymentData = ['method' => $paymentMethod];
 
-        $this->_preparePreconditionsForCreateOrder(
+        $this->preparePreconditionsForCreateOrder(
             $productIdFromFixture,
             $customerEmailFromFixture,
             $shippingMethod,
@@ -603,8 +620,8 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $paymentMethod,
             $customerIdFromFixture
         );
-        $order = $this->_model->createOrder();
-        $this->_verifyCreatedOrder($order, $shippingMethod);
+        $order = $this->model->createOrder();
+        $this->verifyCreatedOrder($order, $shippingMethod);
     }
 
     /**
@@ -617,21 +634,21 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $fixtureCustomerId = 1;
 
         /** Preconditions */
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->create(SessionQuote::class);
         $session->setCustomerId($fixtureCustomerId);
-        /** @var $quoteFixture \Magento\Quote\Model\Quote */
-        $quoteFixture = Bootstrap::getObjectManager()->create(\Magento\Quote\Model\Quote::class);
+        /** @var $quoteFixture Quote */
+        $quoteFixture = $this->objectManager->create(Quote::class);
         $quoteFixture->load('test01', 'reserved_order_id');
         $quoteFixture->setCustomerIsGuest(false)->setCustomerId($fixtureCustomerId)->save();
 
         /** SUT execution */
-        $customerQuote = $this->_model->getCustomerCart();
-        $this->assertEquals($quoteFixture->getId(), $customerQuote->getId(), 'Quote ID is invalid.');
+        $customerQuote = $this->model->getCustomerCart();
+        self::assertEquals($quoteFixture->getId(), $customerQuote->getId(), 'Quote ID is invalid.');
 
         /** Try to load quote once again to ensure that caching works correctly */
-        $customerQuoteFromCache = $this->_model->getCustomerCart();
-        $this->assertSame($customerQuote, $customerQuoteFromCache, 'Customer quote caching does not work correctly.');
+        $customerQuoteFromCache = $this->model->getCustomerCart();
+        self::assertSame($customerQuote, $customerQuoteFromCache, 'Customer quote caching does not work correctly.');
     }
 
     /**
@@ -644,20 +661,20 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $fixtureCustomerId = 1;
 
         /** Preconditions */
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->create(SessionQuote::class);
         $session->setCustomerId($fixtureCustomerId);
-        /** @var $quoteFixture \Magento\Quote\Model\Quote */
-        $quoteFixture = Bootstrap::getObjectManager()->create(\Magento\Quote\Model\Quote::class);
+        /** @var $quoteFixture Quote */
+        $quoteFixture = $this->objectManager->create(Quote::class);
         $quoteFixture->load('test01', 'reserved_order_id');
         $quoteFixture->setCustomerIsGuest(false)->setCustomerId($fixtureCustomerId)->save();
 
-        $customerQuote = $this->_model->getCustomerCart();
+        $customerQuote = $this->model->getCustomerCart();
         $item = $customerQuote->getAllVisibleItems()[0];
 
-        $this->_model->moveQuoteItem($item, 'cart', 3);
-        $this->assertEquals(4, $item->getQty(), 'Number of Qty isn\'t correct for Quote item.');
-        $this->assertEquals(3, $item->getQtyToAdd(), 'Number of added qty isn\'t correct for Quote item.');
+        $this->model->moveQuoteItem($item, 'cart', 3);
+        self::assertEquals(4, $item->getQty(), 'Number of Qty isn\'t correct for Quote item.');
+        self::assertEquals(3, $item->getQtyToAdd(), 'Number of added qty isn\'t correct for Quote item.');
     }
 
     /**
@@ -671,14 +688,14 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $customerEmailFromFixture = 'customer@example.com';
 
         /** Preconditions */
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->create(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->create(SessionQuote::class);
         $session->setCustomerId($customerIdFromFixture);
 
         /** SUT execution */
-        $customerQuote = $this->_model->getCustomerCart();
-        $this->assertNotEmpty($customerQuote->getId(), 'Quote ID is invalid.');
-        $this->assertEquals(
+        $customerQuote = $this->model->getCustomerCart();
+        self::assertNotEmpty($customerQuote->getId(), 'Quote ID is invalid.');
+        self::assertEquals(
             $customerEmailFromFixture,
             $customerQuote->getCustomerEmail(),
             'Customer data is preserved incorrectly in a newly quote.'
@@ -697,7 +714,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      * @param string $paymentMethod
      * @param int|null $customerIdFromFixture
      */
-    protected function _preparePreconditionsForCreateOrder(
+    private function preparePreconditionsForCreateOrder(
         $productIdFromFixture,
         $customerEmail,
         $shippingMethod,
@@ -709,18 +726,18 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     ) {
         /** Disable product options */
         /** @var \Magento\Catalog\Model\Product $product */
-        $product = Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+        $product = $this->objectManager->create(\Magento\Catalog\Model\Product::class);
         $product->load($productIdFromFixture)->setHasOptions(false)->save();
 
         /** Set current customer */
-        /** @var \Magento\Backend\Model\Session\Quote $session */
-        $session = Bootstrap::getObjectManager()->get(\Magento\Backend\Model\Session\Quote::class);
+        /** @var SessionQuote $session */
+        $session = $this->objectManager->get(SessionQuote::class);
         if ($customerIdFromFixture !== null) {
             $session->setCustomerId($customerIdFromFixture);
 
             /** Unset fake IDs for default billing and shipping customer addresses */
-            /** @var \Magento\Customer\Model\Customer $customer */
-            $customer = Bootstrap::getObjectManager()->create(\Magento\Customer\Model\Customer::class);
+            /** @var Customer $customer */
+            $customer = $this->objectManager->create(Customer::class);
             $customer->load($customerIdFromFixture)->setDefaultBilling(null)->setDefaultShipping(null)->save();
         } else {
             /**
@@ -731,48 +748,48 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         }
 
         /** Emulate availability of shipping method (all are disabled by default) */
-        /** @var $rate \Magento\Quote\Model\Quote\Address\Rate */
-        $rate = Bootstrap::getObjectManager()->create(\Magento\Quote\Model\Quote\Address\Rate::class);
+        /** @var $rate Quote\Address\Rate */
+        $rate = $this->objectManager->create(Quote\Address\Rate::class);
         $rate->setCode($shippingMethod);
-        $this->_model->getQuote()->getShippingAddress()->addShippingRate($rate);
+        $this->model->getQuote()->getShippingAddress()->addShippingRate($rate);
 
-        $this->_model->setShippingAsBilling($shippingAddressAsBilling);
-        $this->_model->addProduct($productIdFromFixture, ['qty' => 1]);
-        $this->_model->setPaymentData($paymentData);
-        $this->_model->setIsValidate(true)->importPostData($orderData);
+        $this->model->setShippingAsBilling($shippingAddressAsBilling);
+        $this->model->addProduct($productIdFromFixture, ['qty' => 1]);
+        $this->model->setPaymentData($paymentData);
+        $this->model->setIsValidate(true)->importPostData($orderData);
 
         /** Check preconditions */
 
-        $this->assertEquals(
+        self::assertEquals(
             0,
-            $this->_messageManager->getMessages()->getCount(),
+            $this->messageManager->getMessages()->getCount(),
             "Precondition failed: Errors occurred before SUT execution."
         );
         /** Selectively check quote data */
-        $createOrderData = $this->_model->getData();
-        $this->assertEquals(
+        $createOrderData = $this->model->getData();
+        self::assertEquals(
             $shippingMethod,
             $createOrderData['shipping_method'],
             'Precondition failed: Shipping method specified in create order model is invalid'
         );
-        $this->assertEquals(
+        self::assertEquals(
             'FirstName',
             $createOrderData['billing_address']['firstname'],
             'Precondition failed: Address data is invalid in create order model'
         );
-        $this->assertEquals(
+        self::assertEquals(
             'Simple Product',
-            $this->_model->getQuote()->getItemByProduct($product)->getData('name'),
+            $this->model->getQuote()->getItemByProduct($product)->getData('name'),
             'Precondition failed: Quote items data is invalid in create order model'
         );
-        $this->assertEquals(
+        self::assertEquals(
             $customerEmail,
-            $this->_model->getQuote()->getCustomer()->getEmail(),
+            $this->model->getQuote()->getCustomer()->getEmail(),
             'Precondition failed: Customer data is invalid in create order model'
         );
-        $this->assertEquals(
+        self::assertEquals(
             $paymentMethod,
-            $this->_model->getQuote()->getPayment()->getData('method'),
+            $this->model->getQuote()->getPayment()->getData('method'),
             'Precondition failed: Payment method data is invalid in create order model'
         );
     }
@@ -780,26 +797,26 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     /**
      * Ensure that order is created correctly via createOrder().
      *
-     * @param \Magento\Sales\Model\Order $order
+     * @param Order $order
      * @param string $shippingMethod
      */
-    protected function _verifyCreatedOrder($order, $shippingMethod)
+    private function verifyCreatedOrder($order, $shippingMethod)
     {
         /** Selectively check order data */
         $orderData = $order->getData();
-        $this->assertNotEmpty($orderData['increment_id'], 'Order increment ID is empty.');
-        $this->assertEquals($this->_model->getQuote()->getId(), $orderData['quote_id'], 'Quote ID is invalid.');
-        $this->assertEquals(
-            $this->_model->getQuote()->getCustomer()->getEmail(),
+        self::assertNotEmpty($orderData['increment_id'], 'Order increment ID is empty.');
+        self::assertEquals($this->model->getQuote()->getId(), $orderData['quote_id'], 'Quote ID is invalid.');
+        self::assertEquals(
+            $this->model->getQuote()->getCustomer()->getEmail(),
             $orderData['customer_email'],
             'Customer email is invalid.'
         );
-        $this->assertEquals(
-            $this->_model->getQuote()->getCustomer()->getFirstname(),
+        self::assertEquals(
+            $this->model->getQuote()->getCustomer()->getFirstname(),
             $orderData['customer_firstname'],
             'Customer first name is invalid.'
         );
-        $this->assertEquals($shippingMethod, $orderData['shipping_method'], 'Shipping method is invalid.');
+        self::assertEquals($shippingMethod, $orderData['shipping_method'], 'Shipping method is invalid.');
     }
 
     /**
@@ -807,7 +824,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    protected function _getValidAddressData()
+    private function getValidAddressData()
     {
         return [
             'prefix' => 'prefix',
@@ -828,49 +845,5 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             'fax' => '',
             'vat_id' => ''
         ];
-    }
-
-    /**
-     * @param int $id
-     * @return \Magento\Customer\Api\Data\CustomerInterface
-     */
-    private function getCustomerById($id)
-    {
-        return $this->getCustomerRepository()->getById($id);
-    }
-
-    /**
-     * @return \Magento\Customer\Api\CustomerRepositoryInterface
-     */
-    private function getCustomerRepository()
-    {
-        return Bootstrap::getObjectManager()->create(\Magento\Customer\Api\CustomerRepositoryInterface::class);
-    }
-
-    /**
-     * @param int $id
-     * @return \Magento\Customer\Api\Data\AddressInterface
-     */
-    private function getAddressById($id)
-    {
-        return $this->getAddressRepository()->getById($id);
-    }
-
-    /**
-     * @return \Magento\Customer\Api\AddressRepositoryInterface
-     */
-    private function getAddressRepository()
-    {
-        /** @var \Magento\Customer\Api\AddressRepositoryInterface $addressRepository */
-        return Bootstrap::getObjectManager()->create(\Magento\Customer\Api\AddressRepositoryInterface::class);
-    }
-
-    /**
-     * @return \Magento\Customer\Model\CustomerRegistry
-     */
-    private function getCustomerRegistry()
-    {
-        /** @var \Magento\Customer\Model\CustomerRegistry $addressRepository */
-        return Bootstrap::getObjectManager()->get(\Magento\Customer\Model\CustomerRegistry::class);
     }
 }


### PR DESCRIPTION
### Fixed Issues
1. magento/magento2#10438: Potential error on order edit page when address has extension attributes

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
