### PR TITLE
[backport 2.1]  Magento 2 Store Code validation regex: doesn't support uppercase letters in store code

### DIFF
--- a/app/code/Magento/Store/Model/ResourceModel/Website.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website.php
@@ -47,7 +47,7 @@ class Website extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             ->select()
             ->from($this->getTable('store_website'));
 
-        foreach($this->getConnection()->fetchAll($select) as $websiteData) {
+        foreach ($this->getConnection()->fetchAll($select) as $websiteData) {
             $websites[$websiteData['code']] = $websiteData;
         }
 
@@ -63,7 +63,7 @@ class Website extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     protected function _beforeSave(\Magento\Framework\Model\AbstractModel $object)
     {
-        if (!preg_match('/^[a-z]+[a-z0-9_]*$/', $object->getCode())) {
+        if (!preg_match('/^[a-z]+[a-z0-9_]*$/i', $object->getCode())) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 __(
                     'Website code may only contain letters (a-z), numbers (0-9) or underscore (_),'

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -12,10 +12,10 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Http\Context;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\ScopeInterface as AppScopeInterface;
-use Magento\Framework\Filesystem;
 use Magento\Framework\DataObject\IdentityInterface;
-use Magento\Framework\Url\ScopeInterface as UrlScopeInterface;
+use Magento\Framework\Filesystem;
 use Magento\Framework\Model\AbstractExtensibleModel;
+use Magento\Framework\Url\ScopeInterface as UrlScopeInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Api\Data\StoreInterface;
 
@@ -459,7 +459,7 @@ class Store extends AbstractExtensibleModel implements
         $storeLabelRule->setMessage(__('Name is required'), \Zend_Validate_NotEmpty::IS_EMPTY);
         $validator->addRule($storeLabelRule, 'name');
 
-        $storeCodeRule = new \Zend_Validate_Regex('/^[a-z]+[a-z0-9_]*$/');
+        $storeCodeRule = new \Zend_Validate_Regex('/^[a-z]+[a-z0-9_]*$/i');
         $storeCodeRule->setMessage(
             __(
                 'The store code may contain only letters (a-z), numbers (0-9) or underscore (_),'


### PR DESCRIPTION
### Description
Magento 2 Store Code validation regex: doesn't support uppercase letters in store code

### Fixed Issues (if relevant)
1. magento/magento2#11996: Magento 2 Store Code validation regex: doesn't support uppercase letters in store code

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)