### PR TITLE
7691: address with saveInAddressBook 0 are still being added to the address book for new customers

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -466,6 +466,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                     'email' => $quote->getCustomerEmail()
                 ]
             );
+            $shippingAddress->setData('quote_address_id', $quote->getShippingAddress()->getId());
             $addresses[] = $shippingAddress;
             $order->setShippingAddress($shippingAddress);
             $order->setShippingMethod($quote->getShippingAddress()->getShippingMethod());
@@ -477,6 +478,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                 'email' => $quote->getCustomerEmail()
             ]
         );
+        $billingAddress->setData('quote_address_id', $quote->getBillingAddress()->getId());
         $addresses[] = $billingAddress;
         $order->setBillingAddress($billingAddress);
         $order->setAddresses($addresses);

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
@@ -9,6 +9,7 @@ namespace Magento\Quote\Test\Unit\Model;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 use Magento\Quote\Model\CustomerManagement;
+use Magento\Sales\Api\Data\OrderAddressInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -130,6 +131,11 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Customer\Api\AddressRepositoryInterface
      */
     private $addressRepositoryMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $quoteFactoryMock;
 
     /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
@@ -530,12 +536,12 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
         $shippingAddress = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
         $payment = $this->createMock(\Magento\Quote\Model\Quote\Payment::class);
         $baseOrder = $this->createMock(\Magento\Sales\Api\Data\OrderInterface::class);
-        $convertedBillingAddress = $this->createMock(\Magento\Sales\Api\Data\OrderAddressInterface::class);
-        $convertedShippingAddress = $this->createMock(\Magento\Sales\Api\Data\OrderAddressInterface::class);
+        $convertedBilling = $this->createPartialMockForAbstractClass(OrderAddressInterface::class, ['setData']);
+        $convertedShipping = $this->createPartialMockForAbstractClass(OrderAddressInterface::class, ['setData']);
         $convertedPayment = $this->createMock(\Magento\Sales\Api\Data\OrderPaymentInterface::class);
         $convertedQuoteItem = $this->createMock(\Magento\Sales\Api\Data\OrderItemInterface::class);
 
-        $addresses = [$convertedShippingAddress, $convertedBillingAddress];
+        $addresses = [$convertedShipping, $convertedBilling];
         $quoteItems = [$quoteItem];
         $convertedItems = [$convertedQuoteItem];
 
@@ -564,7 +570,7 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
                     'email' => 'customer@example.com'
                 ]
             )
-            ->willReturn($convertedShippingAddress);
+            ->willReturn($convertedShipping);
         $this->quoteAddressToOrderAddress->expects($this->at(1))
             ->method('convert')
             ->with(
@@ -574,22 +580,26 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
                     'email' => 'customer@example.com'
                 ]
             )
-            ->willReturn($convertedBillingAddress);
+            ->willReturn($convertedBilling);
+        $billingAddress->expects($this->once())->method('getId')->willReturn(4);
+        $convertedBilling->expects($this->once())->method('setData')->with('quote_address_id', 4);
+
         $this->quoteItemToOrderItem->expects($this->once())->method('convert')
             ->with($quoteItem, ['parent_item' => null])
             ->willReturn($convertedQuoteItem);
         $this->quotePaymentToOrderPayment->expects($this->once())->method('convert')->with($payment)
             ->willReturn($convertedPayment);
         $shippingAddress->expects($this->once())->method('getShippingMethod')->willReturn('free');
-
+        $shippingAddress->expects($this->once())->method('getId')->willReturn(5);
+        $convertedShipping->expects($this->once())->method('setData')->with('quote_address_id', 5);
         $order = $this->prepareOrderFactory(
             $baseOrder,
-            $convertedBillingAddress,
+            $convertedBilling,
             $addresses,
             $convertedPayment,
             $convertedItems,
             $quoteId,
-            $convertedShippingAddress
+            $convertedShipping
         );
 
         $this->orderManagement->expects($this->once())
@@ -857,22 +867,22 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param \Magento\Sales\Api\Data\OrderInterface $baseOrder
-     * @param \Magento\Sales\Api\Data\OrderAddressInterface $billingAddress
+     * @param OrderAddressInterface $billingAddress
      * @param array $addresses
      * @param $payment
      * @param array $items
      * @param $quoteId
-     * @param \Magento\Sales\Api\Data\OrderAddressInterface $shippingAddress
+     * @param OrderAddressInterface $shippingAddress
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     protected function prepareOrderFactory(
         \Magento\Sales\Api\Data\OrderInterface $baseOrder,
-        \Magento\Sales\Api\Data\OrderAddressInterface $billingAddress,
+        OrderAddressInterface $billingAddress,
         array $addresses,
         $payment,
         array $items,
         $quoteId,
-        \Magento\Sales\Api\Data\OrderAddressInterface $shippingAddress = null,
+        OrderAddressInterface $shippingAddress = null,
         $customerId = null
     ) {
         $order = $this->createPartialMock(
@@ -963,9 +973,6 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
         return $object;
     }
 
-    /**
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
-     */
     public function testSubmitForCustomer()
     {
         $orderData = [];
@@ -978,16 +985,12 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
         $shippingAddress = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
         $payment = $this->createMock(\Magento\Quote\Model\Quote\Payment::class);
         $baseOrder = $this->createMock(\Magento\Sales\Api\Data\OrderInterface::class);
-        $convertedBillingAddress = $this->createMock(
-            \Magento\Sales\Api\Data\OrderAddressInterface::class
-        );
-        $convertedShippingAddress = $this->createMock(
-            \Magento\Sales\Api\Data\OrderAddressInterface::class
-        );
+        $convertedBilling = $this->createPartialMockForAbstractClass(OrderAddressInterface::class, ['setData']);
+        $convertedShipping = $this->createPartialMockForAbstractClass(OrderAddressInterface::class, ['setData']);
         $convertedPayment = $this->createMock(\Magento\Sales\Api\Data\OrderPaymentInterface::class);
         $convertedQuoteItem = $this->createMock(\Magento\Sales\Api\Data\OrderItemInterface::class);
 
-        $addresses = [$convertedShippingAddress, $convertedBillingAddress];
+        $addresses = [$convertedShipping, $convertedBilling];
         $quoteItems = [$quoteItem];
         $convertedItems = [$convertedQuoteItem];
 
@@ -1016,7 +1019,7 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
                     'email' => 'customer@example.com'
                 ]
             )
