### PR TITLE
[Backport 2.3-develop] #11697 Theme: Added html node to page xml root, cause validation error

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/layout_merged.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/layout_merged.xsd
@@ -9,6 +9,7 @@
     <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/elements.xsd"/>
     <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/head.xsd"/>
     <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/body.xsd"/>
+    <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/html.xsd"/>
 
     <xs:element name="layout">
         <xs:annotation>
@@ -45,6 +46,7 @@
             <xs:element ref="referenceBlock" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="body" type="bodyType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="head" type="headType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="html" type="htmlType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
     </xs:complexType>
 


### PR DESCRIPTION
### Description
Theme: Added html node to page xml root, cause validation error
Unify `Magento/Framework/View/Layout/etc/layout_merged.xsd` and `Magento/Framework/View/Layout/etc/page_configuration.xsd` declarations.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11697: Theme: Added html node to page xml root, cause validation error
2. ...

### Manual testing scenarios
As described in https://github.com/magento/magento2/issues/11697

Result after applying this PR:
![captura de pantalla 2017-10-30 a las 2 40 00](https://user-images.githubusercontent.com/17545750/32151390-b815e534-bd1c-11e7-9025-92a7eee05c11.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
