### PR TITLE
CMS Page - Force validate layout update xml, even in production mode, when saving CMS Page

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
@@ -6,6 +6,9 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Page;
 
+use Magento\Cms\Model\Page\DomValidationState;
+use Magento\Framework\App\ObjectManager;
+
 class PostDataProcessor
 {
     /**
@@ -24,18 +27,27 @@ class PostDataProcessor
     protected $messageManager;
 
     /**
+     * @var DomValidationState
+     */
+    private $validationState;
+
+    /**
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory
+     * @param DomValidationState $validationState
      */
     public function __construct(
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         \Magento\Framework\Message\ManagerInterface $messageManager,
-        \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory
+        \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory,
+        DomValidationState $validationState = null
     ) {
         $this->dateFilter = $dateFilter;
         $this->messageManager = $messageManager;
         $this->validatorFactory = $validatorFactory;
+        $this->validationState = $validationState
+            ?: ObjectManager::getInstance()->get(DomValidationState::class);
     }
 
     /**
@@ -68,7 +80,11 @@ class PostDataProcessor
         $errorNo = true;
         if (!empty($data['layout_update_xml']) || !empty($data['custom_layout_update_xml'])) {
             /** @var $validatorCustomLayout \Magento\Framework\View\Model\Layout\Update\Validator */
-            $validatorCustomLayout = $this->validatorFactory->create();
+            $validatorCustomLayout = $this->validatorFactory->create(
+                [
+                    'validationState' => $this->validationState,
+                ]
+            );
             if (!empty($data['layout_update_xml']) && !$validatorCustomLayout->isValid($data['layout_update_xml'])) {
                 $errorNo = false;
             }

--- a/app/code/Magento/Cms/Model/Page/DomValidationState.php
+++ b/app/code/Magento/Cms/Model/Page/DomValidationState.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Application config file resolver
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Model\Page;
+
+/**
+ * Class DomValidationState
+ * @package Magento\Cms\Model\Page
+ */
+class DomValidationState implements \Magento\Framework\Config\ValidationStateInterface
+{
+    /**
+     * Retrieve validation state
+     * Used in cms page post processor to force validate layout update xml
+     *
+     * @return boolean
+     */
+    public function isValidationRequired()
+    {
+        return true;
+    }
+}

--- a/lib/internal/Magento/Framework/View/Model/Layout/Update/Validator.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Update/Validator.php
@@ -5,8 +5,11 @@
  */
 namespace Magento\Framework\View\Model\Layout\Update;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\Dom\UrnResolver;
 use Magento\Framework\Config\Dom\ValidationSchemaException;
+use Magento\Framework\Config\DomFactory;
+use Magento\Framework\Config\ValidationStateInterface;
 
 /**
  * Validator for custom layout update
@@ -54,17 +57,24 @@ class Validator extends \Zend_Validate_Abstract
     protected $_xsdSchemas;
 
     /**
-     * @var \Magento\Framework\Config\DomFactory
+     * @var DomFactory
      */
     protected $_domConfigFactory;
 
     /**
-     * @param \Magento\Framework\Config\DomFactory $domConfigFactory
+     * @var ValidationStateInterface
+     */
+    private $validationState;
+
+    /**
+     * @param DomFactory $domConfigFactory
      * @param \Magento\Framework\Config\Dom\UrnResolver $urnResolver
+     * @param ValidationStateInterface $validationState
      */
     public function __construct(
-        \Magento\Framework\Config\DomFactory $domConfigFactory,
-        UrnResolver $urnResolver
+        DomFactory $domConfigFactory,
+        UrnResolver $urnResolver,
+        ValidationStateInterface $validationState = null
     ) {
         $this->_domConfigFactory = $domConfigFactory;
         $this->_initMessageTemplates();
@@ -76,6 +86,8 @@ class Validator extends \Zend_Validate_Abstract
                 'urn:magento:framework:View/Layout/etc/layout_merged.xsd'
             ),
         ];
