### PR TITLE
#8810 - REST API - Attribute option creation -> no ID returned

### DIFF
--- a/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
@@ -29,7 +29,7 @@ interface ProductAttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return bool
+     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
      */
     public function add($attributeCode, $option);
 

--- a/app/code/Magento/Eav/Api/AttributeOptionManagementInterface.php
+++ b/app/code/Magento/Eav/Api/AttributeOptionManagementInterface.php
@@ -20,7 +20,7 @@ interface AttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return bool
+     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
      */
     public function add($entityType, $attributeCode, $option);
 

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -49,9 +49,10 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
             throw new StateException(__('Attribute %1 doesn\'t work with options', $attributeCode));
         }
 
+        $optionLabel = $option->getLabel();
         $optionId = $this->getOptionId($option);
         $options = [];
-        $options['value'][$optionId][0] = $option->getLabel();
+        $options['value'][$optionId][0] = $optionLabel;
         $options['order'][$optionId] = $option->getSortOrder();
 
         if (is_array($option->getStoreLabels())) {
@@ -67,11 +68,14 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
         $attribute->setOption($options);
         try {
             $this->resourceModel->save($attribute);
+            if ($optionLabel && $attribute->getAttributeCode()) {
+                $option->setValue($attribute->getSource()->getOptionId($optionLabel));
+            }
         } catch (\Exception $e) {
             throw new StateException(__('Cannot save attribute %1', $attributeCode));
         }
 
-        return true;
+        return $option;
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
@@ -80,7 +80,7 @@ class OptionManagementTest extends \PHPUnit\Framework\TestCase
         $attributeMock->expects($this->once())->method('setDefault')->with(['new_option']);
         $attributeMock->expects($this->once())->method('setOption')->with($option);
         $this->resourceModelMock->expects($this->once())->method('save')->with($attributeMock);
-        $this->assertTrue($this->model->add($entityType, $attributeCode, $optionMock));
+        $this->assertEquals($optionMock, $this->model->add($entityType, $attributeCode, $optionMock));
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Set option_id in value field to attributeoptioninterface return type
### Description
<!--- Provide a description of the changes proposed in the pull request -->
I have changed return type of add function and set value to option. So when we do REST or SOAP api then it will return option_id in 'value' field to attributeoptioninterface return type.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8810: REST API - Attribute option creation -> no ID returned

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Fresh install
2. Make following REST request:
`POST /rest/default/V1/products/attributes/manufacturer/options`
with following Body:
`{
  "option": {
    "label": "Manufacturer 1"
  }
}`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
