### PR TITLE
11700: "Something Went Wrong" error for limited access admin user

### DIFF
--- a/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
@@ -127,7 +127,10 @@ class Render extends AbstractAction
     {
         if (isset($dataProviderConfigData['aclResource'])) {
             if (!$this->_authorization->isAllowed($dataProviderConfigData['aclResource'])) {
-                $this->_redirect('admin/denied');
+                if (!$this->_request->isAjax()) {
+                    $this->_redirect('admin/denied');
+                }
+
                 return false;
             }
         }

--- a/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
@@ -279,6 +279,13 @@ class RenderTest extends \PHPUnit\Framework\TestCase
         $this->requestMock->expects($this->any())
             ->method('getParams')
             ->willReturn([]);
+        if ($isAllowed === false) {
+            $this->requestMock->expects($this->once())
+                ->method('isAjax')
+                ->willReturn(true);
+        }
+        $this->responseMock->expects($this->never())
+            ->method('setRedirect');
         $this->responseMock->expects($this->any())
             ->method('appendBody')
             ->with($renderedData);


### PR DESCRIPTION
When user has access to Dashboard and don't has access to notification, error "something went wrong" appears, because ajax request try to get notifications, but magento try to redirect to "noroute".

### Description
If it is ajax request don't redirect anyway, simple return nothing.

### Fixed Issues (if relevant)
1. magento/magento2#11700: "Something Went Wrong" error for limited access admin user
2. magento/magento2#12149: Error message for user with restricted user role


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Login as an admin user with limited access(Without notification permission).
2. Something went wrong error pops up after every page load.
3. Server Logs and Magento Logs don't record any errors.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
