### PR TITLE
magento/magento2#9002: Anchor categories are showing products of disabled subcategories.

### DIFF
--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -1108,7 +1108,11 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
         }
         $productIndexer = $this->indexerRegistry->get(Indexer\Category\Product::INDEXER_ID);
         if (!$productIndexer->isScheduled()
-            && (!empty($this->getAffectedProductIds()) || $this->dataHasChangedFor('is_anchor'))
+            && (
+                !empty($this->getAffectedProductIds())
+                || $this->dataHasChangedFor('is_anchor')
+                || $this->dataHasChangedFor('is_active')
+            )
         ) {
             $productIndexer->reindexList($this->getPathIds());
         }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -94,6 +94,8 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
      */
     public function execute()
     {
+        $additionalTableName = $this->activeTableSwitcher->getAdditionalTableName($this->getMainTable());
+        $this->connection->delete($additionalTableName);
         $this->reindex();
         $this->activeTableSwitcher->switchTable($this->connection, [$this->getMainTable()]);
         return $this;

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -46,6 +46,9 @@ class CategoryTreeTest extends \PHPUnit\Framework\TestCase
      */
     private $_resource;
 
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
     protected function setUp()
     {
         $this->_objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -296,7 +296,7 @@ class CategoryTreeTest extends \PHPUnit\Framework\TestCase
         /** @var \Magento\Framework\DB\Select $select */
         $select = $connection->select();
         $select
-            ->from($this->_indexer::MAIN_INDEX_TABLE)
+            ->from($this->_resource->getTableName($this->_indexer::MAIN_INDEX_TABLE))
             ->where('category_id = ?', $categoryId);
         return $select->query()->fetchAll();
     }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/category_reindexing.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/category_reindexing.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+/* @var \Magento\Store\Model\StoreManagerInterface $storeManager */
+$storeManager = $objectManager->get(\Magento\Store\Model\StoreManagerInterface::class);
+$storeManager->setCurrentStore(0);
+
+$defaultAttributeSet = $objectManager->get(Magento\Eav\Model\Config::class)
+    ->getEntityType('catalog_product')
+    ->getDefaultAttributeSetId();
+
+$productRepository = $objectManager->create(
+    \Magento\Catalog\Api\ProductRepositoryInterface::class
+);
+
+$categoryLinkRepository = $objectManager->create(
+    \Magento\Catalog\Api\CategoryLinkRepositoryInterface::class,
+    [
+        'productRepository' => $productRepository
+    ]
+);
+
+/** @var Magento\Catalog\Api\CategoryLinkManagementInterface $linkManagement */
+$categoryLinkManagement = $objectManager->create(\Magento\Catalog\Api\CategoryLinkManagementInterface::class);
+
+/**
+ * After installation system has two categories: root one with ID:1 and Default category with ID:2
+ */
+/** @var $category \Magento\Catalog\Model\Category */
+$category = $objectManager->create(\Magento\Catalog\Model\Category::class);
+$category->isObjectNew(true);
+$category->setId(3)
+    ->setName('Category A')
+    ->setParentId(2)
+    ->setPath('1/2/3')
+    ->setLevel(2)
+    ->setIsActive(true)
+    ->setIsAnchor(true)
+    ->save();
+
+$category = $objectManager->create(\Magento\Catalog\Model\Category::class);
+$category->isObjectNew(true);
+$category->setId(4)
+    ->setName('Category B')
+    ->setParentId(3)
+    ->setPath('1/2/3/4')
+    ->setLevel(3)
+    ->setIsActive(false)
+    ->setIsAnchor(false)
+    ->save();
+
+$category = $objectManager->create(\Magento\Catalog\Model\Category::class);
+$category->isObjectNew(true);
+$category->setId(5)
+    ->setName('Category C')
+    ->setParentId(3)
+    ->setPath('1/2/3/4/5')
+    ->setLevel(3)
+    ->setIsActive(false)
+    ->setIsAnchor(false)
+    ->save();
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+$product->isObjectNew(true);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setAttributeSetId($defaultAttributeSet)
+    ->setWebsiteIds([1])
+    ->setName('Product for category_reindexing test')
+    ->setSku('simple')
+    ->setPrice(10)
+    ->setStockData(['use_config_manage_stock' => 0])
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->save();
+
+$categoryLinkManagement->assignProductToCategories(
+    $product->getSku(),
+    [4, 5]
+);

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/category_reindexing_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/category_reindexing_rollback.php
@@ -5,22 +5,25 @@
  */
 
 /** @var \Magento\Framework\Registry $registry */
-$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+$registry = $objectManager->get(\Magento\Framework\Registry::class);
 $registry->unregister('isSecureArea');
 $registry->register('isSecureArea', true);
 
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
 /** @var $product \Magento\Catalog\Model\Product */
-$product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
-$product->loadByAttribute('name', 'Product for category_reindexing test');
+$product = $productRepository->get('simple', false, null, true);
 if ($product->getId()) {
     $product->delete();
 }
 
-/** @var $category \Magento\Catalog\Model\Category */
-$category = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Category::class);
+/** @var Magento\Catalog\Api\CategoryRepositoryInterface $categoryRepository */
+$categoryRepository = $objectManager->get(Magento\Catalog\Api\CategoryRepositoryInterface::class);
 $categoryIds = [3, 4, 5];
 foreach ($categoryIds as $categoryId) {
-    $category->load($categoryId);
+    /** @var $category \Magento\Catalog\Model\Category */
+    $category = $categoryRepository->get($categoryId);
     if ($category->getId()) {
         $category->delete();
     }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/category_reindexing_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/category_reindexing_rollback.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+$product->loadByAttribute('name', 'Product for category_reindexing test');
+if ($product->getId()) {
+    $product->delete();
+}
+
+/** @var $category \Magento\Catalog\Model\Category */
+$category = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Category::class);
+$categoryIds = [3, 4, 5];
+foreach ($categoryIds as $categoryId) {
+    $category->load($categoryId);
+    if ($category->getId()) {
+        $category->delete();
+    }
+}


### PR DESCRIPTION
### Description
Now enabling or disabling category initializes partial reindex, similar as moving category or enabling or disabling category anchor status. Also, table catalog_category_product_index_replica is now cleaned before reindexing.

### Fixed Issues (if relevant)
1. magento/magento2#9002: Anchor categories are showing products of disabled subcategories.

### Manual testing scenarios
1. Create a simple product 'Test' that is in stock and visible in catalog.
2. Create a category A (don't add products to it).
3. Create a disabled subcategory B (parent is A) and add our 'Test' product to it.
4. Goto category A on the frontend.
5. Category A should not have any products.
6. Enable category B.
7. Goto category A on the frontend.
8. Category A is showing 'Test' product.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
