### PR TITLE
Improve urn in xhtml

### DIFF
--- a/app/code/Magento/Ui/view/base/ui_component/templates/container/default.xhtml
+++ b/app/code/Magento/Ui/view/base/ui_component/templates/container/default.xhtml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../Ui/etc/ui_template.xsd">
+<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_template.xsd">
     <div data-bind="scope: '{{getName()}}.areas'" class="entry-edit form-inline">
         <!-- ko template: getTemplate() --><!-- /ko -->
     </div>

--- a/app/code/Magento/Ui/view/base/ui_component/templates/export/button.xhtml
+++ b/app/code/Magento/Ui/view/base/ui_component/templates/export/button.xhtml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../Ui/etc/ui_template.xsd">
+<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_template.xsd">
     <div data-bind="scope: '{{getName()}}.areas'">
         <!-- ko template: getTemplate() --><!-- /ko -->
     </div>

--- a/app/code/Magento/Ui/view/base/ui_component/templates/form/collapsible.xhtml
+++ b/app/code/Magento/Ui/view/base/ui_component/templates/form/collapsible.xhtml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../Ui/etc/ui_template.xsd">
+<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_template.xsd">
     <div data-role="spinner" data-component="{{getName()}}.{{getName()}}" class="admin__form-loading-mask">
         <div class="spinner">
             <span/><span/><span/><span/><span/><span/><span/><span/>

--- a/app/code/Magento/Ui/view/base/ui_component/templates/form/default.xhtml
+++ b/app/code/Magento/Ui/view/base/ui_component/templates/form/default.xhtml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../Ui/etc/ui_template.xsd">
+<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_template.xsd">
     <div data-role="spinner" data-component="{{getName()}}.areas" class="admin__data-grid-loading-mask">
         <div class="spinner">
             <span/><span/><span/><span/><span/><span/><span/><span/>

--- a/app/code/Magento/Ui/view/base/ui_component/templates/listing/default.xhtml
+++ b/app/code/Magento/Ui/view/base/ui_component/templates/listing/default.xhtml
@@ -9,7 +9,7 @@
     class="admin__data-grid-outer-wrap"
     data-bind="scope: '{{getName()}}.{{getName()}}'"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../../../../Ui/etc/ui_template.xsd">
+    xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_template.xsd">
     <div data-role="spinner" data-component="{{getName()}}.{{getName()}}.{{spinner}}" class="admin__data-grid-loading-mask">
         <div class="spinner">
             <span/><span/><span/><span/><span/><span/><span/><span/>


### PR DESCRIPTION
### Description
Improve the urn of xhtml templates.

### Fixed Issues (if relevant)
1. magento/magento2#6661: XHTML templates Don't Use Schema URNs 

### Manual testing scenarios
Check the noNamespaceSchemaLocation of the files:
app/code/Magento/Ui/view/base/ui_component/templates/container/default.xhtml
app/code/Magento/Ui/view/base/ui_component/templates/export/button.xhtml
app/code/Magento/Ui/view/base/ui_component/templates/form/collapsible.xhtml
app/code/Magento/Ui/view/base/ui_component/templates/form/default.xhtml
app/code/Magento/Ui/view/base/ui_component/templates/listing/default.xhtml


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
