### PR TITLE
11532: Duplicate Simple Product Throws Error: Undefined offset: 0 in SaveHandler.php on line 122

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
@@ -119,7 +119,10 @@ class SaveHandler implements ExtensionInterface
 
             if ($key === false) {
                 $result[] = $newCategoryPosition;
-            } elseif ($oldCategoryPositions[$key]['position'] != $newCategoryPosition['position']) {
+            } elseif (
+                isset($oldCategoryPositions[$key])
+                && $oldCategoryPositions[$key]['position'] != $newCategoryPosition['position']
+            ) {
                 $result[] = $newCategoryPositions[$key];
                 unset($oldCategoryPositions[$key]);
             }

--- a/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
@@ -119,8 +119,7 @@ class SaveHandler implements ExtensionInterface
 
             if ($key === false) {
                 $result[] = $newCategoryPosition;
-            } elseif (
-                isset($oldCategoryPositions[$key])
+            } elseif (isset($oldCategoryPositions[$key])
                 && $oldCategoryPositions[$key]['position'] != $newCategoryPosition['position']
             ) {
                 $result[] = $newCategoryPositions[$key];

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
@@ -197,6 +197,21 @@ class SaveHandlerTest extends \PHPUnit\Framework\TestCase
                 ],
                 [], //affected category_ids
             ],
+            [
+                [3], //model category_ids
+                [
+                    ['category_id' => 3, 'position' => 20],
+                    ['category_id' => 4, 'position' => 30],
+                ], // dto category links
+                [
+                    ['category_id' => 3, 'position' => 10],
+                ],
+                [
+                    ['category_id' => 3, 'position' => 20],
+                    ['category_id' => 4, 'position' => 30],
+                ],
+                [3, 4], //affected category_ids
+            ],
         ];
     }
 


### PR DESCRIPTION

### Fixed Issues (if relevant)
1. magento/magento2#11532: Duplicate Simple Product Throws Error: Undefined offset: 0 in SaveHandler.php on line 122


### Manual testing scenarios
Precondition
Two cases:
Create simple product and export his, delete product in catalog manager, and import file from product.
or
Create simple product, and update Magento from 2.1.8 or 2.1.9 to 2.2.0.
Steps to reproduce:
1. Click on an existing simple product in the catalog manager
2. Click the "Save & Duplicate" option
 Expected result
The product saves and creates a duplicate item.
 Actual result
Saves the product but doesn't duplicate it. Throws the following error:
Notice: Undefined offset: 0 in /home/store/public_html/vendor/magento/module-catalog/Model/Category/Link/SaveHandler.php on line 122

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
