### PR TITLE
magento/magento2#11691: Wrong return type for getAttributeText($attributeCode)

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -1712,7 +1712,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      * Get attribute text by its code
      *
      * @param string $attributeCode Code of the attribute
-     * @return string
+     * @return string|array|null
      */
     public function getAttributeText($attributeCode)
     {

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductGettersTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductGettersTest.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Catalog\Model;
 
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
@@ -25,10 +26,18 @@ class ProductGettersTest extends \PHPUnit\Framework\TestCase
      */
     protected $_model;
 
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
     protected function setUp()
     {
         $this->_model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\Product::class
+        );
+        $this->productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            ProductRepositoryInterface::class
         );
     }
 
@@ -196,6 +205,24 @@ class ProductGettersTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->_model->getAttributeText('status'));
         $this->_model->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
         $this->assertEquals('Enabled', $this->_model->getAttributeText('status'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/products_with_multiselect_attribute.php
+     */
+    public function testGetAttributeTextArray()
+    {
+        $product = $this->productRepository->get('simple_ms_2');
+        $product->getAttributeText('multiselect_attribute');
+        $expected = [
+            'Option 2',
+            'Option 3',
+            'Option 4 "!@#$%^&*'
+        ];
+        self::assertEquals(
+            $expected,
+            $product->getAttributeText('multiselect_attribute')
+        );
     }
 
     public function testGetCustomDesignDate()


### PR DESCRIPTION
### Description
Magento\Catalog\Model\Product::getAttributeText return annotation changed to "string|array|null"

### Fixed Issues (if relevant)
1. magento/magento2#11691: Wrong return type for getAttributeText($attributeCode) 

### Manual testing scenarios
1. Open [Magento root]/app/code/Magento/Catalog/Model/Product.php code. 
2. Find getAttributeText method. 
3. It's return annotation should be "@return string|array|null"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
