### PR TITLE
Fix #2156 Js\Dataprovider uses the RendererInterface.

### DIFF
--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -46,7 +46,7 @@ class DataProvider implements DataProviderInterface
     /**
      * Basic translate renderer
      *
-     * @var \Magento\Framework\Phrase\Renderer\Translate
+     * @var \Magento\Framework\Phrase\RendererInterface
      */
     protected $translate;
 
@@ -54,7 +54,7 @@ class DataProvider implements DataProviderInterface
      * @param \Magento\Framework\App\State $appState
      * @param Config $config
      * @param \Magento\Framework\Filesystem\File\ReadFactory $fileReadFactory
-     * @param \Magento\Framework\Phrase\Renderer\Translate $translate
+     * @param \Magento\Framework\Phrase\RendererInterface $translate
      * @param \Magento\Framework\Component\ComponentRegistrar $componentRegistrar
      * @param \Magento\Framework\Component\DirSearch $dirSearch
      * @param \Magento\Framework\View\Design\Theme\ThemePackageList $themePackageList
@@ -64,7 +64,7 @@ class DataProvider implements DataProviderInterface
         \Magento\Framework\App\State $appState,
         Config $config,
         \Magento\Framework\Filesystem\File\ReadFactory $fileReadFactory,
-        \Magento\Framework\Phrase\Renderer\Translate $translate,
+        \Magento\Framework\Phrase\RendererInterface $translate,
         \Magento\Framework\Component\ComponentRegistrar $componentRegistrar,
         \Magento\Framework\Component\DirSearch $dirSearch,
         \Magento\Framework\View\Design\Theme\ThemePackageList $themePackageList,

--- a/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/InlineTest.php
+++ b/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/InlineTest.php
@@ -13,7 +13,7 @@ class InlineTest extends \PHPUnit\Framework\TestCase
     protected $translator;
 
     /**
-     * @var \Magento\Framework\Phrase\Renderer\Translate
+     * @var \Magento\Framework\Phrase\Renderer\Inline
      */
     protected $renderer;
 


### PR DESCRIPTION
### Description

- Fix #2156 changed dataprovider constructor to the RendererInterface
- Changed InlineTest to a Inline class object (which is instantiated) and not a Translate class object

### Fixed Issues
1. magento/magento2#2156: Why does \Magento\Translation\Model\Js\DataProvider use \Magento\Framework\Phrase\Renderer\Translate, not \Magento\Framework\Phrase\Renderer\Composite?
