### PR TITLE
[BACKPORT 2.1] [BUGFIX] All UI input fields should have maxlength of 255 because of …

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/form/element/input.html
+++ b/app/code/Magento/Ui/view/base/web/templates/form/element/input.html
@@ -15,5 +15,6 @@
             placeholder: placeholder,
             'aria-describedby': noticeId,
             id: uid,
-            disabled: disabled
+            disabled: disabled,
+            maxlength: 255
     }"/>


### PR DESCRIPTION
…VARCHAR maxlength 255 in the database

same as magento-partners/magento2ce#61

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you save an input field in the Admin or Frontend area with a value greater then 255 characters the actual saved data in the database is 255 characters.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6238: Meta description allows too many characters

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a Test product
2. Paste a string with more then 255 characters in the Meta Description or the Name
3. Now  the value is visible but after saving the value will be set to 255 characters

Apply Changes and Now it is possible to only insert 255 characters in the UI input fields

See the following image with the max length of 255 for the value column in the varchar column
![image](https://user-images.githubusercontent.com/6040343/31687743-72722e66-b38a-11e7-8250-319c5bfbd885.png)

