### PR TITLE
Set condition for Tier price block.

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -569,7 +569,9 @@ define([
                         'currencyFormat': this.options.spConfig.currencyFormat,
                         'priceUtils': priceUtils
                     });
-                    $(this.options.tierPriceBlockSelector).html(tierPriceHtml).show();
+                    if(options.tierPrices.length){
+                        $(this.options.tierPriceBlockSelector).html(tierPriceHtml).show();
+                    }
                 }
             } else {
                 $(this.options.tierPriceBlockSelector).hide();

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -569,7 +569,7 @@ define([
                         'currencyFormat': this.options.spConfig.currencyFormat,
                         'priceUtils': priceUtils
                     });
-                    if(options.tierPrices.length){
+                    if (options.tierPrices.length) {
                         $(this.options.tierPriceBlockSelector).html(tierPriceHtml).show();
                     }
                 }


### PR DESCRIPTION
Issue arise only after upgrade from Magento 2.1 to Magento 2.2.0
After Upgrade From Magento 2.1.3 to Magento 2.2.0,
In configurable product page, when change variant option value from dropdown box, Tier price block section will display as null above the dropdown option list.
So try to remove those box for product doenst have tier price after debuging got solution from configurable.js file.
If product variant with tier price, Its display block for tier price if product with no tier price its display blank box.

Check for below image with issue,
![config-tier](https://user-images.githubusercontent.com/18594535/32134306-3318ad72-bc08-11e7-8b8d-7ff3bc698959.png)
Blank tier price box will display.
