### PR TITLE
[2.1-develop] Order grid - Sort by Purchase Date Desc by default

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -166,7 +166,6 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">text</item>
-                    <item name="sorting" xsi:type="string">desc</item>
                     <item name="label" xsi:type="string" translate="true">ID</item>
                 </item>
             </argument>
@@ -187,6 +186,7 @@
                     <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/date</item>
                     <item name="dataType" xsi:type="string">date</item>
                     <item name="label" xsi:type="string" translate="true">Purchase Date</item>
+                    <item name="sorting" xsi:type="string">desc</item>
                     <item name="dateFormat" xsi:type="string">MMM dd, YYYY, H:mm:ss A</item>
                 </item>
             </argument>


### PR DESCRIPTION
(Backport to 2.1-develop based on commit ad3c18f) https://github.com/magento/magento2/pull/11911
### Description
As a customer I expect to see new orders at the top of the grid, however during migration from M1 to M2 - order number length changed, as result new orders are NOT located at the top of grid.

In order to fix this issue for all cases - we're changing default sorting order to "Purchase Date" desc.

As we discussed with @okorshenko in https://github.com/magento/magento2/issues/10185#issuecomment-340531557 sorting order grid by Increment is not good idea. I'm proposing change default sorting from increment_id column to created_at.

Sorting issue happens only in following cases:
- Orders were migrated from Magento 1
- Used prefix/suffix for order number
- Customized order ID generation
- Etc.

NOTE: Order grid sorting saves in ui_bookmark table, so before testing need to execute following SQL:
```sql
TRUNCATE table ui_bookmark;
```

### Fixed Issues (if relevant)
1. 

### Manual testing scenarios
1. Create three orders as example 1000000001, 1000000002 and 1000000003
2. Go to order grid (sorting is correct)
![capture 2017-10-02 at 17 58 47](https://user-images.githubusercontent.com/1873745/32234407-5432c646-be65-11e7-8d41-f95d6ca3f614.png)
3. Change 1000000001 order number to 100000001 (remove one 0 in the center) to emulate that order was migrated from M1 & Go to Order grid: (last created order became NOT first)
![capture 2017-10-02 at 18 01 04](https://user-images.githubusercontent.com/1873745/32234456-84d537c0-be65-11e7-9a41-a6f73f2dd930.png)
3. Create new Order & go to order grid (latest order is not at the top)
![capture 2017-10-02 at 18 04 09](https://user-images.githubusercontent.com/1873745/32234616-fc9e893c-be65-11e7-8d9a-c761ddfe6037.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
