### PR TITLE
GITHUB-8970: Cannot assign products to categories not under tree root.

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -207,9 +207,9 @@ class ProductScopeRewriteGenerator
      */
     public function isCategoryProperForGenerating(Category $category, $storeId)
     {
-        $parentId = $category->getParentId();
-        if ($parentId != Category::ROOT_CATEGORY_ID && $parentId != Category::TREE_ROOT_ID) {
-            list(, $rootCategoryId) = $category->getParentIds();
+        $parentIds = $category->getParentIds();
+        if (count($parentIds) >= 2) {
+            $rootCategoryId = $parentIds[1];
             return $rootCategoryId == $this->storeManager->getStore($storeId)->getRootCategoryId();
         }
         return false;

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -207,7 +207,11 @@ class ProductScopeRewriteGenerator
      */
     public function isCategoryProperForGenerating(Category $category, $storeId)
     {
-        if ($category->getParentId() != \Magento\Catalog\Model\Category::TREE_ROOT_ID) {
+        $parentId = $category->getParentId();
+        if (
+            $parentId != Category::ROOT_CATEGORY_ID
+            && $parentId != Category::TREE_ROOT_ID
+        ) {
             list(, $rootCategoryId) = $category->getParentIds();
             return $rootCategoryId == $this->storeManager->getStore($storeId)->getRootCategoryId();
         }

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -208,10 +208,7 @@ class ProductScopeRewriteGenerator
     public function isCategoryProperForGenerating(Category $category, $storeId)
     {
         $parentId = $category->getParentId();
-        if (
-            $parentId != Category::ROOT_CATEGORY_ID
-            && $parentId != Category::TREE_ROOT_ID
-        ) {
+        if ($parentId != Category::ROOT_CATEGORY_ID && $parentId != Category::TREE_ROOT_ID) {
             list(, $rootCategoryId) = $category->getParentIds();
             return $rootCategoryId == $this->storeManager->getStore($storeId)->getRootCategoryId();
         }

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductScopeRewriteGeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductScopeRewriteGeneratorTest.php
@@ -47,6 +47,9 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
     /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
     private $serializer;
 
+    /** @var \Magento\Catalog\Model\Category|\PHPUnit_Framework_MockObject_MockObject */
+    private $categoryMock;
+
     public function setUp()
     {
         $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
@@ -83,6 +86,10 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->storeViewService = $this->getMockBuilder(\Magento\CatalogUrlRewrite\Service\V1\StoreViewService::class)
             ->disableOriginalConstructor()->getMock();
         $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeRootCategoryId = 2;
+        $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)->disableOriginalConstructor()->getMock();
+        $store->expects($this->any())->method('getRootCategoryId')->will($this->returnValue($storeRootCategoryId));
+        $this->storeManager->expects($this->any())->method('getStore')->will($this->returnValue($store));
         $mergeDataProviderFactory = $this->createPartialMock(
             \Magento\UrlRewrite\Model\MergeDataProviderFactory::class,
             ['create']
@@ -103,6 +110,7 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
                 'mergeDataProviderFactory' => $mergeDataProviderFactory
             ]
         );
+        $this->categoryMock = $this->getMockBuilder(Category::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testGenerationForGlobalScope()
@@ -112,12 +120,9 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
         $product->expects($this->any())->method('getStoreIds')->will($this->returnValue([1]));
         $this->storeViewService->expects($this->once())->method('doesEntityHaveOverriddenUrlKeyForStore')
             ->will($this->returnValue(false));
-        $categoryMock = $this->getMockBuilder(Category::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $categoryMock->expects($this->once())
+        $this->categoryMock->expects($this->exactly(2))
             ->method('getParentId')
-            ->willReturn(1);
+            ->willReturn(2);
         $this->initObjectRegistryFactory([]);
         $canonical = new \Magento\UrlRewrite\Service\V1\Data\UrlRewrite([], $this->serializer);
         $canonical->setRequestPath('category-1')
@@ -149,25 +154,23 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
                 'category-3_3' => $current,
                 'category-4_4' => $anchorCategories
             ],
-            $this->productScopeGenerator->generateForGlobalScope([$categoryMock], $product, 1)
+            $this->productScopeGenerator->generateForGlobalScope([$this->categoryMock], $product, 1)
         );
     }
 
     public function testGenerationForSpecificStore()
     {
+        $storeRootCategoryId = 2;
+        $parent_id = 3;
+        $category_id = 4;
         $product = $this->createMock(\Magento\Catalog\Model\Product::class);
         $product->expects($this->any())->method('getStoreId')->will($this->returnValue(1));
         $product->expects($this->never())->method('getStoreIds');
-        $storeRootCategoryId = 'root-for-store-id';
-        $category = $this->createMock(\Magento\Catalog\Model\Category::class);
-        $category->expects($this->any())->method('getParentIds')
+        $this->categoryMock->expects($this->any())->method('getParentIds')
             ->will($this->returnValue(['root-id', $storeRootCategoryId]));
-        $category->expects($this->any())->method('getParentId')->will($this->returnValue('parent_id'));
-        $category->expects($this->any())->method('getId')->will($this->returnValue('category_id'));
-        $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)->disableOriginalConstructor()->getMock();
-        $store->expects($this->any())->method('getRootCategoryId')->will($this->returnValue($storeRootCategoryId));
-        $this->storeManager->expects($this->any())->method('getStore')->will($this->returnValue($store));
-        $this->initObjectRegistryFactory([$category]);
+        $this->categoryMock->expects($this->any())->method('getParentId')->will($this->returnValue($parent_id));
+        $this->categoryMock->expects($this->any())->method('getId')->will($this->returnValue($category_id));
+        $this->initObjectRegistryFactory([$this->categoryMock]);
         $canonical = new \Magento\UrlRewrite\Service\V1\Data\UrlRewrite([], $this->serializer);
         $canonical->setRequestPath('category-1')
             ->setStoreId(1);
@@ -184,7 +187,7 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             ['category-1_1' => $canonical],
-            $this->productScopeGenerator->generateForSpecificStoreView(1, [$category], $product, 1)
+            $this->productScopeGenerator->generateForSpecificStoreView(1, [$this->categoryMock], $product, 1)
         );
     }
 
@@ -211,5 +214,43 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->objectRegistryFactory->expects($this->any())->method('create')
             ->with(['entities' => $entities])
             ->will($this->returnValue($objectRegistry));
+    }
+
+    /**
+     * Test the possibility of url rewrite generation.
+     *
+     * @param int $parentId
+     * @param array $parentIds
+     * @param bool $expectedResult
+     * @dataProvider isCategoryProperForGeneratingDataProvider
+     */
+    public function testIsCategoryProperForGenerating($parentId, $parentIds, $expectedResult)
+    {
+        $storeId = 1;
+        $this->categoryMock->expects(self::any())->method('getParentId')->willReturn($parentId);
+        $this->categoryMock->expects(self::any())->method('getParentIds')->willReturn($parentIds);
+        $result = $this->productScopeGenerator->isCategoryProperForGenerating(
+            $this->categoryMock,
+            $storeId
+        );
+        self::assertEquals(
+            $expectedResult,
+            $result
+        );
+    }
+
+    /**
+     * Data provider for testIsCategoryProperForGenerating.
+     *
+     * @return array
+     */
+    public function isCategoryProperForGeneratingDataProvider()
+    {
+        return [
+            ['0', ['0'], false],
+            ['1', ['1'], false],
+            ['2', ['1', '2'], true],
+            ['2', ['1', '3'], false],
+        ];
     }
 }

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductScopeRewriteGeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductScopeRewriteGeneratorTest.php
@@ -120,7 +120,7 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
         $product->expects($this->any())->method('getStoreIds')->will($this->returnValue([1]));
         $this->storeViewService->expects($this->once())->method('doesEntityHaveOverriddenUrlKeyForStore')
             ->will($this->returnValue(false));
