### PR TITLE
[Backport 2.1-develop] #10767 Race condition causing duplicate orders with double-clicks on Braintree "Pay" button

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/hosted-fields.js
@@ -61,7 +61,7 @@ define([
         },
 
         /**
-         * @returns {Bool}
+         * @returns {Boolean}
          */
         isVaultEnabled: function () {
             return this.vaultEnabler.isVaultEnabled();
@@ -144,10 +144,19 @@ define([
         },
 
         /**
-         * Trigger order placing
+         * Returns state of place order button
+         * @returns {Boolean}
+         */
+        isButtonActive: function () {
+            return this.isActive() && this.isPlaceOrderActionAllowed();
+        },
+
+        /**
+         * Triggers order placing
          */
         placeOrderClick: function () {
             if (this.validateCardType()) {
+                this.isPlaceOrderActionAllowed(false);
                 $(this.getSelector('submit')).trigger('click');
             }
         },

--- a/app/code/Magento/Braintree/view/frontend/web/template/payment/form.html
+++ b/app/code/Magento/Braintree/view/frontend/web/template/payment/form.html
@@ -139,10 +139,9 @@
                 <button class="action primary checkout"
                         type="submit"
                         data-bind="
-                        click: placeOrderClick,
-                        attr: {title: $t('Place Order')},
-                            css: {disabled: !isPlaceOrderActionAllowed()},
-                            enable: isActive()
+                            click: placeOrderClick,
+                            attr: {title: $t('Place Order')},
+                            enable: isButtonActive()
                         "
                         disabled>
                     <span data-bind="i18n: 'Place Order'"></span>


### PR DESCRIPTION
### Description
Backport fixes from https://github.com/magento/magento2/commit/508170225ad966a21a905b16974540ab8fcbd842 raised in https://github.com/magento/magento2/issues/10767. Applied multiple requests to Braintree fix from v2.2.1

### Fixed Issues
1. magento/magento2#10767: Race condition causing duplicate orders with double-clicks on Braintree "Pay" button

### Manual testing scenarios
1. Add items to basket and proceed through checkout, until its time to choose payment method.
2. Select Credit Card payments (Braintree)
3. Enter payment details (I'm using test credentials on a sandbox environment)
4. Continually click the "Pay" button
5. Only one request should be sent to Braintree

See https://github.com/magento/magento2/issues/10767 for more testing information, needs to be done on a substantial host as the bug does not occur if the requests to Braintree are sequential, not concurrent

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
