### PR TITLE
fix for generating 301 url rewrites when changing name/url_key on storeview level

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
@@ -11,6 +11,7 @@ use Magento\CatalogUrlRewrite\Model\ObjectRegistry;
 use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\UrlRewrite\Model\OptionProvider;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewriteFactory;
 
@@ -65,6 +66,7 @@ class AnchorUrlRewriteGenerator
                     $urls[] = $this->urlRewriteFactory->create()
                         ->setEntityType(ProductUrlRewriteGenerator::ENTITY_TYPE)
                         ->setEntityId($product->getId())
+                        ->setRedirectType(OptionProvider::PERMANENT)
                         ->setRequestPath(
                             $this->urlPathGenerator->getUrlPathWithSuffix(
                                 $product,

--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/CanonicalUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/CanonicalUrlRewriteGenerator.php
@@ -8,6 +8,7 @@ namespace Magento\CatalogUrlRewrite\Model\Product;
 use Magento\Catalog\Model\Product;
 use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\UrlRewrite\Model\OptionProvider;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewriteFactory;
 
@@ -46,6 +47,7 @@ class CanonicalUrlRewriteGenerator
             $this->urlRewriteFactory->create()
                 ->setEntityType(ProductUrlRewriteGenerator::ENTITY_TYPE)
                 ->setEntityId($product->getId())
+                ->setRedirectType(OptionProvider::PERMANENT)
                 ->setRequestPath($this->productUrlPathGenerator->getUrlPathWithSuffix($product, $storeId))
                 ->setTargetPath($this->productUrlPathGenerator->getCanonicalUrlPath($product))
                 ->setStoreId($storeId)

--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/CategoriesUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/CategoriesUrlRewriteGenerator.php
@@ -9,6 +9,7 @@ use Magento\Catalog\Model\Product;
 use Magento\CatalogUrlRewrite\Model\ObjectRegistry;
 use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\UrlRewrite\Model\OptionProvider;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewriteFactory;
 
@@ -49,6 +50,7 @@ class CategoriesUrlRewriteGenerator
             $urls[] = $this->urlRewriteFactory->create()
                 ->setEntityType(ProductUrlRewriteGenerator::ENTITY_TYPE)
                 ->setEntityId($product->getId())
+                ->setRedirectType(OptionProvider::PERMANENT)
                 ->setRequestPath($this->productUrlPathGenerator->getUrlPathWithSuffix($product, $storeId, $category))
                 ->setTargetPath($this->productUrlPathGenerator->getCanonicalUrlPath($product, $category))
                 ->setStoreId($storeId)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This fixes problems with generating 301 url rewrites when a product's url key is changed on storeview level. The records are created in the Url Rewrites table for the changed product, but the redirect type is 'No'. This fix changes it to '301 Permanent' 

### Possibly fixes Issues:
1. magento/magento2/issues/10073

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Edit an existing product on storeview scope
2. Change the url key for the product
3. Save the Product
4. Check the url rewrite in URL Rewrites.
5. The Redirect Type should be 301 Parmanent

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