-            ->willReturn($convertedShippingAddress);
+            ->willReturn($convertedShipping);
         $this->quoteAddressToOrderAddress->expects($this->at(1))
             ->method('convert')
             ->with(
@@ -1026,22 +1029,23 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
                     'email' => 'customer@example.com'
                 ]
             )
-            ->willReturn($convertedBillingAddress);
+            ->willReturn($convertedBilling);
         $this->quoteItemToOrderItem->expects($this->once())->method('convert')
             ->with($quoteItem, ['parent_item' => null])
             ->willReturn($convertedQuoteItem);
         $this->quotePaymentToOrderPayment->expects($this->once())->method('convert')->with($payment)
             ->willReturn($convertedPayment);
         $shippingAddress->expects($this->once())->method('getShippingMethod')->willReturn('free');
-
+        $shippingAddress->expects($this->once())->method('getId')->willReturn(5);
+        $convertedShipping->expects($this->once())->method('setData')->with('quote_address_id', 5);
         $order = $this->prepareOrderFactory(
             $baseOrder,
-            $convertedBillingAddress,
+            $convertedBilling,
             $addresses,
             $convertedPayment,
             $convertedItems,
             $quoteId,
-            $convertedShippingAddress
+            $convertedShipping
         );
         $customerAddressMock = $this->getMockBuilder(\Magento\Customer\Api\Data\AddressInterface::class)
             ->getMockForAbstractClass();
@@ -1050,6 +1054,8 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
         $quote->expects($this->any())->method('addCustomerAddress')->with($customerAddressMock);
         $billingAddress->expects($this->once())->method('getCustomerId')->willReturn(2);
         $billingAddress->expects($this->once())->method('getSaveInAddressBook')->willReturn(false);
+        $billingAddress->expects($this->once())->method('getId')->willReturn(4);
+        $convertedBilling->expects($this->once())->method('setData')->with('quote_address_id', 4);
         $this->orderManagement->expects($this->once())
             ->method('place')
             ->with($order)
@@ -1062,5 +1068,26 @@ class QuoteManagementTest extends \PHPUnit\Framework\TestCase
             ->with('sales_model_service_quote_submit_success', ['order' => $order, 'quote' => $quote]);
         $this->quoteRepositoryMock->expects($this->once())->method('save')->with($quote);
         $this->assertEquals($order, $this->model->submit($quote, $orderData));
+    }
+
+    /**
+     * Get mock for abstract class with methods.
+     *
+     * @param string $className
+     * @param array $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createPartialMockForAbstractClass($className, $methods = [])
+    {
+        return $this->getMockForAbstractClass(
+            $className,
+            [],
+            '',
+            true,
+            true,
+            true,
+            $methods
+        );
     }
 }

--- a/app/code/Magento/Sales/etc/module.xml
+++ b/app/code/Magento/Sales/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Sales" setup_version="2.0.7">
+    <module name="Magento_Sales" setup_version="2.0.8">
         <sequence>
             <module name="Magento_Rule"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -313,12 +313,12 @@ define([
                 data = this.serializeData(this.billingAddressContainer);
             } else {
                 data = this.serializeData(this.shippingAddressContainer);
-                areasToLoad.push('shipping_method');
             }
+            areasToLoad.push('shipping_method');
             data = data.toObject();
             data['shipping_as_billing'] = flag ? 1 : 0;
             data['reset_shipping'] = 1;
-            this.loadArea( areasToLoad, true, data);
+            this.loadArea(areasToLoad, true, data);
         },
 
         resetShippingMethod : function(data){

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/Shipping/Method.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/Shipping/Method.php
@@ -44,9 +44,13 @@ class Method extends Block
     public function selectShippingMethod(array $shippingMethod)
     {
         $this->waitFormLoading();
-        if ($this->_rootElement->find($this->shippingMethodsLink)->isVisible()) {
-            $this->_rootElement->find($this->shippingMethodsLink)->click();
-        }
+        $this->_rootElement->waitUntil(
+            function () {
+                return $this->_rootElement->find($this->shippingMethodsLink)->isVisible() ? true : null;
+            }
+        );
+
+        $this->_rootElement->find($this->shippingMethodsLink)->click();
         $selector = sprintf(
             $this->shippingMethod,
             $shippingMethod['shipping_service'],


### PR DESCRIPTION
If you place an order as a guest and set the save_in_address_book for an address on 0, that address will still be copied to the customer address book when registering as a new customer on the checkout success page.

### Fixed Issues (if relevant)
1. magento/magento2#7691: address with saveInAddressBook 0 are still being added to the address book for new customers.

### Manual testing scenarios
1. Place an order as a guest and set the save_in_address_book for your shipping address to 0 
2. Click the register link on the checkout success page
3. Addresses with save_in_address_book set to 0 should not be copied to the new customer address book.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
