### PR TITLE
Fix json encoded attribute backend type when attribute value is null

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/JsonEncoded.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/JsonEncoded.php
@@ -58,7 +58,7 @@ class JsonEncoded extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBa
     {
         parent::afterLoad($object);
         $attrCode = $this->getAttribute()->getAttributeCode();
-        $object->setData($attrCode, $this->jsonSerializer->unserialize($object->getData($attrCode)));
+        $object->setData($attrCode, $this->jsonSerializer->unserialize($object->getData($attrCode) ?: '{}'));
         return $this;
     }
 }

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Backend/JsonEncodedTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Backend/JsonEncodedTest.php
@@ -95,4 +95,18 @@ class JsonEncodedTest extends \PHPUnit\Framework\TestCase
         $this->model->afterLoad($product);
         $this->assertEquals([1, 2, 3], $product->getData('json_encoded'));
     }
+
+    /**
+     * Test after load handler with null attribute value
+     */
+    public function testAfterLoadWithNullAttributeValue()
+    {
+        $product = new \Magento\Framework\DataObject(
+            [
+                'json_encoded' => null
+            ]
+        );
+        $this->model->afterLoad($product);
+        $this->assertEquals([], $product->getData('json_encoded'));
+    }
 }


### PR DESCRIPTION
When you create a new product attribute with JsonEncoded backend type then you always get the following error when you try to load a product which doesn't have value for that specific attribute yet:

```
Exception #0 (Magento\Eav\Model\Entity\Attribute\Exception): Unable to unserialize value.
```

The source of the problem is this method:
```
public function unserialize($string)
    {
        $result = json_decode($string, true);
        if (json_last_error() !== JSON_ERROR_NONE) {
            throw new \InvalidArgumentException('Unable to unserialize value.');
        }
        return $result;
    }
```
When you do `json_decode(null, true)`, then `json_last_error()` will return 4 (`JSON_ERROR_SYNTAX`).

With the suggested fix it will set the attribute value to empty array when the attribute value is null.