### PR TITLE
[BACKPORT 2.1] [BUGFIX] Add FreeShipping to the Items when SalesRule uses

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/SalesRule/Calculator.php
+++ b/app/code/Magento/OfflineShipping/Model/SalesRule/Calculator.php
@@ -45,6 +45,7 @@ class Calculator extends Validator
 
                 case Rule::FREE_SHIPPING_ADDRESS:
                     $address->setFreeShipping(true);
+                    $item->setFreeShipping(true);
                     break;
             }
             if ($rule->getStopRulesProcessing()) {


### PR DESCRIPTION
…ING_ADDRESS

same as magento-partners/magento2ce#59

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you create a Shopping Cart Price Rule for Free Shipping for shipment with matching items.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8172: Free shipping coupon not working with Table Rates shipping - Sorry, no quotes are available for this order.
2. magento/magento2#8089: Cart Price Rules based on Shipping Method can't be applied in basket
3. magento/magento2#10507: Free shipping coupon not working with Table Rates shipping - Sorry, no quotes are available for this order.

_In issue magento/magento2#8172 there is referenced to the shipping method Table Rates but the issue is for all Offline ShippingMethods_

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a Shopping Cart Price Rule with the following Options based on issue magento/magento2#8172

- Coupon Code: FREESHIP
- Enabled from/To: 01/01/2016 - 01/01/2022
- Apply: Percent of product price discount
- Discount Amount: 0
- Discard subsequent rules: YES
- Apply to Shipping Amount: YES
- Free Shipping: **For Shipment with matching items**

2. Add a product to your shopping cart
3. Apply the coupon code in your shopping cart
4. Result is that there is no free shipping calculated

Apply changes and try again and the result will be that there is Free Shipping for the cart.

Before:
![image](https://user-images.githubusercontent.com/6040343/31587304-b8d20ed2-b1df-11e7-8826-993aa8ef5d45.png)



After:
![image](https://user-images.githubusercontent.com/6040343/31587299-a5aa63ea-b1df-11e7-9403-702a3a7abb7f.png)