+        $this->validationState = $validationState
+            ?: ObjectManager::getInstance()->get(ValidationStateInterface::class);
     }
 
     /**
@@ -122,7 +134,13 @@ class Validator extends \Zend_Validate_Abstract
         try {
             //wrap XML value in the "layout" and "handle" tags to make it validatable
             $value = '<layout xmlns:xsi="' . self::XML_NAMESPACE_XSI . '">' . $value . '</layout>';
-            $this->_domConfigFactory->createDom(['xml' => $value, 'schemaFile' => $this->_xsdSchemas[$schema]]);
+            $this->_domConfigFactory->createDom(
+                [
+                    'xml' => $value,
+                    'schemaFile' => $this->_xsdSchemas[$schema],
+                    'validationState' => $this->validationState,
+                ]
+            );
 
             if ($isSecurityCheck) {
                 $value = new \Magento\Framework\Simplexml\Element($value);

--- a/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/Update/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/Update/ValidatorTest.php
@@ -30,6 +30,11 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
      */
     private $urnResolver;
 
+    /**
+     * @var \Magento\Framework\Config\ValidationStateInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $validationState;
+
     protected function setUp()
     {
         $this->_objectHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -39,10 +44,17 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $this->urnResolver = $this->getMockBuilder(
             \Magento\Framework\Config\Dom\UrnResolver::class
         )->disableOriginalConstructor()->getMock();
+        $this->validationState = $this->getMockBuilder(
+            \Magento\Framework\Config\ValidationStateInterface::class
+        )->disableOriginalConstructor()->getMock();
 
         $this->model = $this->_objectHelper->getObject(
             \Magento\Framework\View\Model\Layout\Update\Validator::class,
-            ['domConfigFactory' => $this->domConfigFactory, 'urnResolver' => $this->urnResolver]
+            [
+                'domConfigFactory' => $this->domConfigFactory,
+                'urnResolver' => $this->urnResolver,
+                'validationState' => $this->validationState,
+            ]
         );
     }
 
@@ -56,6 +68,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             'xml' => '<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' .
                 trim($layoutUpdate) . '</layout>',
             'schemaFile' => $this->urnResolver->getRealPath('urn:magento:framework:View/Layout/etc/page_layout.xsd'),
+            'validationState' => $this->validationState,
         ];
 
         $this->domConfigFactory->expects(


### PR DESCRIPTION
When saving custom layout update xml in CMS page, **in production mode**, xml is not validated against schema file, due to `\Magento\Framework\App\Arguments\ValidationState::isValidationRequired`method:
```
    /**
     * Retrieve current validation state
     *
     * @return boolean
     */
    public function isValidationRequired()
    {
        return $this->_appMode == \Magento\Framework\App\State::MODE_DEVELOPER;
    }
```

Actual result:
![captura de pantalla 2017-10-30 a las 3 46 56](https://user-images.githubusercontent.com/17545750/32153389-781e2e24-bd2a-11e7-950f-546d27f384a0.png)
![captura de pantalla 2017-10-30 a las 3 47 15](https://user-images.githubusercontent.com/17545750/32153394-7e39c804-bd2a-11e7-8f9f-c4991846fd05.png)

Desired behaviour would be check the layout update xml against the schema, and show error message to the user if it is invalid:
![captura de pantalla 2017-10-30 a las 3 58 10](https://user-images.githubusercontent.com/17545750/32153406-a3d7bf80-bd2a-11e7-9b71-551be5162d65.png)

### Description
- `\Magento\Cms\Model\Page\DomValidationState` has been added, and it is injected from post data processor to force layout update xml validation, only upon cms page save.

When this PR is applied and validation is performed, application may crush due to unhandled exception. This issue is solved by PR https://github.com/magento/magento2/pull/11857

### Manual testing scenarios
1. Enable production mode
2. Edit or create a CMS page, enter some invalid xml in Layout Update XML textarea
3. Try to save the page

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
