### PR TITLE
[Backport 2.3] Add swatch option: Prevent loosing data and default value if data is not populated via adminhtml

### DIFF
--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -130,9 +130,17 @@ class EavAttribute
             $swatchesArray = $attribute->getData('swatchtext');
         }
         if ($canReplace == true) {
-            $attribute->setData('option', $optionsArray);
-            $attribute->setData('default', $defaultValue);
-            $attribute->setData('swatch', $swatchesArray);
+            if (!empty($optionsArray)) {
+                $attribute->setData('option', $optionsArray);
+            }
+            if (!empty($defaultValue)) {
+                $attribute->setData('default', $defaultValue);
+            } else {
+                $attribute->setData('default', [0 => $attribute->getDefaultValue()]);
+            }
+            if (!empty($swatchesArray)) {
+                $attribute->setData('swatch', $swatchesArray);
+            }
         }
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductSwatchAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductSwatchAttributeOptionManagementInterfaceTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Catalog\Api;
+
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\Eav\Api\Data\AttributeOptionLabelInterface;
+use Magento\TestFramework\TestCase\WebapiAbstract;
+
+class ProductSwatchAttributeOptionManagementInterfaceTest extends WebapiAbstract
+{
+    const SERVICE_NAME = 'catalogProductAttributeOptionManagementV1';
+    const SERVICE_VERSION = 'V1';
+    const RESOURCE_PATH = '/V1/products/attributes';
+
+    /**
+     * @magentoApiDataFixture Magento/Swatches/_files/swatch_attribute.php
+     * @dataProvider addDataProvider
+     */
+    public function testAdd($optionData)
+    {
+        $testAttributeCode = 'color_swatch';
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . '/' . $testAttributeCode . '/options',
+                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_POST,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . 'add',
+            ],
+        ];
+
+        $response = $this->_webApiCall(
+            $serviceInfo,
+            [
+                'attributeCode' => $testAttributeCode,
+                'option' => $optionData,
+            ]
+        );
+
+        $this->assertTrue($response);
+        $updatedData = $this->getAttributeOptions($testAttributeCode);
+        $lastOption = array_pop($updatedData);
+        $this->assertEquals(
+            $optionData[AttributeOptionInterface::STORE_LABELS][0][AttributeOptionLabelInterface::LABEL],
+            $lastOption['label']
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function addDataProvider()
+    {
+        $optionPayload = [
+            AttributeOptionInterface::LABEL => 'new color',
+            AttributeOptionInterface::SORT_ORDER => 100,
+            AttributeOptionInterface::IS_DEFAULT => true,
+            AttributeOptionInterface::STORE_LABELS => [
+                [
+                    AttributeOptionLabelInterface::LABEL => 'DE label',
+                    AttributeOptionLabelInterface::STORE_ID => 1,
+                ],
+            ],
+            AttributeOptionInterface::VALUE => ''
+        ];
+
+        return [
+            'option_without_value_node' => [
+                $optionPayload
+            ],
+            'option_with_value_node_that_starts_with_text' => [
+                array_merge($optionPayload, [AttributeOptionInterface::VALUE => 'some_text'])
+            ],
+            'option_with_value_node_that_starts_with_a_number' => [
+                array_merge($optionPayload, [AttributeOptionInterface::VALUE => '123_some_text'])
+            ],
+
+        ];
+    }
+
+    /**
+     * @param $testAttributeCode
+     * @return array|bool|float|int|string
+     */
+    private function getAttributeOptions($testAttributeCode)
+    {
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . '/' . $testAttributeCode . '/options',
+                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . 'getItems',
+            ],
+        ];
+        return $this->_webApiCall($serviceInfo, ['attributeCode' => $testAttributeCode]);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Swatches/Model/SwatchAttributeOptionAddTest.php
+++ b/dev/tests/integration/testsuite/Magento/Swatches/Model/SwatchAttributeOptionAddTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Swatches\Model;
+
+use Magento\Catalog\Api\ProductAttributeOptionManagementInterface;
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\Eav\Api\Data\AttributeOptionInterfaceFactory;
+
+/**
+ * Test add option of swatch attribute
+ *
+ */
+class SwatchAttributeOptionAddTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+    }
+
+    /**
+     * @magentoAppArea adminhtml
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/Swatches/_files/swatch_attribute.php
+     */
+    public function testSwatchOptionAdd()
+    {
+        /** @var \Magento\Catalog\Api\Data\ProductAttributeInterface $attribute */
+        $attribute = $this->objectManager
+            ->create(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class)
+            ->load('color_swatch', 'attribute_code');
+        $optionsPerAttribute = 3;
+
+        $data['options']['option'] = array_reduce(
+            range(10, $optionsPerAttribute),
+            function ($values, $index) use ($optionsPerAttribute) {
+                $values[] = [
+                    'label' => 'option ' . $index,
+                    'value' => 'option_' . $index
+                ];
+                return $values;
+            },
+            []
+        );
+
+        /** @var AttributeOptionInterface[] $options */
+        $options = [];
+        foreach ($data['options']['option'] as $optionData) {
+            $options[] = $this->objectManager
+                ->get(AttributeOptionInterfaceFactory::class)
+                ->create(['data' => $optionData]);
+        }
+
+        /** @var ProductAttributeOptionManagementInterface $optionManagement */
+        $optionManagement = $this->objectManager->get(ProductAttributeOptionManagementInterface::class);
+        foreach ($options as $option) {
+            $optionManagement->add(
+                $attribute->getAttributeCode(),
+                $option
+            );
+        }
+
+        $items = $optionManagement->getItems($attribute->getAttributeCode());
+        array_walk(
+            $items,
+            function (&$item) {
+                /** @var  AttributeOptionInterface $item */
+                $item = $item->getLabel();
+            }
+        );
+        foreach ($options as $option) {
+            $this->assertTrue(in_array($option->getLabel(), $items));
+        }
+    }
+}


### PR DESCRIPTION
Add swatch option: Prevent loosing data and default value if data is not populated via adminhtml.

### Description
Adapt \Magento\Swatches\Model\Plugin\EavAttribute::setProperOptionsArray to make possible that the plugins afterSave in the same module doesn't delete data if they don't found this data with all the options data, as sent via adminhtml form.

### Fixed Issues (if relevant)
1. magento/magento2#10707: Create attribute option via API for swatch attribute fails
2. magento/magento2#10737: Can't import attribute option over API if option is 'visual swatch'
3. magento/magento2#11032: Unable to add new options to swatch attribute
4. magento/magento2#9410: Impossible to add swatch options via Service Contracts if there is no existing swatch option for attribute

### Manual testing scenarios
1. Create a select attribute
2. Make this attribute use visual or text swatch
3. Try adding attribute options through the API via POST /V1/products/attributes/{attributeCode}/options

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
