### PR TITLE
[BACKPORT 2.2] [BUGFIX] check if currentStoreId === '' so report isn't generated if …

### DIFF
--- a/app/code/Magento/Store/Test/Unit/Model/StoreManagerTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreManagerTest.php
@@ -72,6 +72,9 @@ class StoreManagerTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->with($storeId)
             ->willReturn($storeMock);
+        $this->storeRepositoryMock->expects($this->atLeastOnce())
+            ->method('getList')
+            ->willReturn([$storeId => $storeMock]);
         $actualStore = $this->model->getStore($storeId);
         $this->assertInstanceOf(\Magento\Store\Api\Data\StoreInterface::class, $actualStore);
         $this->assertEquals($storeMock, $actualStore);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
same as magento-partners/magento2ce#60

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you  try to switch to a non-existing or empty store code you the request will result in an Exception.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9433: Accessing url with ___store= creates exception

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Try to switch to http://www.example.com/?___store=
2. This will result in an Exception
3. Try to switch to http://www.example.com/?___store=nonexistingcode
