### PR TITLE
#6948: CatalogImportExport categoryProcessor does not support escaped delimiter

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\CatalogImportExport\Model\Export;
 
+use Magento\CatalogImportExport\Model\Import\Product\CategoryProcessor;
 use Magento\ImportExport\Model\Import;
 use \Magento\Store\Model\Store;
 use \Magento\CatalogImportExport\Model\Import\Product as ImportProduct;
@@ -438,11 +439,12 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             if ($pathSize > 1) {
                 $path = [];
                 for ($i = 1; $i < $pathSize; $i++) {
-                    $path[] = $collection->getItemById($structure[$i])->getName();
+                    $name = $collection->getItemById($structure[$i])->getName();
+                    $path[] = $this->quoteCategoryDelimiter($name);
                 }
                 $this->_rootCategories[$category->getId()] = array_shift($path);
                 if ($pathSize > 2) {
-                    $this->_categories[$category->getId()] = implode('/', $path);
+                    $this->_categories[$category->getId()] = implode(CategoryProcessor::DELIMITER_CATEGORY, $path);
                 }
             }
         }
@@ -1469,5 +1471,20 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
                 ->getLinkField();
         }
         return $this->productEntityLinkField;
+    }
+
+    /**
+     * Quoting category delimiter character in string.
+     *
+     * @param string $string
+     * @return string
+     */
+    private function quoteCategoryDelimiter($string)
+    {
+        return str_replace(
+            CategoryProcessor::DELIMITER_CATEGORY,
+            '\\' . CategoryProcessor::DELIMITER_CATEGORY,
+            $string
+        );
     }
 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -84,7 +84,8 @@ class CategoryProcessor
                 if ($pathSize > 1) {
                     $path = [];
                     for ($i = 1; $i < $pathSize; $i++) {
-                        $path[] = $collection->getItemById((int)$structure[$i])->getName();
+                        $name = $collection->getItemById((int)$structure[$i])->getName();
+                        $path[] = $this->quoteDelimiter($name);
                     }
                     /** @var string $index */
                     $index = $this->standardizeString(
@@ -114,7 +115,7 @@ class CategoryProcessor
         }
         $category->setPath($parentCategory->getPath());
         $category->setParentId($parentId);
-        $category->setName($name);
+        $category->setName($this->unquoteDelimiter($name));
         $category->setIsActive(true);
         $category->setIncludeInMenu(true);
         $category->setAttributeSetId($category->getDefaultAttributeSetId());
@@ -137,7 +138,7 @@ class CategoryProcessor
         $index = $this->standardizeString($categoryPath);
 
         if (!isset($this->categories[$index])) {
-            $pathParts = explode(self::DELIMITER_CATEGORY, $categoryPath);
+            $pathParts = preg_split('~(?<!\\\)' . preg_quote(self::DELIMITER_CATEGORY, '~') . '~', $categoryPath);
             $parentId = \Magento\Catalog\Model\Category::TREE_ROOT_ID;
             $path = '';
 
@@ -242,5 +243,27 @@ class CategoryProcessor
     private function standardizeString($string)
     {
         return mb_strtolower($string);
+    }
+
+    /**
+     * Quoting delimiter character in string.
+     *
+     * @param string $string
+     * @return string
+     */
+    private function quoteDelimiter($string)
+    {
+        return str_replace(self::DELIMITER_CATEGORY, '\\' . self::DELIMITER_CATEGORY, $string);
+    }
+
+    /**
+     * Remove quoting delimiter in string.
+     *
+     * @param string $string
+     * @return string
+     */
+    private function unquoteDelimiter($string)
+    {
+        return str_replace('\\' . self::DELIMITER_CATEGORY, self::DELIMITER_CATEGORY, $string);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/catalog_category_with_slash.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/catalog_category_with_slash.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+$category = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Category::class);
+$category->isObjectNew(true);
+$category->setId(
+    3331
+)->setCreatedAt(
+    '2017-06-23 09:50:07'
+)->setName(
+    'Category with slash/ symbol'
+)->setParentId(
+    2
+)->setPath(
+    '1/2/3331'
+)->setLevel(
+    2
+)->setAvailableSortBy(
+    ['position', 'name']
+)->setDefaultSortBy(
+    'name'
+)->setIsActive(
+    true
+)->setPosition(
+    1
+)->save();

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Export/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Export/ProductTest.php
@@ -104,6 +104,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         );
         $exportData = $this->model->export();
         $this->assertContains('simple ""1""', $exportData);
+        $this->assertContains('Category with slash\/ symbol', $exportData);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/import_new_categories_custom_separator.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/import_new_categories_custom_separator.csv
@@ -1,2 +1,2 @@
 sku,product_type,store_view_code,name,price,attribute_set_code,categories,product_websites
-simple1,simple,,"simple 2",25,Default,"Default Category/Category 1|Default Category/Category 2",base
+simple1,simple,,"simple 2",25,Default,"Default Category/Category 1|Default Category/Category\/ 2",base

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/import_new_categories_default_separator.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/import_new_categories_default_separator.csv
@@ -1,2 +1,2 @@
 sku,product_type,store_view_code,name,price,attribute_set_code,categories,product_websites,url_key
-simple1,simple,,"simple 1",25,Default,"Default Category/Category 1,Default Category/Category 2",base,simple1-ds
+simple1,simple,,"simple 1",25,Default,"Default Category/Category 1,Default Category/Category\/ 2",base,simple1-ds

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/_files/product_export_data_special_chars.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/_files/product_export_data_special_chars.php
@@ -5,6 +5,8 @@
  */
 /** Create category */
 require dirname(dirname(__DIR__)) . '/Catalog/_files/category.php';
+/** Create category with special chars */
+require dirname(dirname(__DIR__)) . '/Catalog/_files/catalog_category_with_slash.php';
 /** Create fixture store */
 require dirname(dirname(__DIR__)) . '/Store/_files/second_store.php';
 /** Create product with multiselect attribute and values */
@@ -28,10 +30,8 @@ $productModel->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
     ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
     ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
     ->setWebsiteIds([1])
-    ->setCateroryIds([])
     ->setStockData(['qty' => 100, 'is_in_stock' => 1])
     ->setCanSaveCustomOptions(true)
-    ->setCategoryIds([333])
-    ->setUpSellLinkData([$product->getId() => ['position' => 1]]);
+    ->setCategoryIds([333, 3331]);
 
 $productModel->setOptions([])->save();


### PR DESCRIPTION
### Description
Allow export/import category name with category delimiter character.
After apply this fix, when exporting, the delimiter character in category mane will be quoted.
Example:
"Category / 1" =>"Category\\/ 1".
And in import apply conversely process.

### Fixed Issues
1. magento/magento2#6948: CatalogImportExport categoryProcessor does not support escaped delimiter

### Manual testing scenarios
1. Create Category with name, that contains category delimiter  "Category /1 test".
2. Create any product and asigne this category.
3. Export this product.
4. File should be contain category name like "Category\\/1 test".
5. Import this file as "Entity Type"="Products" and "Import Behavior"="Add/Update".
6. The Category filed in product should remain unchanged.
7. New category with name "1 test" should not be created.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
