### PR TITLE
fix issue when creating attribute set groups with name configurable

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -19,7 +19,7 @@ use Magento\Catalog\Model\Locator\LocatorInterface;
  */
 class ConfigurablePanel extends AbstractModifier
 {
-    const GROUP_CONFIGURABLE = 'configurable';
+    const GROUP_CONFIGURABLE = 'group_configurable';
     const ASSOCIATED_PRODUCT_MODAL = 'configurable_associated_product_modal';
     const ASSOCIATED_PRODUCT_LISTING = 'configurable_associated_product_listing';
     const CONFIGURABLE_MATRIX = 'configurable-matrix';


### PR DESCRIPTION
### Description
Can't use "configurable" as group name in attribute sets 

### Fixed Issues
1. https://github.com/magento/magento2/issues/6123


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