-        $this->categoryMock->expects($this->exactly(2))
+        $this->categoryMock->expects($this->once())
             ->method('getParentId')
             ->willReturn(2);
         $this->initObjectRegistryFactory([]);

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductScopeRewriteGeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductScopeRewriteGeneratorTest.php
@@ -120,9 +120,6 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
         $product->expects($this->any())->method('getStoreIds')->will($this->returnValue([1]));
         $this->storeViewService->expects($this->once())->method('doesEntityHaveOverriddenUrlKeyForStore')
             ->will($this->returnValue(false));
-        $this->categoryMock->expects($this->once())
-            ->method('getParentId')
-            ->willReturn(2);
         $this->initObjectRegistryFactory([]);
         $canonical = new \Magento\UrlRewrite\Service\V1\Data\UrlRewrite([], $this->serializer);
         $canonical->setRequestPath('category-1')
@@ -161,14 +158,12 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGenerationForSpecificStore()
     {
         $storeRootCategoryId = 2;
-        $parent_id = 3;
         $category_id = 4;
         $product = $this->createMock(\Magento\Catalog\Model\Product::class);
         $product->expects($this->any())->method('getStoreId')->will($this->returnValue(1));
         $product->expects($this->never())->method('getStoreIds');
         $this->categoryMock->expects($this->any())->method('getParentIds')
             ->will($this->returnValue(['root-id', $storeRootCategoryId]));
-        $this->categoryMock->expects($this->any())->method('getParentId')->will($this->returnValue($parent_id));
         $this->categoryMock->expects($this->any())->method('getId')->will($this->returnValue($category_id));
         $this->initObjectRegistryFactory([$this->categoryMock]);
         $canonical = new \Magento\UrlRewrite\Service\V1\Data\UrlRewrite([], $this->serializer);
@@ -219,15 +214,13 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
     /**
      * Test the possibility of url rewrite generation.
      *
-     * @param int $parentId
      * @param array $parentIds
      * @param bool $expectedResult
      * @dataProvider isCategoryProperForGeneratingDataProvider
      */
-    public function testIsCategoryProperForGenerating($parentId, $parentIds, $expectedResult)
+    public function testIsCategoryProperForGenerating($parentIds, $expectedResult)
     {
         $storeId = 1;
-        $this->categoryMock->expects(self::any())->method('getParentId')->willReturn($parentId);
         $this->categoryMock->expects(self::any())->method('getParentIds')->willReturn($parentIds);
         $result = $this->productScopeGenerator->isCategoryProperForGenerating(
             $this->categoryMock,
@@ -247,10 +240,10 @@ class ProductScopeRewriteGeneratorTest extends \PHPUnit\Framework\TestCase
     public function isCategoryProperForGeneratingDataProvider()
     {
         return [
-            ['0', ['0'], false],
-            ['1', ['1'], false],
-            ['2', ['1', '2'], true],
-            ['2', ['1', '3'], false],
+            [['0'], false],
+            [['1'], false],
+            [['1', '2'], true],
+            [['1', '3'], false],
         ];
     }
 }

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_with_category.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_with_category.php
@@ -69,4 +69,4 @@ $productRepository->save($product);
 
 /** @var CategoryLinkManagementInterface $linkManagement */
 $linkManagement = $objectManager->get(CategoryLinkManagementInterface::class);
-$linkManagement->assignProductToCategories($product->getSku(), [$category->getEntityId()]);
+$linkManagement->assignProductToCategories($product->getSku(), [Category::TREE_ROOT_ID, $category->getEntityId()]);


### PR DESCRIPTION
### Description
Added ability to assign products to categories if those products are already assigned to category tree root (id=1).

### Fixed Issues (if relevant)
1.  magento/magento2#8970: Cannot assign products to categories not under tree root.

### Manual testing scenarios
1. Create a Product, assign it to any category.
2. Open your Magento database table "catalog_category_product", locate your Product table entry and change it's "category_id" value to 1.
3. Assign your Product to some category through admin interface and save it.
4. "You saved the product." message should appear.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
