### PR TITLE
#9151: [Github] Sitemap.xml: lastmod timestamp can contain invalid dates

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -44,6 +44,11 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
     const TYPE_URL = 'url';
 
     /**
+     * Last mode date min value
+     */
+    const LAST_MOD_MIN_VAL = '0000-01-01 00:00:00';
+
+    /**
      * Real file path
      *
      * @var string
@@ -156,6 +161,13 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
      * @since 100.2.0
      */
     protected $_cacheTag = true;
+
+    /**
+     * Last mode min timestamp value
+     *
+     * @var int
+     */
+    protected $lastModMinTsVal;
 
     /**
      * Initialize dependencies.
@@ -661,7 +673,11 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
      */
     protected function _getFormattedLastmodDate($date)
     {
-        return date('c', strtotime($date));
+        if ($this->lastModMinTsVal === null) {
+            $this->lastModMinTsVal = strtotime(self::LAST_MOD_MIN_VAL);
+        }
+        $timestamp = max(strtotime($date), $this->lastModMinTsVal);
+        return date('c', $timestamp);
     }
 
     /**

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -167,7 +167,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
      *
      * @var int
      */
-    protected $lastModMinTsVal;
+    private $lastModMinTsVal;
 
     /**
      * Initialize dependencies.

--- a/app/code/Magento/Sitemap/Test/Unit/Model/SitemapTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/SitemapTest.php
@@ -540,7 +540,7 @@ class SitemapTest extends \PHPUnit\Framework\TestCase
             $this->returnValue(
                 [
                     new \Magento\Framework\DataObject(
-                        ['url' => 'product.html', 'updated_at' => '2012-12-21 00:00:00']
+                        ['url' => 'product.html', 'updated_at' => '0000-00-00 00:00:00']
                     ),
                     new \Magento\Framework\DataObject(
                         [

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-3.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-3.xml
@@ -10,7 +10,7 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>http://store.com/product.html</loc>
-        <lastmod>2012-12-21T00:00:00-08:00</lastmod>
+        <lastmod>0000-01-01T00:00:00-08:00</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.5</priority>
     </url>

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-single.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-single.xml
@@ -22,7 +22,7 @@
     </url>
     <url>
         <loc>http://store.com/product.html</loc>
-        <lastmod>2012-12-21T00:00:00-08:00</lastmod>
+        <lastmod>0000-01-01T00:00:00-08:00</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.5</priority>
     </url>


### PR DESCRIPTION
### Description
Allow only valid lastmod values in Sitemap

### Fixed Issues
1. magento/magento2#9151: Sitemap.xml: lastmod timestamp can contain invalid dates

### Manual testing scenarios
1. Create Simple Product with sku='simple1' ;
2. Update field 'updated_at' by query:
```
SET sql_mode = '';
UPDATE catalog_product_entity SET updated_at = '0000-00-00 00:00:00' WHERE sku = 'simple1';
```
3. Generate sitemap.
4. The XML file should not contain
`<lastmod>-001-11-30T00:00:00+00:00</lastmod>`
5. Lastmod vlaue should be like this:
`<lastmod>0000-01-01T00:00:00+00:00</lastmod>`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
