### PR TITLE
5574: quotes not escaped for translations of "Not you?" message in persistent header.

### DIFF
--- a/app/code/Magento/Persistent/Block/Header/Additional.php
+++ b/app/code/Magento/Persistent/Block/Header/Additional.php
@@ -71,7 +71,7 @@ class Additional extends \Magento\Framework\View\Element\Html\Link
     protected function _toHtml()
     {
         if ($this->_persistentSessionHelper->getSession()->getCustomerId()) {
-            return '<span><a ' . $this->getLinkAttributes() . ' >' . __('Not you?')
+            return '<span><a ' . $this->getLinkAttributes() . ' >' . $this->escapeHtml(__('Not you?'))
             . '</a></span>';
         }
 

--- a/app/code/Magento/Persistent/Test/Unit/Block/Header/AdditionalTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Block/Header/AdditionalTest.php
@@ -280,6 +280,8 @@ class AdditionalTest extends \PHPUnit\Framework\TestCase
         $this->sessionMock->expects($this->never())
             ->method('getSessionId')
             ->willReturn($sessionId);
+        $customerId ? $this->escaperMock->expects(self::once())->method('escapeHtml')->willReturn('Not you?')
+            : $this->escaperMock->expects(self::never())->method('escapeHtml');
 
         // call protected _toHtml method
         $sessionMock = $this->createPartialMock(\Magento\Persistent\Model\Session::class, ['getCustomerId']);

--- a/dev/tests/integration/testsuite/Magento/Persistent/Block/Header/AdditionalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Persistent/Block/Header/AdditionalTest.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Persistent\Block\Header;
 
+use Magento\Framework\Phrase;
+
 /**
  * @magentoDataFixture Magento/Persistent/_files/persistent.php
  */
@@ -61,5 +63,34 @@ class AdditionalTest extends \PHPUnit\Framework\TestCase
             $this->_block->toHtml()
         );
         $this->_customerSession->logout();
+    }
+
+    /**
+     * @magentoConfigFixture current_store persistent/options/customer 1
+     * @magentoConfigFixture current_store persistent/options/enabled 1
+     * @magentoConfigFixture current_store persistent/options/remember_enabled 1
+     * @magentoConfigFixture current_store persistent/options/remember_default 1
+     * @magentoAppArea frontend
+     * @magentoAppIsolation enabled
+     */
+    public function testToHtmlEscapeSingleQuote()
+    {
+        /** @var Phrase\Renderer\Placeholder|\PHPUnit_Framework_MockObject_MockObject $rendererMock */
+        $rendererMock = $this->getMockBuilder(Phrase\Renderer\Placeholder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $rendererMock->expects(self::any())->method('render')->willReturn("Test 'phrase 'with 'quotes");
+
+        $defaultRenderer = Phrase::getRenderer();
+        Phrase::setRenderer($rendererMock);
+        $this->_customerSession->loginById(1);
+        $translation = 'Test &#039;phrase &#039;with &#039;quotes';
+
+        $this->assertStringMatchesFormat(
+            '<span><a href="' . $this->_block->getHref() . '"%A>' . $translation . '</a></span>',
+            $this->_block->toHtml()
+        );
+        $this->_customerSession->logout();
+        Phrase::setRenderer($defaultRenderer);
     }
 }


### PR DESCRIPTION
### Description
Fix for quotes not escaped for translations of "Not you?" message in persistent header.

### Fixed Issues (if relevant)
1. magento/magento2#5574: quotes not escaped for translations of "Not you?" message in persistent header

### Manual testing scenarios
1. Install the French translation package by Imaginaerum (https://github.com/Imaginaerum/magento2-language-fr-fr).
2. Log in to admin.
3. Set up to stores, the first with the default locale (en_US), the second with the locale fr_FR.
4. Navigate to Stores > Configuration > Customers > Persistent Shopping Cart.
5. Set "Enable Persistence" =  "Yes".
6. Set "Enable "Remember Me" = "Yes", "Remember Me" Default Value = "Yes", "Clear Persistence on Sign Out" = "No".
7. Save config.
8. Create simple product.
9. Navigate to storefront.
10. Create account and add created simple product to shopping cart.
11. Log out. Check in header **Welcome, YourFirstName YourLastName! Not you?** message appear.
12. Switch to French store. Check in header **Bienvenue, YourFirstName YourLastName ! Ce n’est pas vous ?** message appear, there are no errors in console.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
