### PR TITLE
[Backport 2.1] #11898 - Change NL PostCode Pattern

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -318,7 +318,7 @@
     </zip>
     <zip countryCode="NL">
         <codes>
-            <code id="pattern_1" active="true" example="1234 AB">^[0-9]{4}\s[a-zA-Z]{2}$</code>
+            <code id="pattern_1" active="true" example="1234 AB/1234AB">^[1-9][0-9]{3}\s?[a-zA-Z]{2}$</code>
         </codes>
     </zip>
     <zip countryCode="NO">


### PR DESCRIPTION
Change Pattern for NL PostCodes

### Description
Change Pattern for NL PostCodes based in: http://html5pattern.com/Postal_Codes (Dutch Postal Code

### Fixed Issues (if relevant)
1. magento/magento2#11898: Zip code Netherlands should allow zipcode without space

### Manual testing scenarios
1. Buy Product
2. Go Checkout
3. Select Netherlands Country
4. Put PostCode: `1234 AA`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
