### PR TITLE
Save background color correctly in images. [backport 2.1]

### DIFF
--- a/app/code/Magento/Catalog/Model/ImageExtractor.php
+++ b/app/code/Magento/Catalog/Model/ImageExtractor.php
@@ -5,10 +5,11 @@
  */
 namespace Magento\Catalog\Model;
 
-use Magento\Catalog\Model\Product\Attribute\Backend\Media\ImageEntryConverter;
 use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product\Attribute\Backend\Media\ImageEntryConverter;
+use Magento\Framework\View\Xsd\Media\TypeDataExtractorInterface;
 
-class ImageExtractor implements \Magento\Framework\View\Xsd\Media\TypeDataExtractorInterface
+class ImageExtractor implements TypeDataExtractorInterface
 {
     /**
      * Extract configuration data of images from the DOM structure
@@ -55,6 +56,7 @@ class ImageExtractor implements \Magento\Framework\View\Xsd\Media\TypeDataExtrac
         $backgroundArray = [];
         if (preg_match($pattern, $backgroundString, $backgroundArray)) {
             array_shift($backgroundArray);
+            $backgroundArray = array_map('intval', $backgroundArray);
         }
         return $backgroundArray;
     }

--- a/app/code/Magento/Catalog/Model/ImageExtractor.php
+++ b/app/code/Magento/Catalog/Model/ImageExtractor.php
@@ -31,8 +31,11 @@ class ImageExtractor implements TypeDataExtractorInterface
                 if ($attribute->nodeType != XML_ELEMENT_NODE) {
                     continue;
                 }
-                if ($attribute->tagName == 'background') {
+                $attributeTagName = $attribute->tagName;
+                if ($attributeTagName === 'background') {
                     $nodeValue = $this->processImageBackground($attribute->nodeValue);
+                } elseif ($attributeTagName === 'width' || $attributeTagName === 'height') {
+                    $nodeValue = intval($attribute->nodeValue);
                 } else {
                     $nodeValue = $attribute->nodeValue;
                 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ImageExtractorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ImageExtractorTest.php
@@ -23,7 +23,7 @@ class ImageExtractorTest extends \PHPUnit_Framework_TestCase
     public function testProcess()
     {
         $expectedArray = include(__DIR__ . '/_files/converted_view.php');
-        $this->assertEquals($expectedArray, $this->model->process($this->getDomElement(), 'media'));
+        $this->assertSame($expectedArray, $this->model->process($this->getDomElement(), 'media'));
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Related with the [PR11888](https://github.com/magento/magento2/pull/11888)

### Description
<!--- Provide a description of the changes proposed in the pull request -->
If you updated the background color for image of product, this color always was black and it never was the color indicated in your configuration.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#[8799](https://github.com/magento/magento2/issues/8799): Image brackground

### Steps to reproduce
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Edit view.xml file
`ex: theme-frontend-luma/etc/view.xml`
2. Add background color attribute to an image
```
<image id="related_products_list" type="small_image">
     <width>152</width>
     <height>230</height>
     <background>[250,247,247]</background>
</image>
```
3. Clear cache and reload images.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
