### PR TITLE
5823: Copying custom fields from quote to order table using sales_convert_quote in fieldset.xml

### DIFF
--- a/app/code/Magento/Sales/Observer/SalesEventQuoteSubmitBeforeObserver.php
+++ b/app/code/Magento/Sales/Observer/SalesEventQuoteSubmitBeforeObserver.php
@@ -19,22 +19,14 @@ class SalesEventQuoteSubmitBeforeObserver implements ObserverInterface
     private $fieldsetConfig;
 
     /**
-     * @var \Magento\Sales\Api\Data\OrderInterface
-     */
-    private $order;
-
-    /**
      * SalesEventQuoteSubmitBeforeObserver constructor.
      *
      * @param \Magento\Framework\DataObject\Copy\Config $fieldsetConfig
-     * @param \Magento\Sales\Api\Data\OrderInterface $order
      */
     public function __construct(
-        \Magento\Framework\DataObject\Copy\Config $fieldsetConfig,
-        \Magento\Sales\Api\Data\OrderInterface $order
+        \Magento\Framework\DataObject\Copy\Config $fieldsetConfig
     ) {
         $this->fieldsetConfig = $fieldsetConfig;
-        $this->order = $order;
     }
 
     /**
@@ -52,15 +44,14 @@ class SalesEventQuoteSubmitBeforeObserver implements ObserverInterface
 
         $fields = $this->fieldsetConfig->getFieldset('sales_convert_quote', 'global');
 
-        $methods = get_class_methods($this->order);
+        $methods = get_class_methods($order);
 
         foreach ($fields as $code => $node) {
             $targetCode = (string)$node['to_order'];
             $targetCode = $targetCode == '*' ? $code : $targetCode;
 
             if (!in_array($this->getMethodName($targetCode), $methods)) {
-                $code2 = $quote->getData($code);
-                $order->setData($targetCode, $code2);
+                $order->setData($targetCode, $quote->getData($code));
             }
         }
 

--- a/app/code/Magento/Sales/Observer/SalesEventQuoteSubmitBeforeObserver.php
+++ b/app/code/Magento/Sales/Observer/SalesEventQuoteSubmitBeforeObserver.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Sales\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Copy custom fields from quote tables to order.
+ */
+class SalesEventQuoteSubmitBeforeObserver implements ObserverInterface
+{
+    /**
+     * @var \Magento\Framework\DataObject\Copy\Config
+     */
+    private $fieldsetConfig;
+
+    /**
+     * @var \Magento\Sales\Api\Data\OrderInterface
+     */
+    private $order;
+
+    /**
+     * SalesEventQuoteSubmitBeforeObserver constructor.
+     *
+     * @param \Magento\Framework\DataObject\Copy\Config $fieldsetConfig
+     * @param \Magento\Sales\Api\Data\OrderInterface $order
+     */
+    public function __construct(
+        \Magento\Framework\DataObject\Copy\Config $fieldsetConfig,
+        \Magento\Sales\Api\Data\OrderInterface $order
+    ) {
+        $this->fieldsetConfig = $fieldsetConfig;
+        $this->order = $order;
+    }
+
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     *
+     * @return $this
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        /** @var \Magento\Quote\Api\Data\CartInterface $quote */
+        $quote = $observer->getEvent()->getQuote();
+
+        /** @var \Magento\Sales\Api\Data\OrderInterface $order */
+        $order = $observer->getEvent()->getOrder();
+
+        $fields = $this->fieldsetConfig->getFieldset('sales_convert_quote', 'global');
+
+        $methods = get_class_methods($this->order);
+
+        foreach ($fields as $code => $node) {
+            $targetCode = (string)$node['to_order'];
+            $targetCode = $targetCode == '*' ? $code : $targetCode;
+
+            if (!in_array($this->getMethodName($targetCode), $methods)) {
+                $code2 = $quote->getData($code);
+                $order->setData($targetCode, $code2);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convert key to method name.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    private function getMethodName($key)
+    {
+        return 'get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+    }
+}

--- a/app/code/Magento/Sales/Test/Unit/Observer/SalesEventQuoteSubmitBeforeObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/SalesEventQuoteSubmitBeforeObserverTest.php
@@ -27,7 +27,6 @@ class SalesEventQuoteSubmitBeforeObserverTest extends \PHPUnit\Framework\TestCas
      */
     private $fieldsetConfig;
 
-
     protected function setUp()
     {
         $this->fieldsetConfig = $this->createPartialMock(Config::class, ['getFieldset']);
@@ -77,7 +76,7 @@ class SalesEventQuoteSubmitBeforeObserverTest extends \PHPUnit\Framework\TestCas
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function createPartialMockForAbstractClass($className, $methods =[])
+    private function createPartialMockForAbstractClass($className, $methods = [])
     {
         return $this->getMockForAbstractClass(
             $className,

--- a/app/code/Magento/Sales/Test/Unit/Observer/SalesEventQuoteSubmitBeforeObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/SalesEventQuoteSubmitBeforeObserverTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Sales\Test\Unit\Observer;
+
+use Magento\Framework\DataObject\Copy\Config;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Observer\SalesEventQuoteSubmitBeforeObserver;
+
+/**
+ * Test for Magento\Sales\Observer\SalesEventQuoteSubmitBeforeObserver.
+ */
+class SalesEventQuoteSubmitBeforeObserverTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var SalesEventQuoteSubmitBeforeObserver
+     */
+    private $observer;
+
+    /**
+     * @var Config|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldsetConfig;
+
+    /**
+     * @var OrderInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $order;
+
+    protected function setUp()
+    {
+        $this->fieldsetConfig = $this->createPartialMock(Config::class, ['getFieldset']);
+        $this->order = $this->createPartialMockForAbstractClass(OrderInterface::class);
+
+        $this->observer = new SalesEventQuoteSubmitBeforeObserver(
+            $this->fieldsetConfig,
+            $this->order
+        );
+    }
+
+    public function testExecute()
+    {
+        $fields = [
+            'store_id' => ['to_order' => '*'],
+            'test_field' => ['to_order' => '*'],
+            'coupon_code' => ['to_order' => '*'],
+            'base_subtotal_invoiced' => ['to_order' => '*'],
+            'some_new' => ['to_order' => '*'],
+        ];
+
+        $observerMock = $this->createPartialMock(Observer::class, ['getEvent']);
+        $eventMock = $this->createPartialMock(\Magento\Framework\Event::class, ['getQuote', 'getOrder']);
+        $orderMock = $this->createPartialMockForAbstractClass(OrderInterface::class, ['setData']);
+        $quoteMock = $this->createPartialMockForAbstractClass(CartInterface::class, ['getData']);
+
+        $observerMock->expects($this->exactly(2))->method('getEvent')->willReturn($eventMock);
+        $eventMock->expects($this->once())->method('getQuote')->willReturn($quoteMock);
+        $eventMock->expects($this->once())->method('getOrder')->willReturn($orderMock);
+        $this->fieldsetConfig->expects($this->once())->method('getFieldset')->with('sales_convert_quote', 'global')
+            ->willReturn($fields);
+        $quoteMock->expects($this->exactly(2))->method('getData')->withConsecutive(
+            ['test_field'],
+            ['some_new']
+        )->willReturn('test_data');
+        $orderMock->expects($this->exactly(2))->method('setData')->withConsecutive(
+            ['test_field', 'test_data'],
+            ['some_new', 'test_data']
+        );
+
+        $this->observer->execute($observerMock);
+    }
+
+    /**
+     * Get mock for abstract class with methods.
+     *
+     * @param string $className
+     * @param array $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createPartialMockForAbstractClass($className, $methods =[])
+    {
+        return $this->getMockForAbstractClass(
+            $className,
+            [],
+            '',
+            true,
+            true,
+            true,
+            $methods
+        );
+    }
+}

--- a/app/code/Magento/Sales/Test/Unit/Observer/SalesEventQuoteSubmitBeforeObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/SalesEventQuoteSubmitBeforeObserverTest.php
@@ -27,19 +27,13 @@ class SalesEventQuoteSubmitBeforeObserverTest extends \PHPUnit\Framework\TestCas
      */
     private $fieldsetConfig;
 
-    /**
-     * @var OrderInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $order;
 
     protected function setUp()
     {
         $this->fieldsetConfig = $this->createPartialMock(Config::class, ['getFieldset']);
-        $this->order = $this->createPartialMockForAbstractClass(OrderInterface::class);
 
         $this->observer = new SalesEventQuoteSubmitBeforeObserver(
-            $this->fieldsetConfig,
-            $this->order
+            $this->fieldsetConfig
         );
     }
 

--- a/app/code/Magento/Sales/etc/events.xml
+++ b/app/code/Magento/Sales/etc/events.xml
@@ -51,4 +51,7 @@
     <event name="store_add">
         <observer name="magento_sequence" instance="Magento\SalesSequence\Observer\SequenceCreatorObserver" />
     </event>
+    <event name="sales_model_service_quote_submit_before">
+        <observer name="sales_quote_to_order_observer" instance="Magento\Sales\Observer\SalesEventQuoteSubmitBeforeObserver"/>
+    </event>
 </config>


### PR DESCRIPTION
Copy custom fields from quote table to order.
### Description
Observer created.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5823: Copying custom fields from quote to order table using sales_convert_quote in fieldset.xml

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a custom module that add a field to quote and sales_order table.
2. Update the field in quote table and then place an order.
3. Field from quote table must be copied to order table.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
