### PR TITLE
[BACKPORT 2.2] [TASK] Add resetPassword call to the webapi

### DIFF
--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -194,6 +194,12 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <route url="/V1/customers/resetPassword" method="POST">
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="resetPassword"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
     <route url="/V1/customers/:customerId/confirm" method="GET">
         <service class="Magento\Customer\Api\AccountManagementInterface" method="getConfirmationStatus"/>
         <resources>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
same as magento-partners/magento2ce#58

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This update adds an extra API call to the Interface for managing customer accounts. When you are running a Headless Magento 2 webshop it is impossible to implement the full reset password process without this call.

In the new call you can easily reset the password with the following parameters:
`{
  "email": "string",
  "resetToken": "string",
  "newPassword": "string"
}`


Before webapi.xml update:
![image](https://user-images.githubusercontent.com/6040343/31579143-e16641a2-b12f-11e7-8be6-b71654007a89.png)


After webapi.xml update:

![image](https://user-images.githubusercontent.com/6040343/31579154-528a161a-b130-11e7-80dc-a9993e7e0d12.png)
