### PR TITLE
#10440: Missing $debugHintsPath when sending email via command line

### DIFF
--- a/app/code/Magento/Developer/Model/TemplateEngine/Plugin/DebugHints.php
+++ b/app/code/Magento/Developer/Model/TemplateEngine/Plugin/DebugHints.php
@@ -48,8 +48,8 @@ class DebugHints
      * Allowed values:
      *     dev/debug/template_hints_storefront
      *     dev/debug/template_hints_admin
-     *
-     * @var string
+     *     null
+     * @var string|null
      */
     protected $debugHintsPath;
 
@@ -58,14 +58,14 @@ class DebugHints
      * @param StoreManagerInterface $storeManager
      * @param DevHelper $devHelper
      * @param DebugHintsFactory $debugHintsFactory
-     * @param string $debugHintsPath
+     * @param string|null $debugHintsPath
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         StoreManagerInterface $storeManager,
         DevHelper $devHelper,
         DebugHintsFactory $debugHintsFactory,
-        $debugHintsPath
+        $debugHintsPath = null
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
@@ -88,7 +88,8 @@ class DebugHints
         TemplateEngineInterface $invocationResult
     ) {
         $storeCode = $this->storeManager->getStore()->getCode();
-        if ($this->scopeConfig->getValue($this->debugHintsPath, ScopeInterface::SCOPE_STORE, $storeCode)
+        if ($this->debugHintsPath &&
+            $this->scopeConfig->getValue($this->debugHintsPath, ScopeInterface::SCOPE_STORE, $storeCode)
             && $this->devHelper->isDevAllowed()) {
             $showBlockHints = $this->scopeConfig->getValue(
                 self::XML_PATH_DEBUG_TEMPLATE_HINTS_BLOCKS,


### PR DESCRIPTION
Fix for #10440 

### Description
Exception "'BadMethodCallException' with message 'Missing required argument $debugHintsPath of Magento\Developer\Model\TemplateEngine\Plugin\DebugHints.'" triggered while running console command and sending email message with "layout" handle. It happens b/c there is no value for "debugHintsPath" variable of  in "base" di.xml, but it exist in frontend/di.xml and adminhtml/di.xml.
There are 2 possible solutions: declare $debugHinthsPath variable in base di.xml or add default value in constructor. I decided to add default value in constructor.

### Fixed Issues (if relevant)
1. magento/magento2#10440: Missing $debugHintsPath when sending email via command line

### Manual testing scenarios
1. Create console with the following code:
```php
 protected function execute(InputInterface $input, OutputInterface $output)
 {
        $this->state->setAreaCode('frontend');
        $transport = $this->transportBuilder
            ->setTemplateIdentifier('sales_email_order_guest_template')
            ->setTemplateOptions(
                [
                    'area' => 'frontend',
                    'store' => $this->storeManager->getStore()->getId()
                ]
            )
            ->setTemplateVars([])
            ->setFrom(['email' => 'webmaster@magento.dev', 'name' => 'webmaster'])
            ->addTo('user@magento.dev')
            ->setReplyTo('webmaster@magento.dev', 'webmaster')
            ->getTransport();

        $transport->sendMessage();
 }
```

2. execute command from console (assuming command name is "bugfix:10440")
$ magento bugfix:10440
3. Email sent, exception wasn't triggered
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
