### PR TITLE
#11825: Generate new FormKey and replace for oldRequestParams Wishlist

### DIFF
--- a/app/code/Magento/Customer/Model/Plugin/CustomerFlushFormKey.php
+++ b/app/code/Magento/Customer/Model/Plugin/CustomerFlushFormKey.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Model\Plugin;
+
+use Magento\Customer\Model\Session;
+use Magento\Framework\Data\Form\FormKey as DataFormKey;
+use Magento\PageCache\Observer\FlushFormKey;
+
+class CustomerFlushFormKey
+{
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var DataFormKey
+     */
+    private $dataFormKey;
+
+    /**
+     * Initialize dependencies.
+     *
+     * @param Session $session
+     * @param DataFormKey $dataFormKey
+     */
+    public function __construct(Session $session, DataFormKey $dataFormKey)
+    {
+        $this->session = $session;
+        $this->dataFormKey = $dataFormKey;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @param FlushFormKey $subject
+     * @param callable $proceed
+     * @param $args
+     */
+    public function aroundExecute(FlushFormKey $subject, callable $proceed, ...$args)
+    {
+        $currentFormKey = $this->dataFormKey->getFormKey();
+        $proceed(...$args);
+        $beforeParams = $this->session->getBeforeRequestParams();
+        if ($beforeParams['form_key'] == $currentFormKey) {
+            $beforeParams['form_key'] = $this->dataFormKey->getFormKey();
+            $this->session->setBeforeRequestParams($beforeParams);
+        }
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Model/Plugin/CustomerFlushFormKeyTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Plugin/CustomerFlushFormKeyTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Model\Plugin;
+
+use Magento\Customer\Model\Plugin\CustomerFlushFormKey;
+use Magento\Customer\Model\Session;
+use Magento\Framework\App\PageCache\FormKey as CookieFormKey;
+use Magento\Framework\Data\Form\FormKey as DataFormKey;
+use Magento\PageCache\Observer\FlushFormKey;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class CustomerFlushFormKeyTest extends TestCase
+{
+    const CLOSURE_VALUE = 'CLOSURE';
+
+    /**
+     * @var CookieFormKey | MockObject
+     */
+    private $cookieFormKey;
+
+    /**
+     * @var Session | MockObject
+     */
+    private $customerSession;
+
+    /**
+     * @var DataFormKey | MockObject
+     */
+    private $dataFormKey;
+
+    /**
+     * @var \Closure
+     */
+    private $closure;
+
+    protected function setUp()
+    {
+
+        /** @var CookieFormKey | MockObject */
+        $this->cookieFormKey = $this->getMockBuilder(CookieFormKey::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var DataFormKey | MockObject */
+        $this->dataFormKey = $this->getMockBuilder(DataFormKey::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var Session | MockObject */
+        $this->customerSession = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBeforeRequestParams', 'setBeforeRequestParams'])
+            ->getMock();
+
+        $this->closure = function () {
+            return static::CLOSURE_VALUE;
+        };
+    }
+
+    /**
+     * @dataProvider aroundFlushFormKeyProvider
+     * @param $beforeFormKey
+     * @param $currentFormKey
+     * @param $getFormKeyTimes
+     * @param $setBeforeParamsTimes
+     */
+    public function testAroundFlushFormKey(
+        $beforeFormKey,
+        $currentFormKey,
+        $getFormKeyTimes,
+        $setBeforeParamsTimes
+    ) {
+        $observer = new FlushFormKey($this->cookieFormKey, $this->dataFormKey);
+        $plugin = new CustomerFlushFormKey($this->customerSession, $this->dataFormKey);
+
+        $beforeParams['form_key'] = $beforeFormKey;
+
+        $this->dataFormKey->expects($this->exactly($getFormKeyTimes))
+            ->method('getFormKey')
+            ->willReturn($currentFormKey);
+
+        $this->customerSession->expects($this->once())
+            ->method('getBeforeRequestParams')
+            ->willReturn($beforeParams);
+
+        $this->customerSession->expects($this->exactly($setBeforeParamsTimes))
+            ->method('setBeforeRequestParams')
+            ->with($beforeParams);
+
+        $plugin->aroundExecute($observer, $this->closure, $observer);
+    }
+
+    /**
+     * Data provider for testAroundFlushFormKey
+     *
+     * @return array
+     */
+    public function aroundFlushFormKeyProvider()
+    {
+        return [
+            ['form_key_value', 'form_key_value', 2, 1],
+            ['form_old_key_value', 'form_key_value', 1, 0],
+            [null, 'form_key_value', 1, 0]
+        ];
+    }
+}

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -323,6 +323,9 @@
     <type name="Magento\Framework\App\Action\AbstractAction">
         <plugin name="customerNotification" type="Magento\Customer\Model\Plugin\CustomerNotification"/>
     </type>
+    <type name="Magento\PageCache\Observer\FlushFormKey">
+        <plugin name="customerFlushFormKey" type="Magento\Customer\Model\Plugin\CustomerFlushFormKey"/>
+    </type>
     <type name="Magento\Customer\Model\Customer\NotificationStorage">
         <arguments>
             <argument name="cache" xsi:type="object">Magento\Customer\Model\Cache\Type\Notification</argument>


### PR DESCRIPTION
Generate new FormKey afterLogin and set to the beforeRequest(Wishlist)

### Description
Generate new FormKey afterLogin and set to the beforeRequest(Wishlist)

### Fixed Issues (if relevant)
1. magento/magento2#11825: 2.1.9 Item not added to the Wishlist if the user is not logged at the moment he click on the button to add it
2. magento/magento2#11908: Adding to wishlist doesn't work when not logged in

### Manual testing scenarios
1. Create an user account.
2. Logout from the user account
3. Add a product to your Wishlist , you will get redirected to the login page
4. Login

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
