### PR TITLE
[Backport 2.1-develop] CMS Page - Force validate layout update xml, even in production mode, when saving CMS Page

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
@@ -6,6 +6,9 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Page;
 
+use Magento\Cms\Model\Page\DomValidationState;
+use Magento\Framework\App\ObjectManager;
+
 class PostDataProcessor
 {
     /**
@@ -24,18 +27,27 @@ class PostDataProcessor
     protected $messageManager;
 
     /**
+     * @var DomValidationState
+     */
+    private $validationState;
+
+    /**
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory
+     * @param DomValidationState $validationState
      */
     public function __construct(
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         \Magento\Framework\Message\ManagerInterface $messageManager,
-        \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory
+        \Magento\Framework\View\Model\Layout\Update\ValidatorFactory $validatorFactory,
+        DomValidationState $validationState = null
     ) {
         $this->dateFilter = $dateFilter;
         $this->messageManager = $messageManager;
         $this->validatorFactory = $validatorFactory;
+        $this->validationState = $validationState
+            ?: ObjectManager::getInstance()->get(DomValidationState::class);
     }
 
     /**
@@ -68,7 +80,11 @@ class PostDataProcessor
         $errorNo = true;
         if (!empty($data['layout_update_xml']) || !empty($data['custom_layout_update_xml'])) {
             /** @var $validatorCustomLayout \Magento\Framework\View\Model\Layout\Update\Validator */
-            $validatorCustomLayout = $this->validatorFactory->create();
+            $validatorCustomLayout = $this->validatorFactory->create(
+                [
+                    'validationState' => $this->validationState,
+                ]
+            );
             if (!empty($data['layout_update_xml']) && !$validatorCustomLayout->isValid($data['layout_update_xml'])) {
                 $errorNo = false;
             }

--- a/app/code/Magento/Cms/Model/Page/DomValidationState.php
+++ b/app/code/Magento/Cms/Model/Page/DomValidationState.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Application config file resolver
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Model\Page;
+
+/**
+ * Class DomValidationState
+ * @package Magento\Cms\Model\Page
+ */
+class DomValidationState implements \Magento\Framework\Config\ValidationStateInterface
+{
+    /**
+     * Retrieve validation state
+     * Used in cms page post processor to force validate layout update xml
+     *
+     * @return boolean
+     */
+    public function isValidationRequired()
+    {
+        return true;
+    }
+}

--- a/lib/internal/Magento/Framework/View/Model/Layout/Update/Validator.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Update/Validator.php
@@ -5,7 +5,10 @@
  */
 namespace Magento\Framework\View\Model\Layout\Update;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\Dom\UrnResolver;
+use Magento\Framework\Config\DomFactory;
+use Magento\Framework\Config\ValidationStateInterface;
 
 /**
  * Validator for custom layout update
@@ -51,17 +54,24 @@ class Validator extends \Zend_Validate_Abstract
     protected $_xsdSchemas;
 
     /**
-     * @var \Magento\Framework\Config\DomFactory
+     * @var DomFactory
      */
     protected $_domConfigFactory;
 
     /**
-     * @param \Magento\Framework\Config\DomFactory $domConfigFactory
+     * @var ValidationStateInterface
+     */
+    private $validationState;
+
+    /**
+     * @param DomFactory $domConfigFactory
      * @param \Magento\Framework\Config\Dom\UrnResolver $urnResolver
+     * @param ValidationStateInterface $validationState
      */
     public function __construct(
-        \Magento\Framework\Config\DomFactory $domConfigFactory,
-        UrnResolver $urnResolver
+        DomFactory $domConfigFactory,
+        UrnResolver $urnResolver,
+        ValidationStateInterface $validationState = null
     ) {
         $this->_domConfigFactory = $domConfigFactory;
         $this->_initMessageTemplates();
@@ -73,6 +83,8 @@ class Validator extends \Zend_Validate_Abstract
                 'urn:magento:framework:View/Layout/etc/layout_merged.xsd'
             ),
         ];
