### PR TITLE
Fix missing discount label in checkout

### DIFF
--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
@@ -44,6 +44,22 @@ define([
             return this.totals()['coupon_label'];
         },
 
+        getTitle: function () {
+            if (!this.totals()) {
+                return null;
+            }
+
+            var total = this.totals();
+
+            for(var i = 0, len = total.total_segments.length; i < len; i++) {
+                if(total.total_segments[i].code == "discount") {
+                    return total.total_segments[i].title;
+                }
+            }
+
+            return null;
+        },
+
         /**
          * @return {Number}
          */

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
@@ -44,20 +44,21 @@ define([
             return this.totals()['coupon_label'];
         },
 
+        /**
+         * Get discount title
+         *
+         * @returns {null|string}
+         */
         getTitle: function () {
+            var discountSegments = null;
             if (!this.totals()) {
                 return null;
             }
 
-            var total = this.totals();
-
-            for(var i = 0, len = total.total_segments.length; i < len; i++) {
-                if(total.total_segments[i].code == "discount") {
-                    return total.total_segments[i].title;
-                }
-            }
-
-            return null;
+            discountSegments = this.totals()['total_segments'].filter(function (segment) {
+                return (segment.code === 'discount');
+            });
+            return discountSegments.length ? discountSegments[0].title : null;
         },
 
         /**

--- a/app/code/Magento/SalesRule/view/frontend/web/template/cart/totals/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/cart/totals/discount.html
@@ -7,7 +7,7 @@
 <!-- ko if: isDisplayed() -->
 <tr class="totals">
     <th colspan="1" style="" class="mark" scope="row">
-        <span class="title" data-bind="text: title"></span>
+        <span class="title" data-bind="text: getTitle()"></span>
         <span class="discount coupon" data-bind="text: getCouponLabel()"></span>
     </th>
     <td class="amount" data-bind="attr: {'data-th': title}">

--- a/app/code/Magento/SalesRule/view/frontend/web/template/summary/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/summary/discount.html
@@ -7,7 +7,7 @@
 <!-- ko if: isDisplayed() -->
 <tr class="totals discount">
     <th class="mark" scope="row">
-        <span class="title" data-bind="text: title"></span>
+        <span class="title" data-bind="text: getTitle()"></span>
         <span class="discount coupon" data-bind="text: getCouponCode()"></span>
     </th>
     <td class="amount">


### PR DESCRIPTION
### Description
The discount label was not being shown in the shopping cart totals description

### Fixed Issues
1. magento/magento2#11497: Discount Rule does not show Default Rule Label
2. magento/magento2#11428: Cart Price Rule Label is not working

### Manual testing scenarios
1. Add a discount to quote
2. Go to the shopping cart and now see the discount label in the totals description

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
