### PR TITLE
Fix #8820 #8171: set default product type when inexistent on productrepository->save

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -7,19 +7,19 @@
 namespace Magento\Catalog\Model;
 
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\Product\Gallery\MimeTypeExtensionMap;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Api\Data\ImageContentInterface;
 use Magento\Framework\Api\Data\ImageContentInterfaceFactory;
 use Magento\Framework\Api\ImageContentValidatorInterface;
 use Magento\Framework\Api\ImageProcessorInterface;
 use Magento\Framework\Api\SortOrder;
+use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 use Magento\Framework\Exception\ValidatorException;
-use Magento\Framework\Exception\CouldNotSaveException;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -278,6 +278,10 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      */
     protected function initializeProductData(array $productData, $createNew)
     {
+        if (empty($productData['type_id'])) {
+            $productData['type_id'] = \Magento\Catalog\Model\Product\Type::DEFAULT_TYPE;
+        }
+
         unset($productData['media_gallery']);
         if ($createNew) {
             $product = $this->productFactory->create();
@@ -304,7 +308,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     private function assignProductToWebsites(\Magento\Catalog\Model\Product $product)
     {
         if (!$this->storeManager->hasSingleStore()) {
-
             if ($this->storeManager->getStore()->getCode() == \Magento\Store\Model\Store::ADMIN_CODE) {
                 $websiteIds = array_keys($this->storeManager->getWebsites());
             } else {


### PR DESCRIPTION
… #8820 #8171 
When saving a product, check typeId control. If it's value isn't one of available, set the default one before saving.

### Description
Set the default product type before saving it on repository, for prevent error on create stockitem and the undesired attributes deleting on \Magento\Catalog\Model\Product\Type\AbstractType::_removeNotApplicableAttributes()

### Fixed Issues
1. magento/magento2#8820: WEBAPI: Unable to save Product when typeId and status is missing
2. magento/magento2#8171 Price not saved when creating product via REST API

### Manual testing scenarios
Same testing described at issues #8820 and #8171. Save product via API.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

