### PR TITLE
Order grid - Sort by Purchase Date Desc by default

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -139,7 +139,6 @@
             <settings>
                 <filter>text</filter>
                 <label translate="true">ID</label>
-                <sorting>desc</sorting>
             </settings>
         </column>
         <column name="store_id" class="Magento\Store\Ui\Component\Listing\Column\Store">
@@ -154,6 +153,7 @@
                 <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <label translate="true">Purchase Date</label>
+                <sorting>desc</sorting>
             </settings>
         </column>
         <column name="billing_name">


### PR DESCRIPTION
### Description
As a customer I expect to see new orders at the top of the grid, however during migration from M1 to M2 - order number length changed, as result new orders are NOT located at the top of grid.

In order to fix this issue for all cases - we're changing default sorting order to "Purchase Date" desc.

As we discussed with @okorshenko in https://github.com/magento/magento2/issues/10185#issuecomment-340531557 sorting order grid by Increment is not good idea. I'm proposing change default sorting from increment_id column to created_at.

Sorting issue happens only in following cases:
- Orders were migrated from Magento 1
- Used prefix/suffix for order number
- Customized order ID generation
- Etc.

NOTE: Order grid sorting saves in ui_bookmark table, so before testing need to execute following SQL:
```sql
TRUNCATE table ui_bookmark;
```

### Fixed Issues (if relevant)
1. 

### Manual testing scenarios
1. Create three orders as example 1000000001, 1000000002 and 1000000003
2. Go to order grid (sorting is correct)
![capture 2017-10-02 at 17 58 47](https://user-images.githubusercontent.com/1873745/32234407-5432c646-be65-11e7-8d41-f95d6ca3f614.png)
3. Change 1000000001 order number to 100000001 (remove one 0 in the center) to emulate that order was migrated from M1 & Go to Order grid: (last created order became NOT first)
![capture 2017-10-02 at 18 01 04](https://user-images.githubusercontent.com/1873745/32234456-84d537c0-be65-11e7-9a41-a6f73f2dd930.png)
3. Create new Order & go to order grid (latest order is not at the top)
![capture 2017-10-02 at 18 04 09](https://user-images.githubusercontent.com/1873745/32234616-fc9e893c-be65-11e7-8d9a-c761ddfe6037.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
