### PR TITLE
Fix newsletter subscriptions between stores

### DIFF
--- a/app/code/Magento/Newsletter/Model/ResourceModel/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/ResourceModel/Subscriber.php
@@ -118,17 +118,37 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function loadByCustomerData(\Magento\Customer\Api\Data\CustomerInterface $customer)
     {
-        $select = $this->connection->select()->from($this->getMainTable())->where('customer_id=:customer_id');
+        $select = $this->connection
+            ->select()
+            ->from($this->getMainTable())
+            ->where('customer_id=:customer_id and store_id=:store_id');
 
-        $result = $this->connection->fetchRow($select, ['customer_id' => $customer->getId()]);
+        $result = $this->connection
+            ->fetchRow(
+                $select,
+                [
+                    'customer_id' => $customer->getId(),
+                    'store_id' => $customer->getStoreId()
+                ]
+            );
 
         if ($result) {
             return $result;
         }
 
-        $select = $this->connection->select()->from($this->getMainTable())->where('subscriber_email=:subscriber_email');
+        $select = $this->connection
+            ->select()
+            ->from($this->getMainTable())
+            ->where('subscriber_email=:subscriber_email and store_id=:store_id');
 
-        $result = $this->connection->fetchRow($select, ['subscriber_email' => $customer->getEmail()]);
+        $result = $this->connection
+            ->fetchRow(
+                $select,
+                [
+                    'subscriber_email' => $customer->getEmail(),
+                    'store_id' => $customer->getStoreId()
+                ]
+            );
 
         if ($result) {
             return $result;

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -349,6 +349,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
     {
         try {
             $customerData = $this->customerRepository->getById($customerId);
+            $customerData->setStoreId($this->_storeManager->getStore()->getId());
             $data = $this->getResource()->loadByCustomerData($customerData);
             $this->addData($data);
             if (!empty($data) && $customerData->getId() && !$this->getCustomerId()) {

--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
@@ -187,6 +187,12 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
 
+        $storeModel = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId'])
+            ->getMock();
+        $this->storeManager->expects($this->any())->method('getStore')->willReturn($storeModel);
+
         $this->assertEquals($this->subscriber, $this->subscriber->updateSubscription($customerId));
     }
 

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
@@ -347,6 +347,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
                 'email' => 'customer@example.com',
                 'firstname' => 'test firstname',
                 'lastname' => 'test lastname',
+                'sendemail_store_id' => 1
             ],
             'subscription' => '0'
         ];

--- a/dev/tests/integration/testsuite/Magento/Newsletter/_files/subscribers.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/_files/subscribers.php
@@ -28,7 +28,7 @@ $firstSubscriberId = $subscriber->getId();
 
 $subscriber = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
     ->create(\Magento\Newsletter\Model\Subscriber::class);
-$subscriber->setStoreId($otherStore)
+$subscriber->setStoreId($currentStore)
     // Intentionally setting ID to 0 instead of 2 to test fallback mechanism in Subscriber model
     ->setCustomerId(0)
     ->setSubscriberEmail('customer_two@example.com')


### PR DESCRIPTION
Include store_id in query result in order to ensure that the action (subscribe/unsubscribe) it’s done in the correct store.

### Description
When user have different accounts in two or more stores newsletter table save the subscription status, store_id and customer_id.
The problem is that when we try to update this information the query result don't keep in mind the store of the user.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10014: Newsletter subscriptions status not isolated between multi stores

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create user: 'me@domain.com' in the first store (Website 1). Subscribe it to general subscription list.
2. Login this user 'me@domain.com' in the second store (Website 2). Subscribe it to general subscription list.
3. Login in the second store and uncheck subscription list.
4. Logout and login the user in the first store. The user mantain the subscription.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
