### PR TITLE
9990: Product import doesn't allow empty attribute values for non-static attributes

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -22,6 +22,12 @@ use Magento\Framework\EntityManager\MetadataPool;
 abstract class AbstractType
 {
     /**
+     * When you want to import product with empty value you need
+     * to change its value to value of this constant.
+     */
+    const EMPTY_VALUE = '__EMPTY__VALUE__';
+
+    /**
      * Common attributes cache
      *
      * @var array
@@ -536,6 +542,10 @@ abstract class AbstractType
         foreach ($this->_getProductAttributes($rowData) as $attrCode => $attrParams) {
             if (!$attrParams['is_static'] && empty($rowData[$attrCode])) {
                 unset($rowData[$attrCode]);
+            }
+
+            if (isset($rowData[$attrCode]) && $rowData[$attrCode] === self::EMPTY_VALUE) {
+                $rowData[$attrCode] = null;
             }
         }
         return $rowData;

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
@@ -6,6 +6,7 @@
 namespace Magento\CatalogImportExport\Model\Import\Product;
 
 use Magento\CatalogImportExport\Model\Import\Product;
+use Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType;
 use Magento\Framework\Validator\AbstractValidator;
 
 /**
@@ -188,6 +189,11 @@ class Validator extends AbstractValidator implements RowValidatorInterface
         if (!strlen(trim($rowData[$attrCode]))) {
             return true;
         }
+
+        if ($rowData[$attrCode] === AbstractType::EMPTY_VALUE && !$attrParams['is_required']) {
+            return true;
+        }
+
         switch ($attrParams['type']) {
             case 'varchar':
             case 'text':

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Quantity.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Quantity.php
@@ -6,6 +6,7 @@
 namespace Magento\CatalogImportExport\Model\Import\Product\Validator;
 
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
+use Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType;
 
 /**
  * Class Quantity
@@ -18,7 +19,7 @@ class Quantity extends AbstractImportValidator implements RowValidatorInterface
     public function isValid($value)
     {
         $this->_clearMessages();
-        if (!empty($value['qty']) && !is_numeric($value['qty'])) {
+        if (!empty($value['qty']) && (!is_numeric($value['qty']) && $value['qty'] !== AbstractType::EMPTY_VALUE)) {
             $this->_addMessages(
                 [
                     sprintf(

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Weight.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Weight.php
@@ -6,6 +6,7 @@
 namespace Magento\CatalogImportExport\Model\Import\Product\Validator;
 
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
+use Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType;
 
 class Weight extends AbstractImportValidator implements RowValidatorInterface
 {
@@ -15,7 +16,9 @@ class Weight extends AbstractImportValidator implements RowValidatorInterface
     public function isValid($value)
     {
         $this->_clearMessages();
-        if (!empty($value['weight']) && (!is_numeric($value['weight']) || $value['weight'] < 0)) {
+        if (!empty($value['weight']) && (!is_numeric($value['weight']) || $value['weight'] < 0)
+            && $value['weight'] !== AbstractType::EMPTY_VALUE
+        ) {
             $this->_addMessages(
                 [
                     sprintf(

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/WeightTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/WeightTest.php
@@ -7,27 +7,24 @@ namespace Magento\CatalogImportExport\Test\Unit\Model\Import\Product\Validator;
 
 use Magento\CatalogImportExport\Model\Import\Product;
 use Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType;
-use Magento\CatalogImportExport\Model\Import\Product\Validator\Quantity;
+use Magento\CatalogImportExport\Model\Import\Product\Validator\Weight;
 
-/**
- * Class QuantityTest
- */
-class QuantityTest extends \PHPUnit\Framework\TestCase
+class WeightTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var Quantity
+     * @var Weight
      */
-    private $quantity;
+    private $weight;
 
     protected function setUp()
     {
-        $this->quantity = new Quantity();
+        $this->weight = new Weight();
 
         $contextStub = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
             ->getMock();
         $contextStub->method('retrieveMessageTemplate')->willReturn(null);
-        $this->quantity->init($contextStub);
+        $this->weight->init($contextStub);
     }
 
     /**
@@ -37,7 +34,7 @@ class QuantityTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsValid($expectedResult, $value)
     {
-        $result = $this->quantity->isValid($value);
+        $result = $this->weight->isValid($value);
         $this->assertEquals($expectedResult, $result);
     }
 
@@ -47,14 +44,15 @@ class QuantityTest extends \PHPUnit\Framework\TestCase
     public function isValidDataProvider()
     {
         return [
-            [true, ['qty' => 0]],
-            [true, ['qty' => 1]],
-            [true, ['qty' => 5]],
-            [true, ['qty' => -1]],
-            [true, ['qty' => -10]],
-            [true, ['qty' => '']],
-            [false, ['qty' => 'abc']],
-            [false, ['qty' => true]],
+            [true, ['weight' => 0]],
+            [true, ['weight' => 1]],
+            [true, ['weight' => 5]],
+            [false, ['weight' => -1]],
+            [false, ['weight' => -10]],
+            [true, ['weight' => '']],
+            [false, ['weight' => 'abc']],
+            [false, ['weight' => true]],
+            [false, ['weight' => true]],
             [true, ['weight' => AbstractType::EMPTY_VALUE]],
         ];
     }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
@@ -178,7 +178,56 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
                     'product_type' => '',
                     'name' => 'Simple 01 German'
                 ]
-            ]
+            ],
+            [
+                [
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                    'test_attribute' => '0',
+                ],
+            ],
+            [
+                [
+                    'sku' => null,
+                    'store_view_code' => '',
+                    '_attribute_set' => 'Default',
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                    'test_attribute' => null,
+                ],
+                [
+                    'sku' => null,
+                    'store_view_code' => '',
+                    '_attribute_set' => 'Default',
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                ],
+            ],
+            [
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'price' => AbstractType::EMPTY_VALUE,
+                    'description' => AbstractType::EMPTY_VALUE,
+                    'weight' => AbstractType::EMPTY_VALUE,
+                ],
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'price' => null,
+                    'description' => null,
+                    'weight' => null
+                ],
+            ],
         ];
     }
 }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
@@ -181,33 +181,6 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [
-                    'product_type' => 'simple',
-                    'name' => 'Simple 01',
-                    'price' => 10,
-                    'test_attribute' => '0',
-                ],
-            ],
-            [
-                [
-                    'sku' => null,
-                    'store_view_code' => '',
-                    '_attribute_set' => 'Default',
-                    'product_type' => 'simple',
-                    'name' => 'Simple 01',
-                    'price' => 10,
-                    'test_attribute' => null,
-                ],
-                [
-                    'sku' => null,
-                    'store_view_code' => '',
-                    '_attribute_set' => 'Default',
-                    'product_type' => 'simple',
-                    'name' => 'Simple 01',
-                    'price' => 10,
-                ],
-            ],
-            [
-                [
                     'sku' => '',
                     'store_view_code' => 'German',
                     '_attribute_set' => 'Default',


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#9990: Product import doesn't allow empty attribute values for non-static attributes

### Manual testing scenarios
1. Change value to empty for some attribute in csv.
2. Run product import.
3. Check this attribute for value. It should be empty.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
