### PR TITLE
Update wrong layout update xml handle installed in CMS Home Page by default

### DIFF
--- a/app/code/Magento/Reports/Setup/InstallData.php
+++ b/app/code/Magento/Reports/Setup/InstallData.php
@@ -83,8 +83,7 @@ class InstallData implements \Magento\Framework\Setup\InstallDataInterface
         // @codingStandardsIgnoreStart
         $reportLayoutUpdate = '<!--
     <referenceContainer name="right">
-        <action method="unsetChild"><argument name="alias" xsi:type="string">right.reports.product.viewed</argument></action>
-        <action method="unsetChild"><argument name="alias" xsi:type="string">right.reports.product.compared</argument></action>
+        <referenceBlock name="catalog.compare.sidebar" remove="true" />
     </referenceContainer>-->';
         // @codingStandardsIgnoreEnd
 


### PR DESCRIPTION
Preinstalled xml layout update handle in Home Page is invalid, element action is not expected anymore under referenceContainer node:
![captura de pantalla 2017-10-30 a las 1 02 34](https://user-images.githubusercontent.com/17545750/32152055-cb6c1eaa-bd21-11e7-88c5-336c1bb2a649.png)

![captura de pantalla 2017-10-30 a las 1 03 01](https://user-images.githubusercontent.com/17545750/32152119-49b05074-bd22-11e7-9cd1-31ee5a62a192.png)

Exception handling for this validation will be done when changes from PR https://github.com/magento/magento2/pull/11857 are applied.

### Description
This legacy code shows a demo of how can be removed `right.reports.product.viewed` and `right.reports.product.compared` from right column, but it is outdated; the instructions are not valid and referenced blocks have changed.

This PR suggest changing that preinstalled layout update handle, adapting reference to compared block and removing the viewed block reference, since this last one is now handled via widget and is not at the right column by default, so there is no need to try to remove it: 
```
<referenceContainer name="right">
    <referenceBlock name="catalog.compare.sidebar" remove="true" />
</referenceContainer>
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

### Related Pull Requests
https://github.com/magento/magento2/pull/11891