### PR TITLE
11832: Create order (on Customer edit page) - not working from admin environment

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/AbstractCreate.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/AbstractCreate.php
@@ -160,4 +160,22 @@ abstract class AbstractCreate extends \Magento\Backend\Block\Widget
             )
             : $this->priceCurrency->convert($value, $this->getStore());
     }
+
+    /**
+     * If item is quote or wishlist we need to get product from it.
+     *
+     * @param $item
+     *
+     * @return Product
+     */
+    public function getProduct($item)
+    {
+        if ($item instanceof Product) {
+            $product = $item;
+        } else {
+            $product = $item->getProduct();
+        }
+
+        return $product;
+    }
 }

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/AbstractCreateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/AbstractCreateTest.php
@@ -3,8 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Sales\Test\Unit\Block\Adminhtml\Order\Create;
 
+use Magento\Catalog\Model\Product;
 use Magento\Catalog\Pricing\Price\FinalPrice;
 
 class AbstractCreateTest extends \PHPUnit\Framework\TestCase
@@ -66,5 +68,35 @@ class AbstractCreateTest extends \PHPUnit\Framework\TestCase
             ->with($price)
             ->willReturn($resultPrice);
         $this->assertEquals($resultPrice, $this->model->getItemPrice($this->productMock));
+    }
+
+    /**
+     * @param $item
+     *
+     * @dataProvider getProductDataProvider
+     */
+    public function testGetProduct($item)
+    {
+        $product = $this->model->getProduct($item);
+
+        self::assertInstanceOf(Product::class, $product);
+    }
+
+    /**
+     * DataProvider for testGetProduct.
+     *
+     * @return array
+     */
+    public function getProductDataProvider()
+    {
+        $productMock = $this->createMock(Product::class);
+
+        $itemMock = $this->createMock(\Magento\Wishlist\Model\Item::class);
+        $itemMock->expects($this->once())->method('getProduct')->willReturn($productMock);
+
+        return [
+            [$productMock],
+            [$itemMock],
+        ];
     }
 }

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar/items.phtml
@@ -67,11 +67,7 @@
 
                         <?php if ($block->canDisplayPrice()): ?>
                             <td class="col-price">
-                                <?php if ($block->getDataId() == 'cart'): ?>
-                                    <?= /* @noEscape */ $block->getItemPrice($_item->getProduct()) ?>
-                                <?php else: ?>
-                                    <?= /* @noEscape */ $block->getItemPrice($_item) ?>
-                                <?php endif; ?>
+                                <?= /* @noEscape */ $block->getItemPrice($block->getProduct($_item)) ?>
                             </td>
                         <?php endif; ?>
 


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
1. magento/magento2#11832: Create order (on Customer edit page) - not working from admin environment

### Manual testing scenarios
1. Go to storefront and log in with that sample customer.
2. Add some products to her wishlist.
3. Login to Admin Panel.
4. Navigate to Customers -> All Customers.
5. Enter Edit page of the customer.
6. Use top Action - Create Order.
7. No js errors in console.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
