### PR TITLE
Unable to save some dropdown attributes

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -194,6 +194,7 @@
         var empty = $(element).closest('table')
             .find('input.required-option:visible')
             .filter(function (i, el) {
+                if($(element).is(":visible"))
                 return $.mage.isEmpty(el.value);
             })
             .length;


### PR DESCRIPTION

### Description
Some dropdown product attributes can´t be saved in admin, for example Country of manufacturer attr. This was because the JS table validation. Added here: https://github.com/magento/magento2/commit/023b7925dc648bf09813d839990ef5398254264b
 Had a problem with hidden attr for validation

### Fixed Issues (if relevant)
Unable to change country of manufacture default label value #6879

### Manual testing scenarios

1. Navigate to product attributes in admin panel
2. Edit country of manufacture attribute
3. Try to change default label
4. Hit save
5. Now is saved


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
