### PR TITLE
Explicitly set table strategy in Price\Action\Rows::execute($ids)

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Price/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Price/Action/Rows.php
@@ -25,6 +25,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Product\Price\AbstractAction
             throw new \Magento\Framework\Exception\InputException(__('Bad value was supplied.'));
         }
         try {
+            $this->_defaultIndexerResource->getTableStrategy()->setUseIdxTable(false);
             $this->_reindexRows($ids);
         } catch (\Exception $e) {
             throw new \Magento\Framework\Exception\LocalizedException(__($e->getMessage()), $e);


### PR DESCRIPTION
Table strategy for indexer should be set explicitly when indexing row list.

### Description
When calling Magento\Catalog\Model\Indexer\Product\Price\Action\Rows::execute($ids) after Magento\Catalog\Model\Indexer\Product\Price\Action\Full:execute() incorrect table strategy is being used and as a result since it's chaning in Full:execute().

I don't think it can be reproduced anyhow, but I hit it when writing integration tests.

### Manual testing scenarios

```
$indexer = Bootstrap::getObjectManager()->create('Magento\Indexer\Model\Indexer');
$indexer->load('catalog_product_price');
$indexer->reindexAll();
$indexer->reindexList([1]);
// entity_id=1 is removed from catalog_product_index_price now
```


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
