### PR TITLE
Better respect plugin disabled attribute

### DIFF
--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -175,8 +175,8 @@ class PluginList extends Scoped implements InterceptionPluginList
                         unset($plugins[$key]);
                         continue;
                     }
-                    $this->trimInstanceStartingBackslash($plugin);
 
+                    $plugin['instance'] = ltrim($plugin['instance'], '\\');
                     $pluginType = $this->_omConfig->getOriginalInstanceType($plugin['instance']);
                     if (!class_exists($pluginType)) {
                         throw new \InvalidArgumentException('Plugin class ' . $pluginType . ' doesn\'t exist');
@@ -201,17 +201,6 @@ class PluginList extends Scoped implements InterceptionPluginList
             return $plugins;
         }
         return $this->_inherited[$type];
-    }
-
-    /**
-     * Trims starting backslash from plugin instance name
-     *
-     * @param array $plugin
-     * @return void
-     */
-    private function trimInstanceStartingBackslash(&$plugin)
-    {
-        $plugin['instance'] = ltrim($plugin['instance'], '\\');
     }
 
     /**

--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -168,8 +168,6 @@ class PluginList extends Scoped implements InterceptionPluginList
             if (is_array($plugins) && count($plugins)) {
                 $this->filterPlugins($plugins);
                 uasort($plugins, [$this, '_sort']);
-                $this->trimInstanceStartingBackslash($plugins);
-                $this->_inherited[$type] = $plugins;
                 $lastPerMethod = [];
                 foreach ($plugins as $key => $plugin) {
                     // skip disabled plugins
@@ -177,6 +175,8 @@ class PluginList extends Scoped implements InterceptionPluginList
                         unset($plugins[$key]);
                         continue;
                     }
+                    $this->trimInstanceStartingBackslash($plugin);
+
                     $pluginType = $this->_omConfig->getOriginalInstanceType($plugin['instance']);
                     if (!class_exists($pluginType)) {
                         throw new \InvalidArgumentException('Plugin class ' . $pluginType . ' doesn\'t exist');
@@ -196,6 +196,7 @@ class PluginList extends Scoped implements InterceptionPluginList
                         }
                     }
                 }
+                $this->_inherited[$type] = $plugins;
             }
             return $plugins;
         }
@@ -205,14 +206,12 @@ class PluginList extends Scoped implements InterceptionPluginList
     /**
      * Trims starting backslash from plugin instance name
      *
-     * @param array $plugins
+     * @param array $plugin
      * @return void
      */
-    private function trimInstanceStartingBackslash(&$plugins)
+    private function trimInstanceStartingBackslash(&$plugin)
     {
-        foreach ($plugins as &$plugin) {
-            $plugin['instance'] = ltrim($plugin['instance'], '\\');
-        }
+        $plugin['instance'] = ltrim($plugin['instance'], '\\');
     }
 
     /**


### PR DESCRIPTION
### Description
Prior to this fix, the `disabled` attribute on a plugin was not consistently respected: for example, if a plugin was defined in a specific scope but disabled by another module in global scope, it would generate an error because the `instance` wasn't defined in all scopes.

### Manual testing scenarios
1. Define a plugin in a `frontend` or `adminhtml` scope.
2. Add a reference to the plugin in global scope of another module, disabling it.
3. Ensure that `bin/magento setup:di:compile` completes successfully, without generating an error about `'instance'` being an undefined index.