### PR TITLE
signing in after selecting checkout button, will not end up to checko…

### DIFF
--- a/app/code/Magento/Customer/Controller/Ajax/Login.php
+++ b/app/code/Magento/Customer/Controller/Ajax/Login.php
@@ -175,14 +175,15 @@ class Login extends \Magento\Framework\App\Action\Action
             $this->customerSession->setCustomerDataAsLoggedIn($customer);
             $this->customerSession->regenerateId();
             $redirectRoute = $this->getAccountRedirect()->getRedirectCookie();
+            
+            if(isset($credentials['context']) && $credentials['context'] == 'checkout'){
+                $response['redirectUrl'] = $this->_redirect->success($this->_url->getUrl('checkout', ['_secure' => true]));
+                $this->getAccountRedirect()->clearRedirectCookie();
+            }
+            
             if (!$this->getScopeConfig()->getValue('customer/startup/redirect_dashboard') && $redirectRoute) {
                 $response['redirectUrl'] = $this->_redirect->success($redirectRoute);
                 $this->getAccountRedirect()->clearRedirectCookie();
-            }else{
-                if(isset($credentials['context']) && $credentials['context'] == 'checkout'){
-                    $response['redirectUrl'] = $this->_redirect->success($this->_url->getUrl('checkout', ['_secure' => true]));
-                    $this->getAccountRedirect()->clearRedirectCookie();
-                }
             }
         } catch (EmailNotConfirmedException $e) {
             $response = [

--- a/app/code/Magento/Customer/Controller/Ajax/Login.php
+++ b/app/code/Magento/Customer/Controller/Ajax/Login.php
@@ -61,7 +61,7 @@ class Login extends \Magento\Framework\App\Action\Action
     /**
      * @var url
      */
-    protected $_url;
+    private $url;
 
     /**
      * Initialize Login controller
@@ -177,8 +177,8 @@ class Login extends \Magento\Framework\App\Action\Action
             $redirectRoute = $this->getAccountRedirect()->getRedirectCookie();
             
             if (isset($credentials['context']) && $credentials['context'] == 'checkout') {
-                $url_checkout = $this->_url->getUrl('checkout', ['_secure' => true]);
-                $response['redirectUrl'] = $this->_redirect->success($url_checkout);
+                $checkoutUrl = $this->url->getUrl('checkout', ['_secure' => true]);
+                $response['redirectUrl'] = $this->_redirect->success($checkoutUrl);
                 $this->getAccountRedirect()->clearRedirectCookie();
             }
             

--- a/app/code/Magento/Customer/Controller/Ajax/Login.php
+++ b/app/code/Magento/Customer/Controller/Ajax/Login.php
@@ -57,6 +57,11 @@ class Login extends \Magento\Framework\App\Action\Action
      * @var ScopeConfigInterface
      */
     protected $scopeConfig;
+    
+    /**
+     * @var url
+     */
+    protected $_url;
 
     /**
      * Initialize Login controller
@@ -82,6 +87,7 @@ class Login extends \Magento\Framework\App\Action\Action
         $this->customerAccountManagement = $customerAccountManagement;
         $this->resultJsonFactory = $resultJsonFactory;
         $this->resultRawFactory = $resultRawFactory;
+        $this->_url = $context->getUrl();
     }
 
     /**
@@ -172,6 +178,11 @@ class Login extends \Magento\Framework\App\Action\Action
             if (!$this->getScopeConfig()->getValue('customer/startup/redirect_dashboard') && $redirectRoute) {
                 $response['redirectUrl'] = $this->_redirect->success($redirectRoute);
                 $this->getAccountRedirect()->clearRedirectCookie();
+            }else{
+                if(isset($credentials['context']) && $credentials['context'] == 'checkout'){
+                    $response['redirectUrl'] = $this->_redirect->success($this->_url->getUrl('checkout', ['_secure' => true]));
+                    $this->getAccountRedirect()->clearRedirectCookie();
+                }
             }
         } catch (EmailNotConfirmedException $e) {
             $response = [

--- a/app/code/Magento/Customer/Controller/Ajax/Login.php
+++ b/app/code/Magento/Customer/Controller/Ajax/Login.php
@@ -176,8 +176,9 @@ class Login extends \Magento\Framework\App\Action\Action
             $this->customerSession->regenerateId();
             $redirectRoute = $this->getAccountRedirect()->getRedirectCookie();
             
-            if(isset($credentials['context']) && $credentials['context'] == 'checkout'){
-                $response['redirectUrl'] = $this->_redirect->success($this->_url->getUrl('checkout', ['_secure' => true]));
+            if (isset($credentials['context']) && $credentials['context'] == 'checkout') {
+                $url_checkout = $this->_url->getUrl('checkout', ['_secure' => true]);
+                $response['redirectUrl'] = $this->_redirect->success($url_checkout);
                 $this->getAccountRedirect()->clearRedirectCookie();
             }
             


### PR DESCRIPTION
…ut page! #10834

signing in after selecting checkout button, will not end up to checkout page! #10834

### Description
Apparently I was not taking into account the "context" parameter that comes in the form with the value of "checkout", and not controlling this did not have a url to redirect.

### Fixed Issues (if relevant)
1.- After login redirect the checkout page, previously clicking on the checkout button


### Manual testing scenarios
1.- disable guest checkout
2.- open magento store
3.- add product to your cart and select checkout button
4.- fill the login window details
5.- and you should select checkout button once again after signing in

result: after signing in, user should redirected to checkout page, as he want this before signing in

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
