### PR TITLE
10195: Order relation child is not set during edit operation

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1907,6 +1907,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             $oldOrder = $this->getSession()->getOrder();
             $oldOrder->setRelationChildId($order->getId());
             $oldOrder->setRelationChildRealId($order->getIncrementId());
+            $oldOrder->save();
             $this->orderManagement->cancel($oldOrder->getEntityId());
             $order->save();
         }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/AdminOrder/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/AdminOrder/CreateTest.php
@@ -104,6 +104,10 @@ class CreateTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(1, $newOrderItems->count());
 
+        $order->loadByIncrementId('100000001');
+        $this->assertEquals($newOrder->getRealOrderId(), $order->getRelationChildRealId());
+        $this->assertEquals($newOrder->getId(), $order->getRelationChildId());
+
         $newOrderItem = $newOrderItems->getFirstItem();
 
         $this->assertEquals(


### PR DESCRIPTION
Order relation child is not set during edit operation.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10195:  Order relation child is not set during edit operation.

### Manual testing scenarios
### Steps to reproduce
1. Create an order
2. Edit the order through admin panel
3. Check `relation_child_id`and `relation_child_real_id` fields of the **old** order. It should be filled.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
