### PR TITLE
Fix #7127 Decimal input validation (for product attributes) fails with some locales (adminhtml) 

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Edit/Tab/Advanced.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Edit/Tab/Advanced.php
@@ -44,7 +44,7 @@ class Advanced extends Generic
     protected $disableScopeChangeList;
 
     /**
-     * @var \Magento\Framework\Locale\ResolverInterface
+     * @var ResolverInterface
      */
     protected $localeResolver;
     


### PR DESCRIPTION
Fix #7127 Decimal input validation (for product attributes) fails with some locales (adminhtml) 

### Description
Convert default value used in input to locale used in backend

### Fixed Issues (if relevant)
1. magento/magento2#7127: Decimal input validation (for product attributes) fails with some locales (adminhtml)

### Manual testing scenarios
1. Go to Stores > Attributes > Product > Edit attribute, e.g. "weight"
2. Expand section "Advanced Attribute Properties"
3. Set a "Default Value" to "0.01"
4. Change the backend language to Portuguese / Dutch or any language that uses comma as decimal separator
5. Go back to Stores > Attributes > Product > Edit attribute, e.g. "weight"
6. Default value now comes converted to 0,01
7. Save without error

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
