### PR TITLE
FilterBuilder Doc Block Update

### DIFF
--- a/lib/internal/Magento/Framework/Api/FilterBuilder.php
+++ b/lib/internal/Magento/Framework/Api/FilterBuilder.php
@@ -29,7 +29,7 @@ class FilterBuilder extends AbstractSimpleObjectBuilder
     /**
      * Set value
      *
-     * @param string $value
+     * @param string|array $value
      * @return $this
      */
     public function setValue($value)


### PR DESCRIPTION
### Description
Edited doc block of setValue in FilterBuilder to reflect that this method will accept an array

The following filter is created by passing an array of product skus. While this results in a successful request, the doc block of the setValue method of the filter builder incorrectly reports that it will only accept a string, while the following example uses an array.

```php
<?php
/* @var $this->filterBuilder = \Magento\Framework\Api\FilterBuilder */
/* @var $this->searchCriteriaBuilder = \Magento\Framework\Api\SearchCriteriaBuilder */
/* @var $this->productRepository = \Magento\Catalog\Model\ProductRepository */

$skus = ['sku1', 'sku2', 'sku3']

$filters[] = $this->filterBuilder
                  ->setField('sku')
                  ->setValue($skus)
                  ->setConditionType('in')
                  ->create();

$searchCriteria = $this->searchCriteriaBuilder
                       ->addFilters($filters)
                       ->setPageSize(5)
                       ->create();

$products = $this->productRepository->getList($searchCriteria);
        
$collection = $products->getItems();
```

### Manual testing scenarios
Code is provided above to show a scenario where the doc block does not reflect what it will actually accept. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)