### PR TITLE
Translate cache doesn't always fetch correct data

### DIFF
--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -214,6 +214,7 @@ class Translate implements \Magento\Framework\TranslateInterface
         if (!isset($this->_config['module'])) {
             $this->_config['module'] = $this->getControllerModuleName();
         }
+        $this->getCacheId(true);
         return $this;
     }
 


### PR DESCRIPTION
## Description
Their is an issue when Magento emulates another store localisation used is not always correct. This happens because the setConfig is populated with new data. But the cache ID is never cleared. So for example you wont get translations from the selected stores theme.

This was discovered while testing Magento's checkout when Magento sends out order emails with a 3rd party extension as payment provider. 

## Fixed Issues (if relevant)
Unknown

## Steps to reproduce

1. (Might be optional, but was originally found this way) Create new store in Magento admin
2. Create new theme and assign it the store.
3. Set locale to whatever, but add a specific theme translation. 
4. Translate something in the newly created theme that appears in the order confirmation email
5. Go through checkout 
6. Check the email order confirmation send by the checkout (not the one you can send via the administration).
