### PR TITLE
11197: Blank page at the checkout 'shipping' step[backport].

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/step-navigator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/step-navigator.js
@@ -47,7 +47,7 @@ define([
 
             steps.sort(this.sortItems).forEach(function (element) {
                 if (element.code == hashString || element.alias == hashString) { //eslint-disable-line eqeqeq
-                    element.navigate();
+                    element.navigate(element);
                 } else {
                     element.isVisible(false);
                 }

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -127,10 +127,12 @@ define([
         },
 
         /**
-         * Load data from server for shipping step
+         * Navigator change hash handler.
+         *
+         * @param {Object} step - navigation step
          */
-        navigate: function () {
-            //load data from server for shipping step
+        navigate: function (step) {
+            step && step.isVisible(true);
         },
 
         /**

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/view/shipping.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/view/shipping.test.js
@@ -80,7 +80,12 @@ define(['squire', 'ko', 'jquery', 'jquery/validate'], function (Squire, ko, $) {
     describe('Magento_Checkout/js/view/shipping', function () {
         describe('"navigate" method', function () {
             it('Check for return value.', function () {
-                expect(obj.navigate()).toBeUndefined();
+                var step = {
+                    isVisible: ko.observable(false)
+                };
+
+                expect(obj.navigate(step)).toBeUndefined();
+                expect(step.isVisible()).toBe(true);
             });
         });
 


### PR DESCRIPTION
### Description
Blank page at the checkout 'shipping' step[backport].

### Fixed Issues (if relevant)
1. magento/magento2#11197: Blank page at the checkout 'shipping' step

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add any product to the cart as a guest user
2. Proceed to the checkout
3. Fill address and customer data
4. Proceed to the payment step
5. Click 'Shipping' in the progress bar to return to the shipping step
6. Click next and proceed again to the payment step
7. Click 'back' button in the browser
8. Check that customer is redirected to shipping step and is able to change address data.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
