### PR TITLE
Fix #11581: Reference to wrong / non-existing class

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Pdf/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Creditmemo.php
@@ -75,12 +75,12 @@ class Creditmemo extends AbstractPdf
     protected function _drawHeader(\Zend_Pdf_Page $page)
     {
         $this->_setFontRegular($page, 10);
-        $page->setFillColor(new \Zend_Pdf_Color_RGB(0.93, 0.92, 0.92));
+        $page->setFillColor(new \Zend_Pdf_Color_Rgb(0.93, 0.92, 0.92));
         $page->setLineColor(new \Zend_Pdf_Color_GrayScale(0.5));
         $page->setLineWidth(0.5);
         $page->drawRectangle(25, $this->y, 570, $this->y - 30);
         $this->y -= 10;
-        $page->setFillColor(new \Zend_Pdf_Color_RGB(0, 0, 0));
+        $page->setFillColor(new \Zend_Pdf_Color_Rgb(0, 0, 0));
 
         //columns headers
         $lines[0][] = ['text' => __('Products'), 'feed' => 35];

--- a/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php
@@ -82,12 +82,12 @@ class Invoice extends AbstractPdf
     {
         /* Add table head */
         $this->_setFontRegular($page, 10);
-        $page->setFillColor(new \Zend_Pdf_Color_RGB(0.93, 0.92, 0.92));
+        $page->setFillColor(new \Zend_Pdf_Color_Rgb(0.93, 0.92, 0.92));
         $page->setLineColor(new \Zend_Pdf_Color_GrayScale(0.5));
         $page->setLineWidth(0.5);
         $page->drawRectangle(25, $this->y, 570, $this->y - 15);
         $this->y -= 10;
-        $page->setFillColor(new \Zend_Pdf_Color_RGB(0, 0, 0));
+        $page->setFillColor(new \Zend_Pdf_Color_Rgb(0, 0, 0));
 
         //columns headers
         $lines[0][] = ['text' => __('Products'), 'feed' => 35];

--- a/app/code/Magento/Sales/Model/Order/Pdf/Shipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Shipment.php
@@ -80,12 +80,12 @@ class Shipment extends AbstractPdf
     {
         /* Add table head */
         $this->_setFontRegular($page, 10);
-        $page->setFillColor(new \Zend_Pdf_Color_RGB(0.93, 0.92, 0.92));
+        $page->setFillColor(new \Zend_Pdf_Color_Rgb(0.93, 0.92, 0.92));
         $page->setLineColor(new \Zend_Pdf_Color_GrayScale(0.5));
         $page->setLineWidth(0.5);
         $page->drawRectangle(25, $this->y, 570, $this->y - 15);
         $this->y -= 10;
-        $page->setFillColor(new \Zend_Pdf_Color_RGB(0, 0, 0));
+        $page->setFillColor(new \Zend_Pdf_Color_Rgb(0, 0, 0));
 
         //columns headers
         $lines[0][] = ['text' => __('Products'), 'feed' => 100];


### PR DESCRIPTION
### Description
Changed references from Zend_Pdf_Color_RGB to the correct camel case class name Zend_Pdf_Color_Rgb

### Fixed Issues
1. magento/magento2#11581: Reference to wrong / non-existing class