+        $this->validationState = $validationState
+            ?: ObjectManager::getInstance()->get(ValidationStateInterface::class);
     }
 
     /**
@@ -115,7 +127,13 @@ class Validator extends \Zend_Validate_Abstract
         try {
             //wrap XML value in the "layout" and "handle" tags to make it validatable
             $value = '<layout xmlns:xsi="' . self::XML_NAMESPACE_XSI . '">' . $value . '</layout>';
-            $this->_domConfigFactory->createDom(['xml' => $value, 'schemaFile' => $this->_xsdSchemas[$schema]]);
+            $this->_domConfigFactory->createDom(
+                [
+                    'xml' => $value,
+                    'schemaFile' => $this->_xsdSchemas[$schema],
+                    'validationState' => $this->validationState,
+                ]
+            );
 
             if ($isSecurityCheck) {
                 $value = new \Magento\Framework\Simplexml\Element($value);

--- a/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/Update/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/Update/ValidatorTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\Model\Layout\Update;
 
-use \Magento\Framework\View\Model\Layout\Update\Validator;
+use Magento\Framework\View\Model\Layout\Update\Validator;
 
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,6 +13,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
      */
     protected $_objectHelper;
+
+    /**
+     * @var \Magento\Framework\Config\ValidationStateInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $validationState;
 
     protected function setUp()
     {
@@ -29,12 +34,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $domConfigFactory = $this->getMockBuilder(
             'Magento\Framework\Config\DomFactory'
         )->disableOriginalConstructor()->getMock();
+        $this->validationState = $this->getMockBuilder(
+            \Magento\Framework\Config\ValidationStateInterface::class
+        )->disableOriginalConstructor()->getMock();
 
         $urnResolver = new \Magento\Framework\Config\Dom\UrnResolver();
         $params = [
             'xml' => '<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' .
                 trim($layoutUpdate) . '</layout>',
             'schemaFile' => $urnResolver->getRealPath('urn:magento:framework:View/Layout/etc/page_layout.xsd'),
+            'validationState' => $this->validationState,
         ];
 
         $exceptionMessage = 'validation exception';
@@ -52,7 +61,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $urnResolver = $this->_objectHelper->getObject('Magento\Framework\Config\Dom\UrnResolver');
         $model = $this->_objectHelper->getObject(
             'Magento\Framework\View\Model\Layout\Update\Validator',
-            ['domConfigFactory' => $domConfigFactory, 'urnResolver' => $urnResolver]
+            [
+                'domConfigFactory' => $domConfigFactory,
+                'urnResolver' => $urnResolver,
+                'validationState' => $this->validationState,
+            ]
         );
 
         return $model;


### PR DESCRIPTION
When saving custom layout update xml in CMS page, **in production mode**, xml is not validated against schema file, due to `\Magento\Framework\App\Arguments\ValidationState::isValidationRequired`method:
```
    /**
     * Retrieve current validation state
     *
     * @return boolean
     */
    public function isValidationRequired()
    {
        return $this->_appMode == \Magento\Framework\App\State::MODE_DEVELOPER;
    }
```

Actual result:
![captura de pantalla 2017-10-30 a las 3 46 56](https://user-images.githubusercontent.com/17545750/32153389-781e2e24-bd2a-11e7-950f-546d27f384a0.png)
![captura de pantalla 2017-10-30 a las 3 47 15](https://user-images.githubusercontent.com/17545750/32153394-7e39c804-bd2a-11e7-8f9f-c4991846fd05.png)

Desired behaviour would be check the layout update xml against the schema, and show error message to the user if it is invalid:
![captura de pantalla 2017-10-30 a las 3 58 10](https://user-images.githubusercontent.com/17545750/32153406-a3d7bf80-bd2a-11e7-9b71-551be5162d65.png)

### Description
- `\Magento\Cms\Model\Page\DomValidationState` has been added, and it is injected from post data processor to force layout update xml validation, only upon cms page save.

When this PR is applied and validation is performed, application may crush due to unhandled exception. This issue is solved by PR https://github.com/magento/magento2/pull/11860

### Manual testing scenarios
1. Enable production mode
2. Edit or create a CMS page, enter some invalid xml in Layout Update XML textarea
3. Try to save the page

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
