### PR TITLE
Add validation for number of street lines

### DIFF
--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -198,7 +198,8 @@
                 <field id="street_lines" translate="label comment" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Number of Lines in a Street Address</label>
                     <backend_model>Magento\Customer\Model\Config\Backend\Address\Street</backend_model>
-                    <comment>Leave empty for default (2). Valid range: 1-4</comment>
+                    <comment>Valid range: 1-4</comment>
+                    <validate>validate-digits validate-digits-range digits-range-1-4</validate>
                 </field>
                 <field id="prefix_show" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Prefix</label>

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -199,7 +199,7 @@
                     <label>Number of Lines in a Street Address</label>
                     <backend_model>Magento\Customer\Model\Config\Backend\Address\Street</backend_model>
                     <comment>Valid range: 1-4</comment>
-                    <validate>validate-digits validate-digits-range digits-range-1-4</validate>
+                    <validate>required-entry validate-digits validate-digits-range digits-range-1-4</validate>
                 </field>
                 <field id="prefix_show" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Prefix</label>


### PR DESCRIPTION
### Description
Shipping address lines dissapear when street_lines on customer configuration is set to 0.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/7995

### Manual testing scenarios
1. Go to Stores > Configuration > Customer > Customer Configuration
2. Set Number of Lines in a Street Address to 0

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
