### PR TITLE
Create cancel invoice method on API

### DIFF
--- a/app/code/Magento/Sales/Api/InvoiceCancelInterface.php
+++ b/app/code/Magento/Sales/Api/InvoiceCancelInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Sales\Api;
+
+/**
+ * Interface InvoiceCancelInterface
+ *
+ * @package Magento\Sales\Api
+ */
+interface InvoiceCancelInterface
+{
+
+    /**
+     * Cancel invoice
+     *
+     * @param int $invoiceId
+     * @return bool
+     */
+    public function cancel($invoiceId);
+}

--- a/app/code/Magento/Sales/Model/Order/InvoiceCancel.php
+++ b/app/code/Magento/Sales/Model/Order/InvoiceCancel.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Sales\Model\Order;
+
+use Magento\Sales\Api\InvoiceCancelInterface;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+
+/**
+ * Class InvoiceCancel
+ */
+class InvoiceCancel implements InvoiceCancelInterface
+{
+
+    /**
+     * @var InvoiceRepositoryInterface
+     */
+    protected $invoiceRepository;
+
+    /**
+     * InvoiceCancel constructor.
+     * @param InvoiceRepositoryInterface $invoiceRepository
+     */
+    public function __construct(
+        InvoiceRepositoryInterface $invoiceRepository
+    ) {
+        $this->invoiceRepository = $invoiceRepository;
+    }
+
+    /**
+     * Cancel invoice
+     *
+     * @param int $invoiceId
+     * @return bool
+     */
+    public function cancel($invoiceId)
+    {
+        /** @var \Magento\Sales\Api\Data\InvoiceInterface $invoice */
+        $invoice = $this->invoiceRepository->get($invoiceId);
+        if ($invoice && $invoice->canCancel()) {
+            $invoice->cancel();
+            $this->invoiceRepository->save($invoice);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/InvoiceServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/InvoiceServiceTest.php
@@ -20,6 +20,13 @@ class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
     protected $repositoryMock;
 
     /**
+     * Invoice Cancel
+     *
+     * @var \Magento\Sales\Api\InvoiceCancelInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $invoiceCancelMock;
+
+    /**
      * Repository
      *
      * @var \Magento\Sales\Api\InvoiceCommentRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -53,6 +60,11 @@ class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
     protected $invoiceService;
 
     /**
+     * @var \Magento\Sales\Model\Order\Invoice
+     */
+    protected $invoiceMock;
+
+    /**
      * SetUp
      */
     protected function setUp()
@@ -83,6 +95,16 @@ class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
             \Magento\Sales\Model\Order\InvoiceNotifier::class,
             ['notify']
         );
+
+        $this->invoiceCancelMock = new \Magento\Sales\Model\Order\InvoiceCancel(
+            $this->repositoryMock
+        );
+
+        $this->invoiceMock = $this->getMockBuilder(
+            \Magento\Sales\Model\Order\Invoice::class
+        )
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->invoiceService = $objectManager->getObject(
             \Magento\Sales\Model\Service\InvoiceService::class,
@@ -203,5 +225,41 @@ class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($returnValue));
 
         $this->assertTrue($this->invoiceService->setVoid($id));
+    }
+
+    /**
+     * Run test for Invoice::cancel()
+     */
+    public function testCancel()
+    {
+        $this->repositoryMock->expects($this->once())
+            ->method('get')
+            ->with(123)
+            ->willReturn($this->invoiceMock);
+        $this->invoiceMock->expects($this->once())
+            ->method('cancel')
+            ->willReturn($this->invoiceMock);
+        $this->invoiceMock->expects($this->once())
+            ->method('canCancel')
+            ->willReturn(true);
+        $this->assertTrue($this->invoiceCancelMock->cancel(123));
+    }
+
+    /**
+     * test for Invoice::cancel() fail case
+     */
+    public function testCancelFailed()
+    {
+        $this->repositoryMock->expects($this->once())
+            ->method('get')
+            ->with(123)
+            ->willReturn($this->invoiceMock);
+        $this->invoiceMock->expects($this->never())
+            ->method('cancel')
+            ->willReturn($this->invoiceMock);
+        $this->invoiceMock->expects($this->once())
+            ->method('canCancel')
+            ->willReturn(false);
+        $this->assertFalse($this->invoiceCancelMock->cancel(123));
     }
 }

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -56,6 +56,7 @@
     <preference for="Magento\Sales\Api\Data\InvoiceCreationArgumentsInterface" type="Magento\Sales\Model\Order\Invoice\CreationArguments"/>
     <preference for="Magento\Sales\Api\Data\InvoiceItemCreationInterface" type="Magento\Sales\Model\Order\Invoice\ItemCreation"/>
     <preference for="Magento\Sales\Api\Data\InvoiceCommentCreationInterface" type="Magento\Sales\Model\Order\Invoice\CommentCreation"/>
+    <preference for="Magento\Sales\Api\InvoiceCancelInterface" type="Magento\Sales\Model\Order\InvoiceCancel"/>
     <preference for="Magento\Sales\Api\Data\ShipmentCommentCreationInterface" type="Magento\Sales\Model\Order\Shipment\CommentCreation"/>
     <preference for="Magento\Sales\Api\Data\CreditmemoCommentCreationInterface" type="Magento\Sales\Model\Order\Creditmemo\CommentCreation"/>
     <preference for="Magento\Sales\Api\OrderAddressRepositoryInterface" type="Magento\Sales\Model\Order\AddressRepository"/>

--- a/app/code/Magento/Sales/etc/webapi.xml
+++ b/app/code/Magento/Sales/etc/webapi.xml
@@ -139,6 +139,12 @@
             <resource ref="Magento_Sales::sales" />
         </resources>
     </route>
+    <route url="/V1/invoice/:invoiceId/cancel" method="POST">
+        <service class="Magento\Sales\Api\InvoiceCancelInterface" method="cancel"/>
+        <resources>
+            <resource ref="Magento_Sales::sales" />
+        </resources>
+    </route>
     <route url="/V1/creditmemo/:id/comments" method="GET">
         <service class="Magento\Sales\Api\CreditmemoManagementInterface" method="getCommentsList"/>
         <resources>


### PR DESCRIPTION
I have worked on this PR at #MM17ES

### Description
Magento have not implemented cancel invoice method on API.
I have added the cancel method and created the tests.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/pull/11073#issuecomment-332433488

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
