### PR TITLE
11793: Magento2.1.5 admin shipping report shows wrong currency code

### DIFF
--- a/app/code/Magento/Reports/Block/Adminhtml/Grid/AbstractGrid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Grid/AbstractGrid.php
@@ -363,12 +363,11 @@ class AbstractGrid extends \Magento\Backend\Block\Widget\Grid\Extended
     public function getCurrentCurrencyCode()
     {
         if ($this->_currentCurrencyCode === null) {
-            $this->_currentCurrencyCode = count(
-                $this->_storeIds
-            ) > 0 ? $this->_storeManager->getStore(
-                array_shift($this->_storeIds)
-            )->getBaseCurrencyCode() : $this->_storeManager->getStore()->getBaseCurrencyCode();
+            $this->_currentCurrencyCode = count($this->_storeIds) > 0
+                ? $this->_storeManager->getStore(array_shift($this->_storeIds))->getCurrentCurrencyCode()
+                : $this->_storeManager->getStore()->getBaseCurrencyCode();
         }
+
         return $this->_currentCurrencyCode;
     }
 

--- a/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Grid/AbstractGridTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Grid/AbstractGridTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Reports\Test\Unit\Block\Adminhtml\Grid;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * Test for class \Magento\Reports\Block\Adminhtml\Grid\AbstractGrid.
+ */
+class AbstractGridTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Reports\Block\Adminhtml\Grid\AbstractGrid|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $model;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
+    protected function setUp()
+    {
+        $objectManager = new ObjectManager($this);
+
+        $this->storeManagerMock = $this->getMockForAbstractClass(
+            \Magento\Store\Model\StoreManagerInterface::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['getStore']
+        );
+
+        $this->model = $objectManager->getObject(
+            \Magento\Reports\Block\Adminhtml\Grid\AbstractGrid::class,
+            ['_storeManager' => $this->storeManagerMock]
+        );
+
+    }
+
+    /**
+     * @param $storeIds
+     *
+     * @dataProvider getCurrentCurrencyCodeDataProvider
+     */
+    public function testGetCurrentCurrencyCode($storeIds)
+    {
+        $storeMock = $this->getMockForAbstractClass(
+            \Magento\Store\Api\Data\StoreInterface::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['getBaseCurrencyCode', 'getCurrentCurrencyCode']
+        );
+
+        $this->storeManagerMock->expects($this->once())->method('getStore')->willReturn($storeMock);
+
+        $this->model->setStoreIds($storeIds);
+
+        if ($storeIds) {
+            $storeMock->expects($this->once())->method('getCurrentCurrencyCode')->willReturn('EUR');
+            $expectedCurrencyCode = 'EUR';
+        } else {
+            $storeMock->expects($this->once())->method('getBaseCurrencyCode')->willReturn('USD');
+            $expectedCurrencyCode = 'USD';
+        }
+
+        $currencyCode = $this->model->getCurrentCurrencyCode();
+        $this->assertEquals($expectedCurrencyCode, $currencyCode);
+    }
+
+    /**
+     * DataProvider for testGetCurrentCurrencyCode.
+     *
+     * @return array
+     */
+    public function getCurrentCurrencyCodeDataProvider()
+    {
+        return [
+            [[]],
+            [[2]],
+        ];
+    }
+}

--- a/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Grid/AbstractGridTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Grid/AbstractGridTest.php
@@ -41,7 +41,6 @@ class AbstractGridTest extends \PHPUnit\Framework\TestCase
             \Magento\Reports\Block\Adminhtml\Grid\AbstractGrid::class,
             ['_storeManager' => $this->storeManagerMock]
         );
-
     }
 
     /**


### PR DESCRIPTION
Admin reports show only default currency code.

### Fixed Issues (if relevant)
1. magento/magento2#11793: Magento2.1.5 admin shipping report shows wrong currency code

### Manual testing scenarios
Steps to reproduce:
1. Create a single website with multi-store views (2 stores).
2. Go to Stores-Configuration->General->Currency Setup->Currency Options and set it up to show USD currency for the 1 store, and EUR currency (as an example) for the second store.
3. Create 2 orders for each store (go to Sales->Orders), invoices and shippings for them.
4. Go to Admin->Reports->Sales->Shipping and set up the filters so you can see shipments for that orders you created earlier.
5. Currency must change depends on store.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
