### PR TITLE
[Backport 2.1-develop] CMS Page - Force validate layout update xml in production mode when saving CMS Page - Handle layout update xml validation exceptions

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
@@ -6,6 +6,14 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Page;
 
+use Magento\Cms\Model\Page\DomValidationState;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Config\Dom\ValidationException;
+
+/**
+ * Class PostDataProcessor
+ * @package Magento\Cms\Controller\Adminhtml\Page
+ */
 class PostDataProcessor
 {
     /**
@@ -24,18 +32,27 @@ class PostDataProcessor
     protected $messageManager;
 
     /**
+     * @var DomValidationState
+     */
+    private $validationState;
+
+    /**
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory
+     * @param DomValidationState $validationState
      */
     public function __construct(
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         \Magento\Framework\Message\ManagerInterface $messageManager,
-        \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory
+        \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory,
+        DomValidationState $validationState = null
     ) {
         $this->dateFilter = $dateFilter;
         $this->messageManager = $messageManager;
         $this->validatorFactory = $validatorFactory;
+        $this->validationState = $validationState
+            ?: ObjectManager::getInstance()->get(DomValidationState::class);
     }
 
     /**
@@ -61,27 +78,27 @@ class PostDataProcessor
      * Validate post data
      *
      * @param array $data
-     * @return bool     Return FALSE if someone item is invalid
+     * @return bool     Return FALSE if some item is invalid
      */
     public function validate($data)
     {
-        $errorNo = true;
         if (!empty($data['layout_update_xml']) || !empty($data['custom_layout_update_xml'])) {
-            /** @var $validatorCustomLayout \Magento\Framework\View\Model\Layout\Update\Validator */
-            $validatorCustomLayout = $this->validatorFactory->create();
-            if (!empty($data['layout_update_xml']) && !$validatorCustomLayout->isValid($data['layout_update_xml'])) {
-                $errorNo = false;
-            }
-            if (!empty($data['custom_layout_update_xml'])
-                && !$validatorCustomLayout->isValid($data['custom_layout_update_xml'])
-            ) {
-                $errorNo = false;
-            }
-            foreach ($validatorCustomLayout->getMessages() as $message) {
-                $this->messageManager->addError($message);
+            /** @var $layoutXmlValidator \Magento\Framework\View\Model\Layout\Update\Validator */
+            $layoutXmlValidator = $this->validatorFactory->create(
+                [
+                    'validationState' => $this->validationState,
+                ]
+            );
+
+            if (!$this->validateData($data, $layoutXmlValidator)) {
+                $validatorMessages = $layoutXmlValidator->getMessages();
+                foreach ($validatorMessages as $message) {
+                    $this->messageManager->addErrorMessage($message);
+                }
+                return false;
             }
         }
-        return $errorNo;
+        return true;
     }
 
     /**
@@ -107,5 +124,33 @@ class PostDataProcessor
             }
         }
         return $errorNo;
+    }
+
+    /**
+     * Validate data, avoid cyclomatic complexity
+     *
+     * @param array $data
+     * @param \Magento\Framework\View\Model\Layout\Update\Validator $layoutXmlValidator
+     * @return bool
+     */
+    private function validateData($data, $layoutXmlValidator)
+    {
+        try {
+            if (!empty($data['layout_update_xml']) && !$layoutXmlValidator->isValid($data['layout_update_xml'])) {
+                return false;
+            }
+            if (!empty($data['custom_layout_update_xml']) &&
+                !$layoutXmlValidator->isValid($data['custom_layout_update_xml'])
+            ) {
+                return false;
+            }
+        } catch (ValidationException $e) {
+            return false;
+        } catch (\Exception $e) {
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/code/Magento/Cms/Model/Page/DomValidationState.php
+++ b/app/code/Magento/Cms/Model/Page/DomValidationState.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Application config file resolver
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Model\Page;
+
+/**
+ * Class DomValidationState
+ * @package Magento\Cms\Model\Page
+ */
+class DomValidationState implements \Magento\Framework\Config\ValidationStateInterface
+{
+    /**
+     * Retrieve validation state
+     * Used in cms page post processor to force validate layout update xml
+     *
+     * @return boolean
+     */
+    public function isValidationRequired()
+    {
+        return true;
+    }
+}

--- a/app/code/Magento/Cms/Model/Page/DomValidationState.php
+++ b/app/code/Magento/Cms/Model/Page/DomValidationState.php
@@ -2,7 +2,7 @@
 /**
  * Application config file resolver
  *
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Cms\Model\Page;

--- a/lib/internal/Magento/Framework/View/Model/Layout/Update/Validator.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Update/Validator.php
@@ -5,7 +5,10 @@
  */
 namespace Magento\Framework\View\Model\Layout\Update;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\Dom\UrnResolver;
+use Magento\Framework\Config\DomFactory;
+use Magento\Framework\Config\ValidationStateInterface;
 
 /**
  * Validator for custom layout update
@@ -51,17 +54,24 @@ class Validator extends \Zend_Validate_Abstract
     protected $_xsdSchemas;
 
     /**
-     * @var \Magento\Framework\Config\DomFactory
+     * @var DomFactory
      */
     protected $_domConfigFactory;
 
     /**
-     * @param \Magento\Framework\Config\DomFactory $domConfigFactory
+     * @var ValidationStateInterface
+     */
+    private $validationState;
+
+    /**
+     * @param DomFactory $domConfigFactory
      * @param \Magento\Framework\Config\Dom\UrnResolver $urnResolver
+     * @param ValidationStateInterface $validationState
      */
     public function __construct(
-        \Magento\Framework\Config\DomFactory $domConfigFactory,
-        UrnResolver $urnResolver
+        DomFactory $domConfigFactory,
+        UrnResolver $urnResolver,
+        ValidationStateInterface $validationState = null
     ) {
         $this->_domConfigFactory = $domConfigFactory;
         $this->_initMessageTemplates();
@@ -73,6 +83,8 @@ class Validator extends \Zend_Validate_Abstract
                 'urn:magento:framework:View/Layout/etc/layout_merged.xsd'
             ),
         ];
+        $this->validationState = $validationState
+            ?: ObjectManager::getInstance()->get(ValidationStateInterface::class);
     }
 
     /**
@@ -115,7 +127,13 @@ class Validator extends \Zend_Validate_Abstract
         try {
             //wrap XML value in the "layout" and "handle" tags to make it validatable
             $value = '<layout xmlns:xsi="' . self::XML_NAMESPACE_XSI . '">' . $value . '</layout>';
-            $this->_domConfigFactory->createDom(['xml' => $value, 'schemaFile' => $this->_xsdSchemas[$schema]]);
+            $this->_domConfigFactory->createDom(
+                [
+                    'xml' => $value,
+                    'schemaFile' => $this->_xsdSchemas[$schema],
+                    'validationState' => $this->validationState,
+                ]
+            );
 
             if ($isSecurityCheck) {
                 $value = new \Magento\Framework\Simplexml\Element($value);

--- a/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/Update/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/Update/ValidatorTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\Model\Layout\Update;
 
-use \Magento\Framework\View\Model\Layout\Update\Validator;
+use Magento\Framework\View\Model\Layout\Update\Validator;
 
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,6 +13,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
      */
     protected $_objectHelper;
+
+    /**
+     * @var \Magento\Framework\Config\ValidationStateInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $validationState;
 
     protected function setUp()
     {
@@ -27,7 +32,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     protected function _createValidator($layoutUpdate, $isSchemaValid = true)
     {
         $domConfigFactory = $this->getMockBuilder(
-            'Magento\Framework\Config\DomFactory'
+            \Magento\Framework\Config\DomFactory::class
+        )->disableOriginalConstructor()->getMock();
+        $this->validationState = $this->getMockBuilder(
+            \Magento\Framework\Config\ValidationStateInterface::class
         )->disableOriginalConstructor()->getMock();
 
         $urnResolver = new \Magento\Framework\Config\Dom\UrnResolver();
@@ -35,6 +43,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             'xml' => '<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' .
                 trim($layoutUpdate) . '</layout>',
             'schemaFile' => $urnResolver->getRealPath('urn:magento:framework:View/Layout/etc/page_layout.xsd'),
+            'validationState' => $this->validationState,
         ];
 
         $exceptionMessage = 'validation exception';
@@ -49,10 +58,14 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 new \Magento\Framework\Config\Dom\ValidationException($exceptionMessage)
             )
         );
-        $urnResolver = $this->_objectHelper->getObject('Magento\Framework\Config\Dom\UrnResolver');
+        $urnResolver = $this->_objectHelper->getObject(\Magento\Framework\Config\Dom\UrnResolver::class);
         $model = $this->_objectHelper->getObject(
-            'Magento\Framework\View\Model\Layout\Update\Validator',
-            ['domConfigFactory' => $domConfigFactory, 'urnResolver' => $urnResolver]
+            \Magento\Framework\View\Model\Layout\Update\Validator::class,
+            [
+                'domConfigFactory' => $domConfigFactory,
+                'urnResolver' => $urnResolver,
+                'validationState' => $this->validationState,
+            ]
         );
 
         return $model;


### PR DESCRIPTION
When saving custom layout update xml in CMS page, **in production mode**, xml is not validated against schema file, due to `\Magento\Framework\App\Arguments\ValidationState::isValidationRequired`method:
```
    /**
     * Retrieve current validation state
     *
     * @return boolean
     */
    public function isValidationRequired()
    {
        return $this->_appMode == \Magento\Framework\App\State::MODE_DEVELOPER;
    }
```

Actual result:
![captura de pantalla 2017-10-30 a las 3 46 56](https://user-images.githubusercontent.com/17545750/32153389-781e2e24-bd2a-11e7-950f-546d27f384a0.png)
![captura de pantalla 2017-10-30 a las 3 47 15](https://user-images.githubusercontent.com/17545750/32153394-7e39c804-bd2a-11e7-8f9f-c4991846fd05.png)

Desired behaviour would be check the layout update xml against the schema, and show error message to the user if it is invalid:
![captura de pantalla 2017-10-30 a las 3 58 10](https://user-images.githubusercontent.com/17545750/32153406-a3d7bf80-bd2a-11e7-9b71-551be5162d65.png)

Also, when layout update is validated, validation exceptions are unhandled, showing a report error in production mode, and showing this error in developer mode:
![captura de pantalla 2017-10-30 a las 1 03 01](https://user-images.githubusercontent.com/17545750/32150375-49cb3c6e-bd12-11e7-89f8-47f41afb8985.png)

For example, uncomment demo layout handle in home page:
![captura de pantalla 2017-10-30 a las 1 02 34](https://user-images.githubusercontent.com/17545750/32150371-38df549e-bd12-11e7-8e32-9b8d2f839a53.png)

Desired behaviour would be handle the exception properly instead of crash, and show error message to the user:
![captura de pantalla 2017-10-30 a las 1 26 21](https://user-images.githubusercontent.com/17545750/32150381-688c2668-bd12-11e7-81e9-da0510e329de.png)

### Description
- According to doc block, `\Magento\Cms\Controller\Adminhtml\Page\PostDataProcessor::validate` should always return a boolean value. It uses `\Magento\Framework\View\Model\Layout\Update\Validator::isValid` method, that may throw an exception if xml is not valid, so `\Magento\Cms\Controller\Adminhtml\Page\PostDataProcessor::validate` must handle possible exceptions thrown by xml validator, in order to always return a boolean value.
- `\Magento\Cms\Model\Page\DomValidationState` has been added, and it is injected from post data processor to force layout update xml validation, only upon cms page save.

This PR include changes of PR https://github.com/magento/magento2/pull/11866

### Manual testing scenarios
1. Enable developer mode
2. Edit or create a CMS page, enter some invalid xml in Layout Update XML textarea
3. Try to save the page, application crashes

1. Enable production mode
2. Edit or create a CMS page, enter some invalid xml in Layout Update XML textarea
3. Try to save the page, xml does not get validated

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
