### PR TITLE
[Backport 2.3-develop] Remove adminhtml message manager deprecated calls

### DIFF
--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MarkAsRead.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MarkAsRead.php
@@ -28,11 +28,11 @@ class MarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Notific
                 )->markAsRead(
                     $notificationId
                 );
-                $this->messageManager->addSuccess(__('The message has been marked as Read.'));
+                $this->messageManager->addSuccessMessage(__('The message has been marked as Read.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __("We couldn't mark the notification as Read because of an error.")
                 );

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassMarkAsRead.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassMarkAsRead.php
@@ -23,7 +23,7 @@ class MassMarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Not
     {
         $ids = $this->getRequest()->getParam('notification');
         if (!is_array($ids)) {
-            $this->messageManager->addError(__('Please select messages.'));
+            $this->messageManager->addErrorMessage(__('Please select messages.'));
         } else {
             try {
                 foreach ($ids as $id) {
@@ -32,13 +32,13 @@ class MassMarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Not
                         $model->setIsRead(1)->save();
                     }
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been marked as Read.', count($ids))
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __("We couldn't mark the notification as Read because of an error.")
                 );

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
@@ -8,7 +8,6 @@ namespace Magento\AdminNotification\Controller\Adminhtml\Notification;
 
 class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notification
 {
-
     /**
      * Authorization level of a basic admin session
      *
@@ -23,7 +22,7 @@ class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notific
     {
         $ids = $this->getRequest()->getParam('notification');
         if (!is_array($ids)) {
-            $this->messageManager->addError(__('Please select messages.'));
+            $this->messageManager->addErrorMessage(__('Please select messages.'));
         } else {
             try {
                 foreach ($ids as $id) {
@@ -32,11 +31,14 @@ class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notific
                         $model->setIsRemove(1)->save();
                     }
                 }
-                $this->messageManager->addSuccess(__('Total of %1 record(s) have been removed.', count($ids)));
+                $this->messageManager->addSuccessMessage(__('Total of %1 record(s) have been removed.', count($ids)));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __("We couldn't remove the messages because of an error."));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __("We couldn't remove the messages because of an error.")
+                );
             }
         }
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/Remove.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/Remove.php
@@ -8,7 +8,6 @@ namespace Magento\AdminNotification\Controller\Adminhtml\Notification;
 
 class Remove extends \Magento\AdminNotification\Controller\Adminhtml\Notification
 {
-
     /**
      * Authorization level of a basic admin session
      *
@@ -31,11 +30,14 @@ class Remove extends \Magento\AdminNotification\Controller\Adminhtml\Notificatio
 
             try {
                 $model->setIsRemove(1)->save();
-                $this->messageManager->addSuccess(__('The message has been removed.'));
+                $this->messageManager->addSuccessMessage(__('The message has been removed.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __("We couldn't remove the messages because of an error."));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __("We couldn't remove the messages because of an error.")
+                );
             }
 
             $this->_redirect('adminhtml/*/');

--- a/app/code/Magento/AdvancedPricingImportExport/Controller/Adminhtml/Export/GetFilter.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Controller/Adminhtml/Export/GetFilter.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\AdvancedPricingImportExport\Controller\Adminhtml\Export;
 
-use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
-use Magento\Framework\Controller\ResultFactory;
 use Magento\AdvancedPricingImportExport\Model\Export\AdvancedPricing as ExportAdvancedPricing;
 use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 
 class GetFilter extends ExportController
 {
@@ -37,10 +37,10 @@ class GetFilter extends ExportController
                 );
                 return $resultLayout;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } else {
-            $this->messageManager->addError(__('Please correct the data sent.'));
+            $this->messageManager->addErrorMessage(__('Please correct the data sent.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Authorizenet/Block/Transparent/Iframe.php
+++ b/app/code/Magento/Authorizenet/Block/Transparent/Iframe.php
@@ -73,7 +73,7 @@ class Iframe extends TransparentIframe
     {
         $params = $this->getParams();
         if (isset($params['redirect_parent'])) {
-            $this->messageManager->addSuccess(__('You created the order.'));
+            $this->messageManager->addSuccessMessage(__('You created the order.'));
         }
     }
 }

--- a/app/code/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/Redirect.php
+++ b/app/code/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/Redirect.php
@@ -121,7 +121,7 @@ class Redirect extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_getSession()->clearStorage();
             $directpostSession->removeCheckoutOrderIncrementId($redirectParams['x_invoice_num']);
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->clearStorage();
-            $this->messageManager->addSuccess(__('You created the order.'));
+            $this->messageManager->addSuccessMessage(__('You created the order.'));
         }
 
         if (!empty($redirectParams['error_msg'])) {

--- a/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
+++ b/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
@@ -160,7 +160,7 @@ class Authentication
             } else {
                 $this->_actionFlag->set('', \Magento\Framework\App\ActionInterface::FLAG_NO_DISPATCH, true);
                 $this->_response->setRedirect($this->_url->getCurrentUrl());
-                $this->messageManager->addError(__('Invalid Form Key. Please refresh the page.'));
+                $this->messageManager->addErrorMessage(__('Invalid Form Key. Please refresh the page.'));
                 $isRedirectNeeded = true;
             }
         }
@@ -205,7 +205,7 @@ class Authentication
             $this->_auth->login($username, $password);
         } catch (AuthenticationException $e) {
             if (!$request->getParam('messageSent')) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $request->setParam('messageSent', true);
                 $outputValue = false;
             }

--- a/app/code/Magento/Backend/Controller/Adminhtml/Auth/Logout.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Auth/Logout.php
@@ -16,7 +16,7 @@ class Logout extends \Magento\Backend\Controller\Adminhtml\Auth
     public function execute()
     {
         $this->_auth->logout();
-        $this->messageManager->addSuccess(__('You have logged out.'));
+        $this->messageManager->addSuccessMessage(__('You have logged out.'));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanImages.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanImages.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Backend\Controller\Adminhtml\Cache;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 
 class CleanImages extends \Magento\Backend\Controller\Adminhtml\Cache
 {
@@ -21,11 +21,11 @@ class CleanImages extends \Magento\Backend\Controller\Adminhtml\Cache
         try {
             $this->_objectManager->create(\Magento\Catalog\Model\Product\Image::class)->clearCache();
             $this->_eventManager->dispatch('clean_catalog_images_cache_after');
-            $this->messageManager->addSuccess(__('The image cache was cleaned.'));
+            $this->messageManager->addSuccessMessage(__('The image cache was cleaned.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while clearing the image cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the image cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Backend\Controller\Adminhtml\Cache;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 
 class CleanMedia extends \Magento\Backend\Controller\Adminhtml\Cache
 {
@@ -21,11 +21,14 @@ class CleanMedia extends \Magento\Backend\Controller\Adminhtml\Cache
         try {
             $this->_objectManager->get(\Magento\Framework\View\Asset\MergeService::class)->cleanMergedJsCss();
             $this->_eventManager->dispatch('clean_media_cache_after');
-            $this->messageManager->addSuccess(__('The JavaScript/CSS cache has been cleaned.'));
+            $this->messageManager->addSuccessMessage(__('The JavaScript/CSS cache has been cleaned.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
+            $this->messageManager->addExceptionMessage(
+                $e,
+                __('An error occurred while clearing the JavaScript/CSS cache.')
+            );
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanStaticFiles.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanStaticFiles.php
@@ -19,7 +19,7 @@ class CleanStaticFiles extends \Magento\Backend\Controller\Adminhtml\Cache
     {
         $this->_objectManager->get(\Magento\Framework\App\State\CleanupFiles::class)->clearMaterializedViewFiles();
         $this->_eventManager->dispatch('clean_static_files_cache_after');
-        $this->messageManager->addSuccess(__('The static files cache has been cleaned.'));
+        $this->messageManager->addSuccessMessage(__('The static files cache has been cleaned.'));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushAll.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushAll.php
@@ -20,7 +20,7 @@ class FlushAll extends \Magento\Backend\Controller\Adminhtml\Cache
         foreach ($this->_cacheFrontendPool as $cacheFrontend) {
             $cacheFrontend->getBackend()->clean();
         }
-        $this->messageManager->addSuccess(__("You flushed the cache storage."));
+        $this->messageManager->addSuccessMessage(__("You flushed the cache storage."));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();
         return $resultRedirect->setPath('adminhtml/*');

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushSystem.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushSystem.php
@@ -20,7 +20,7 @@ class FlushSystem extends \Magento\Backend\Controller\Adminhtml\Cache
             $cacheFrontend->clean();
         }
         $this->_eventManager->dispatch('adminhtml_cache_flush_system');
-        $this->messageManager->addSuccess(__("The Magento cache storage has been flushed."));
+        $this->messageManager->addSuccessMessage(__("The Magento cache storage has been flushed."));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();
         return $resultRedirect->setPath('adminhtml/*');

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassDisable.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassDisable.php
@@ -6,10 +6,10 @@
  */
 namespace Magento\Backend\Controller\Adminhtml\Cache;
 
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\App\State;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\State;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Controller disables some types of cache
@@ -60,12 +60,17 @@ class MassDisable extends \Magento\Backend\Controller\Adminhtml\Cache
             }
             if ($updatedTypes > 0) {
                 $this->_cacheState->persist();
-                $this->messageManager->addSuccess(__("%1 cache type(s) disabled.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) disabled.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addComplexErrorMessage(
+                'addUnescapedMessage',
+                [
+                    'text' => $e->getMessage(),
+                ]
+            );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while disabling cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while disabling cache.'));
         }
     }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassEnable.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassEnable.php
@@ -6,10 +6,10 @@
  */
 namespace Magento\Backend\Controller\Adminhtml\Cache;
 
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\App\State;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\State;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Controller enables some types of cache
@@ -59,12 +59,17 @@ class MassEnable extends \Magento\Backend\Controller\Adminhtml\Cache
             }
             if ($updatedTypes > 0) {
                 $this->_cacheState->persist();
-                $this->messageManager->addSuccess(__("%1 cache type(s) enabled.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) enabled.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addComplexErrorMessage(
+                'addUnescapedMessage',
+                [
+                    'text' => $e->getMessage(),
+                ]
+            );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while enabling cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while enabling cache.'));
         }
     }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassRefresh.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassRefresh.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Backend\Controller\Adminhtml\Cache;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 
 class MassRefresh extends \Magento\Backend\Controller\Adminhtml\Cache
 {
@@ -30,12 +30,17 @@ class MassRefresh extends \Magento\Backend\Controller\Adminhtml\Cache
                 $updatedTypes++;
             }
             if ($updatedTypes > 0) {
-                $this->messageManager->addSuccess(__("%1 cache type(s) refreshed.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) refreshed.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addComplexErrorMessage(
+                'addUnescapedMessage',
+                [
+                    'text' => $e->getMessage(),
+                ]
+            );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while refreshing cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while refreshing cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
@@ -34,9 +34,9 @@ class RefreshStatistics extends \Magento\Reports\Controller\Adminhtml\Report\Sta
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate();
             }
-            $this->messageManager->addSuccess(__('We updated lifetime statistic.'));
+            $this->messageManager->addSuccessMessage(__('We updated lifetime statistic.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh lifetime statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh lifetime statistics.'));
             $this->logger->critical($e);
         }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Account/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Account/Save.php
@@ -5,11 +5,10 @@
  */
 namespace Magento\Backend\Controller\Adminhtml\System\Account;
 
-use Magento\Framework\Validator\Exception as ValidatorException;
-use Magento\Framework\Exception\AuthenticationException;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\State\UserLockedException;
+use Magento\Framework\Validator\Exception as ValidatorException;
 use Magento\Security\Model\SecurityCookie;
 
 /**
@@ -77,12 +76,12 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Account
             $errors = $user->validate();
             if ($errors !== true && !empty($errors)) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addError($error);
+                    $this->messageManager->addErrorMessage($error);
                 }
             } else {
                 $user->save();
                 $user->sendNotificationEmailsIfRequired();
-                $this->messageManager->addSuccess(__('You saved the account.'));
+                $this->messageManager->addSuccessMessage(__('You saved the account.'));
             }
         } catch (UserLockedException $e) {
             $this->_auth->logout();
@@ -92,12 +91,12 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Account
         } catch (ValidatorException $e) {
             $this->messageManager->addMessages($e->getMessages());
             if ($e->getMessage()) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while saving account.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while saving account.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Delete.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Delete.php
@@ -19,11 +19,11 @@ class Delete extends \Magento\Backend\Controller\Adminhtml\System\Design
 
             try {
                 $design->delete();
-                $this->messageManager->addSuccess(__('You deleted the design change.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the design change.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __("You can't delete the design change."));
+                $this->messageManager->addExceptionMessage($e, __("You can't delete the design change."));
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Save.php
@@ -50,9 +50,9 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Design
             try {
                 $design->save();
                 $this->_eventManager->dispatch('theme_save_after');
-                $this->messageManager->addSuccess(__('You saved the design change.'));
+                $this->messageManager->addSuccessMessage(__('You saved the design change.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setDesignData($data);
                 return $resultRedirect->setPath('adminhtml/*/', ['id' => $design->getId()]);
             }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
@@ -103,12 +103,12 @@ abstract class Store extends Action
                 ->setType('db')
                 ->setPath($filesystem->getDirectoryRead(DirectoryList::VAR_DIR)->getAbsolutePath('backups'));
             $backupDb->createBackup($backup);
-            $this->messageManager->addSuccess(__('The database was backed up.'));
+            $this->messageManager->addSuccessMessage(__('The database was backed up.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return false;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('We can\'t create a backup right now. Please try again later.')
             );
@@ -125,7 +125,7 @@ abstract class Store extends Action
      */
     protected function _addDeletionNotice($typeTitle)
     {
-        $this->messageManager->addNotice(
+        $this->messageManager->addNoticeMessage(
             __(
                 'Deleting a %1 will not delete the information associated with the %1 (e.g. categories, products, etc.)'
                 . ', but the %1 will not be able to be restored. It is suggested that you create a database backup '

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroup.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroup.php
@@ -15,13 +15,13 @@ class DeleteGroup extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Group::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroupPost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroupPost.php
@@ -21,11 +21,11 @@ class DeleteGroupPost extends \Magento\Backend\Controller\Adminhtml\System\Store
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Group::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $model->getId()]);
         }
 
@@ -35,12 +35,12 @@ class DeleteGroupPost extends \Magento\Backend\Controller\Adminhtml\System\Store
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the store.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the store.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the store. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store. Please try again later.'));
         }
         return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStore.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStore.php
@@ -15,13 +15,13 @@ class DeleteStore extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Store::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store view cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store view cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
@@ -22,11 +22,11 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Store::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store view cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store view cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $model->getId()]);
         }
 
@@ -39,12 +39,15 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
 
             $this->_eventManager->dispatch('store_delete', ['store' => $model]);
 
-            $this->messageManager->addSuccess(__('You deleted the store view.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the store view.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the store view. Please try again later.'));
+            $this->messageManager->addExceptionMessage(
+                $e,
+                __('Unable to delete the store view. Please try again later.')
+            );
         }
         return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsite.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsite.php
@@ -15,13 +15,13 @@ class DeleteWebsite extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Website::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This website cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This website cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editWebsite', ['website_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsitePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsitePost.php
@@ -23,11 +23,11 @@ class DeleteWebsitePost extends \Magento\Backend\Controller\Adminhtml\System\Sto
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
         if (!$model) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This website cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This website cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editWebsite', ['website_id' => $model->getId()]);
         }
 
@@ -37,12 +37,12 @@ class DeleteWebsitePost extends \Magento\Backend\Controller\Adminhtml\System\Sto
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the website.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the website.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the website. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the website. Please try again later.'));
         }
         return $redirectResult->setPath('*/*/editWebsite', ['website_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/EditStore.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/EditStore.php
@@ -57,7 +57,7 @@ class EditStore extends \Magento\Backend\Controller\Adminhtml\System\Store
         if ($model->getId() || $this->_coreRegistry->registry('store_action') == 'add') {
             $this->_coreRegistry->register('store_data', $model);
             if ($this->_coreRegistry->registry('store_action') == 'edit' && $codeBase && !$model->isReadOnly()) {
-                $this->messageManager->addNotice($codeBase);
+                $this->messageManager->addNoticeMessage($codeBase);
             }
             $resultPage = $this->createPage();
             if ($this->_coreRegistry->registry('store_action') == 'add') {
@@ -71,7 +71,7 @@ class EditStore extends \Magento\Backend\Controller\Adminhtml\System\Store
             ));
             return $resultPage;
         } else {
-            $this->messageManager->addError($notExists);
+            $this->messageManager->addErrorMessage($notExists);
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             return $resultRedirect->setPath('adminhtml/*/');

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/Save.php
@@ -32,7 +32,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
         }
 
         $websiteModel->save();
-        $this->messageManager->addSuccess(__('You saved the website.'));
+        $this->messageManager->addSuccessMessage(__('You saved the website.'));
 
         return $postData;
     }
@@ -72,7 +72,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
         $storeModel->save();
         $this->_objectManager->get(\Magento\Store\Model\StoreManager::class)->reinitStores();
         $this->_eventManager->dispatch($eventName, ['store' => $storeModel]);
-        $this->messageManager->addSuccess(__('You saved the store view.'));
+        $this->messageManager->addSuccessMessage(__('You saved the store view.'));
 
         return $postData;
     }
@@ -103,7 +103,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
         }
         $groupModel->save();
         $this->_eventManager->dispatch('store_group_save', ['group' => $groupModel]);
-        $this->messageManager->addSuccess(__('You saved the store.'));
+        $this->messageManager->addSuccessMessage(__('You saved the store.'));
 
         return $postData;
     }
@@ -139,10 +139,10 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
                 $redirectResult->setPath('adminhtml/*/');
                 return $redirectResult;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_getSession()->setPostData($postData);
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while saving. Please review the error log.')
                 );

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
@@ -38,7 +38,7 @@ class CleanMediaTest extends \PHPUnit\Framework\TestCase
         $messageManagerParams = $helper->getConstructArguments(\Magento\Framework\Message\Manager::class);
         $messageManagerParams['exceptionMessageFactory'] = $exceptionMessageFactory;
         $messageManager = $this->getMockBuilder(\Magento\Framework\Message\Manager::class)
-            ->setMethods(['addSuccess'])
+            ->setMethods(['addSuccessMessage'])
             ->setConstructorArgs($messageManagerParams)
             ->getMock();
 
@@ -86,7 +86,7 @@ class CleanMediaTest extends \PHPUnit\Framework\TestCase
         $mergeService->expects($this->once())->method('cleanMergedJsCss');
 
         $messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The JavaScript/CSS cache has been cleaned.');
 
         $valueMap = [

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
@@ -76,7 +76,7 @@ class CleanStaticFilesTest extends \PHPUnit\Framework\TestCase
             ->with('clean_static_files_cache_after');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The static files cache has been cleaned.');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
@@ -5,17 +5,17 @@
  */
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Cache;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Magento\Backend\Controller\Adminhtml\Cache\MassDisable;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use Magento\Framework\App\State;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\Message\ManagerInterface as MessageManager;
-use Magento\Framework\Controller\ResultFactory;
+use Magento\Backend\Controller\Adminhtml\Cache\MassDisable;
 use Magento\Backend\Model\View\Result\Redirect;
-use Magento\Framework\App\RequestInterface as Request;
-use Magento\Framework\App\Cache\TypeListInterface as CacheTypeList;
 use Magento\Framework\App\Cache\StateInterface as CacheState;
+use Magento\Framework\App\Cache\TypeListInterface as CacheTypeList;
+use Magento\Framework\App\RequestInterface as Request;
+use Magento\Framework\App\State;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Message\ManagerInterface as MessageManager;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -155,8 +155,8 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['someCache']);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
-            ->with('Specified cache type(s) don\'t exist: someCache')
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => 'Specified cache type(s) don\'t exist: someCache'])
             ->willReturnSelf();
 
         $this->assertSame($this->redirectMock, $this->controller->execute());
@@ -175,7 +175,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'An error occurred while disabling cache.')
             ->willReturnSelf();
 
@@ -215,7 +215,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->method('persist');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 cache type(s) disabled.')
             ->willReturnSelf();
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
@@ -5,17 +5,17 @@
  */
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Cache;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Magento\Backend\Controller\Adminhtml\Cache\MassEnable;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use Magento\Framework\App\State;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\Message\ManagerInterface as MessageManager;
-use Magento\Framework\Controller\ResultFactory;
+use Magento\Backend\Controller\Adminhtml\Cache\MassEnable;
 use Magento\Backend\Model\View\Result\Redirect;
-use Magento\Framework\App\RequestInterface as Request;
-use Magento\Framework\App\Cache\TypeListInterface as CacheTypeList;
 use Magento\Framework\App\Cache\StateInterface as CacheState;
+use Magento\Framework\App\Cache\TypeListInterface as CacheTypeList;
+use Magento\Framework\App\RequestInterface as Request;
+use Magento\Framework\App\State;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Message\ManagerInterface as MessageManager;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -155,8 +155,8 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['someCache']);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
-            ->with('Specified cache type(s) don\'t exist: someCache')
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => 'Specified cache type(s) don\'t exist: someCache'])
             ->willReturnSelf();
 
         $this->assertSame($this->redirectMock, $this->controller->execute());
@@ -175,7 +175,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'An error occurred while enabling cache.')
             ->willReturnSelf();
 
@@ -215,7 +215,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->method('persist');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 cache type(s) enabled.')
             ->willReturnSelf();
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/RefreshStatisticsTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/RefreshStatisticsTest.php
@@ -107,7 +107,7 @@ class RefreshStatisticsTest extends \PHPUnit\Framework\TestCase
         $this->resultRedirectFactory->expects($this->any())->method('create')->willReturn($this->resultRedirect);
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('We updated lifetime statistic.'));
 
         $this->objectManager->expects($this->any())

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
@@ -71,7 +71,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $this->_messagesMock = $this->getMockBuilder(\Magento\Framework\Message\Manager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess'])
+            ->setMethods(['addSuccessMessage'])
             ->getMockForAbstractClass();
 
         $this->_authSessionMock = $this->getMockBuilder(\Magento\Backend\Model\Auth\Session::class)
@@ -221,7 +221,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         $this->_requestMock->setParams($requestParams);
 
-        $this->_messagesMock->expects($this->once())->method('addSuccess')->with($this->equalTo($testedMessage));
+        $this->_messagesMock->expects($this->once())->method('addSuccessMessage')->with($this->equalTo($testedMessage));
 
         $this->_controller->execute();
     }

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/Create.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/Create.php
@@ -82,7 +82,7 @@ class Create extends \Magento\Backup\Controller\Adminhtml\Index
 
             $backupManager->create();
 
-            $this->messageManager->addSuccess($successMessage);
+            $this->messageManager->addSuccessMessage($successMessage);
 
             $response->setRedirectUrl($this->getUrl('*/*/index'));
         } catch (\Magento\Framework\Backup\Exception\NotEnoughFreeSpace $e) {

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/MassDelete.php
@@ -49,13 +49,13 @@ class MassDelete extends \Magento\Backup\Controller\Adminhtml\Index
 
             $resultData->setIsSuccess(true);
             if ($allBackupsDeleted) {
-                $this->messageManager->addSuccess(__('You deleted the selected backup(s).'));
+                $this->messageManager->addSuccessMessage(__('You deleted the selected backup(s).'));
             } else {
                 throw new \Exception($deleteFailMessage);
             }
         } catch (\Exception $e) {
             $resultData->setIsSuccess(false);
-            $this->messageManager->addError($deleteFailMessage);
+            $this->messageManager->addErrorMessage($deleteFailMessage);
         }
 
         return $this->_redirect('backup/*/index');

--- a/app/code/Magento/Captcha/Observer/CheckContactUsFormObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckContactUsFormObserver.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Captcha\Observer;
 
-use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Request\DataPersistorInterface;
+use Magento\Framework\Event\ObserverInterface;
 
 class CheckContactUsFormObserver implements ObserverInterface
 {
@@ -76,7 +76,7 @@ class CheckContactUsFormObserver implements ObserverInterface
             /** @var \Magento\Framework\App\Action\Action $controller */
             $controller = $observer->getControllerAction();
             if (!$captcha->isCorrect($this->captchaStringResolver->resolve($controller->getRequest(), $formId))) {
-                $this->messageManager->addError(__('Incorrect CAPTCHA.'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA.'));
                 $this->getDataPersistor()->set($formId, $controller->getRequest()->getPostValue());
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->redirect->redirect($controller->getResponse(), 'contact/index/index');

--- a/app/code/Magento/Captcha/Observer/CheckForgotpasswordObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckForgotpasswordObserver.php
@@ -69,7 +69,7 @@ class CheckForgotpasswordObserver implements ObserverInterface
             /** @var \Magento\Framework\App\Action\Action $controller */
             $controller = $observer->getControllerAction();
             if (!$captchaModel->isCorrect($this->captchaStringResolver->resolve($controller->getRequest(), $formId))) {
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->redirect->redirect($controller->getResponse(), '*/*/forgotpassword');
             }

--- a/app/code/Magento/Captcha/Observer/CheckUserCreateObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserCreateObserver.php
@@ -86,7 +86,7 @@ class CheckUserCreateObserver implements ObserverInterface
             /** @var \Magento\Framework\App\Action\Action $controller */
             $controller = $observer->getControllerAction();
             if (!$captchaModel->isCorrect($this->captchaStringResolver->resolve($controller->getRequest(), $formId))) {
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->_session->setCustomerFormData($controller->getRequest()->getPostValue());
                 $url = $this->_urlManager->getUrl('*/*/create', ['_nosecret' => true]);

--- a/app/code/Magento/Captcha/Observer/CheckUserEditObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserEditObserver.php
@@ -6,9 +6,9 @@
 namespace Magento\Captcha\Observer;
 
 use Magento\Customer\Model\AuthenticationInterface;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Event\ObserverInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -119,9 +119,9 @@ class CheckUserEditObserver implements ObserverInterface
                         'The account is locked. Please wait and try again or contact %1.',
                         $this->scopeConfig->getValue('contact/email/recipient_email')
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                 }
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->redirect->redirect($controller->getResponse(), '*/*/edit');
             }

--- a/app/code/Magento/Captcha/Observer/CheckUserForgotPasswordBackendObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserForgotPasswordBackendObserver.php
@@ -75,7 +75,7 @@ class CheckUserForgotPasswordBackendObserver implements ObserverInterface
                 ) {
                     $this->_session->setEmail((string)$controller->getRequest()->getPost('email'));
                     $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
-                    $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                    $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                     $controller->getResponse()->setRedirect(
                         $controller->getUrl('*/*/forgotpassword', ['_nosecret' => true])
                     );

--- a/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Captcha\Observer;
 
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\AuthenticationInterface;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Customer\Api\CustomerRepositoryInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -90,7 +90,6 @@ class CheckUserLoginObserver implements ObserverInterface
      */
     private function getCustomerRepository()
     {
-
         if (!($this->customerRepository instanceof \Magento\Customer\Api\CustomerRepositoryInterface)) {
             return \Magento\Framework\App\ObjectManager::getInstance()->get(
                 \Magento\Customer\Api\CustomerRepositoryInterface::class
@@ -107,7 +106,6 @@ class CheckUserLoginObserver implements ObserverInterface
      */
     private function getAuthentication()
     {
-
         if (!($this->authentication instanceof AuthenticationInterface)) {
             return \Magento\Framework\App\ObjectManager::getInstance()->get(
                 AuthenticationInterface::class
@@ -142,7 +140,7 @@ class CheckUserLoginObserver implements ObserverInterface
                 } catch (NoSuchEntityException $e) {
                     //do nothing as customer existance is validated later in authenticate method
                 }
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->_session->setUsername($login);
                 $beforeUrl = $this->_session->getBeforeAuthUrl();

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckContactUsFormObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckContactUsFormObserverTest.php
@@ -69,18 +69,22 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
         $this->messageManagerMock = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
         $this->redirectMock = $this->createMock(\Magento\Framework\App\Response\RedirectInterface::class);
         $this->captchaStringResolverMock = $this->createMock(\Magento\Captcha\Observer\CaptchaStringResolver::class);
-        $this->sessionMock = $this->createPartialMock(\Magento\Framework\Session\SessionManager::class, ['addError']);
-        $this->dataPersistorMock = $this->getMockBuilder(\Magento\Framework\App\Request\DataPersistorInterface::class)
-            ->getMockForAbstractClass();
+        $this->sessionMock = $this->createPartialMock(
+            \Magento\Framework\Session\SessionManager::class,
+            ['addErrorMessage']
+        );
+        $this->dataPersistorMock =
+            $this->getMockBuilder(\Magento\Framework\App\Request\DataPersistorInterface::class)
+                ->getMockForAbstractClass();
 
         $this->checkContactUsFormObserver = $this->objectManagerHelper->getObject(
             \Magento\Captcha\Observer\CheckContactUsFormObserver::class,
             [
-                'helper' => $this->helperMock,
-                'actionFlag' => $this->actionFlagMock,
-                'messageManager' => $this->messageManagerMock,
-                'redirect' => $this->redirectMock,
-                'captchaStringResolver' => $this->captchaStringResolverMock
+                'helper'                => $this->helperMock,
+                'actionFlag'            => $this->actionFlagMock,
+                'messageManager'        => $this->messageManagerMock,
+                'redirect'              => $this->redirectMock,
+                'captchaStringResolver' => $this->captchaStringResolverMock,
             ]
         );
         $this->objectManagerHelper->setBackwardCompatibleProperty(
@@ -99,24 +103,19 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
 
         $controller = $this->createMock(\Magento\Framework\App\Action\Action::class);
         $request = $this->createMock(\Magento\Framework\App\Request\Http::class);
-        $request->expects($this->any())
-            ->method('getPost')
-            ->with(\Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE, null)
-            ->willReturn([$formId => $captchaValue]);
+        $request->expects($this->any())->method('getPost')->with(
+            \Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE,
+            null
+        )->willReturn([$formId => $captchaValue]);
         $controller->expects($this->any())->method('getRequest')->willReturn($request);
         $this->captchaMock->expects($this->any())->method('isRequired')->willReturn(true);
-        $this->captchaMock->expects($this->once())
-            ->method('isCorrect')
-            ->with($captchaValue)
-            ->willReturn(true);
+        $this->captchaMock->expects($this->once())->method('isCorrect')->with($captchaValue)->willReturn(true);
         $this->captchaStringResolverMock->expects($this->once())
             ->method('resolve')
             ->with($request, $formId)
             ->willReturn($captchaValue);
-        $this->helperMock->expects($this->any())
-            ->method('getCaptcha')
-            ->with($formId)->willReturn($this->captchaMock);
-        $this->sessionMock->expects($this->never())->method('addError');
+        $this->helperMock->expects($this->any())->method('getCaptcha')->with($formId)->willReturn($this->captchaMock);
+        $this->sessionMock->expects($this->never())->method('addErrorMessage');
 
         $this->checkContactUsFormObserver->execute(
             new \Magento\Framework\Event\Observer(['controller_action' => $controller])
@@ -134,13 +133,11 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
 
         $request = $this->createMock(\Magento\Framework\App\Request\Http::class);
         $response = $this->createMock(\Magento\Framework\App\Response\Http::class);
-        $request->expects($this->any())
-            ->method('getPost')
-            ->with(\Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE, null)
-            ->willReturn([$formId => $captchaValue]);
-        $request->expects($this->once())
-            ->method('getPostValue')
-            ->willReturn($postData);
+        $request->expects($this->any())->method('getPost')->with(
+            \Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE,
+            null
+        )->willReturn([$formId => $captchaValue]);
+        $request->expects($this->once())->method('getPostValue')->willReturn($postData);
 
         $this->redirectMock->expects($this->once())
             ->method('redirect')
@@ -151,25 +148,19 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
         $controller->expects($this->any())->method('getRequest')->willReturn($request);
         $controller->expects($this->any())->method('getResponse')->willReturn($response);
         $this->captchaMock->expects($this->any())->method('isRequired')->willReturn(true);
-        $this->captchaMock->expects($this->once())
-            ->method('isCorrect')
-            ->with($captchaValue)
-            ->willReturn(false);
+        $this->captchaMock->expects($this->once())->method('isCorrect')->with($captchaValue)->willReturn(false);
         $this->captchaStringResolverMock->expects($this->once())
             ->method('resolve')
             ->with($request, $formId)
             ->willReturn($captchaValue);
-        $this->helperMock->expects($this->any())
-            ->method('getCaptcha')
-            ->with($formId)
-            ->willReturn($this->captchaMock);
-        $this->messageManagerMock->expects($this->once())->method('addError')->with($warningMessage);
-        $this->actionFlagMock->expects($this->once())
-            ->method('set')
-            ->with('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
-        $this->dataPersistorMock->expects($this->once())
-            ->method('set')
-            ->with($formId, $postData);
+        $this->helperMock->expects($this->any())->method('getCaptcha')->with($formId)->willReturn($this->captchaMock);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage')->with($warningMessage);
+        $this->actionFlagMock->expects($this->once())->method('set')->with(
+            '',
+            \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH,
+            true
+        );
+        $this->dataPersistorMock->expects($this->once())->method('set')->with($formId, $postData);
 
         $this->checkContactUsFormObserver->execute(
             new \Magento\Framework\Event\Observer(['controller_action' => $controller])
@@ -178,10 +169,9 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
 
     public function testCheckContactUsFormDoesNotCheckCaptchaWhenItIsNotRequired()
     {
-        $this->helperMock->expects($this->any())
-            ->method('getCaptcha')
-            ->with('contact_us')
-            ->willReturn($this->captchaMock);
+        $this->helperMock->expects($this->any())->method('getCaptcha')->with('contact_us')->willReturn(
+            $this->captchaMock
+        );
         $this->captchaMock->expects($this->any())->method('isRequired')->willReturn(false);
         $this->captchaMock->expects($this->never())->method('isCorrect');
 

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckForgotpasswordObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckForgotpasswordObserverTest.php
@@ -138,7 +138,7 @@ class CheckForgotpasswordObserverTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($this->_captcha)
         );
-        $this->_messageManager->expects($this->once())->method('addError')->with($warningMessage);
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($warningMessage);
         $this->_actionFlag->expects(
             $this->once()
         )->method(

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserCreateObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserCreateObserverTest.php
@@ -151,7 +151,7 @@ class CheckUserCreateObserverTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($this->_captcha)
         );
-        $this->_messageManager->expects($this->once())->method('addError')->with($warningMessage);
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($warningMessage);
         $this->_actionFlag->expects(
             $this->once()
         )->method(

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserEditObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserEditObserverTest.php
@@ -146,7 +146,7 @@ class CheckUserEditObserverTest extends \PHPUnit\Framework\TestCase
 
         $message = __('The account is locked. Please wait and try again or contact %1.', $email);
         $this->messageManagerMock->expects($this->exactly(2))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->withConsecutive([$message], [__('Incorrect CAPTCHA')]);
 
         $this->actionFlagMock->expects($this->once())

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserLoginObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserLoginObserverTest.php
@@ -145,7 +145,7 @@ class CheckUserLoginObserverTest extends \PHPUnit\Framework\TestCase
             ->with($customerId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Incorrect CAPTCHA'));
 
         $this->actionFlagMock->expects($this->once())

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
@@ -44,12 +44,12 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Category
                 $this->_eventManager->dispatch('catalog_controller_category_delete', ['category' => $category]);
                 $this->_auth->getAuthStorage()->setDeletedPath($category->getPath());
                 $this->categoryRepository->delete($category);
-                $this->messageManager->addSuccess(__('You deleted the category.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the category.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while trying to delete the category.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while trying to delete the category.'));
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
@@ -54,7 +54,7 @@ abstract class Attribute extends Action
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
         }
 
         return !$error;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -192,7 +192,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_eventManager->dispatch('catalog_product_to_website_change', ['products' => $productIds]);
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) were updated.', count($this->attributeHelper->getProductIds()))
             );
 
@@ -205,9 +205,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_productPriceIndexerProcessor->reindexList($this->attributeHelper->getProductIds());
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
@@ -68,7 +68,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attr
             $response->setError(true);
             $response->setMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
@@ -21,23 +21,23 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             // entity type check
             $model->load($id);
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('We can\'t delete the attribute.'));
+                $this->messageManager->addErrorMessage(__('We can\'t delete the attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             try {
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the product attribute.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the product attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath(
                     'catalog/*/edit',
                     ['attribute_id' => $this->getRequest()->getParam('attribute_id')]
                 );
             }
         }
-        $this->messageManager->addError(__('We can\'t find an attribute to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find an attribute to delete.'));
         return $resultRedirect->setPath('catalog/*/');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
@@ -25,14 +25,14 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $model->load($id);
 
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This attribute no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This attribute no longer exists.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             // entity type check
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('This attribute cannot be edited.'));
+                $this->messageManager->addErrorMessage(__('This attribute cannot be edited.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -91,7 +91,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $attributeSet->setEntityTypeId($this->_entityTypeId)->load($setName, 'attribute_set_name');
             if ($attributeSet->getId()) {
                 $setName = $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($setName);
-                $this->messageManager->addError(__('An attribute set named \'%1\' already exists.', $setName));
+                $this->messageManager->addErrorMessage(__('An attribute set named \'%1\' already exists.', $setName));
 
                 $layout = $this->layoutFactory->create();
                 $layout->initMessages();

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
@@ -43,11 +43,11 @@ class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
         $product = $this->productBuilder->build($this->getRequest());
         try {
             $newProduct = $this->productCopier->copy($product);
-            $this->messageManager->addSuccess(__('You duplicated the product.'));
+            $this->messageManager->addSuccessMessage(__('You duplicated the product.'));
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true, 'id' => $newProduct->getId()]);
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
@@ -52,12 +52,12 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product
         if (($productId && !$product->getEntityId())) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('This product doesn\'t exist.'));
+            $this->messageManager->addErrorMessage(__('This product doesn\'t exist.'));
             return $resultRedirect->setPath('catalog/*/');
         } elseif ($productId === 0) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('Invalid product id. Should be numeric value greater than 0'));
+            $this->messageManager->addErrorMessage(__('Invalid product id. Should be numeric value greater than 0'));
             return $resultRedirect->setPath('catalog/*/');
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
@@ -29,12 +29,12 @@ class Save extends \Magento\Backend\App\Action
         );
 
         if ($model->itemExists()) {
-            $this->messageManager->addError(__('A group with the same name already exists.'));
+            $this->messageManager->addErrorMessage(__('A group with the same name already exists.'));
         } else {
             try {
                 $model->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving this group.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving this group.'));
             }
         }
     }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -6,11 +6,11 @@
  */
 namespace Magento\Catalog\Controller\Adminhtml\Product;
 
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product
 {
@@ -64,7 +64,7 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product
             $this->productRepository->delete($product);
             $productDeleted++;
         }
-        $this->messageManager->addSuccess(
+        $this->messageManager->addSuccessMessage(
             __('A total of %1 record(s) have been deleted.', $productDeleted)
         );
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
@@ -36,10 +36,10 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         $resultRedirect = $this->resultRedirectFactory->create();
         try {
             $this->attributeSetRepository->deleteById($setId);
-            $this->messageManager->addSuccess(__('The attribute set has been removed.'));
+            $this->messageManager->addSuccessMessage(__('The attribute set has been removed.'));
             $resultRedirect->setPath('catalog/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete this set right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete this set right now.'));
             $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -100,15 +100,15 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
                 $model->initFromSkeleton($this->getRequest()->getParam('skeleton_set'));
             }
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the attribute set.'));
+            $this->messageManager->addSuccessMessage(__('You saved the attribute set.'));
         } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong while saving the attribute set.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the attribute set.'));
             $hasError = true;
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
@@ -137,7 +137,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product
             $response->setError(true);
             $response->setMessages([$e->getMessage()]);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $layout = $this->layoutFactory->create();
             $layout->initMessages();
             $response->setError(true);

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Add.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Add.php
@@ -36,7 +36,9 @@ class Add extends \Magento\Catalog\Controller\Product\Compare
                 $productName = $this->_objectManager->get(
                     \Magento\Framework\Escaper::class
                 )->escapeHtml($product->getName());
-                $this->messageManager->addSuccess(__('You added product %1 to the comparison list.', $productName));
+                $this->messageManager->addSuccessMessage(
+                    __('You added product %1 to the comparison list.', $productName)
+                );
                 $this->_eventManager->dispatch('catalog_product_compare_add_product', ['product' => $product]);
             }
 

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
@@ -30,12 +30,12 @@ class Clear extends \Magento\Catalog\Controller\Product\Compare
 
         try {
             $items->clear();
-            $this->messageManager->addSuccess(__('You cleared the comparison list.'));
+            $this->messageManager->addSuccessMessage(__('You cleared the comparison list.'));
             $this->_objectManager->get(\Magento\Catalog\Helper\Product\Compare::class)->calculate();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong  clearing the comparison list.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong  clearing the comparison list.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
@@ -44,7 +44,7 @@ class Remove extends \Magento\Catalog\Controller\Product\Compare
                     $item->delete();
                     $productName = $this->_objectManager->get(\Magento\Framework\Escaper::class)
                         ->escapeHtml($product->getName());
-                    $this->messageManager->addSuccess(
+                    $this->messageManager->addSuccessMessage(
                         __('You removed product %1 from the comparison list.', $productName)
                     );
                     $this->_eventManager->dispatch(

--- a/app/code/Magento/Catalog/Controller/Product/View.php
+++ b/app/code/Magento/Catalog/Controller/Product/View.php
@@ -83,7 +83,7 @@ class View extends \Magento\Catalog\Controller\Product
             }
             if ($specifyOptions) {
                 $notice = $product->getTypeInstance()->getSpecifyOptionMessage();
-                $this->messageManager->addNotice($notice);
+                $this->messageManager->addNoticeMessage($notice);
             }
             if ($this->getRequest()->isAjax()) {
                 $this->getResponse()->representJson(

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/DeleteTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/DeleteTest.php
@@ -71,7 +71,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             false,
             true,
             true,
-            ['addSuccess']
+            ['addSuccessMessage']
         );
         $this->categoryRepository = $this->createMock(\Magento\Catalog\Api\CategoryRepositoryInterface::class);
         $context->expects($this->any())

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/SaveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/SaveTest.php
@@ -104,7 +104,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             false,
             true,
             true,
-            ['addSuccess', 'getMessages']
+            ['addSuccessMessage', 'getMessages']
         );
 
         $this->save = $this->objectManager->getObject(
@@ -394,7 +394,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $categoryMock->expects($this->once())
             ->method('save');
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the category.'));
         $categoryMock->expects($this->at(1))
             ->method('getId')

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/EditTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/EditTest.php
@@ -94,7 +94,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         $messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->setMethods([])
             ->disableOriginalConstructor()->getMock();
-        $messageManager->expects($this->any())->method('addError')->willReturn(true);
+        $messageManager->expects($this->any())->method('addErrorMessage')->willReturn(true);
         $this->context = $this->getMockBuilder(\Magento\Backend\App\Action\Context::class)
             ->setMethods(['getRequest', 'getObjectManager', 'getMessageManager', 'getResultRedirectFactory'])
             ->disableOriginalConstructor()->getMock();

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/SaveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/SaveTest.php
@@ -250,8 +250,8 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ['inventory', [], [7]],
         ]));
 
-        $this->messageManager->expects($this->never())->method('addError');
-        $this->messageManager->expects($this->never())->method('addException');
+        $this->messageManager->expects($this->never())->method('addErrorMessage');
+        $this->messageManager->expects($this->never())->method('addExceptionMessage');
 
         $this->object->execute();
     }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
@@ -25,14 +25,14 @@ class ApplyRules extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
             $ruleJob->applyAll();
 
             if ($ruleJob->hasSuccess()) {
-                $this->messageManager->addSuccess($ruleJob->getSuccess());
+                $this->messageManager->addSuccessMessage($ruleJob->getSuccess());
                 $this->_objectManager->create(\Magento\CatalogRule\Model\Flag::class)->loadSelf()->setState(0)->save();
             } elseif ($ruleJob->hasError()) {
-                $this->messageManager->addError($errorMessage . ' ' . $ruleJob->getError());
+                $this->messageManager->addErrorMessage($errorMessage . ' ' . $ruleJob->getError());
             }
         } catch (\Exception $e) {
             $this->_objectManager->create(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError($errorMessage);
+            $this->messageManager->addErrorMessage($errorMessage);
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php
@@ -25,13 +25,13 @@ class Delete extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 $ruleRepository->deleteById($id);
 
                 $this->_objectManager->create(\Magento\CatalogRule\Model\Flag::class)->loadSelf()->setState(1)->save();
-                $this->messageManager->addSuccess(__('You deleted the rule.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rule.'));
                 $this->_redirect('catalog_rule/*/');
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete this rule right now. Please review the log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -39,7 +39,7 @@ class Delete extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a rule to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a rule to delete.'));
         $this->_redirect('catalog_rule/*/');
     }
 }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php
@@ -24,7 +24,7 @@ class Edit extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
             try {
                 $model = $ruleRepository->get($id);
             } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 $this->_redirect('catalog_rule/*');
                 return;
             }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -7,10 +7,10 @@
 namespace Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog;
 
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\DateTime\Filter\Date;
-use Magento\Framework\App\Request\DataPersistorInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -68,7 +68,7 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 $validateResult = $model->validateData(new \Magento\Framework\DataObject($data));
                 if ($validateResult !== true) {
                     foreach ($validateResult as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                     $this->_getSession()->setPageData($data);
                     $this->dataPersistor->set('catalog_rule', $data);
@@ -88,7 +88,7 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
 
                 $ruleRepository->save($model);
 
-                $this->messageManager->addSuccess(__('You saved the rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rule.'));
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setPageData(false);
                 $this->dataPersistor->clear('catalog_rule');
 
@@ -111,9 +111,9 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 }
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Something went wrong while saving the rule data. Please review the error log.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/CatalogRule/Observer/AddDirtyRulesNotice.php
+++ b/app/code/Magento/CatalogRule/Observer/AddDirtyRulesNotice.php
@@ -37,7 +37,7 @@ class AddDirtyRulesNotice implements ObserverInterface
         $dirtyRules = $observer->getData('dirty_rules');
         if (!empty($dirtyRules)) {
             if ($dirtyRules->getState()) {
-                $this->messageManager->addNotice($observer->getData('message'));
+                $this->messageManager->addNoticeMessage($observer->getData('message'));
             }
         }
     }

--- a/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
+++ b/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
@@ -103,7 +103,7 @@ class Attribute
 
         if ($disabledRulesCount) {
             $this->ruleProductProcessor->markIndexerAsInvalid();
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __(
                     'You disabled %1 Catalog Price Rules based on "%2" attribute.',
                     $disabledRulesCount,

--- a/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
@@ -49,7 +49,7 @@ class AddDirtyRulesNoticeTest extends \PHPUnit\Framework\TestCase
         $eventObserverMock->expects($this->at(0))->method('getData')->with('dirty_rules')->willReturn($flagMock);
         $flagMock->expects($this->once())->method('getState')->willReturn(1);
         $eventObserverMock->expects($this->at(1))->method('getData')->with('message')->willReturn($message);
-        $this->messageManagerMock->expects($this->once())->method('addNotice')->with($message);
+        $this->messageManagerMock->expects($this->once())->method('addNoticeMessage')->with($message);
         $this->observer->execute($eventObserverMock);
     }
 }

--- a/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
+++ b/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
@@ -6,7 +6,6 @@
  */
 namespace Magento\CatalogSearch\Controller\Advanced;
 
-use Magento\Catalog\Model\Layer\Resolver;
 use Magento\CatalogSearch\Model\Advanced as ModelAdvanced;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\UrlFactory;
@@ -54,7 +53,7 @@ class Result extends \Magento\Framework\App\Action\Action
             $this->_view->loadLayout();
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $defaultUrl = $this->_urlFactory->create()
                 ->addQueryParams($this->getRequest()->getQueryValue())
                 ->getUrl('*/*/');

--- a/app/code/Magento/Checkout/Block/Cart/ValidationMessages.php
+++ b/app/code/Magento/Checkout/Block/Cart/ValidationMessages.php
@@ -84,7 +84,7 @@ class ValidationMessages extends \Magento\Framework\View\Element\Messages
     protected function validateMinimumAmount()
     {
         if (!$this->cartHelper->getQuote()->validateMinimumAmount()) {
-            $this->messageManager->addNotice($this->getMinimumAmountErrorMessage()->getMessage());
+            $this->messageManager->addNoticeMessage($this->getMinimumAmountErrorMessage()->getMessage());
         }
     }
 

--- a/app/code/Magento/Checkout/Controller/Account/Create.php
+++ b/app/code/Magento/Checkout/Controller/Account/Create.php
@@ -83,7 +83,7 @@ class Create extends \Magento\Framework\App\Action\Action
                 ]
             );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, $e->getMessage());
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
             throw $e;
         }
     }

--- a/app/code/Magento/Checkout/Controller/Action.php
+++ b/app/code/Magento/Checkout/Controller/Action.php
@@ -70,7 +70,7 @@ abstract class Action extends \Magento\Framework\App\Action\Action
             if (!$validationResult->isValid()) {
                 if ($addErrors) {
                     foreach ($validationResult->getMessages() as $error) {
-                        $this->messageManager->addError($error);
+                        $this->messageManager->addErrorMessage($error);
                     }
                 }
                 if ($redirect) {

--- a/app/code/Magento/Checkout/Controller/Cart/Add.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Add.php
@@ -88,9 +88,11 @@ class Add extends \Magento\Checkout\Controller\Cart
         try {
             if (isset($params['qty'])) {
                 $filter = new \Zend_Filter_LocalizedToNormalized(
-                    ['locale' => $this->_objectManager->get(
-                        \Magento\Framework\Locale\ResolverInterface::class
-                    )->getLocale()]
+                    [
+                        'locale' => $this->_objectManager->get(
+                            \Magento\Framework\Locale\ResolverInterface::class
+                        )->getLocale(),
+                    ]
                 );
                 $params['qty'] = $filter->filter($params['qty']);
             }
@@ -132,13 +134,13 @@ class Add extends \Magento\Checkout\Controller\Cart
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             if ($this->_checkoutSession->getUseNotice(true)) {
-                $this->messageManager->addNotice(
+                $this->messageManager->addNoticeMessage(
                     $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($e->getMessage())
                 );
             } else {
                 $messages = array_unique(explode("\n", $e->getMessage()));
                 foreach ($messages as $message) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($message)
                     );
                 }
@@ -153,7 +155,10 @@ class Add extends \Magento\Checkout\Controller\Cart
 
             return $this->goBack($url);
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t add this item to your shopping cart right now.'));
+            $this->messageManager->addExceptionMessage(
+                $e,
+                __('We can\'t add this item to your shopping cart right now.')
+            );
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             return $this->goBack();
         }
@@ -179,7 +184,7 @@ class Add extends \Magento\Checkout\Controller\Cart
         } else {
             if ($product && !$product->getIsSalable()) {
                 $result['product'] = [
-                    'statusText' => __('Out of stock')
+                    'statusText' => __('Out of stock'),
                 ];
             }
         }

--- a/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
@@ -7,8 +7,8 @@
 namespace Magento\Checkout\Controller\Cart;
 
 use Magento\Checkout\Model\Cart as CustomerCart;
-use Magento\Framework\Escaper;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Escaper;
 use Magento\Sales\Model\Order\Item;
 
 /**
@@ -60,12 +60,12 @@ class Addgroup extends \Magento\Checkout\Controller\Cart
                     $this->addOrderItem($item);
                 } catch (\Magento\Framework\Exception\LocalizedException $e) {
                     if ($this->_checkoutSession->getUseNotice(true)) {
-                        $this->messageManager->addNotice($e->getMessage());
+                        $this->messageManager->addNoticeMessage($e->getMessage());
                     } else {
-                        $this->messageManager->addError($e->getMessage());
+                        $this->messageManager->addErrorMessage($e->getMessage());
                     }
                 } catch (\Exception $e) {
-                    $this->messageManager->addException(
+                    $this->messageManager->addExceptionMessage(
                         $e,
                         __('We can\'t add this item to your shopping cart right now.')
                     );

--- a/app/code/Magento/Checkout/Controller/Cart/Configure.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Configure.php
@@ -63,7 +63,7 @@ class Configure extends \Magento\Checkout\Controller\Cart
 
         try {
             if (!$quoteItem || $productId != $quoteItem->getProduct()->getId()) {
-                $this->messageManager->addError(__("We can't find the quote item."));
+                $this->messageManager->addErrorMessage(__("We can't find the quote item."));
                 return $this->resultFactory->create(ResultFactory::TYPE_REDIRECT)->setPath('checkout/cart');
             }
 
@@ -82,7 +82,7 @@ class Configure extends \Magento\Checkout\Controller\Cart
                 );
             return $resultPage;
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We cannot configure the product.'));
+            $this->messageManager->addErrorMessage(__('We cannot configure the product.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             return $this->_goBack();
         }

--- a/app/code/Magento/Checkout/Controller/Cart/CouponPost.php
+++ b/app/code/Magento/Checkout/Controller/Cart/CouponPost.php
@@ -95,14 +95,14 @@ class CouponPost extends \Magento\Checkout\Controller\Cart
                 if (!$itemsCount) {
                     if ($isCodeLengthValid && $coupon->getId()) {
                         $this->_checkoutSession->getQuote()->setCouponCode($couponCode)->save();
-                        $this->messageManager->addSuccess(
+                        $this->messageManager->addSuccessMessage(
                             __(
                                 'You used coupon code "%1".',
                                 $escaper->escapeHtml($couponCode)
                             )
                         );
                     } else {
-                        $this->messageManager->addError(
+                        $this->messageManager->addErrorMessage(
                             __(
                                 'The coupon code "%1" is not valid.',
                                 $escaper->escapeHtml($couponCode)
@@ -111,14 +111,14 @@ class CouponPost extends \Magento\Checkout\Controller\Cart
                     }
                 } else {
                     if ($isCodeLengthValid && $coupon->getId() && $couponCode == $cartQuote->getCouponCode()) {
-                        $this->messageManager->addSuccess(
+                        $this->messageManager->addSuccessMessage(
                             __(
                                 'You used coupon code "%1".',
                                 $escaper->escapeHtml($couponCode)
                             )
                         );
                     } else {
-                        $this->messageManager->addError(
+                        $this->messageManager->addErrorMessage(
                             __(
                                 'The coupon code "%1" is not valid.',
                                 $escaper->escapeHtml($couponCode)
@@ -127,12 +127,12 @@ class CouponPost extends \Magento\Checkout\Controller\Cart
                     }
                 }
             } else {
-                $this->messageManager->addSuccess(__('You canceled the coupon code.'));
+                $this->messageManager->addSuccessMessage(__('You canceled the coupon code.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We cannot apply the coupon code.'));
+            $this->messageManager->addErrorMessage(__('We cannot apply the coupon code.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Checkout/Controller/Cart/Delete.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Delete.php
@@ -24,7 +24,7 @@ class Delete extends \Magento\Checkout\Controller\Cart
             try {
                 $this->cart->removeItem($id)->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t remove the item.'));
+                $this->messageManager->addErrorMessage(__('We can\'t remove the item.'));
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             }
         }

--- a/app/code/Magento/Checkout/Controller/Cart/UpdateItemOptions.php
+++ b/app/code/Magento/Checkout/Controller/Cart/UpdateItemOptions.php
@@ -64,17 +64,17 @@ class UpdateItemOptions extends \Magento\Checkout\Controller\Cart
                         $this->_objectManager->get(\Magento\Framework\Escaper::class)
                             ->escapeHtml($item->getProduct()->getName())
                     );
-                    $this->messageManager->addSuccess($message);
+                    $this->messageManager->addSuccessMessage($message);
                 }
                 return $this->_goBack($this->_url->getUrl('checkout/cart'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             if ($this->_checkoutSession->getUseNotice(true)) {
-                $this->messageManager->addNotice($e->getMessage());
+                $this->messageManager->addNoticeMessage($e->getMessage());
             } else {
                 $messages = array_unique(explode("\n", $e->getMessage()));
                 foreach ($messages as $message) {
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                 }
             }
 
@@ -86,7 +86,7 @@ class UpdateItemOptions extends \Magento\Checkout\Controller\Cart
                 return $this->resultRedirectFactory->create()->setUrl($this->_redirect->getRedirectUrl($cartUrl));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the item right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t update the item right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             return $this->_goBack();
         }

--- a/app/code/Magento/Checkout/Controller/Cart/UpdatePost.php
+++ b/app/code/Magento/Checkout/Controller/Cart/UpdatePost.php
@@ -18,9 +18,9 @@ class UpdatePost extends \Magento\Checkout\Controller\Cart
         try {
             $this->cart->truncate()->save();
         } catch (\Magento\Framework\Exception\LocalizedException $exception) {
-            $this->messageManager->addError($exception->getMessage());
+            $this->messageManager->addErrorMessage($exception->getMessage());
         } catch (\Exception $exception) {
-            $this->messageManager->addException($exception, __('We can\'t update the shopping cart.'));
+            $this->messageManager->addExceptionMessage($exception, __('We can\'t update the shopping cart.'));
         }
     }
 
@@ -52,11 +52,11 @@ class UpdatePost extends \Magento\Checkout\Controller\Cart
                 $this->cart->updateItems($cartData)->save();
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($e->getMessage())
             );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the shopping cart.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t update the shopping cart.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
     }

--- a/app/code/Magento/Checkout/Controller/Index/Index.php
+++ b/app/code/Magento/Checkout/Controller/Index/Index.php
@@ -18,7 +18,7 @@ class Index extends \Magento\Checkout\Controller\Onepage
         /** @var \Magento\Checkout\Helper\Data $checkoutHelper */
         $checkoutHelper = $this->_objectManager->get(\Magento\Checkout\Helper\Data::class);
         if (!$checkoutHelper->canOnepageCheckout()) {
-            $this->messageManager->addError(__('One-page checkout is turned off.'));
+            $this->messageManager->addErrorMessage(__('One-page checkout is turned off.'));
             return $this->resultRedirectFactory->create()->setPath('checkout/cart');
         }
 
@@ -28,7 +28,7 @@ class Index extends \Magento\Checkout\Controller\Onepage
         }
 
         if (!$this->_customerSession->isLoggedIn() && !$checkoutHelper->isAllowedGuestCheckout($quote)) {
-            $this->messageManager->addError(__('Guest checkout is disabled.'));
+            $this->messageManager->addErrorMessage(__('Guest checkout is disabled.'));
             return $this->resultRedirectFactory->create()->setPath('checkout/cart');
         }
 

--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -433,10 +433,10 @@ class Cart extends DataObject implements CartInterface
             }
 
             if (!$allAvailable) {
-                $this->messageManager->addError(__("We don't have some of the products you want."));
+                $this->messageManager->addErrorMessage(__("We don't have some of the products you want."));
             }
             if (!$allAdded) {
-                $this->messageManager->addError(__("We don't have as many of some products as you want."));
+                $this->messageManager->addErrorMessage(__("We don't have as many of some products as you want."));
             }
         }
         return $this;
@@ -522,7 +522,7 @@ class Cart extends DataObject implements CartInterface
 
                 if (isset($itemInfo['before_suggest_qty']) && $itemInfo['before_suggest_qty'] != $qty) {
                     $qtyRecalculatedFlag = true;
-                    $this->messageManager->addNotice(
+                    $this->messageManager->addNoticeMessage(
                         __('Quantity was recalculated from %1 to %2', $itemInfo['before_suggest_qty'], $qty),
                         'quote_item' . $item->getId()
                     );
@@ -531,7 +531,7 @@ class Cart extends DataObject implements CartInterface
         }
 
         if ($qtyRecalculatedFlag) {
-            $this->messageManager->addNotice(
+            $this->messageManager->addNoticeMessage(
                 __('We adjusted product quantities to fit the required increments.')
             );
         }

--- a/app/code/Magento/Checkout/Model/Type/Onepage.php
+++ b/app/code/Magento/Checkout/Model/Type/Onepage.php
@@ -666,12 +666,15 @@ class Onepage
         $confirmationStatus = $this->accountManagement->getConfirmationStatus($customer->getId());
         if ($confirmationStatus === \Magento\Customer\Model\AccountManagement::ACCOUNT_CONFIRMATION_REQUIRED) {
             $url = $this->_customerUrl->getEmailConfirmationUrl($customer->getEmail());
-            $this->messageManager->addSuccess(
+            $this->messageManager->addComplexSuccessMessage(
                 // @codingStandardsIgnoreStart
-                __(
-                    'You must confirm your account. Please check your email for the confirmation link or <a href="%1">click here</a> for a new link.',
-                    $url
-                )
+                'addUnescapedMessage',
+                [
+                    'text' => __(
+                        'You must confirm your account. Please check your email for the confirmation link or <a href="%1">click here</a> for a new link.',
+                        $url
+                    ),
+                ]
                 // @codingStandardsIgnoreEnd
             );
         } else {

--- a/app/code/Magento/Checkout/Observer/LoadCustomerQuoteObserver.php
+++ b/app/code/Magento/Checkout/Observer/LoadCustomerQuoteObserver.php
@@ -42,9 +42,9 @@ class LoadCustomerQuoteObserver implements ObserverInterface
         try {
             $this->checkoutSession->loadCustomerQuote();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Load customer quote error'));
+            $this->messageManager->addExceptionMessage($e, __('Load customer quote error'));
         }
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Cart/ConfigureTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Cart/ConfigureTest.php
@@ -198,7 +198,7 @@ class ConfigureTest extends \PHPUnit\Framework\TestCase
         $quoteItemMock->expects($this->once())->method('getProduct')->willReturn($productMock);
         $productMock->expects($this->once())->method('getId')->willReturn($productIdInQuota);
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->willReturn('');
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Checkout/Test/Unit/Observer/LoadCustomerQuoteObserverTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Observer/LoadCustomerQuoteObserverTest.php
@@ -40,7 +40,7 @@ class LoadCustomerQuoteObserverTest extends \PHPUnit\Framework\TestCase
         $this->checkoutSession->expects($this->once())->method('loadCustomerQuote')->willThrowException(
             new \Magento\Framework\Exception\LocalizedException(__('Message'))
         );
-        $this->messageManager->expects($this->once())->method('addError')->with('Message');
+        $this->messageManager->expects($this->once())->method('addErrorMessage')->with('Message');
 
         $observerMock = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
             ->disableOriginalConstructor()
@@ -55,7 +55,7 @@ class LoadCustomerQuoteObserverTest extends \PHPUnit\Framework\TestCase
         $this->checkoutSession->expects($this->once())->method('loadCustomerQuote')->will(
             $this->throwException($exception)
         );
-        $this->messageManager->expects($this->once())->method('addException')
+        $this->messageManager->expects($this->once())->method('addExceptionMessage')
             ->with($exception, 'Load customer quote error');
 
         $observerMock = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Delete.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Delete.php
@@ -16,20 +16,20 @@ class Delete extends \Magento\CheckoutAgreements\Controller\Adminhtml\Agreement
         $id = (int)$this->getRequest()->getParam('id');
         $model = $this->_objectManager->get(\Magento\CheckoutAgreements\Model\Agreement::class)->load($id);
         if (!$model->getId()) {
-            $this->messageManager->addError(__('This condition no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This condition no longer exists.'));
             $this->_redirect('checkout/*/');
             return;
         }
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the condition.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the condition.'));
             $this->_redirect('checkout/*/');
             return;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Something went wrong  while deleting this condition.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong  while deleting this condition.'));
         }
 
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Edit.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Edit.php
@@ -20,7 +20,7 @@ class Edit extends \Magento\CheckoutAgreements\Controller\Adminhtml\Agreement
         if ($id) {
             $agreementModel->load($id);
             if (!$agreementModel->getId()) {
-                $this->messageManager->addError(__('This condition no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This condition no longer exists.'));
                 $this->_redirect('checkout/*/');
                 return;
             }

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Save.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Save.php
@@ -22,18 +22,18 @@ class Save extends \Magento\CheckoutAgreements\Controller\Adminhtml\Agreement
                 $validationResult = $model->validateData(new \Magento\Framework\DataObject($postData));
                 if ($validationResult !== true) {
                     foreach ($validationResult as $message) {
-                        $this->messageManager->addError($message);
+                        $this->messageManager->addErrorMessage($message);
                     }
                 } else {
                     $model->save();
-                    $this->messageManager->addSuccess(__('You saved the condition.'));
+                    $this->messageManager->addSuccessMessage(__('You saved the condition.'));
                     $this->_redirect('checkout/*/');
                     return;
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving this condition.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving this condition.'));
             }
 
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setAgreementData($postData);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
@@ -26,18 +26,18 @@ class Delete extends \Magento\Cms\Controller\Adminhtml\Block
                 $model->load($id);
                 $model->delete();
                 // display success message
-                $this->messageManager->addSuccess(__('You deleted the block.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the block.'));
                 // go to grid
                 return $resultRedirect->setPath('*/*/');
             } catch (\Exception $e) {
                 // display error message
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 // go back to edit form
                 return $resultRedirect->setPath('*/*/edit', ['block_id' => $id]);
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find a block to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a block to delete.'));
         // go to grid
         return $resultRedirect->setPath('*/*/');
     }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Edit.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Edit.php
@@ -42,7 +42,7 @@ class Edit extends \Magento\Cms\Controller\Adminhtml\Block
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This block no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This block no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/MassDelete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/MassDelete.php
@@ -6,10 +6,10 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Block;
 
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Cms\Model\ResourceModel\Block\CollectionFactory;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassDelete
@@ -60,7 +60,7 @@ class MassDelete extends \Magento\Backend\App\Action
             $block->delete();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been deleted.', $collectionSize));
+        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been deleted.', $collectionSize));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Save.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Save.php
@@ -10,7 +10,6 @@ use Magento\Backend\App\Action\Context;
 use Magento\Cms\Model\Block;
 use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\TestFramework\Inspection\Exception;
 
 class Save extends \Magento\Cms\Controller\Adminhtml\Block
 {
@@ -57,7 +56,7 @@ class Save extends \Magento\Cms\Controller\Adminhtml\Block
             /** @var \Magento\Cms\Model\Block $model */
             $model = $this->_objectManager->create(\Magento\Cms\Model\Block::class)->load($id);
             if (!$model->getId() && $id) {
-                $this->messageManager->addError(__('This block no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This block no longer exists.'));
                 return $resultRedirect->setPath('*/*/');
             }
 
@@ -65,7 +64,7 @@ class Save extends \Magento\Cms\Controller\Adminhtml\Block
 
             try {
                 $model->save();
-                $this->messageManager->addSuccess(__('You saved the block.'));
+                $this->messageManager->addSuccessMessage(__('You saved the block.'));
                 $this->dataPersistor->clear('cms_block');
 
                 if ($this->getRequest()->getParam('back')) {
@@ -73,9 +72,9 @@ class Save extends \Magento\Cms\Controller\Adminhtml\Block
                 }
                 return $resultRedirect->setPath('*/*/');
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while saving the block.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the block.'));
             }
 
             $this->dataPersistor->set('cms_block', $data);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Delete.php
@@ -35,7 +35,7 @@ class Delete extends \Magento\Backend\App\Action
                 $title = $model->getTitle();
                 $model->delete();
                 // display success message
-                $this->messageManager->addSuccess(__('The page has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The page has been deleted.'));
                 // go to grid
                 $this->_eventManager->dispatch(
                     'adminhtml_cmspage_on_delete',
@@ -48,13 +48,13 @@ class Delete extends \Magento\Backend\App\Action
                     ['title' => $title, 'status' => 'fail']
                 );
                 // display error message
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 // go back to edit form
                 return $resultRedirect->setPath('*/*/edit', ['page_id' => $id]);
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find a page to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a page to delete.'));
         // go to grid
         return $resultRedirect->setPath('*/*/');
     }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Edit.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Edit.php
@@ -76,7 +76,7 @@ class Edit extends \Magento\Backend\App\Action
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This page no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This page no longer exists.'));
                 /** \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDelete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDelete.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Page;
 
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassDelete
@@ -59,7 +59,7 @@ class MassDelete extends \Magento\Backend\App\Action
             $page->delete();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been deleted.', $collectionSize));
+        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been deleted.', $collectionSize));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDisable.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDisable.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Page;
 
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassDisable
@@ -59,7 +59,9 @@ class MassDisable extends \Magento\Backend\App\Action
             $item->save();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been disabled.', $collection->getSize()));
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 record(s) have been disabled.', $collection->getSize())
+        );
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassEnable.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassEnable.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Page;
 
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassEnable
@@ -59,7 +59,9 @@ class MassEnable extends \Magento\Backend\App\Action
             $item->save();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been enabled.', $collection->getSize()));
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 record(s) have been enabled.', $collection->getSize())
+        );
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
@@ -119,7 +119,7 @@ class PostDataProcessor
         foreach ($data as $field => $value) {
             if (in_array($field, array_keys($requiredFields)) && $value == '') {
                 $errorNo = false;
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('To apply changes you should fill in hidden required "%1" field', $requiredFields[$field])
                 );
             }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Index.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Index.php
@@ -39,7 +39,7 @@ class Index extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images
         try {
             $this->_objectManager->get(\Magento\Cms\Helper\Wysiwyg\Images::class)->getCurrentPath();
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
         $this->_initAction();
         /** @var \Magento\Framework\View\Result\Layout $resultLayout */

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/DeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/DeleteTest.php
@@ -134,10 +134,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->with($this->blockId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You deleted the block.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -154,10 +154,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t find a block to delete.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -181,10 +181,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception(__($errorMsg)));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMsg);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/EditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/EditTest.php
@@ -139,7 +139,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('This block no longer exists.'));
 
         $this->resultRedirectFactoryMock->expects($this->atLeastOnce())

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/MassDeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/MassDeleteTest.php
@@ -68,9 +68,9 @@ class MassDeleteTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been deleted.', $deletedBlocksCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/SaveTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/SaveTest.php
@@ -177,10 +177,10 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with('cms_block');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the block.'));
 
-        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/') ->willReturnSelf();
+        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/')->willReturnSelf();
 
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
@@ -188,7 +188,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     public function testSaveActionWithoutData()
     {
         $this->requestMock->expects($this->any())->method('getPostValue')->willReturn(false);
-        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/') ->willReturnSelf();
+        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/')->willReturnSelf();
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
@@ -217,10 +217,10 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('This block no longer exists.'));
 
-        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/') ->willReturnSelf();
+        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/')->willReturnSelf();
 
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
@@ -252,7 +252,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->blockMock->expects($this->once())->method('save');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the block.'));
 
         $this->dataPersistorMock->expects($this->any())
@@ -294,9 +294,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->blockMock->expects($this->once())->method('save')->willThrowException(new \Exception('Error message.'));
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
 
         $this->dataPersistorMock->expects($this->any())
             ->method('set')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/DeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/DeleteTest.php
@@ -124,10 +124,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->method('delete');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The page has been deleted.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->eventManagerMock->expects($this->once())
             ->method('dispatch')
@@ -151,10 +151,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t find a page to delete.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -195,10 +195,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMsg);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/EditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/EditTest.php
@@ -139,7 +139,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('This page no longer exists.'));
 
         $this->resultRedirectFactoryMock->expects($this->atLeastOnce())

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDeleteTest.php
@@ -68,9 +68,9 @@ class MassDeleteTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been deleted.', $deletedPagesCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDisableTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDisableTest.php
@@ -67,9 +67,9 @@ class MassDisableTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been disabled.', $disabledPagesCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassEnableTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassEnableTest.php
@@ -67,9 +67,9 @@ class MassEnableTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been enabled.', $enabledPagesCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Page/PostDataProcessorTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Page/PostDataProcessorTest.php
@@ -6,8 +6,8 @@
 namespace Magento\Cms\Test\Unit\Controller\Page;
 
 use Magento\Cms\Controller\Adminhtml\Page\PostDataProcessor;
-use Magento\Framework\Stdlib\DateTime\Filter\Date;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Stdlib\DateTime\Filter\Date;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Model\Layout\Update\ValidatorFactory;
 
@@ -65,7 +65,7 @@ class PostDataProcessorTest extends \PHPUnit\Framework\TestCase
             'title' => ''
         ];
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('To apply changes you should fill in hidden required "%1" field', 'Page Title'));
 
         $this->assertFalse($this->postDataProcessor->validateRequireEntry($postData));

--- a/app/code/Magento/Config/Controller/Adminhtml/System/Config/Save.php
+++ b/app/code/Magento/Config/Controller/Adminhtml/System/Config/Save.php
@@ -163,14 +163,14 @@ class Save extends AbstractConfig
                 'configData' => $configData,
                 'request' => $this->getRequest()
             ]);
-            $this->messageManager->addSuccess(__('You saved the configuration.'));
+            $this->messageManager->addSuccessMessage(__('You saved the configuration.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $messages = explode("\n", $e->getMessage());
             foreach ($messages as $message) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while saving this configuration:') . ' ' . $e->getMessage()
             );

--- a/app/code/Magento/Config/Test/Unit/Controller/Adminhtml/System/Config/SaveTest.php
+++ b/app/code/Magento/Config/Test/Unit/Controller/Adminhtml/System/Config/SaveTest.php
@@ -79,7 +79,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManagerMock = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addException']
+            ['addSuccessMessage', 'addExceptionMessage']
         );
 
         $this->_authMock = $this->createPartialMock(\Magento\Backend\Model\Auth::class, ['getUser']);
@@ -92,7 +92,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $configStructureMock->expects($this->any())->method('getSectionList')->willReturn(
             [
                 'some_key_0' => '0',
-                'some_key_1' => '1'
+                'some_key_1' => '1',
             ]
         );
 
@@ -100,29 +100,29 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
-        $this->resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->resultRedirect =
+            $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
+                ->disableOriginalConstructor()
+                ->getMock();
         $this->resultRedirect->expects($this->atLeastOnce())
             ->method('setPath')
             ->with('adminhtml/system_config/edit')
             ->willReturnSelf();
-        $resultRedirectFactory = $this->getMockBuilder(\Magento\Backend\Model\View\Result\RedirectFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
-        $resultRedirectFactory->expects($this->atLeastOnce())
-            ->method('create')
-            ->willReturn($this->resultRedirect);
+        $resultRedirectFactory =
+            $this->getMockBuilder(\Magento\Backend\Model\View\Result\RedirectFactory::class)
+                ->disableOriginalConstructor()
+                ->setMethods(['create'])
+                ->getMock();
+        $resultRedirectFactory->expects($this->atLeastOnce())->method('create')->willReturn($this->resultRedirect);
 
         $arguments = [
-            'request' => $this->_requestMock,
-            'response' => $this->_responseMock,
-            'helper' => $helperMock,
-            'eventManager' => $this->_eventManagerMock,
-            'auth' => $this->_authMock,
-            'messageManager' => $this->messageManagerMock,
-            'resultRedirectFactory' => $resultRedirectFactory
+            'request'               => $this->_requestMock,
+            'response'              => $this->_responseMock,
+            'helper'                => $helperMock,
+            'eventManager'          => $this->_eventManagerMock,
+            'auth'                  => $this->_authMock,
+            'messageManager'        => $this->messageManagerMock,
+            'resultRedirectFactory' => $resultRedirectFactory,
         ];
 
         $this->_sectionCheckerMock = $this->createMock(
@@ -130,9 +130,10 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         );
 
         $context = $helper->getObject(\Magento\Backend\App\Action\Context::class, $arguments);
-        $this->_controller = $this->getMockBuilder(\Magento\Config\Controller\Adminhtml\System\Config\Save::class)
-            ->setMethods(['deniedAction'])
-            ->setConstructorArgs(
+        $this->_controller =
+            $this->getMockBuilder(\Magento\Config\Controller\Adminhtml\System\Config\Save::class)->setMethods(
+                ['deniedAction']
+            )->setConstructorArgs(
                 [
                     $context,
                     $configStructureMock,
@@ -141,14 +142,15 @@ class SaveTest extends \PHPUnit\Framework\TestCase
                     $this->_cacheMock,
                     new \Magento\Framework\Stdlib\StringUtils(),
                 ]
-            )
-            ->getMock();
+            )->getMock();
     }
 
     public function testIndexActionWithAllowedSection()
     {
         $this->_sectionCheckerMock->expects($this->any())->method('isSectionAllowed')->will($this->returnValue(true));
-        $this->messageManagerMock->expects($this->once())->method('addSuccess')->with('You saved the configuration.');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage')->with(
+            'You saved the configuration.'
+        );
 
         $groups = ['some_key' => 'some_value'];
         $requestParamMap = [
@@ -168,8 +170,8 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $params = [
             'section' => 'test_section',
             'website' => 'test_website',
-            'store' => 'test_store',
-            'groups' => $groups,
+            'store'   => 'test_store',
+            'groups'  => $groups,
         ];
         $this->_configFactoryMock->expects(
             $this->once()
@@ -246,8 +248,8 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $params = [
             'section' => 'test_section',
             'website' => 'test_website',
-            'store' => 'test_store',
-            'groups' => $groupToSave,
+            'store'   => 'test_store',
+            'groups'  => $groupToSave,
         ];
         $backendConfigMock = $this->createMock(\Magento\Config\Model\Config::class);
         $this->_configFactoryMock->expects(

--- a/app/code/Magento/Contact/Controller/Index/Post.php
+++ b/app/code/Magento/Contact/Controller/Index/Post.php
@@ -71,8 +71,10 @@ class Post extends \Magento\Contact\Controller\Index
         }
         try {
             $this->sendEmail($this->validatedParams());
-            $this->messageManager->addSuccess(
-                __('Thanks for contacting us with your comments and questions. We\'ll respond to you very soon.')
+            $this->messageManager->addSuccessMessage(
+                __(
+                    'Thanks for contacting us with your comments and questions. We\'ll respond to you very soon.'
+                )
             );
             $this->getDataPersistor()->clear('contact_us');
         } catch (LocalizedException $e) {
@@ -96,8 +98,7 @@ class Post extends \Magento\Contact\Controller\Index
     private function getDataPersistor()
     {
         if ($this->dataPersistor === null) {
-            $this->dataPersistor = ObjectManager::getInstance()
-                ->get(DataPersistorInterface::class);
+            $this->dataPersistor = ObjectManager::getInstance()->get(DataPersistorInterface::class);
         }
 
         return $this->dataPersistor;

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/FetchRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/FetchRates.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\CurrencySymbol\Controller\Adminhtml\System\Currency;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
 
 class FetchRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Currency
 {
@@ -37,18 +37,16 @@ class FetchRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Cur
             $errors = $importModel->getMessages();
             if (sizeof($errors) > 0) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addWarning($error);
+                    $this->messageManager->addWarningMessage($error);
                 }
-                $this->messageManager->addWarning(
-                    __('Click "Save" to apply the rates we found.')
-                );
+                $this->messageManager->addWarningMessage(__('Click "Save" to apply the rates we found.'));
             } else {
-                $this->messageManager->addSuccess(__('Click "Save" to apply the rates we found.'));
+                $this->messageManager->addSuccessMessage(__('Click "Save" to apply the rates we found.'));
             }
 
             $backendSession->setRates($rates);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -21,22 +21,31 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
             try {
                 foreach ($data as $currencyCode => $rate) {
                     foreach ($rate as $currencyTo => $value) {
-                        $value = abs($this->_objectManager->get(
-                            \Magento\Framework\Locale\FormatInterface::class
-                        )->getNumber($value));
+                        $value = abs(
+                            $this->_objectManager->get(
+                                \Magento\Framework\Locale\FormatInterface::class
+                            )->getNumber($value)
+                        );
                         $data[$currencyCode][$currencyTo] = $value;
                         if ($value == 0) {
-                            $this->messageManager->addWarning(
-                                __('Please correct the input data for "%1 => %2" rate.', $currencyCode, $currencyTo)
+                            $this->messageManager->addComplexWarningMessage(
+                                'addUnescapedMessage',
+                                [
+                                    'text' => __(
+                                        'Please correct the input data for "%1 => %2" rate.',
+                                        $currencyCode,
+                                        $currencyTo
+                                    ),
+                                ]
                             );
                         }
                     }
                 }
 
                 $this->_objectManager->create(\Magento\Directory\Model\Currency::class)->saveRates($data);
-                $this->messageManager->addSuccess(__('All valid rates have been saved.'));
+                $this->messageManager->addSuccessMessage(__('All valid rates have been saved.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol/Save.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol/Save.php
@@ -27,9 +27,9 @@ class Save extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Currencys
         try {
             $this->_objectManager->create(\Magento\CurrencySymbol\Model\System\Currencysymbol::class)
                 ->setCurrencySymbolsData($symbolsDataArray);
-            $this->messageManager->addSuccess(__('You applied the custom currency symbols.'));
+            $this->messageManager->addSuccessMessage(__('You applied the custom currency symbols.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/CurrencySymbol/Test/Unit/Controller/Adminhtml/System/Currencysymbol/SaveTest.php
+++ b/app/code/Magento/CurrencySymbol/Test/Unit/Controller/Adminhtml/System/Currencysymbol/SaveTest.php
@@ -128,7 +128,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->filterManagerMock);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You applied the custom currency symbols.'));
 
         $this->action->execute();

--- a/app/code/Magento/Customer/Controller/Account/Confirm.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirm.php
@@ -6,18 +6,18 @@
  */
 namespace Magento\Customer\Controller\Account;
 
-use Magento\Customer\Model\Url;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session;
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Helper\Address;
-use Magento\Framework\UrlFactory;
-use Magento\Framework\Exception\StateException;
-use Magento\Store\Model\ScopeInterface;
+use Magento\Customer\Model\Session;
+use Magento\Customer\Model\Url;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\StateException;
+use Magento\Framework\UrlFactory;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class Confirm
@@ -163,13 +163,18 @@ class Confirm extends \Magento\Customer\Controller\AbstractAccount
                 $metadata->setPath('/');
                 $this->getCookieManager()->deleteCookie('mage-cache-sessid', $metadata);
             }
-            $this->messageManager->addSuccess($this->getSuccessMessage());
+            $this->messageManager->addComplexSuccessMessage(
+                'addUnescapedMessage',
+                [
+                    'text' => $this->getSuccessMessage(),
+                ]
+            );
             $resultRedirect->setUrl($this->getSuccessRedirect());
             return $resultRedirect;
         } catch (StateException $e) {
-            $this->messageManager->addException($e, __('This confirmation key is invalid or has expired.'));
+            $this->messageManager->addExceptionMessage($e, __('This confirmation key is invalid or has expired.'));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('There was an error confirming the account'));
+            $this->messageManager->addExceptionMessage($e, __('There was an error confirming the account'));
         }
 
         $url = $this->urlModel->getUrl('*/*/index', ['_secure' => true]);

--- a/app/code/Magento/Customer/Controller/Account/Confirmation.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirmation.php
@@ -6,12 +6,12 @@
  */
 namespace Magento\Customer\Controller\Account;
 
-use Magento\Framework\App\Action\Context;
+use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Model\Session;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\Exception\State\InvalidTransitionException;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Customer\Api\AccountManagementInterface;
-use Magento\Framework\Exception\State\InvalidTransitionException;
 
 class Confirmation extends \Magento\Customer\Controller\AbstractAccount
 {
@@ -81,11 +81,11 @@ class Confirmation extends \Magento\Customer\Controller\AbstractAccount
                     $email,
                     $this->storeManager->getStore()->getWebsiteId()
                 );
-                $this->messageManager->addSuccess(__('Please check your email for confirmation key.'));
+                $this->messageManager->addSuccessMessage(__('Please check your email for confirmation key.'));
             } catch (InvalidTransitionException $e) {
-                $this->messageManager->addSuccess(__('This email does not require confirmation.'));
+                $this->messageManager->addSuccessMessage(__('This email does not require confirmation.'));
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Wrong email.'));
+                $this->messageManager->addExceptionMessage($e, __('Wrong email.'));
                 $resultRedirect->setPath('*/*/*', ['email' => $email, '_secure' => true]);
                 return $resultRedirect;
             }

--- a/app/code/Magento/Customer/Controller/Account/CreatePassword.php
+++ b/app/code/Magento/Customer/Controller/Account/CreatePassword.php
@@ -8,8 +8,8 @@ namespace Magento\Customer\Controller\Account;
 
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Model\Session;
-use Magento\Framework\View\Result\PageFactory;
 use Magento\Framework\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
 
 class CreatePassword extends \Magento\Customer\Controller\AbstractAccount
 {
@@ -78,7 +78,7 @@ class CreatePassword extends \Magento\Customer\Controller\AbstractAccount
                 return $resultPage;
             }
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Your password reset link has expired.'));
+            $this->messageManager->addErrorMessage(__('Your password reset link has expired.'));
             /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('*/*/forgotpassword');

--- a/app/code/Magento/Customer/Controller/Account/EditPost.php
+++ b/app/code/Magento/Customer/Controller/Account/EditPost.php
@@ -6,17 +6,16 @@
  */
 namespace Magento\Customer\Controller\Account;
 
-use Magento\Customer\Model\AuthenticationInterface;
-use Magento\Customer\Model\Customer\Mapper;
-use Magento\Customer\Model\EmailNotificationInterface;
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\ObjectManager;
-use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\AuthenticationInterface;
+use Magento\Customer\Model\Customer\Mapper;
 use Magento\Customer\Model\CustomerExtractor;
+use Magento\Customer\Model\EmailNotificationInterface;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\InvalidEmailOrPasswordException;
 use Magento\Framework\Exception\State\UserLockedException;
@@ -103,7 +102,6 @@ class EditPost extends \Magento\Customer\Controller\AbstractAccount
      */
     private function getAuthentication()
     {
-
         if (!($this->authentication instanceof AuthenticationInterface)) {
             return ObjectManager::getInstance()->get(
                 \Magento\Customer\Model\AuthenticationInterface::class
@@ -162,27 +160,52 @@ class EditPost extends \Magento\Customer\Controller\AbstractAccount
                     $isPasswordChanged
                 );
                 $this->dispatchSuccessEvent($customerCandidateDataObject);
-                $this->messageManager->addSuccess(__('You saved the account information.'));
+                $this->messageManager->addSuccessMessage(__('You saved the account information.'));
                 return $resultRedirect->setPath('customer/account');
             } catch (InvalidEmailOrPasswordException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $e->getMessage(),
+                    ]
+                );
             } catch (UserLockedException $e) {
                 $message = __(
                     'You did not sign in correctly or your account is temporarily disabled.'
                 );
                 $this->session->logout();
                 $this->session->start();
-                $this->messageManager->addError($message);
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $message,
+                    ]
+                );
                 return $resultRedirect->setPath('customer/account/login');
             } catch (InputException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $e->getMessage(),
+                    ]
+                );
                 foreach ($e->getErrors() as $error) {
-                    $this->messageManager->addError($error->getMessage());
+                    $this->messageManager->addComplexErrorMessage(
+                        'addUnescapedMessage',
+                        [
+                            'text' => $error->getMessage(),
+                        ]
+                    );
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $e->getMessage(),
+                    ]
+                );
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t save the customer.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t save the customer.'));
             }
 
             $this->session->setCustomerFormData($this->getRequest()->getPostValue());

--- a/app/code/Magento/Customer/Controller/Account/LoginPost.php
+++ b/app/code/Magento/Customer/Controller/Account/LoginPost.php
@@ -5,17 +5,17 @@
  */
 namespace Magento\Customer\Controller\Account;
 
-use Magento\Customer\Model\Account\Redirect as AccountRedirect;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session;
 use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Model\Account\Redirect as AccountRedirect;
+use Magento\Customer\Model\Session;
 use Magento\Customer\Model\Url as CustomerUrl;
-use Magento\Framework\Exception\EmailNotConfirmedException;
-use Magento\Framework\Exception\AuthenticationException;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\FormKey\Validator;
+use Magento\Framework\Exception\AuthenticationException;
+use Magento\Framework\Exception\EmailNotConfirmedException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\State\UserLockedException;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -171,30 +171,35 @@ class LoginPost extends \Magento\Customer\Controller\AbstractAccount
                         'This account is not confirmed. <a href="%1">Click here</a> to resend confirmation email.',
                         $value
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addComplexErrorMessage(
+                        'addUnescapedMessage',
+                        [
+                            'text' => $message,
+                        ]
+                    );
                     $this->session->setUsername($login['username']);
                 } catch (UserLockedException $e) {
                     $message = __(
                         'You did not sign in correctly or your account is temporarily disabled.'
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (AuthenticationException $e) {
                     $message = __('You did not sign in correctly or your account is temporarily disabled.');
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (LocalizedException $e) {
                     $message = $e->getMessage();
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (\Exception $e) {
                     // PA DSS violation: throwing or logging an exception here can disclose customer password
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __('An unspecified error occurred. Please contact us for assistance.')
                     );
                 }
             } else {
-                $this->messageManager->addError(__('A login and a password are required.'));
+                $this->messageManager->addErrorMessage(__('A login and a password are required.'));
             }
         }
 

--- a/app/code/Magento/Customer/Controller/Account/ResetPasswordPost.php
+++ b/app/code/Magento/Customer/Controller/Account/ResetPasswordPost.php
@@ -8,11 +8,11 @@ namespace Magento\Customer\Controller\Account;
 
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\Customer\CredentialsValidator;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action\Context;
-use Magento\Framework\Exception\InputException;
-use Magento\Customer\Model\Customer\CredentialsValidator;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\InputException;
 
 class ResetPasswordPost extends \Magento\Customer\Controller\AbstractAccount
 {
@@ -75,12 +75,12 @@ class ResetPasswordPost extends \Magento\Customer\Controller\AbstractAccount
         $passwordConfirmation = (string)$this->getRequest()->getPost('password_confirmation');
 
         if ($password !== $passwordConfirmation) {
-            $this->messageManager->addError(__("New Password and Confirm New Password values didn't match."));
+            $this->messageManager->addErrorMessage(__("New Password and Confirm New Password values didn't match."));
             $resultRedirect->setPath('*/*/createPassword', ['id' => $customerId, 'token' => $resetPasswordToken]);
             return $resultRedirect;
         }
         if (iconv_strlen($password) <= 0) {
-            $this->messageManager->addError(__('Please enter a new password.'));
+            $this->messageManager->addErrorMessage(__('Please enter a new password.'));
             $resultRedirect->setPath('*/*/createPassword', ['id' => $customerId, 'token' => $resetPasswordToken]);
             return $resultRedirect;
         }
@@ -91,16 +91,16 @@ class ResetPasswordPost extends \Magento\Customer\Controller\AbstractAccount
             $this->accountManagement->resetPassword($customerEmail, $resetPasswordToken, $password);
             $this->session->unsRpToken();
             $this->session->unsRpCustomerId();
-            $this->messageManager->addSuccess(__('You updated your password.'));
+            $this->messageManager->addSuccessMessage(__('You updated your password.'));
             $resultRedirect->setPath('*/*/login');
             return $resultRedirect;
         } catch (InputException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             foreach ($e->getErrors() as $error) {
-                $this->messageManager->addError($error->getMessage());
+                $this->messageManager->addErrorMessage($error->getMessage());
             }
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Something went wrong while saving the new password.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while saving the new password.'));
         }
         $resultRedirect->setPath('*/*/createPassword', ['id' => $customerId, 'token' => $resetPasswordToken]);
         return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Address/Delete.php
+++ b/app/code/Magento/Customer/Controller/Address/Delete.php
@@ -20,12 +20,17 @@ class Delete extends \Magento\Customer\Controller\Address
                 $address = $this->_addressRepository->getById($addressId);
                 if ($address->getCustomerId() === $this->_getSession()->getCustomerId()) {
                     $this->_addressRepository->deleteById($addressId);
-                    $this->messageManager->addSuccess(__('You deleted the address.'));
+                    $this->messageManager->addSuccessMessage(__('You deleted the address.'));
                 } else {
-                    $this->messageManager->addError(__('We can\'t delete the address right now.'));
+                    $this->messageManager->addComplexErrorMessage(
+                        'addUnescapedMessage',
+                        [
+                            'text' => __('We can\'t delete the address right now.'),
+                        ]
+                    );
                 }
             } catch (\Exception $other) {
-                $this->messageManager->addException($other, __('We can\'t delete the address right now.'));
+                $this->messageManager->addExceptionMessage($other, __('We can\'t delete the address right now.'));
             }
         }
         return $this->resultRedirectFactory->create()->setPath('*/*/index');

--- a/app/code/Magento/Customer/Controller/Address/FormPost.php
+++ b/app/code/Magento/Customer/Controller/Address/FormPost.php
@@ -197,17 +197,17 @@ class FormPost extends \Magento\Customer\Controller\Address
         try {
             $address = $this->_extractAddress();
             $this->_addressRepository->save($address);
-            $this->messageManager->addSuccess(__('You saved the address.'));
+            $this->messageManager->addSuccessMessage(__('You saved the address.'));
             $url = $this->_buildUrl('*/*/index', ['_secure' => true]);
             return $this->resultRedirectFactory->create()->setUrl($this->_redirect->success($url));
         } catch (InputException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             foreach ($e->getErrors() as $error) {
-                $this->messageManager->addError($error->getMessage());
+                $this->messageManager->addErrorMessage($error->getMessage());
             }
         } catch (\Exception $e) {
             $redirectUrl = $this->_buildUrl('*/*/index');
-            $this->messageManager->addException($e, __('We can\'t save the address.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t save the address.'));
         }
 
         $url = $redirectUrl;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
@@ -7,15 +7,15 @@
 
 namespace Magento\Customer\Controller\Adminhtml\Customer;
 
-use Magento\Integration\Api\CustomerTokenServiceInterface;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterfaceFactory;
 use Magento\Customer\Api\Data\CustomerInterfaceFactory;
 use Magento\Customer\Model\Address\Mapper;
-use Magento\Framework\DataObjectFactory;
 use Magento\Framework\Api\DataObjectHelper;
+use Magento\Framework\DataObjectFactory;
+use Magento\Integration\Api\CustomerTokenServiceInterface;
 
 /**
  * Class to invalidate tokens for customers
@@ -131,14 +131,14 @@ class InvalidateToken extends \Magento\Customer\Controller\Adminhtml\Index
         if ($customerId = $this->getRequest()->getParam('customer_id')) {
             try {
                 $this->tokenService->revokeCustomerAccessToken($customerId);
-                $this->messageManager->addSuccess(__('You have revoked the customer\'s tokens.'));
+                $this->messageManager->addSuccessMessage(__('You have revoked the customer\'s tokens.'));
                 $resultRedirect->setPath('customer/index/edit', ['id' => $customerId, '_current' => true]);
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $resultRedirect->setPath('customer/index/edit', ['id' => $customerId, '_current' => true]);
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find a customer to revoke.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find a customer to revoke.'));
             $resultRedirect->setPath('customer/index/index');
         }
         return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/Delete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/Delete.php
@@ -23,12 +23,12 @@ class Delete extends \Magento\Customer\Controller\Adminhtml\Group
         if ($id) {
             try {
                 $this->groupRepository->deleteById($id);
-                $this->messageManager->addSuccess(__('You deleted the customer group.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the customer group.'));
             } catch (NoSuchEntityException $e) {
-                $this->messageManager->addError(__('The customer group no longer exists.'));
+                $this->messageManager->addErrorMessage(__('The customer group no longer exists.'));
                 return $resultRedirect->setPath('customer/*/');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('customer/group/edit', ['id' => $id]);
             }
         }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
@@ -7,7 +7,6 @@
 namespace Magento\Customer\Controller\Adminhtml\Group;
 
 use Magento\Customer\Api\Data\GroupInterfaceFactory;
-use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Api\GroupRepositoryInterface;
 
 class Save extends \Magento\Customer\Controller\Adminhtml\Group
@@ -89,10 +88,10 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Group
 
                 $this->groupRepository->save($customerGroup);
 
-                $this->messageManager->addSuccess(__('You saved the customer group.'));
+                $this->messageManager->addSuccessMessage(__('You saved the customer group.'));
                 $resultRedirect->setPath('customer/group');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 if ($customerGroup != null) {
                     $this->storeCustomerGroupDataToSession(
                         $this->dataObjectProcessor->buildOutputDataArray(

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index.php
@@ -12,9 +12,9 @@ use Magento\Customer\Api\Data\AddressInterfaceFactory;
 use Magento\Customer\Api\Data\CustomerInterfaceFactory;
 use Magento\Customer\Controller\RegistryConstants;
 use Magento\Customer\Model\Address\Mapper;
-use Magento\Framework\Message\Error;
-use Magento\Framework\DataObjectFactory as ObjectFactory;
 use Magento\Framework\Api\DataObjectHelper;
+use Magento\Framework\DataObjectFactory as ObjectFactory;
+use Magento\Framework\Message\Error;
 
 /**
  * Class Index
@@ -311,7 +311,7 @@ abstract class Index extends \Magento\Backend\App\Action
     protected function actUponMultipleCustomers(callable $singleAction, $customerIds)
     {
         if (!is_array($customerIds)) {
-            $this->messageManager->addError(__('Please select customer(s).'));
+            $this->messageManager->addErrorMessage(__('Please select customer(s).'));
             return 0;
         }
         $customersUpdated = 0;
@@ -320,7 +320,7 @@ abstract class Index extends \Magento\Backend\App\Action
                 $singleAction($customerId);
                 $customersUpdated++;
             } catch (\Exception $exception) {
-                $this->messageManager->addError($exception->getMessage());
+                $this->messageManager->addErrorMessage($exception->getMessage());
             }
         }
         return $customersUpdated;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/AbstractMassAction.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/AbstractMassAction.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
-use Magento\Eav\Model\Entity\Collection\AbstractCollection;
-use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\Controller\ResultInterface;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+use Magento\Eav\Model\Entity\Collection\AbstractCollection;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class AbstractMassStatus
@@ -64,7 +64,7 @@ abstract class AbstractMassAction extends \Magento\Backend\App\Action
             $collection = $this->filter->getCollection($this->collectionFactory->create());
             return $this->massAction($collection);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);
@@ -79,7 +79,7 @@ abstract class AbstractMassAction extends \Magento\Backend\App\Action
      */
     protected function getComponentRefererUrl()
     {
-        return $this->filter->getComponentRefererUrl()?: 'customer/*/index';
+        return $this->filter->getComponentRefererUrl() ?: 'customer/*/index';
     }
 
     /**

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
@@ -20,7 +20,7 @@ class Delete extends \Magento\Customer\Controller\Adminhtml\Index
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addError(__('Customer could not be deleted.'));
+            $this->messageManager->addErrorMessage(__('Customer could not be deleted.'));
             return $resultRedirect->setPath('customer/index');
         }
 
@@ -28,9 +28,9 @@ class Delete extends \Magento\Customer\Controller\Adminhtml\Index
         if (!empty($customerId)) {
             try {
                 $this->_customerRepository->deleteById($customerId);
-                $this->messageManager->addSuccess(__('You deleted the customer.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the customer.'));
             } catch (\Exception $exception) {
-                $this->messageManager->addError($exception->getMessage());
+                $this->messageManager->addErrorMessage($exception->getMessage());
             }
         }
 

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Edit.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Edit.php
@@ -42,7 +42,7 @@ class Edit extends \Magento\Customer\Controller\Adminhtml\Index
                     //do nothing
                 }
             } catch (NoSuchEntityException $e) {
-                $this->messageManager->addException($e, __('Something went wrong while editing the customer.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while editing the customer.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 $resultRedirect->setPath('customer/*/index');
                 return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/InlineEdit.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/InlineEdit.php
@@ -6,11 +6,10 @@
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
 use Magento\Backend\App\Action;
-use Magento\Customer\Model\EmailNotificationInterface;
-use Magento\Customer\Test\Block\Form\Login;
-use Magento\Customer\Ui\Component\Listing\AttributeRepository;
-use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\EmailNotificationInterface;
+use Magento\Customer\Ui\Component\Listing\AttributeRepository;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -214,13 +213,13 @@ class InlineEdit extends \Magento\Backend\App\Action
         try {
             $this->customerRepository->save($customer);
         } catch (\Magento\Framework\Exception\InputException $e) {
-            $this->getMessageManager()->addError($this->getErrorWithCustomerId($e->getMessage()));
+            $this->getMessageManager()->addErrorMessage($this->getErrorWithCustomerId($e->getMessage()));
             $this->logger->critical($e);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->getMessageManager()->addError($this->getErrorWithCustomerId($e->getMessage()));
+            $this->getMessageManager()->addErrorMessage($this->getErrorWithCustomerId($e->getMessage()));
             $this->logger->critical($e);
         } catch (\Exception $e) {
-            $this->getMessageManager()->addError($this->getErrorWithCustomerId('We can\'t save the customer.'));
+            $this->getMessageManager()->addErrorMessage($this->getErrorWithCustomerId('We can\'t save the customer.'));
             $this->logger->critical($e);
         }
     }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassAssignGroup.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassAssignGroup.php
@@ -6,11 +6,11 @@
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
 use Magento\Backend\App\Action\Context;
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
 use Magento\Eav\Model\Entity\Collection\AbstractCollection;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassAssignGroup
@@ -56,7 +56,7 @@ class MassAssignGroup extends AbstractMassAction
         }
 
         if ($customersUpdated) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', $customersUpdated));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', $customersUpdated));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
@@ -6,11 +6,11 @@
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
 use Magento\Backend\App\Action\Context;
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
 use Magento\Eav\Model\Entity\Collection\AbstractCollection;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassDelete
@@ -51,7 +51,7 @@ class MassDelete extends AbstractMassAction
         }
 
         if ($customersDeleted) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were deleted.', $customersDeleted));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were deleted.', $customersDeleted));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassSubscribe.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassSubscribe.php
@@ -6,12 +6,12 @@
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
 use Magento\Eav\Model\Entity\Collection\AbstractCollection;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassSubscribe
@@ -64,7 +64,7 @@ class MassSubscribe extends AbstractMassAction
         }
 
         if ($customersUpdated) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', $customersUpdated));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', $customersUpdated));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassUnsubscribe.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassUnsubscribe.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
-use Magento\Customer\Api\CustomerRepositoryInterface;
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
-use Magento\Newsletter\Model\SubscriberFactory;
-use Magento\Ui\Component\MassAction\Filter;
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
 use Magento\Eav\Model\Entity\Collection\AbstractCollection;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassUnsubscribe
@@ -64,7 +64,7 @@ class MassUnsubscribe extends AbstractMassAction
         }
 
         if ($customersUpdated) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', $customersUpdated));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', $customersUpdated));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
@@ -31,7 +31,9 @@ class ResetPassword extends \Magento\Customer\Controller\Adminhtml\Index
                 \Magento\Customer\Model\AccountManagement::EMAIL_REMINDER,
                 $customer->getWebsiteId()
             );
-            $this->messageManager->addSuccess(__('The customer will receive an email with a link to reset password.'));
+            $this->messageManager->addSuccessMessage(
+                __('The customer will receive an email with a link to reset password.')
+            );
         } catch (NoSuchEntityException $exception) {
             $resultRedirect->setPath('customer/index');
             return $resultRedirect;
@@ -44,7 +46,7 @@ class ResetPassword extends \Magento\Customer\Controller\Adminhtml\Index
         } catch (SecurityViolationException $exception) {
             $this->messageManager->addErrorMessage($exception->getMessage());
         } catch (\Exception $exception) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $exception,
                 __('Something went wrong while resetting customer password.')
             );

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -46,7 +46,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
         }
 
         if (isset($customerData['disable_auto_group_change'])) {
-            $customerData['disable_auto_group_change'] = (int) filter_var(
+            $customerData['disable_auto_group_change'] = (int)filter_var(
                 $customerData['disable_auto_group_change'],
                 FILTER_VALIDATE_BOOLEAN
             );
@@ -87,9 +87,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
         foreach ($formAttributes as $attribute) {
             /** @var \Magento\Customer\Api\Data\AttributeMetadataInterface $attribute */
             $attributeCode = $attribute->getAttributeCode();
-            if ($attribute->getFrontendInput() != 'boolean'
-                && $formData[$attributeCode] === false
-            ) {
+            if ($attribute->getFrontendInput() != 'boolean' && $formData[$attributeCode] === false) {
                 unset($formData[$attributeCode]);
             }
         }
@@ -258,7 +256,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                 $this->_getSession()->unsCustomerFormData();
                 // Done Saving customer, finish save action
                 $this->_coreRegistry->register(RegistryConstants::CURRENT_CUSTOMER_ID, $customerId);
-                $this->messageManager->addSuccess(__('You saved the customer.'));
+                $this->messageManager->addSuccessMessage(__('You saved the customer.'));
                 $returnToEdit = (bool)$this->getRequest()->getParam('back', false);
             } catch (\Magento\Framework\Validator\Exception $exception) {
                 $messages = $exception->getMessages();
@@ -273,7 +271,10 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                 $this->_getSession()->setCustomerFormData($originalRequestData);
                 $returnToEdit = true;
             } catch (\Exception $exception) {
-                $this->messageManager->addException($exception, __('Something went wrong while saving the customer.'));
+                $this->messageManager->addExceptionMessage(
+                    $exception,
+                    __('Something went wrong while saving the customer.')
+                );
                 $this->_getSession()->setCustomerFormData($originalRequestData);
                 $returnToEdit = true;
             }
@@ -362,9 +363,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
     {
         $originalRequestData = $this->getRequest()->getPostValue(CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER);
 
-        $customerId = isset($originalRequestData['entity_id'])
-            ? $originalRequestData['entity_id']
-            : null;
+        $customerId = isset($originalRequestData['entity_id']) ? $originalRequestData['entity_id'] : null;
 
         return $customerId;
     }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Locks/Unlock.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Locks/Unlock.php
@@ -6,9 +6,9 @@
  */
 namespace Magento\Customer\Controller\Adminhtml\Locks;
 
+use Magento\Backend\App\Action;
 use Magento\Customer\Model\AuthenticationInterface;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Backend\App\Action;
 
 /**
  * Unlock Customer Controller
@@ -55,10 +55,10 @@ class Unlock extends \Magento\Backend\App\Action
             // unlock customer
             if ($customerId) {
                 $this->authentication->unlock($customerId);
-                $this->getMessageManager()->addSuccess(__('Customer has been unlocked successfully.'));
+                $this->getMessageManager()->addSuccessMessage(__('Customer has been unlocked successfully.'));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
+++ b/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
@@ -255,7 +255,7 @@ class AfterAddressSaveObserver implements ObserverInterface
                 : (string)__('You will not be charged tax.');
         }
 
-        $this->messageManager->addSuccess(implode(' ', $message));
+        $this->messageManager->addSuccessMessage(implode(' ', $message));
 
         return $this;
     }
@@ -280,7 +280,7 @@ class AfterAddressSaveObserver implements ObserverInterface
             $message[] = (string)__('You will be charged tax.');
         }
 
-        $this->messageManager->addError(implode(' ', $message));
+        $this->messageManager->addErrorMessage(implode(' ', $message));
 
         return $this;
     }
@@ -307,7 +307,7 @@ class AfterAddressSaveObserver implements ObserverInterface
         $email = $this->scopeConfig->getValue('trans_email/ident_support/email', ScopeInterface::SCOPE_STORE);
         $message[] = (string)__('If you believe this is an error, please contact us at %1', $email);
 
-        $this->messageManager->addError(implode(' ', $message));
+        $this->messageManager->addErrorMessage(implode(' ', $message));
 
         return $this;
     }

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
@@ -205,7 +205,7 @@ class ConfirmTest extends \PHPUnit\Framework\TestCase
 
         $exception = new \Exception('Bad request.');
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($this->equalTo($exception), $this->equalTo('There was an error confirming the account'));
 
         $testUrl = 'http://example.com';
@@ -281,7 +281,7 @@ class ConfirmTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->willReturnSelf();
 
@@ -399,7 +399,7 @@ class ConfirmTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePasswordTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePasswordTest.php
@@ -209,7 +209,7 @@ class CreatePasswordTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Exception.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Your password reset link has expired.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePostTest.php
@@ -371,7 +371,7 @@ class CreatePostTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo($customerId));
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->will($this->returnSelf());
 
@@ -502,7 +502,7 @@ class CreatePostTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo($customerId));
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->will($this->returnSelf());
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/EditPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/EditPostTest.php
@@ -280,7 +280,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the account information.'))
             ->willReturnSelf();
 
@@ -358,8 +358,8 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
-            ->with($errorMessage)
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => $errorMessage])
             ->willReturnSelf();
 
         if ($testNumber==1) {
@@ -495,7 +495,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
                 ->willReturnSelf();
 
             $this->messageManager->expects($this->once())
-                ->method('addSuccess')
+                ->method('addSuccessMessage')
                 ->with(__('You saved the account information.'))
                 ->willReturnSelf();
 
@@ -770,7 +770,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
                 ->willThrowException($exception);
 
             $this->messageManager->expects($this->any())
-                ->method('addException')
+                ->method('addExceptionMessage')
                 ->with($exception, __('We can\'t save the customer.'))
                 ->willReturnSelf();
         }
@@ -781,7 +781,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->any())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errors['message'])
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/LoginPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/LoginPostTest.php
@@ -221,7 +221,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
             ->willReturn([]);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('A login and a password are required.'))
             ->willReturnSelf();
 
@@ -550,8 +550,8 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
                     $url
                 );
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
-                    ->with($message)
+                    ->method('addComplexErrorMessage')
+                    ->with('addUnescapedMessage', ['text' => $message])
                     ->willReturnSelf();
 
                 $this->session->expects($this->once())
@@ -562,7 +562,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
 
             case \Magento\Framework\Exception\AuthenticationException::class:
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with(__('You did not sign in correctly or your account is temporarily disabled.'))
                     ->willReturnSelf();
 
@@ -574,7 +574,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
 
             case '\Exception':
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with(__('An unspecified error occurred. Please contact us for assistance.'))
                     ->willReturnSelf();
                 break;
@@ -584,7 +584,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
                     'You did not sign in correctly or your account is temporarily disabled.'
                 );
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($message)
                     ->willReturnSelf();
                 $this->session->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ResetPasswordPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ResetPasswordPostTest.php
@@ -126,7 +126,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             ->method('unsRpCustomerId');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You updated your password.'))
             ->willReturnSelf();
 
@@ -192,7 +192,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Exception.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Something went wrong while saving the new password.'))
             ->willReturnSelf();
 
@@ -261,7 +261,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\InputException(__('InputException.')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('InputException.'))
             ->willReturnSelf();
 
@@ -308,7 +308,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('New Password and Confirm New Password values didn\'t match.'))
             ->willReturnSelf();
 
@@ -355,7 +355,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Please enter a new password.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Address/DeleteTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Address/DeleteTest.php
@@ -146,7 +146,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->method('deleteById')
             ->with($addressId);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You deleted the address.'));
         $this->resultRedirect->expects($this->once())
             ->method('setPath')
@@ -183,11 +183,11 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(34);
         $exception = new \Exception('Exception');
         $this->messageManager->expects($this->once())
-            ->method('addError')
-            ->with(__('We can\'t delete the address right now.'))
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => __('We can\'t delete the address right now.')])
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('We can\'t delete the address right now.'));
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Customer/Test/Unit/Controller/Address/FormPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Address/FormPostTest.php
@@ -549,7 +549,7 @@ class FormPostTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the address.'))
             ->willReturnSelf();
 
@@ -637,7 +637,7 @@ class FormPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new InputException(__('InputException')));
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('InputException')
             ->willReturnSelf();
 
@@ -700,7 +700,7 @@ class FormPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('We can\'t save the address.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Group/SaveTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Group/SaveTest.php
@@ -7,8 +7,8 @@ namespace Magento\Customer\Test\Unit\Controller\Adminhtml\Group;
 
 use Magento\Customer\Api\Data\GroupInterfaceFactory;
 use Magento\Customer\Controller\Adminhtml\Group\Save;
-use Magento\Framework\Controller\Result\RedirectFactory;
 use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\Result\RedirectFactory;
 use Magento\Framework\Reflection\DataObjectProcessor;
 
 /**
@@ -167,7 +167,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('save')
             ->with($this->group);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the customer group.'));
         $exception = new \Exception('Exception');
         $this->resultRedirect->expects($this->at(0))
@@ -175,7 +175,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with('customer/group')
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Exception');
         $this->dataObjectProcessorMock->expects($this->once())
             ->method('buildOutputDataArray')

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
@@ -312,7 +312,7 @@ class InlineEditTest extends \PHPUnit\Framework\TestCase
             ->with($this->customerData)
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('[Customer ID: 12] Exception message');
         $this->logger->expects($this->once())
             ->method('critical')
@@ -334,7 +334,7 @@ class InlineEditTest extends \PHPUnit\Framework\TestCase
             ->with($this->customerData)
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('[Customer ID: 12] We can\'t save the customer.');
         $this->logger->expects($this->once())
             ->method('critical')

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassAssignGroupTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassAssignGroupTest.php
@@ -157,7 +157,7 @@ class MassAssignGroupTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, $customerMock], [11, $customerMock], [12, $customerMock]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were updated.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -181,7 +181,7 @@ class MassAssignGroupTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassDeleteTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassDeleteTest.php
@@ -155,7 +155,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, true], [11, true], [12, true]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were deleted.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -179,7 +179,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassSubscribeTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassSubscribeTest.php
@@ -171,7 +171,7 @@ class MassSubscribeTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, true], [11, true], [12, true]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were updated.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -195,7 +195,7 @@ class MassSubscribeTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassUnsubscribeTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassUnsubscribeTest.php
@@ -171,7 +171,7 @@ class MassUnsubscribeTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, true], [11, true], [12, true]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were updated.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -195,7 +195,7 @@ class MassUnsubscribeTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/NewsletterTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/NewsletterTest.php
@@ -150,7 +150,7 @@ class NewsletterTest extends \PHPUnit\Framework\TestCase
         $this->messageManager = $this->getMockBuilder(
             \Magento\Framework\Message\Manager::class
         )->disableOriginalConstructor()->setMethods(
-            ['addSuccess', 'addMessage', 'addException']
+            ['addSuccessMessage', 'addMessage', 'addExceptionMessage']
         )->getMock();
 
         $contextArgs = [

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/ResetPasswordTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/ResetPasswordTest.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Customer\Test\Unit\Controller\Adminhtml\Index;
 
-use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\AccountManagement;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -141,7 +140,7 @@ class ResetPasswordTest extends \PHPUnit\Framework\TestCase
         $this->messageManager = $this->getMockBuilder(
             \Magento\Framework\Message\Manager::class
         )->disableOriginalConstructor()->setMethods(
-            ['addSuccess', 'addMessage', 'addException', 'addErrorMessage']
+            ['addSuccessMessage', 'addMessage', 'addExceptionMessage', 'addErrorMessage']
         )->getMock();
 
         $this->resultRedirectFactoryMock = $this->getMockBuilder(
@@ -442,7 +441,7 @@ class ResetPasswordTest extends \PHPUnit\Framework\TestCase
         $this->messageManager->expects(
             $this->once()
         )->method(
-            'addException'
+            'addExceptionMessage'
         )->with(
             $this->equalTo($exception),
             $this->equalTo('Something went wrong while resetting customer password.')
@@ -502,7 +501,7 @@ class ResetPasswordTest extends \PHPUnit\Framework\TestCase
         $this->messageManager->expects(
             $this->once()
         )->method(
-            'addSuccess'
+            'addSuccessMessage'
         )->with(
             $this->equalTo('The customer will receive an email with a link to reset password.')
         );

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/SaveTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/SaveTest.php
@@ -574,7 +574,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with(RegistryConstants::CURRENT_CUSTOMER_ID, $customerId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the customer.'))
             ->willReturnSelf();
 
@@ -841,7 +841,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with(RegistryConstants::CURRENT_CUSTOMER_ID, $customerId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the customer.'))
             ->willReturnSelf();
 
@@ -982,7 +982,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('register');
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->messageManagerMock->expects($this->once())
             ->method('addMessage')
@@ -1125,7 +1125,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('register');
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->messageManagerMock->expects($this->once())
             ->method('addMessage')
@@ -1269,10 +1269,10 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('register');
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('Something went wrong while saving the customer.'));
 
         $this->sessionMock->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Locks/UnlockTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Locks/UnlockTest.php
@@ -118,7 +118,7 @@ class UnlockTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('customer_id'))
             ->will($this->returnValue($customerId));
         $this->authenticationMock->expects($this->once())->method('unlock')->with($customerId);
-        $this->messageManagerMock->expects($this->once())->method('addSuccess');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
         $this->redirectMock->expects($this->once())
             ->method('setPath')
             ->with($this->equalTo('customer/index/edit'))
@@ -141,7 +141,7 @@ class UnlockTest extends \PHPUnit\Framework\TestCase
             ->method('unlock')
             ->with($customerId)
             ->willThrowException(new \Exception($phrase));
-        $this->messageManagerMock->expects($this->once())->method('addError');
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
         $this->controller->execute();
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Observer/AfterAddressSaveObserverTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Observer/AfterAddressSaveObserverTest.php
@@ -572,7 +572,7 @@ class AfterAddressSaveObserverTest extends \PHPUnit\Framework\TestCase
 
         if ($resultValidMessage) {
             $this->messageManager->expects($this->once())
-                ->method('addSuccess')
+                ->method('addSuccessMessage')
                 ->with($resultValidMessage)
                 ->willReturnSelf();
         }
@@ -582,7 +582,7 @@ class AfterAddressSaveObserverTest extends \PHPUnit\Framework\TestCase
                 ->with($vatId)
                 ->willReturn($vatId);
             $this->messageManager->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with($resultInvalidMessage)
                 ->willReturnSelf();
         }
@@ -592,7 +592,7 @@ class AfterAddressSaveObserverTest extends \PHPUnit\Framework\TestCase
                 ->with('trans_email/ident_support/email', ScopeInterface::SCOPE_STORE)
                 ->willReturn('admin@example.com');
             $this->messageManager->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with($resultErrorMessage)
                 ->willReturnSelf();
         }

--- a/app/code/Magento/Developer/Model/Config/Backend/AllowedIps.php
+++ b/app/code/Magento/Developer/Model/Config/Backend/AllowedIps.php
@@ -77,7 +77,7 @@ class AllowedIps extends \Magento\Framework\App\Config\Value
 
         $noticeMsg = implode(',', $noticeMsgArray);
         if (!empty($noticeMsgArray)) {
-            $this->messageManager->addNotice(
+            $this->messageManager->addNoticeMessage(
                 __(
                     __('The following invalid values cannot be saved: %values', ['values' => $noticeMsg])
                 )

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Link.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Link.php
@@ -116,7 +116,7 @@ class Link extends \Magento\Catalog\Controller\Adminhtml\Product\Edit
             try {
                 $this->_processDownload($resource, $resourceType);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
             }
         }
     }

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Sample.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Sample.php
@@ -54,7 +54,7 @@ class Sample extends \Magento\Downloadable\Controller\Adminhtml\Downloadable\Pro
             try {
                 $this->_processDownload($resource, $resourceType);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
             }
         }
     }

--- a/app/code/Magento/Downloadable/Controller/Download/Link.php
+++ b/app/code/Magento/Downloadable/Controller/Download/Link.php
@@ -44,7 +44,7 @@ class Link extends \Magento\Downloadable\Controller\Download
             'link_hash'
         );
         if (!$linkPurchasedItem->getId()) {
-            $this->messageManager->addNotice(__("We can't find the link you requested."));
+            $this->messageManager->addNoticeMessage(__("We can't find the link you requested."));
             return $this->_redirect('*/customer/products');
         }
         if (!$this->_objectManager->get(\Magento\Downloadable\Helper\Data::class)->getIsShareable($linkPurchasedItem)) {
@@ -65,7 +65,12 @@ class Link extends \Magento\Downloadable\Controller\Download
                 } else {
                     $notice = __('Please sign in to download your product.');
                 }
-                $this->messageManager->addNotice($notice);
+                $this->messageManager->addComplexNoticeMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $notice,
+                    ]
+                );
                 $session->authenticate();
                 $session->setBeforeAuthUrl(
                     $this->_objectManager->create(
@@ -84,7 +89,7 @@ class Link extends \Magento\Downloadable\Controller\Download
                 $linkPurchasedItem->getPurchasedId()
             );
             if ($linkPurchased->getCustomerId() != $customerId) {
-                $this->messageManager->addNotice(__("We can't find the link you requested."));
+                $this->messageManager->addNoticeMessage(__("We can't find the link you requested."));
                 return $this->_redirect('*/customer/products');
             }
         }
@@ -119,15 +124,15 @@ class Link extends \Magento\Downloadable\Controller\Download
                 $linkPurchasedItem->save();
                 exit(0);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
             }
         } elseif ($status == PurchasedLink::LINK_STATUS_EXPIRED) {
-            $this->messageManager->addNotice(__('The link has expired.'));
+            $this->messageManager->addNoticeMessage(__('The link has expired.'));
         } elseif ($status == PurchasedLink::LINK_STATUS_PENDING || $status == PurchasedLink::LINK_STATUS_PAYMENT_REVIEW
         ) {
-            $this->messageManager->addNotice(__('The link is not available.'));
+            $this->messageManager->addNoticeMessage(__('The link is not available.'));
         } else {
-            $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
         }
         return $this->_redirect('*/customer/products');
     }

--- a/app/code/Magento/Downloadable/Controller/Download/LinkSample.php
+++ b/app/code/Magento/Downloadable/Controller/Download/LinkSample.php
@@ -41,7 +41,7 @@ class LinkSample extends \Magento\Downloadable\Controller\Download
                 $this->_processDownload($resource, $resourceType);
                 exit(0);
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Sorry, there was an error getting requested content. Please contact the store owner.')
                 );
             }

--- a/app/code/Magento/Downloadable/Controller/Download/Sample.php
+++ b/app/code/Magento/Downloadable/Controller/Download/Sample.php
@@ -38,7 +38,7 @@ class Sample extends \Magento\Downloadable\Controller\Download
                 $this->_processDownload($resource, $resourceType);
                 exit(0);
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Sorry, there was an error getting requested content. Please contact the store owner.')
                 );
             }

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkSampleTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkSampleTest.php
@@ -146,7 +146,7 @@ class LinkSampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');
@@ -193,7 +193,7 @@ class LinkSampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
@@ -175,7 +175,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with("We can't find the link you requested.");
         $this->redirect->expects($this->once())->method('redirect')->with($this->response, '*/customer/products', []);
 
@@ -216,9 +216,11 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->product->expects($this->once())->method('getId')->willReturn('product_id');
         $this->product->expects($this->once())->method('getProductUrl')->willReturn('product_url');
         $this->product->expects($this->once())->method('getName')->willReturn('product_name');
+        $message = 'Please sign in to download your product or purchase <a href="product_url">product_name</a>.';
         $this->messageManager->expects($this->once())
-            ->method('addNotice')
-            ->with('Please sign in to download your product or purchase <a href="product_url">product_name</a>.');
+            ->method('addComplexNoticeMessage')
+            ->with('addUnescapedMessage', ['text' => $message])
+            ->willReturnSelf();
         $this->session->expects($this->once())->method('authenticate')->willReturn(true);
         $this->objectManager->expects($this->at(4))
             ->method('create')
@@ -266,7 +268,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->linkPurchased->expects($this->once())->method('load')->with('purchased_id')->willReturnSelf();
         $this->linkPurchased->expects($this->once())->method('getCustomerId')->willReturn('other_customer_id');
         $this->messageManager->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with("We can't find the link you requested.");
         $this->redirect->expects($this->once())->method('redirect')->with($this->response, '*/customer/products', []);
 
@@ -309,7 +311,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->linkPurchasedItem->expects($this->any())->method('setStatus')->with('expired')->willReturnSelf();
         $this->linkPurchasedItem->expects($this->any())->method('save')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Something went wrong while getting the requested content.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('redirect')->with($this->response, '*/customer/products', []);
@@ -400,10 +402,10 @@ class LinkTest extends \PHPUnit\Framework\TestCase
     public function linkNotAvailableDataProvider()
     {
         return [
-            ['addNotice', 'expired', 'The link has expired.'],
-            ['addNotice', 'pending', 'The link is not available.'],
-            ['addNotice', 'payment_review', 'The link is not available.'],
-            ['addError', 'wrong_status', 'Something went wrong while getting the requested content.']
+            ['addNoticeMessage', 'expired', 'The link has expired.'],
+            ['addNoticeMessage', 'pending', 'The link is not available.'],
+            ['addNoticeMessage', 'payment_review', 'The link is not available.'],
+            ['addErrorMessage', 'wrong_status', 'Something went wrong while getting the requested content.']
         ];
     }
 }

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/SampleTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/SampleTest.php
@@ -146,7 +146,7 @@ class SampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');
@@ -189,7 +189,7 @@ class SampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Delete.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Delete.php
@@ -22,21 +22,21 @@ class Delete extends \Magento\Email\Controller\Adminhtml\Email\Template
                 if (count($template->getSystemConfigPathsWhereCurrentlyUsed()) == 0) {
                     $template->delete();
                     // display success message
-                    $this->messageManager->addSuccess(__('You deleted the email template.'));
+                    $this->messageManager->addSuccessMessage(__('You deleted the email template.'));
                     $this->_objectManager->get(\Magento\Framework\App\ReinitableConfig::class)->reinit();
                     // go to grid
                     $this->_redirect('adminhtml/*/');
                     return;
                 }
                 // display error  message
-                $this->messageManager->addError(__('The email template is currently being used.'));
+                $this->messageManager->addErrorMessage(__('The email template is currently being used.'));
                 // redirect to edit form
                 $this->_redirect('adminhtml/*/edit', ['id' => $template->getId()]);
                 return;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete email template data right now. Please review log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -52,7 +52,7 @@ class Delete extends \Magento\Email\Controller\Adminhtml\Email\Template
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find an email template to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find an email template to delete.'));
         // go to grid
         $this->_redirect('adminhtml/*/');
     }

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Preview.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Preview.php
@@ -21,7 +21,9 @@ class Preview extends \Magento\Email\Controller\Adminhtml\Email\Template
             $this->_view->renderLayout();
             $this->getResponse()->setHeader('Content-Security-Policy', "script-src 'none'");
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred. The email template can not be opened for preview.'));
+            $this->messageManager->addErrorMessage(
+                __('An error occurred. The email template can not be opened for preview.')
+            );
             $this->_redirect('adminhtml/*/');
         }
     }

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Save.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Save.php
@@ -22,7 +22,7 @@ class Save extends \Magento\Email\Controller\Adminhtml\Email\Template
 
         $template = $this->_initTemplate('id');
         if (!$template->getId() && $id) {
-            $this->messageManager->addError(__('This email template no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This email template no longer exists.'));
             $this->_redirect('adminhtml/*/');
             return;
         }
@@ -55,7 +55,7 @@ class Save extends \Magento\Email\Controller\Adminhtml\Email\Template
 
             $template->save();
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData(false);
-            $this->messageManager->addSuccess(__('You saved the email template.'));
+            $this->messageManager->addSuccessMessage(__('You saved the email template.'));
             $this->_redirect('adminhtml/*');
         } catch (\Exception $e) {
             $this->_objectManager->get(
@@ -64,7 +64,7 @@ class Save extends \Magento\Email\Controller\Adminhtml\Email\Template
                 'email_template_form_data',
                 $request->getParams()
             );
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_forward('new');
         }
     }

--- a/app/code/Magento/EncryptionKey/Controller/Adminhtml/Crypt/Key/Index.php
+++ b/app/code/Magento/EncryptionKey/Controller/Adminhtml/Crypt/Key/Index.php
@@ -21,7 +21,7 @@ class Index extends \Magento\EncryptionKey\Controller\Adminhtml\Crypt\Key
         /** @var \Magento\Framework\App\DeploymentConfig\Writer $writer */
         $writer = $this->_objectManager->get(\Magento\Framework\App\DeploymentConfig\Writer::class);
         if (!$writer->checkIfWritable()) {
-            $this->messageManager->addError(__('Deployment configuration file is not writable.'));
+            $this->messageManager->addErrorMessage(__('Deployment configuration file is not writable.'));
         }
 
         $this->_view->loadLayout();

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/Export.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/Export.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\ImportExport\Controller\Adminhtml\Export;
 
-use Magento\Framework\Controller\ResultFactory;
-use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\App\Response\Http\FileFactory;
-use Magento\ImportExport\Model\Export as ExportModel;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
+use Magento\ImportExport\Model\Export as ExportModel;
 
 class Export extends ExportController
 {
@@ -62,13 +62,13 @@ class Export extends ExportController
                     $model->getContentType()
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                $this->messageManager->addError(__('Please correct the data sent value.'));
+                $this->messageManager->addErrorMessage(__('Please correct the data sent value.'));
             }
         } else {
-            $this->messageManager->addError(__('Please correct the data sent value.'));
+            $this->messageManager->addErrorMessage(__('Please correct the data sent value.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/GetFilter.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/GetFilter.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\ImportExport\Controller\Adminhtml\Export;
 
-use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 
 class GetFilter extends ExportController
 {
@@ -33,10 +33,10 @@ class GetFilter extends ExportController
                 );
                 return $resultLayout;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } else {
-            $this->messageManager->addError(__('Please correct the data sent value.'));
+            $this->messageManager->addErrorMessage(__('Please correct the data sent value.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\ImportExport\Controller\Adminhtml\Import;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\ImportExport\Controller\Adminhtml\Import as ImportController;
-use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Download sample file controller
@@ -76,7 +76,7 @@ class Download extends ImportController
 
         if (!$directoryRead->isFile($filePath)) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
-            $this->messageManager->addError(__('There is no sample file for this entity.'));
+            $this->messageManager->addErrorMessage(__('There is no sample file for this entity.'));
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('*/import');
             return $resultRedirect;

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Index.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Index.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\ImportExport\Controller\Adminhtml\Import;
 
-use Magento\ImportExport\Controller\Adminhtml\Import as ImportController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\ImportExport\Controller\Adminhtml\Import as ImportController;
 
 class Index extends ImportController
 {
@@ -17,8 +17,12 @@ class Index extends ImportController
      */
     public function execute()
     {
-        $this->messageManager->addNotice(
-            $this->_objectManager->get(\Magento\ImportExport\Helper\Data::class)->getMaxUploadSizeMessage()
+        $message = $this->_objectManager->get(\Magento\ImportExport\Helper\Data::class)->getMaxUploadSizeMessage();
+        $this->messageManager->addComplexNoticeMessage(
+            'addUnescapedMessage',
+            [
+                'text' => $message,
+            ]
         );
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Validate.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Validate.php
@@ -5,11 +5,11 @@
  */
 namespace Magento\ImportExport\Controller\Adminhtml\Import;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\ImportExport\Block\Adminhtml\Import\Frame\Result;
 use Magento\ImportExport\Controller\Adminhtml\ImportResult as ImportResultController;
 use Magento\ImportExport\Model\Import;
-use Magento\ImportExport\Block\Adminhtml\Import\Frame\Result;
-use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\ImportExport\Model\Import\Adapter as ImportAdapter;
 use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregatorInterface;
 
@@ -59,7 +59,7 @@ class Validate extends ImportResultController
             $resultBlock->addError(__('The file was not uploaded.'));
             return $resultLayout;
         }
-        $this->messageManager->addError(__('Sorry, but the data is invalid or the file is not uploaded.'));
+        $this->messageManager->addErrorMessage(__('Sorry, but the data is invalid or the file is not uploaded.'));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $resultRedirect->setPath('adminhtml/*/index');

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Import/ValidateTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Import/ValidateTest.php
@@ -144,7 +144,7 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
             ]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Sorry, but the data is invalid or the file is not uploaded.'));
 
         $this->assertEquals($resultRedirectMock, $this->validate->execute());

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
@@ -17,7 +17,7 @@ class MassChangelog extends \Magento\Indexer\Controller\Adminhtml\Indexer
     {
         $indexerIds = $this->getRequest()->getParam('indexer_ids');
         if (!is_array($indexerIds)) {
-            $this->messageManager->addError(__('Please select indexers.'));
+            $this->messageManager->addErrorMessage(__('Please select indexers.'));
         } else {
             try {
                 foreach ($indexerIds as $indexerId) {
@@ -27,13 +27,13 @@ class MassChangelog extends \Magento\Indexer\Controller\Adminhtml\Indexer
                     )->get($indexerId);
                     $model->setScheduled(true);
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('%1 indexer(s) are in "Update by Schedule" mode.', count($indexerIds))
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __("We couldn't change indexer(s)' mode because of an error.")
                 );

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
@@ -17,7 +17,7 @@ class MassOnTheFly extends \Magento\Indexer\Controller\Adminhtml\Indexer
     {
         $indexerIds = $this->getRequest()->getParam('indexer_ids');
         if (!is_array($indexerIds)) {
-            $this->messageManager->addError(__('Please select indexers.'));
+            $this->messageManager->addErrorMessage(__('Please select indexers.'));
         } else {
             try {
                 foreach ($indexerIds as $indexerId) {
@@ -27,13 +27,13 @@ class MassOnTheFly extends \Magento\Indexer\Controller\Adminhtml\Indexer
                     )->get($indexerId);
                     $model->setScheduled(false);
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('%1 indexer(s) are in "Update on Save" mode.', count($indexerIds))
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __("We couldn't change indexer(s)' mode because of an error.")
                 );

--- a/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassChangelogTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassChangelogTest.php
@@ -147,7 +147,7 @@ class MassChangelogTest extends \PHPUnit\Framework\TestCase
         $this->title = $this->createMock(\Magento\Framework\View\Page\Title::class);
         $this->messageManager = $this->getMockForAbstractClass(
             \Magento\Framework\Message\ManagerInterface::class,
-            ['addError', 'addSuccess'],
+            ['addErrorMessage', 'addSuccessMessage'],
             '',
             false
         );
@@ -181,7 +181,7 @@ class MassChangelogTest extends \PHPUnit\Framework\TestCase
 
         if (!is_array($indexerIds)) {
             $this->messageManager->expects($this->once())
-                ->method('addError')->with(__('Please select indexers.'))
+                ->method('addErrorMessage')->with(__('Please select indexers.'))
                 ->will($this->returnValue(1));
         } else {
             $this->objectManager->expects($this->any())
@@ -205,15 +205,15 @@ class MassChangelogTest extends \PHPUnit\Framework\TestCase
                     ->method('setScheduled')->with(true)->will($this->returnValue(1));
             }
 
-            $this->messageManager->expects($this->any())->method('addSuccess')->will($this->returnValue(1));
+            $this->messageManager->expects($this->any())->method('addSuccessMessage')->will($this->returnValue(1));
 
             if ($exception !== null) {
                 $this->messageManager
                     ->expects($this->exactly($expectsExceptionValues[2]))
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($exception->getMessage());
                 $this->messageManager->expects($this->exactly($expectsExceptionValues[1]))
-                    ->method('addException')
+                    ->method('addExceptionMessage')
                     ->with($exception, "We couldn't change indexer(s)' mode because of an error.");
             }
         }

--- a/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
@@ -150,7 +150,7 @@ class MassOnTheFlyTest extends \PHPUnit\Framework\TestCase
         $this->title = $this->createMock(\Magento\Framework\View\Page\Title::class);
         $this->messageManager = $this->getMockForAbstractClass(
             \Magento\Framework\Message\ManagerInterface::class,
-            ['addError', 'addSuccess'],
+            ['addErrorMessage', 'addSuccessMessage'],
             '',
             false
         );
@@ -184,7 +184,7 @@ class MassOnTheFlyTest extends \PHPUnit\Framework\TestCase
 
         if (!is_array($indexerIds)) {
             $this->messageManager->expects($this->once())
-                ->method('addError')->with(__('Please select indexers.'))
+                ->method('addErrorMessage')->with(__('Please select indexers.'))
                 ->will($this->returnValue(1));
         } else {
             $this->objectManager->expects($this->any())
@@ -208,14 +208,14 @@ class MassOnTheFlyTest extends \PHPUnit\Framework\TestCase
                     ->method('setScheduled')->with(false)->will($this->returnValue(1));
             }
 
-            $this->messageManager->expects($this->any())->method('addSuccess')->will($this->returnValue(1));
+            $this->messageManager->expects($this->any())->method('addSuccessMessage')->will($this->returnValue(1));
 
             if ($exception !== null) {
                 $this->messageManager->expects($this->exactly($expectsExceptionValues[2]))
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($exception->getMessage());
                 $this->messageManager->expects($this->exactly($expectsExceptionValues[1]))
-                    ->method('addException')
+                    ->method('addExceptionMessage')
                     ->with($exception, "We couldn't change indexer(s)' mode because of an error.");
             }
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Delete.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Delete.php
@@ -6,9 +6,9 @@
  */
 namespace Magento\Integration\Controller\Adminhtml\Integration;
 
-use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
-use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\IntegrationException;
+use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 
 class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
 {
@@ -26,7 +26,7 @@ class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
             if ($integrationId) {
                 $integrationData = $this->_integrationService->get($integrationId);
                 if ($this->_integrationData->isConfigType($integrationData)) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __(
                             "Uninstall the extension to remove integration '%1'.",
                             $this->escaper->escapeHtml($integrationData[Info::DATA_NAME])
@@ -36,14 +36,14 @@ class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
                 }
                 $integrationData = $this->_integrationService->delete($integrationId);
                 if (!$integrationData[Info::DATA_ID]) {
-                    $this->messageManager->addError(__('This integration no longer exists.'));
+                    $this->messageManager->addErrorMessage(__('This integration no longer exists.'));
                 } else {
                     //Integration deleted successfully, now safe to delete the associated consumer data
                     if (isset($integrationData[Info::DATA_CONSUMER_ID])) {
                         $this->_oauthService->deleteConsumer($integrationData[Info::DATA_CONSUMER_ID]);
                     }
                     $this->_registry->register(self::REGISTRY_KEY_CURRENT_INTEGRATION, $integrationData);
-                    $this->messageManager->addSuccess(
+                    $this->messageManager->addSuccessMessage(
                         __(
                             "The integration '%1' has been deleted.",
                             $this->escaper->escapeHtml($integrationData[Info::DATA_NAME])
@@ -51,10 +51,10 @@ class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
                     );
                 }
             } else {
-                $this->messageManager->addError(__('Integration ID is not specified or is invalid.'));
+                $this->messageManager->addErrorMessage(__('Integration ID is not specified or is invalid.'));
             }
         } catch (IntegrationException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_logger->critical($e);
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Edit.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Edit.php
@@ -7,8 +7,8 @@
 namespace Magento\Integration\Controller\Adminhtml\Integration;
 
 use Magento\Backend\App\Action;
-use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 use Magento\Framework\Exception\IntegrationException;
+use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 
 class Edit extends \Magento\Integration\Controller\Adminhtml\Integration
 {
@@ -26,12 +26,12 @@ class Edit extends \Magento\Integration\Controller\Adminhtml\Integration
                 $integrationData = $this->_integrationService->get($integrationId)->getData();
                 $originalName = $this->escaper->escapeHtml($integrationData[Info::DATA_NAME]);
             } catch (IntegrationException $e) {
-                $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+                $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
                 $this->_redirect('*/*/');
                 return;
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
-                $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+                $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
                 $this->_redirect('*/*');
                 return;
             }
@@ -40,7 +40,7 @@ class Edit extends \Magento\Integration\Controller\Adminhtml\Integration
                 $integrationData = array_merge($integrationData, $restoredIntegration);
             }
         } else {
-            $this->messageManager->addError(__('Integration ID is not specified or is invalid.'));
+            $this->messageManager->addErrorMessage(__('Integration ID is not specified or is invalid.'));
             $this->_redirect('*/*/');
             return;
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Index.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Index.php
@@ -18,7 +18,7 @@ class Index extends \Magento\Integration\Controller\Adminhtml\Integration
         $unsecureIntegrationsCount = $this->_integrationCollection->addUnsecureUrlsFilter()->getSize();
         if ($unsecureIntegrationsCount > 0) {
             // @codingStandardsIgnoreStart
-            $this->messageManager->addNotice(__('Warning! Integrations not using HTTPS are insecure and potentially expose private or personally identifiable information')
+            $this->messageManager->addNoticeMessage(__('Warning! Integrations not using HTTPS are insecure and potentially expose private or personally identifiable information')
             // @codingStandardsIgnoreEnd
             );
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/PermissionsDialog.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/PermissionsDialog.php
@@ -23,17 +23,17 @@ class PermissionsDialog extends \Magento\Integration\Controller\Adminhtml\Integr
                 $integrationData = $this->_integrationService->get($integrationId)->getData();
                 $this->_registry->register(self::REGISTRY_KEY_CURRENT_INTEGRATION, $integrationData);
             } catch (IntegrationException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('*/*/');
                 return;
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
-                $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+                $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
                 $this->_redirect('*/*');
                 return;
             }
         } else {
-            $this->messageManager->addError(__('Integration ID is not specified or is invalid.'));
+            $this->messageManager->addErrorMessage(__('Integration ID is not specified or is invalid.'));
             $this->_redirect('*/*/');
             return;
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Save.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Save.php
@@ -5,11 +5,11 @@
  */
 namespace Magento\Integration\Controller\Adminhtml\Integration;
 
-use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Integration\Model\Integration as IntegrationModel;
 use Magento\Framework\Exception\State\UserLockedException;
+use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
+use Magento\Integration\Model\Integration as IntegrationModel;
 use Magento\Security\Model\SecurityCookie;
 
 /**
@@ -68,19 +68,19 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
             );
             $this->_redirect('*');
         } catch (\Magento\Framework\Exception\AuthenticationException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_getSession()->setIntegrationData($this->getRequest()->getPostValue());
             $this->_redirectOnSaveError();
         } catch (IntegrationException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_getSession()->setIntegrationData($integrationData);
             $this->_redirectOnSaveError();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_redirectOnSaveError();
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_redirectOnSaveError();
         }
     }
@@ -114,12 +114,12 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
         try {
             $integrationData = $this->_integrationService->get($integrationId)->getData();
         } catch (IntegrationException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_redirect('*/*/');
             return null;
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+            $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
             $this->_redirect('*/*');
             return null;
         }
@@ -163,11 +163,14 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
                 $integration = $this->_integrationService->update($integrationData);
             }
             if (!$this->getRequest()->isXmlHttpRequest()) {
-                $this->messageManager->addSuccess(
-                    __(
-                        'The integration \'%1\' has been saved.',
-                        $this->escaper->escapeHtml($integration->getName())
-                    )
+                $this->messageManager->addComplexSuccessMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => __(
+                            'The integration \'%1\' has been saved.',
+                            $this->escaper->escapeHtml($integration->getName())
+                        ),
+                    ]
                 );
                 $this->_redirect('*/*/');
             } else {
@@ -179,7 +182,7 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
                 );
             }
         } else {
-            $this->messageManager->addError(__('The integration was not saved.'));
+            $this->messageManager->addErrorMessage(__('The integration was not saved.'));
         }
     }
 }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensDialog.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensDialog.php
@@ -27,7 +27,7 @@ class TokensDialog extends \Magento\Integration\Controller\Adminhtml\Integration
             "The integration '%1' has been activated.",
             $integrationName
         );
-        $this->messageManager->addSuccess($successMsg);
+        $this->messageManager->addSuccessMessage($successMsg);
     }
 
     /**
@@ -50,12 +50,12 @@ class TokensDialog extends \Magento\Integration\Controller\Adminhtml\Integration
                 $this->_integrationService->get($integrationId)->getData()
             );
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*');
             return;
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+            $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
             $this->_redirect('*/*');
             return;
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensExchange.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensExchange.php
@@ -27,7 +27,7 @@ class TokensExchange extends \Magento\Integration\Controller\Adminhtml\Integrati
             "Integration '%1' has been sent for activation.",
             $integrationName
         );
-        $this->messageManager->addNotice($msg);
+        $this->messageManager->addNoticeMessage($msg);
     }
 
     /**
@@ -68,12 +68,12 @@ class TokensExchange extends \Magento\Integration\Controller\Adminhtml\Integrati
             ];
             $this->getResponse()->representJson($this->jsonHelper->jsonEncode($result));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*');
             return;
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+            $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
             $this->_redirect('*/*');
             return;
         }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/DeleteTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/DeleteTest.php
@@ -6,9 +6,9 @@
 
 namespace Magento\Integration\Test\Unit\Controller\Adminhtml\Integration;
 
+use Magento\Framework\Exception\IntegrationException;
 use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 use Magento\Integration\Model\Integration as IntegrationModel;
-use Magento\Framework\Exception\IntegrationException;
 
 class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\IntegrationTest
 {
@@ -55,7 +55,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_translateModelMock = null;
         // verify success message
         $this->_messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The integration \'%1\' has been deleted.', $intData[Info::DATA_NAME]));
 
         $this->_escaper->expects($this->once())
@@ -88,7 +88,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_translateModelMock = null;
         // verify success message
         $this->_messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The integration \'%1\' has been deleted.', $intData[Info::DATA_NAME]));
 
         $this->_escaper->expects($this->once())
@@ -115,13 +115,13 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
             ->willReturn(true);
         // verify error message
         $this->_messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Uninstall the extension to remove integration \'%1\'.', $intData[Info::DATA_NAME]));
         $this->_integrationSvcMock->expects($this->never())->method('delete');
         // Use real translate model
         $this->_translateModelMock = null;
         // verify success message
-        $this->_messageManager->expects($this->never())->method('addSuccess');
+        $this->_messageManager->expects($this->never())->method('addSuccessMessage');
 
         $this->_escaper->expects($this->once())
             ->method('escapeHtml')
@@ -138,7 +138,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_translateModelMock = null;
         // verify error message
         $this->_messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Integration ID is not specified or is invalid.'));
 
         $this->integrationController->execute();
@@ -161,7 +161,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_integrationSvcMock->expects($this->once())
             ->method('delete')
             ->willThrowException($invalidIdException);
-        $this->_messageManager->expects($this->once())->method('addError');
+        $this->_messageManager->expects($this->once())->method('addErrorMessage');
 
         $this->integrationController->execute();
     }
@@ -183,7 +183,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_integrationSvcMock->expects($this->once())
             ->method('delete')
             ->willThrowException($invalidIdException);
-        $this->_messageManager->expects($this->never())->method('addError');
+        $this->_messageManager->expects($this->never())->method('addErrorMessage');
 
         $this->integrationController->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/EditTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/EditTest.php
@@ -6,8 +6,8 @@
 
 namespace Magento\Integration\Test\Unit\Controller\Adminhtml\Integration;
 
-use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 use Magento\Framework\Exception\IntegrationException;
+use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 
 class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\IntegrationTest
 {
@@ -42,16 +42,13 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
                     ['setIntegrationData'],
                     [
                         'getIntegrationData',
-                        [Info::DATA_ID => self::INTEGRATION_ID, Info::DATA_NAME => 'testIntegration']
+                        [Info::DATA_ID => self::INTEGRATION_ID, Info::DATA_NAME => 'testIntegration'],
                     ],
                 ]
             )
         );
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
-        $this->pageTitleMock->expects($this->atLeastOnce())
-            ->method('prepend');
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
+        $this->pageTitleMock->expects($this->atLeastOnce())->method('prepend');
         $this->_verifyLoadAndRenderLayout();
         $controller = $this->_createIntegrationController('Edit');
         $controller->execute();
@@ -61,7 +58,9 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'This integration no longer exists.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $this->_requestMock->expects($this->any())->method('getParam')->will($this->returnValue(self::INTEGRATION_ID));
         // put data in session, the magic function getFormData is called so, must match __call method name
         $this->_backendSessionMock->expects(
@@ -80,9 +79,7 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
         )->will(
             $this->throwException($invalidIdException)
         );
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
         $this->_verifyLoadAndRenderLayout();
         $integrationContr = $this->_createIntegrationController('Edit');
         $integrationContr->execute();
@@ -92,7 +89,9 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'Integration ID is not specified or is invalid.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $this->_verifyLoadAndRenderLayout();
         $integrationContr = $this->_createIntegrationController('Edit');
         $integrationContr->execute();
@@ -102,7 +101,9 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'Integration ID is not specified or is invalid.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $this->_controller = $this->_createIntegrationController('Edit');
         $this->_controller->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/SaveTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/SaveTest.php
@@ -6,12 +6,12 @@
 
 namespace Magento\Integration\Test\Unit\Controller\Adminhtml\Integration;
 
+use Magento\Framework\Exception\AuthenticationException;
+use Magento\Framework\Exception\IntegrationException;
+use Magento\Framework\Exception\State\UserLockedException;
 use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info;
 use Magento\Integration\Controller\Adminhtml\Integration as IntegrationController;
 use Magento\Integration\Model\Integration as IntegrationModel;
-use Magento\Framework\Exception\IntegrationException;
-use Magento\Framework\Exception\State\UserLockedException;
-use Magento\Framework\Exception\AuthenticationException;
 
 class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\IntegrationTest
 {
@@ -19,27 +19,54 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         // Use real translate model
         $this->_translateModelMock = null;
-        $this->_requestMock->expects($this->any())
-            ->method('getPostValue')
-            ->will($this->returnValue([IntegrationController::PARAM_INTEGRATION_ID => self::INTEGRATION_ID]));
+        $this->_requestMock->expects(
+            $this->any()
+        )->method(
+            'getPostValue'
+        )->will(
+            $this->returnValue(
+                [
+                    IntegrationController::PARAM_INTEGRATION_ID => self::INTEGRATION_ID,
+                ]
+            )
+        );
         $this->_requestMock->expects($this->any())->method('getParam')->will($this->returnValue(self::INTEGRATION_ID));
         $intData = $this->_getSampleIntegrationData();
-        $this->_integrationSvcMock->expects($this->any())
-            ->method('get')
-            ->with(self::INTEGRATION_ID)
-            ->will($this->returnValue($intData));
-        $this->_integrationSvcMock->expects($this->any())
-            ->method('update')
-            ->with($this->anything())
-            ->will($this->returnValue($intData));
-        // verify success message
-        $this->_messageManager->expects($this->once())
-            ->method('addSuccess')
-            ->with(__('The integration \'%1\' has been saved.', $intData[Info::DATA_NAME]));
+        $this->_integrationSvcMock->expects(
+            $this->any()
+        )->method(
+            'get'
+        )->with(
+            self::INTEGRATION_ID
+        )->will(
+            $this->returnValue($intData)
+        );
 
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
+        $this->_integrationSvcMock->expects(
+            $this->any()
+        )->method(
+            'update'
+        )->with(
+            $this->anything()
+        )->will(
+            $this->returnValue($intData)
+        );
+        // verify success message
+        $this->_messageManager->expects(
+            $this->once()
+        )->method(
+            'addComplexSuccessMessage'
+        )->with(
+            'addUnescapedMessage',
+            [
+                'text' => __(
+                    'The integration \'%1\' has been saved.',
+                    $intData[Info::DATA_NAME]
+                ),
+            ]
+        );
+
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
 
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
@@ -51,12 +78,19 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
 
         // Have integration service throw an exception to test exception path
         $exceptionMessage = 'Internal error. Check exception log for details.';
-        $this->_integrationSvcMock->expects($this->any())
-            ->method('get')
-            ->with(self::INTEGRATION_ID)
-            ->will($this->throwException(new \Magento\Framework\Exception\LocalizedException(__($exceptionMessage))));
+        $this->_integrationSvcMock->expects(
+            $this->any()
+        )->method(
+            'get'
+        )->with(
+            self::INTEGRATION_ID
+        )->will(
+            $this->throwException(new \Magento\Framework\Exception\LocalizedException(__($exceptionMessage)))
+        );
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -77,11 +111,11 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             $this->throwException(new IntegrationException(__($exceptionMessage)))
         );
 
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -123,14 +157,18 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
         $this->_messageManager->expects(
             $this->once()
         )->method(
-            'addSuccess'
+            'addComplexSuccessMessage'
         )->with(
-            __('The integration \'%1\' has been saved.', $integration->getName())
+            'addUnescapedMessage',
+            [
+                'text' => __(
+                    'The integration \'%1\' has been saved.',
+                    $integration->getName()
+                ),
+            ]
         );
 
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -168,13 +206,11 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             $this->returnValue(null)
         );
 
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
         // Use real translate model
         $this->_translateModelMock = null;
         // Verify success message
-        $this->_messageManager->expects($this->once())->method('addError')->with($exceptionMessage);
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($exceptionMessage);
         $integrationController = $this->_createIntegrationController('Save');
         $integrationController->execute();
     }
@@ -184,28 +220,26 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
         $exceptionMessage = 'Cannot edit integrations created via config file.';
         $intData = new \Magento\Framework\DataObject(
             [
-                Info::DATA_NAME => 'nameTest',
-                Info::DATA_ID => self::INTEGRATION_ID,
-                'id' => self::INTEGRATION_ID,
-                Info::DATA_EMAIL => 'test@magento.com',
-                Info::DATA_ENDPOINT => 'http://magento.ll/endpoint',
+                Info::DATA_NAME       => 'nameTest',
+                Info::DATA_ID         => self::INTEGRATION_ID,
+                'id'                  => self::INTEGRATION_ID,
+                Info::DATA_EMAIL      => 'test@magento.com',
+                Info::DATA_ENDPOINT   => 'http://magento.ll/endpoint',
                 Info::DATA_SETUP_TYPE => IntegrationModel::TYPE_CONFIG,
             ]
         );
 
         $this->_requestMock->expects($this->any())->method('getParam')->will($this->returnValue(self::INTEGRATION_ID));
-        $this->_integrationSvcMock
-            ->expects($this->once())
-            ->method('get')
-            ->with(self::INTEGRATION_ID)
-            ->will($this->returnValue($intData));
+        $this->_integrationSvcMock->expects($this->once())->method('get')->with(self::INTEGRATION_ID)->will(
+            $this->returnValue($intData)
+        );
 
-        $this->_escaper->expects($this->once())
-            ->method('escapeHtml')
-            ->willReturnArgument(0);
+        $this->_escaper->expects($this->once())->method('escapeHtml')->willReturnArgument(0);
 
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -218,31 +252,25 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
         $exceptionMessage = __('Your account is temporarily disabled.');
         $passwordString = '1234567';
 
-        $this->_requestMock->expects($this->exactly(2))
-            ->method('getParam')
-            ->withConsecutive(
-                [\Magento\Integration\Controller\Adminhtml\Integration\Save::PARAM_INTEGRATION_ID],
-                [\Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info::DATA_CONSUMER_PASSWORD]
-            )
-            ->willReturnOnConsecutiveCalls(self::INTEGRATION_ID, $passwordString);
+        $this->_requestMock->expects($this->exactly(2))->method('getParam')->withConsecutive(
+            [\Magento\Integration\Controller\Adminhtml\Integration\Save::PARAM_INTEGRATION_ID],
+            [\Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info::DATA_CONSUMER_PASSWORD]
+        )->willReturnOnConsecutiveCalls(self::INTEGRATION_ID, $passwordString);
 
         $intData = $this->_getSampleIntegrationData();
-        $this->_integrationSvcMock->expects($this->once())
-            ->method('get')
-            ->with(self::INTEGRATION_ID)
-            ->willReturn($intData);
+        $this->_integrationSvcMock->expects($this->once())->method('get')->with(self::INTEGRATION_ID)->willReturn(
+            $intData
+        );
 
-        $this->_userMock->expects($this->any())
-            ->method('performIdentityCheck')
-            ->with($passwordString)
-            ->will($this->throwException(new UserLockedException(__($exceptionMessage))));
+        $this->_userMock->expects($this->any())->method('performIdentityCheck')->with($passwordString)->will(
+            $this->throwException(new UserLockedException(__($exceptionMessage)))
+        );
 
-        $this->_authMock->expects($this->once())
-            ->method('logout');
+        $this->_authMock->expects($this->once())->method('logout');
 
-        $this->securityCookieMock->expects($this->once())
-            ->method('setLogoutReasonCookie')
-            ->with(\Magento\Security\Model\AdminSessionsManager::LOGOUT_REASON_USER_LOCKED);
+        $this->securityCookieMock->expects($this->once())->method('setLogoutReasonCookie')->with(
+            \Magento\Security\Model\AdminSessionsManager::LOGOUT_REASON_USER_LOCKED
+        );
 
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
@@ -256,27 +284,24 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
         $passwordString = '1234567';
         $exceptionMessage = __('You have entered an invalid password for current user.');
 
-        $this->_requestMock->expects($this->any())
-            ->method('getParam')
-            ->withConsecutive(
-                [\Magento\Integration\Controller\Adminhtml\Integration\Save::PARAM_INTEGRATION_ID],
-                [\Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info::DATA_CONSUMER_PASSWORD]
-            )
-            ->willReturnOnConsecutiveCalls(self::INTEGRATION_ID, $passwordString);
+        $this->_requestMock->expects($this->any())->method('getParam')->withConsecutive(
+            [\Magento\Integration\Controller\Adminhtml\Integration\Save::PARAM_INTEGRATION_ID],
+            [\Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Info::DATA_CONSUMER_PASSWORD]
+        )->willReturnOnConsecutiveCalls(self::INTEGRATION_ID, $passwordString);
 
         $intData = $this->_getSampleIntegrationData();
-        $this->_integrationSvcMock->expects($this->once())
-            ->method('get')
-            ->with(self::INTEGRATION_ID)
-            ->willReturn($intData);
+        $this->_integrationSvcMock->expects($this->once())->method('get')->with(self::INTEGRATION_ID)->willReturn(
+            $intData
+        );
 
-        $this->_userMock->expects($this->any())
-            ->method('performIdentityCheck')
-            ->with($passwordString)
-            ->will($this->throwException(new AuthenticationException(__($exceptionMessage))));
+        $this->_userMock->expects($this->any())->method('performIdentityCheck')->with($passwordString)->will(
+            $this->throwException(new AuthenticationException(__($exceptionMessage)))
+        );
 
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with(
+            $this->equalTo($exceptionMessage)
+        );
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/TokensExchangeTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/TokensExchangeTest.php
@@ -37,9 +37,9 @@ class TokensExchangeTest extends \Magento\Integration\Test\Unit\Controller\Admin
         $consumerMock->expects($this->once())->method('getId')->willReturn(1);
         $this->_oauthSvcMock->expects($this->once())->method('loadConsumer')->willReturn($consumerMock);
 
-        $this->_messageManager->expects($this->once())->method('addNotice');
-        $this->_messageManager->expects($this->never())->method('addError');
-        $this->_messageManager->expects($this->never())->method('addSuccess');
+        $this->_messageManager->expects($this->once())->method('addNoticeMessage');
+        $this->_messageManager->expects($this->never())->method('addErrorMessage');
+        $this->_messageManager->expects($this->never())->method('addSuccessMessage');
 
         $this->_viewMock->expects($this->once())->method('loadLayout');
         $this->_viewMock->expects($this->once())->method('renderLayout');

--- a/app/code/Magento/Multishipping/Controller/Checkout.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout.php
@@ -123,7 +123,7 @@ abstract class Checkout extends \Magento\Checkout\Controller\Action implements
                 \Magento\Multishipping\Helper\Data::class
             )->isMultishippingCheckoutAvailable()) {
                 $error = $this->_getCheckout()->getMinimumAmountError();
-                $this->messageManager->addError($error);
+                $this->messageManager->addErrorMessage($error);
                 $this->getResponse()->setRedirect($this->_getHelper()->getCartUrl());
                 $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
                 return parent::dispatch($request);
@@ -170,7 +170,7 @@ abstract class Checkout extends \Magento\Checkout\Controller\Action implements
     {
         if (!$this->_getCheckout()->validateMinimumAmount()) {
             $error = $this->_getCheckout()->getMinimumAmountError();
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->_forward('backToAddresses');
             return false;
         }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Addresses.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Addresses.php
@@ -28,7 +28,7 @@ class Addresses extends \Magento\Multishipping\Controller\Checkout
         $this->_getState()->setActiveStep(State::STEP_SELECT_ADDRESSES);
         if (!$this->_getCheckout()->validateMinimumAmount()) {
             $message = $this->_getCheckout()->getMinimumAmountDescription();
-            $this->messageManager->addNotice($message);
+            $this->messageManager->addNoticeMessage($message);
         }
         $this->_view->loadLayout();
         $this->_view->renderLayout();

--- a/app/code/Magento/Multishipping/Controller/Checkout/AddressesPost.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/AddressesPost.php
@@ -36,10 +36,10 @@ class AddressesPost extends \Magento\Multishipping\Controller\Checkout
                 $this->_getCheckout()->setShippingItemsInformation($shipToInfo);
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/addresses');
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Data saving problem'));
+            $this->messageManager->addExceptionMessage($e, __('Data saving problem'));
             $this->_redirect('*/*/addresses');
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Overview.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Overview.php
@@ -38,11 +38,11 @@ class Overview extends \Magento\Multishipping\Controller\Checkout
             $this->_view->loadLayout();
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/billing');
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addException($e, __('We cannot open the overview page.'));
+            $this->messageManager->addExceptionMessage($e, __('We cannot open the overview page.'));
             $this->_redirect('*/*/billing');
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/OverviewPost.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/OverviewPost.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Multishipping\Controller\Checkout;
 
-use Magento\Multishipping\Model\Checkout\Type\Multishipping\State;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\Exception\PaymentException;
+use Magento\Multishipping\Model\Checkout\Type\Multishipping\State;
 
 /**
  * Class OverviewPost
@@ -79,7 +79,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
 
         try {
             if (!$this->agreementsValidator->isValid(array_keys($this->getRequest()->getPost('agreement', [])))) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Please agree to all Terms and Conditions before placing the order.')
                 );
                 $this->_redirect('*/*/billing');
@@ -103,7 +103,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
         } catch (PaymentException $e) {
             $message = $e->getMessage();
             if (!empty($message)) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $this->_redirect('*/*/billing');
         } catch (\Magento\Checkout\Exception $e) {
@@ -115,7 +115,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
                 'multi-shipping'
             );
             $this->_getCheckout()->getCheckoutSession()->clearQuote();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/cart');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->_objectManager->get(
@@ -125,7 +125,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
                 $e->getMessage(),
                 'multi-shipping'
             );
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/billing');
         } catch (\Exception $e) {
             $this->logger->critical($e);
@@ -140,7 +140,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
             } catch (\Exception $e) {
                 $this->logger->error($e->getMessage());
             }
-            $this->messageManager->addError(__('Order place error'));
+            $this->messageManager->addErrorMessage(__('Order place error'));
             $this->_redirect('*/*/billing');
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/ShippingPost.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/ShippingPost.php
@@ -26,7 +26,7 @@ class ShippingPost extends \Magento\Multishipping\Controller\Checkout
             $this->_getState()->setCompleteStep(State::STEP_SHIPPING);
             $this->_redirect('*/*/billing');
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/shipping');
         }
     }

--- a/app/code/Magento/NewRelicReporting/Model/Observer/CheckConfig.php
+++ b/app/code/Magento/NewRelicReporting/Model/Observer/CheckConfig.php
@@ -7,8 +7,8 @@ namespace Magento\NewRelicReporting\Model\Observer;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\NewRelicReporting\Model\Config;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\NewRelicReporting\Model\Config;
 use Magento\NewRelicReporting\Model\NewRelicWrapper;
 
 /**
@@ -58,7 +58,7 @@ class CheckConfig implements ObserverInterface
         if ($this->config->isNewRelicEnabled()) {
             if (!$this->newRelicWrapper->isExtensionInstalled()) {
                 $this->config->disableModule();
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __(
                         'The New Relic integration requires the newrelic-php5 agent, which is not installed. More 
                         information on installing the agent is available <a target="_blank" href="%1">here</a>.',

--- a/app/code/Magento/NewRelicReporting/Test/Unit/Model/Observer/CheckConfigTest.php
+++ b/app/code/Magento/NewRelicReporting/Test/Unit/Model/Observer/CheckConfigTest.php
@@ -120,7 +120,7 @@ class CheckConfigTest extends \PHPUnit\Framework\TestCase
         $this->config->expects($this->once())
             ->method('disableModule');
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->model->execute($eventObserver);
     }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Grid.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Grid.php
@@ -28,7 +28,7 @@ class Grid extends \Magento\Newsletter\Controller\Adminhtml\Problem
                 $collection->walk('unsubscribe');
             }
 
-            $this->messageManager->addSuccess(__('We unsubscribed the people you identified.'));
+            $this->messageManager->addSuccessMessage(__('We unsubscribed the people you identified.'));
         }
 
         if ($this->getRequest()->getParam('_delete')) {
@@ -43,7 +43,7 @@ class Grid extends \Magento\Newsletter\Controller\Adminhtml\Problem
                 $collection->walk('delete');
             }
 
-            $this->messageManager->addSuccess(__('The problems you identified have been deleted.'));
+            $this->messageManager->addSuccessMessage(__('The problems you identified have been deleted.'));
         }
         $this->_view->loadLayout(false);
         $this->_view->getLayout()->getMessagesBlock()->setMessages($this->messageManager->getMessages(true));

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Queue/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Queue/Save.php
@@ -80,13 +80,13 @@ class Save extends \Magento\Newsletter\Controller\Adminhtml\Queue
 
             $queue->save();
 
-            $this->messageManager->addSuccess(__('You saved the newsletter queue.'));
+            $this->messageManager->addSuccessMessage(__('You saved the newsletter queue.'));
             $this->_getSession()->setFormData(false);
             $this->_getSession()->unsPreviewData();
 
             $this->_redirect('*/*');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $id = $this->getRequest()->getParam('id');
             if ($id) {
                 $this->_redirect('*/*/edit', ['id' => $id]);

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
@@ -17,7 +17,7 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
     {
         $subscribersIds = $this->getRequest()->getParam('subscriber');
         if (!is_array($subscribersIds)) {
-            $this->messageManager->addError(__('Please select one or more subscribers.'));
+            $this->messageManager->addErrorMessage(__('Please select one or more subscribers.'));
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
@@ -28,9 +28,11 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
                     );
                     $subscriber->delete();
                 }
-                $this->messageManager->addSuccess(__('Total of %1 record(s) were deleted.', count($subscribersIds)));
+                $this->messageManager->addSuccessMessage(
+                    __('Total of %1 record(s) were deleted.', count($subscribersIds))
+                );
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -17,7 +17,7 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
     {
         $subscribersIds = $this->getRequest()->getParam('subscriber');
         if (!is_array($subscribersIds)) {
-            $this->messageManager->addError(__('Please select one or more subscribers.'));
+            $this->messageManager->addErrorMessage(__('Please select one or more subscribers.'));
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
@@ -28,9 +28,11 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
                     );
                     $subscriber->unsubscribe();
                 }
-                $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', count($subscribersIds)));
+                $this->messageManager->addSuccessMessage(
+                    __('A total of %1 record(s) were updated.', count($subscribersIds))
+                );
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Delete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Delete.php
@@ -23,12 +23,12 @@ class Delete extends \Magento\Newsletter\Controller\Adminhtml\Template
         if ($template->getId()) {
             try {
                 $template->delete();
-                $this->messageManager->addSuccess(__('The newsletter template has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The newsletter template has been deleted.'));
                 $this->_getSession()->setFormData(false);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t delete this template right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t delete this template right now.'));
             }
         }
         $this->_redirect('*/template');

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Save.php
@@ -62,16 +62,16 @@ class Save extends \Magento\Newsletter\Controller\Adminhtml\Template
 
             $template->save();
 
-            $this->messageManager->addSuccess(__('The newsletter template has been saved.'));
+            $this->messageManager->addSuccessMessage(__('The newsletter template has been saved.'));
             $this->_getSession()->setFormData(false);
             $this->_getSession()->unsPreviewData();
             $this->_redirect('*/template');
             return;
         } catch (LocalizedException $e) {
-            $this->messageManager->addError(nl2br($e->getMessage()));
+            $this->messageManager->addErrorMessage(nl2br($e->getMessage()));
             $this->_getSession()->setData('newsletter_template_form_data', $this->getRequest()->getParams());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong while saving this template.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving this template.'));
             $this->_getSession()->setData('newsletter_template_form_data', $this->getRequest()->getParams());
         }
 

--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -68,7 +68,7 @@ class Save extends \Magento\Newsletter\Controller\Manage
 
         $customerId = $this->_customerSession->getCustomerId();
         if ($customerId === null) {
-            $this->messageManager->addError(__('Something went wrong while saving your subscription.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while saving your subscription.'));
         } else {
             try {
                 $customer = $this->customerRepository->getById($customerId);
@@ -77,13 +77,13 @@ class Save extends \Magento\Newsletter\Controller\Manage
                 $this->customerRepository->save($customer);
                 if ((boolean)$this->getRequest()->getParam('is_subscribed', false)) {
                     $this->subscriberFactory->create()->subscribeCustomerById($customerId);
-                    $this->messageManager->addSuccess(__('We saved the subscription.'));
+                    $this->messageManager->addSuccessMessage(__('We saved the subscription.'));
                 } else {
                     $this->subscriberFactory->create()->unsubscribeCustomerById($customerId);
-                    $this->messageManager->addSuccess(__('We removed the subscription.'));
+                    $this->messageManager->addSuccessMessage(__('We removed the subscription.'));
                 }
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving your subscription.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving your subscription.'));
             }
         }
         $this->_redirect('customer/account/');

--- a/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
@@ -23,12 +23,12 @@ class Confirm extends \Magento\Newsletter\Controller\Subscriber
 
             if ($subscriber->getId() && $subscriber->getCode()) {
                 if ($subscriber->confirm($code)) {
-                    $this->messageManager->addSuccess(__('Your subscription has been confirmed.'));
+                    $this->messageManager->addSuccessMessage(__('Your subscription has been confirmed.'));
                 } else {
-                    $this->messageManager->addError(__('This is an invalid subscription confirmation code.'));
+                    $this->messageManager->addErrorMessage(__('This is an invalid subscription confirmation code.'));
                 }
             } else {
-                $this->messageManager->addError(__('This is an invalid subscription ID.'));
+                $this->messageManager->addErrorMessage(__('This is an invalid subscription ID.'));
             }
         }
 

--- a/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
@@ -10,8 +10,8 @@ use Magento\Customer\Api\AccountManagementInterface as CustomerAccountManagement
 use Magento\Customer\Model\Session;
 use Magento\Customer\Model\Url as CustomerUrl;
 use Magento\Framework\App\Action\Context;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -135,17 +135,17 @@ class NewAction extends \Magento\Newsletter\Controller\Subscriber
 
                 $status = $this->_subscriberFactory->create()->subscribe($email);
                 if ($status == \Magento\Newsletter\Model\Subscriber::STATUS_NOT_ACTIVE) {
-                    $this->messageManager->addSuccess(__('The confirmation request has been sent.'));
+                    $this->messageManager->addSuccessMessage(__('The confirmation request has been sent.'));
                 } else {
-                    $this->messageManager->addSuccess(__('Thank you for your subscription.'));
+                    $this->messageManager->addSuccessMessage(__('Thank you for your subscription.'));
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('There was a problem with the subscription: %1', $e->getMessage())
                 );
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong with the subscription.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong with the subscription.'));
             }
         }
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl());

--- a/app/code/Magento/Newsletter/Controller/Subscriber/Unsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Unsubscribe.php
@@ -20,11 +20,11 @@ class Unsubscribe extends \Magento\Newsletter\Controller\Subscriber
         if ($id && $code) {
             try {
                 $this->_subscriberFactory->create()->load($id)->setCheckCode($code)->unsubscribe();
-                $this->messageManager->addSuccess(__('You unsubscribed.'));
+                $this->messageManager->addSuccessMessage(__('You unsubscribed.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addException($e, $e->getMessage());
+                $this->messageManager->addExceptionMessage($e, $e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while unsubscribing you.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while unsubscribing you.'));
             }
         }
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl());

--- a/app/code/Magento/Newsletter/Test/Unit/Controller/Manage/SaveTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Controller/Manage/SaveTest.php
@@ -105,9 +105,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('redirect')
             ->with($this->responseMock, 'customer/account/', []);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->action->execute();
     }
 
@@ -123,9 +123,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('redirect')
             ->with($this->responseMock, 'customer/account/', []);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Something went wrong while saving your subscription.');
         $this->action->execute();
     }
@@ -154,9 +154,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('redirect')
             ->with($this->responseMock, 'customer/account/', []);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Something went wrong while saving your subscription.');
         $this->action->execute();
     }

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Express/PlaceOrderTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Express/PlaceOrderTest.php
@@ -147,7 +147,7 @@ class PlaceOrderTest extends \Magento\Paypal\Test\Unit\Controller\ExpressTest
                 ->with($redirectUrl);
         } else {
             $this->messageManager->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with('User Message');
             $this->_expectRedirect('checkout/cart');
         }

--- a/app/code/Magento/Persistent/Controller/Index/ExpressCheckout.php
+++ b/app/code/Magento/Persistent/Controller/Index/ExpressCheckout.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Persistent\Controller\Index;
 
-use Magento\Persistent\Controller\Index;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Persistent\Controller\Index;
 
 /**
  * @codeCoverageIgnore
@@ -20,7 +20,7 @@ class ExpressCheckout extends Index
      */
     public function execute()
     {
-        $this->messageManager->addNotice(__('Your shopping cart has been updated with new prices.'));
+        $this->messageManager->addNoticeMessage(__('Your shopping cart has been updated with new prices.'));
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $resultRedirect->setPath('checkout/cart');

--- a/app/code/Magento/Persistent/Observer/PreventExpressCheckoutObserver.php
+++ b/app/code/Magento/Persistent/Observer/PreventExpressCheckoutObserver.php
@@ -81,7 +81,7 @@ class PreventExpressCheckoutObserver implements ObserverInterface
             return;
         }
 
-        $this->messageManager->addNotice(__('To check out, please sign in using your email address.'));
+        $this->messageManager->addNoticeMessage(__('To check out, please sign in using your email address.'));
         $customerBeforeAuthUrl = $this->_url->getUrl('persistent/index/expressCheckout');
 
         $this->_expressRedirectHelper->redirectLogin($controllerAction, $customerBeforeAuthUrl);

--- a/app/code/Magento/ProductAlert/Controller/Add/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Price.php
@@ -5,15 +5,15 @@
  */
 namespace Magento\ProductAlert\Controller\Add;
 
-use Magento\ProductAlert\Controller\Add as AddController;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Framework\UrlInterface;
+use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
+use Magento\ProductAlert\Controller\Add as AddController;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Price extends AddController
 {
@@ -88,9 +88,9 @@ class Price extends AddController
                         ->getWebsiteId()
                 );
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the alert subscription.'));
+            $this->messageManager->addSuccessMessage(__('You saved the alert subscription.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('There are not enough parameters.'));
+            $this->messageManager->addErrorMessage(__('There are not enough parameters.'));
             if ($this->isInternal($backUrl)) {
                 $resultRedirect->setUrl($backUrl);
             } else {
@@ -98,7 +98,7 @@ class Price extends AddController
             }
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the alert subscription right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t update the alert subscription right now.'));
         }
         $resultRedirect->setUrl($this->_redirect->getRedirectUrl());
         return $resultRedirect;

--- a/app/code/Magento/ProductAlert/Controller/Add/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Stock.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\ProductAlert\Controller\Add;
 
-use Magento\ProductAlert\Controller\Add as AddController;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\ProductAlert\Controller\Add as AddController;
 
 class Stock extends AddController
 {
@@ -61,13 +61,13 @@ class Stock extends AddController
                         ->getWebsiteId()
                 );
             $model->save();
-            $this->messageManager->addSuccess(__('Alert subscription has been saved.'));
+            $this->messageManager->addSuccessMessage(__('Alert subscription has been saved.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('There are not enough parameters.'));
+            $this->messageManager->addErrorMessage(__('There are not enough parameters.'));
             $resultRedirect->setUrl($backUrl);
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the alert subscription right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t update the alert subscription right now.'));
         }
         $resultRedirect->setUrl($this->_redirect->getRedirectUrl());
         return $resultRedirect;

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Price.php
@@ -5,12 +5,12 @@
  */
 namespace Magento\ProductAlert\Controller\Unsubscribe;
 
-use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 
 class Price extends UnsubscribeController
 {
@@ -66,13 +66,13 @@ class Price extends UnsubscribeController
                 $model->delete();
             }
 
-            $this->messageManager->addSuccess(__('You deleted the alert subscription.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the alert subscription.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('We can\'t find the product.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find the product.'));
             $resultRedirect->setPath('customer/account/');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the alert subscription right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t update the alert subscription right now.'));
         }
         $resultRedirect->setUrl($product->getProductUrl());
         return $resultRedirect;

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/PriceAll.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/PriceAll.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\ProductAlert\Controller\Unsubscribe;
 
-use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 
 class PriceAll extends UnsubscribeController
 {
@@ -23,9 +23,9 @@ class PriceAll extends UnsubscribeController
                         ->getStore()
                         ->getWebsiteId()
                 );
-            $this->messageManager->addSuccess(__('You will no longer receive price alerts for this product.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive price alerts for this product.'));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to update the alert subscription.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to update the alert subscription.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
@@ -5,12 +5,12 @@
  */
 namespace Magento\ProductAlert\Controller\Unsubscribe;
 
-use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 
 class Stock extends UnsubscribeController
 {
@@ -64,13 +64,13 @@ class Stock extends UnsubscribeController
             if ($model->getId()) {
                 $model->delete();
             }
-            $this->messageManager->addSuccess(__('You will no longer receive stock alerts for this product.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive stock alerts for this product.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('The product was not found.'));
+            $this->messageManager->addErrorMessage(__('The product was not found.'));
             $resultRedirect->setPath('customer/account/');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the alert subscription right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t update the alert subscription right now.'));
         }
         $resultRedirect->setUrl($product->getProductUrl());
         return $resultRedirect;

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/StockAll.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/StockAll.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\ProductAlert\Controller\Unsubscribe;
 
-use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 
 class StockAll extends UnsubscribeController
 {
@@ -23,9 +23,9 @@ class StockAll extends UnsubscribeController
                         ->getStore()
                         ->getWebsiteId()
                 );
-            $this->messageManager->addSuccess(__('You will no longer receive stock alerts.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive stock alerts.'));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to update the alert subscription.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to update the alert subscription.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/AbstractReport.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/AbstractReport.php
@@ -157,7 +157,7 @@ abstract class AbstractReport extends \Magento\Backend\App\Action
         $refreshStatsLink = $this->getUrl('reports/report_statistics');
         $directRefreshLink = $this->getUrl('reports/report_statistics/refreshRecent', ['code' => $refreshCode]);
 
-        $this->messageManager->addNotice(
+        $this->messageManager->addNoticeMessage(
             __(
                 'Last updated: %1. To refresh last day\'s <a href="%2">statistics</a>, ' .
                 'click <a href="%3">here</a>.',

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Viewed.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Viewed.php
@@ -42,9 +42,9 @@ class Viewed extends \Magento\Reports\Controller\Adminhtml\Report\Product
 
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('An error occurred while showing the product views report. Please review the log and try again.')
             );
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
@@ -20,11 +20,11 @@ class RefreshLifetime extends \Magento\Reports\Controller\Adminhtml\Report\Stati
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate();
             }
-            $this->messageManager->addSuccess(__('You refreshed lifetime statistics.'));
+            $this->messageManager->addSuccessMessage(__('You refreshed lifetime statistics.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh lifetime statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh lifetime statistics.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshRecent.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshRecent.php
@@ -25,11 +25,11 @@ class RefreshRecent extends \Magento\Reports\Controller\Adminhtml\Report\Statist
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate($date);
             }
-            $this->messageManager->addSuccess(__('Recent statistics have been updated.'));
+            $this->messageManager->addSuccessMessage(__('Recent statistics have been updated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh recent statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh recent statistics.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Product/ViewedTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Product/ViewedTest.php
@@ -6,9 +6,9 @@
 
 namespace Magento\Reports\Test\Unit\Controller\Adminhtml\Report\Product;
 
-use Magento\Reports\Controller\Adminhtml\Report\Product\Viewed;
 use Magento\Framework\DataObject;
 use Magento\Framework\Phrase;
+use Magento\Reports\Controller\Adminhtml\Report\Product\Viewed;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -190,7 +190,7 @@ class ViewedTest extends \Magento\Reports\Test\Unit\Controller\Adminhtml\Report\
 
         $this->messageManagerMock
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorText);
 
         $logMock
@@ -217,7 +217,7 @@ class ViewedTest extends \Magento\Reports\Test\Unit\Controller\Adminhtml\Report\
 
         $this->messageManagerMock
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorText);
 
         $this->menuBlockMock

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Delete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Delete.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Review\Controller\Adminhtml\Product as ProductController;
 
 class Delete extends ProductController
 {
@@ -21,7 +21,7 @@ class Delete extends ProductController
         try {
             $this->reviewFactory->create()->setId($reviewId)->aggregate()->delete();
 
-            $this->messageManager->addSuccess(__('The review has been deleted.'));
+            $this->messageManager->addSuccessMessage(__('The review has been deleted.'));
             if ($this->getRequest()->getParam('ret') == 'pending') {
                 $resultRedirect->setPath('review/*/pending');
             } else {
@@ -29,9 +29,9 @@ class Delete extends ProductController
             }
             return $resultRedirect;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong  deleting this review.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong  deleting this review.'));
         }
 
         return $resultRedirect->setPath('review/*/edit/', ['id' => $reviewId]);

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassDelete.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Review\Controller\Adminhtml\Product as ProductController;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Review\Controller\Adminhtml\Product as ProductController;
 
 class MassDelete extends ProductController
 {
@@ -18,20 +18,23 @@ class MassDelete extends ProductController
     {
         $reviewsIds = $this->getRequest()->getParam('reviews');
         if (!is_array($reviewsIds)) {
-            $this->messageManager->addError(__('Please select review(s).'));
+            $this->messageManager->addErrorMessage(__('Please select review(s).'));
         } else {
             try {
                 foreach ($reviewsIds as $reviewId) {
                     $model = $this->reviewFactory->create()->load($reviewId);
                     $model->delete();
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been deleted.', count($reviewsIds))
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while deleting these records.'));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __('Something went wrong while deleting these records.')
+                );
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassUpdateStatus.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassUpdateStatus.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Review\Controller\Adminhtml\Product as ProductController;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Review\Controller\Adminhtml\Product as ProductController;
 
 class MassUpdateStatus extends ProductController
 {
@@ -18,7 +18,7 @@ class MassUpdateStatus extends ProductController
     {
         $reviewsIds = $this->getRequest()->getParam('reviews');
         if (!is_array($reviewsIds)) {
-            $this->messageManager->addError(__('Please select review(s).'));
+            $this->messageManager->addErrorMessage(__('Please select review(s).'));
         } else {
             try {
                 $status = $this->getRequest()->getParam('status');
@@ -26,13 +26,13 @@ class MassUpdateStatus extends ProductController
                     $model = $this->reviewFactory->create()->load($reviewId);
                     $model->setStatusId($status)->save()->aggregate();
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been updated.', count($reviewsIds))
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while updating these review(s).')
                 );

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassVisibleIn.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassVisibleIn.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Review\Controller\Adminhtml\Product as ProductController;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Review\Controller\Adminhtml\Product as ProductController;
 
 class MassVisibleIn extends ProductController
 {
@@ -18,7 +18,7 @@ class MassVisibleIn extends ProductController
     {
         $reviewsIds = $this->getRequest()->getParam('reviews');
         if (!is_array($reviewsIds)) {
-            $this->messageManager->addError(__('Please select review(s).'));
+            $this->messageManager->addErrorMessage(__('Please select review(s).'));
         } else {
             try {
                 $stores = $this->getRequest()->getParam('stores');
@@ -27,13 +27,13 @@ class MassVisibleIn extends ProductController
                     $model->setSelectStores($stores);
                     $model->save();
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been updated.', count($reviewsIds))
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while updating these review(s).')
                 );

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Post.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Post.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Store\Model\Store;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Review\Controller\Adminhtml\Product as ProductController;
+use Magento\Store\Model\Store;
 
 class Post extends ProductController
 {
@@ -49,7 +49,7 @@ class Post extends ProductController
 
                 $review->aggregate();
 
-                $this->messageManager->addSuccess(__('You saved the review.'));
+                $this->messageManager->addSuccessMessage(__('You saved the review.'));
                 if ($this->getRequest()->getParam('ret') == 'pending') {
                     $resultRedirect->setPath('review/*/pending');
                 } else {
@@ -57,9 +57,9 @@ class Post extends ProductController
                 }
                 return $resultRedirect;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while saving this review.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving this review.'));
             }
         }
         $resultRedirect->setPath('review/*/');

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Review\Controller\Adminhtml\Product as ProductController;
 
 class Save extends ProductController
 {
@@ -22,19 +22,20 @@ class Save extends ProductController
         if (($data = $this->getRequest()->getPostValue()) && ($reviewId = $this->getRequest()->getParam('id'))) {
             $review = $this->reviewFactory->create()->load($reviewId);
             if (!$review->getId()) {
-                $this->messageManager->addError(__('The review was removed by another user or does not exist.'));
+                $this->messageManager->addErrorMessage(__('The review was removed by another user or does not exist.'));
             } else {
                 try {
                     $review->addData($data)->save();
 
                     $arrRatingId = $this->getRequest()->getParam('ratings', []);
                     /** @var \Magento\Review\Model\Rating\Option\Vote $votes */
-                    $votes = $this->_objectManager->create(\Magento\Review\Model\Rating\Option\Vote::class)
-                        ->getResourceCollection()
-                        ->setReviewFilter($reviewId)
-                        ->addOptionInfo()
-                        ->load()
-                        ->addRatingOptions();
+                    $votes =
+                        $this->_objectManager->create(\Magento\Review\Model\Rating\Option\Vote::class)
+                            ->getResourceCollection()
+                            ->setReviewFilter($reviewId)
+                            ->addOptionInfo()
+                            ->load()
+                            ->addRatingOptions();
                     foreach ($arrRatingId as $ratingId => $optionId) {
                         if ($vote = $votes->getItemByColumnValue('rating_id', $ratingId)) {
                             $this->ratingFactory->create()
@@ -51,11 +52,14 @@ class Save extends ProductController
 
                     $review->aggregate();
 
-                    $this->messageManager->addSuccess(__('You saved the review.'));
+                    $this->messageManager->addSuccessMessage(__('You saved the review.'));
                 } catch (LocalizedException $e) {
-                    $this->messageManager->addError($e->getMessage());
+                    $this->messageManager->addErrorMessage($e->getMessage());
                 } catch (\Exception $e) {
-                    $this->messageManager->addException($e, __('Something went wrong while saving this review.'));
+                    $this->messageManager->addExceptionMessage(
+                        $e,
+                        __('Something went wrong while saving this review.')
+                    );
                 }
             }
 

--- a/app/code/Magento/Review/Controller/Adminhtml/Rating/Delete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Rating/Delete.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Rating;
 
-use Magento\Review\Controller\Adminhtml\Rating as RatingController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Review\Controller\Adminhtml\Rating as RatingController;
 
 class Delete extends RatingController
 {
@@ -22,9 +22,9 @@ class Delete extends RatingController
                 /** @var \Magento\Review\Model\Rating $model */
                 $model = $this->_objectManager->create(\Magento\Review\Model\Rating::class);
                 $model->load($this->getRequest()->getParam('id'))->delete();
-                $this->messageManager->addSuccess(__('You deleted the rating.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rating.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $resultRedirect->setPath('review/rating/edit', ['id' => $this->getRequest()->getParam('id')]);
                 return $resultRedirect;
             }

--- a/app/code/Magento/Review/Controller/Adminhtml/Rating/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Rating/Save.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Rating;
 
-use Magento\Review\Controller\Adminhtml\Rating as RatingController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Review\Controller\Adminhtml\Rating as RatingController;
 
 class Save extends RatingController
 {
@@ -57,10 +57,10 @@ class Save extends RatingController
                     }
                 }
 
-                $this->messageManager->addSuccess(__('You saved the rating.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rating.'));
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setRatingData(false);
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)
                     ->setRatingData($this->getRequest()->getPostValue());
                 $resultRedirect->setPath('review/rating/edit', ['id' => $this->getRequest()->getParam('id')]);

--- a/app/code/Magento/Review/Controller/Product/Post.php
+++ b/app/code/Magento/Review/Controller/Product/Post.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Review\Controller\Product;
 
-use Magento\Review\Controller\Product as ProductController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Review\Controller\Product as ProductController;
 use Magento\Review\Model\Review;
 
 class Post extends ProductController
@@ -62,19 +62,19 @@ class Post extends ProductController
                     }
 
                     $review->aggregate();
-                    $this->messageManager->addSuccess(__('You submitted your review for moderation.'));
+                    $this->messageManager->addSuccessMessage(__('You submitted your review for moderation.'));
                 } catch (\Exception $e) {
                     $this->reviewSession->setFormData($data);
-                    $this->messageManager->addError(__('We can\'t post your review right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t post your review right now.'));
                 }
             } else {
                 $this->reviewSession->setFormData($data);
                 if (is_array($validate)) {
                     foreach ($validate as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                 } else {
-                    $this->messageManager->addError(__('We can\'t post your review right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t post your review right now.'));
                 }
             }
         }

--- a/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
+++ b/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
@@ -286,7 +286,7 @@ class PostTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->review->expects($this->once())->method('aggregate')
             ->willReturnSelf();
-        $this->messageManager->expects($this->once())->method('addSuccess')
+        $this->messageManager->expects($this->once())->method('addSuccessMessage')
             ->with(__('You submitted your review for moderation.'))
             ->willReturnSelf();
         $this->reviewSession->expects($this->once())->method('getRedirectUrl')

--- a/app/code/Magento/Sales/Controller/AbstractController/Reorder.php
+++ b/app/code/Magento/Sales/Controller/AbstractController/Reorder.php
@@ -59,13 +59,16 @@ abstract class Reorder extends Action\Action
                 $cart->addOrderItem($item);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 if ($this->_objectManager->get(\Magento\Checkout\Model\Session::class)->getUseNotice(true)) {
-                    $this->messageManager->addNotice($e->getMessage());
+                    $this->messageManager->addNoticeMessage($e->getMessage());
                 } else {
-                    $this->messageManager->addError($e->getMessage());
+                    $this->messageManager->addErrorMessage($e->getMessage());
                 }
                 return $resultRedirect->setPath('*/*/history');
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t add this item to your shopping cart right now.'));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __('We can\'t add this item to your shopping cart right now.')
+                );
                 return $resultRedirect->setPath('checkout/cart');
             }
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Email.php
@@ -33,7 +33,7 @@ class Email extends \Magento\Backend\App\Action
         $this->_objectManager->create(\Magento\Sales\Api\CreditmemoManagementInterface::class)
             ->notify($creditmemoId);
 
-        $this->messageManager->addSuccess(__('You sent the message.'));
+        $this->messageManager->addSuccessMessage(__('You sent the message.'));
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath('sales/order_creditmemo/view', ['creditmemo_id' => $creditmemoId]);
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Email.php
@@ -57,7 +57,7 @@ abstract class Email extends \Magento\Backend\App\Action
             \Magento\Sales\Api\InvoiceManagementInterface::class
         )->notify($invoice->getEntityId());
 
-        $this->messageManager->addSuccess(__('You sent the message.'));
+        $this->messageManager->addSuccessMessage(__('You sent the message.'));
         return $this->resultRedirectFactory->create()->setPath(
             'sales/invoice/view',
             ['order_id' => $invoice->getOrder()->getId(), 'invoice_id' => $invoiceId]

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/View.php
@@ -79,7 +79,7 @@ abstract class View extends \Magento\Backend\App\Action
                 ->get($this->getRequest()->getParam('invoice_id'));
             $this->registry->register('current_invoice', $invoice);
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice capturing error'));
+            $this->messageManager->addErrorMessage(__('Invoice capturing error'));
             return false;
         }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order.php
@@ -6,10 +6,10 @@
 namespace Magento\Sales\Controller\Adminhtml;
 
 use Magento\Backend\App\Action;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Exception\InputException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -154,11 +154,11 @@ abstract class Order extends \Magento\Backend\App\Action
         try {
             $order = $this->orderRepository->get($id);
         } catch (NoSuchEntityException $e) {
-            $this->messageManager->addError(__('This order no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This order no longer exists.'));
             $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
             return false;
         } catch (InputException $e) {
-            $this->messageManager->addError(__('This order no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This order no longer exists.'));
             $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
             return false;
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AbstractMassAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AbstractMassAction.php
@@ -61,7 +61,7 @@ abstract class AbstractMassAction extends \Magento\Backend\App\Action
             $collection = $this->filter->getCollection($this->collectionFactory->create());
             return $this->massAction($collection);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -10,21 +10,21 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
 use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Controller\Result\RawFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Registry;
+use Magento\Framework\Translate\InlineInterface;
+use Magento\Framework\View\Result\LayoutFactory;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Sales\Api\Data\OrderAddressInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
-use Magento\Sales\Api\Data\OrderAddressInterface;
 use Magento\Sales\Controller\Adminhtml\Order;
 use Magento\Sales\Model\Order\Address as AddressModel;
 use Psr\Log\LoggerInterface;
-use Magento\Framework\Registry;
-use Magento\Framework\App\Response\Http\FileFactory;
-use Magento\Framework\Translate\InlineInterface;
-use Magento\Framework\View\Result\PageFactory;
-use Magento\Framework\Controller\Result\JsonFactory;
-use Magento\Framework\View\Result\LayoutFactory;
-use Magento\Framework\Controller\Result\RawFactory;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\App\ObjectManager;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -114,19 +114,19 @@ class AddressSave extends Order
                         'order_id' => $address->getParentId()
                     ]
                 );
-                $this->messageManager->addSuccess(__('You updated the order address.'));
+                $this->messageManager->addSuccessMessage(__('You updated the order address.'));
                 return $resultRedirect->setPath('sales/*/view', ['order_id' => $address->getParentId()]);
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t update the order address right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t update the order address right now.'));
             }
             return $resultRedirect->setPath('sales/*/address', ['address_id' => $address->getId()]);
         } else {
             return $resultRedirect->setPath('sales/*/');
         }
     }
-    
+
     /**
      * Update region data
      *

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Cancel.php
@@ -24,18 +24,18 @@ class Cancel extends \Magento\Sales\Controller\Adminhtml\Order
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         if (!$this->isValidPostRequest()) {
-            $this->messageManager->addError(__('You have not canceled the item.'));
+            $this->messageManager->addErrorMessage(__('You have not canceled the item.'));
             return $resultRedirect->setPath('sales/*/');
         }
         $order = $this->_initOrder();
         if ($order) {
             try {
                 $this->orderManagement->cancel($order->getEntityId());
-                $this->messageManager->addSuccess(__('You canceled the order.'));
+                $this->messageManager->addSuccessMessage(__('You canceled the order.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('You have not canceled the item.'));
+                $this->messageManager->addErrorMessage(__('You have not canceled the item.'));
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             }
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create.php
@@ -6,8 +6,8 @@
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
 use Magento\Backend\App\Action;
-use Magento\Framework\View\Result\PageFactory;
 use Magento\Backend\Model\View\Result\ForwardFactory;
+use Magento\Framework\View\Result\PageFactory;
 
 /**
  * Adminhtml sales orders creation process controller
@@ -317,7 +317,7 @@ abstract class Create extends \Magento\Backend\App\Action
                 }
             }
             if (!$isApplyDiscount) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __(
                         '"%1" coupon code was not applied. Do not apply discount is selected for item(s)',
                         $this->escaper->escapeHtml($couponCode)
@@ -325,14 +325,14 @@ abstract class Create extends \Magento\Backend\App\Action
                 );
             } else {
                 if ($this->_getQuote()->getCouponCode() !== $couponCode) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __(
                             '"%1" coupon code is not valid.',
                             $this->escaper->escapeHtml($couponCode)
                         )
                     );
                 } else {
-                    $this->messageManager->addSuccess(__('The coupon code has been accepted.'));
+                    $this->messageManager->addSuccessMessage(__('The coupon code has been accepted.'));
                 }
             }
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/LoadBlock.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/LoadBlock.php
@@ -7,8 +7,8 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Create;
 
 use Magento\Backend\App\Action;
 use Magento\Backend\Model\View\Result\ForwardFactory;
-use Magento\Framework\View\Result\PageFactory;
 use Magento\Framework\Controller\Result\RawFactory;
+use Magento\Framework\View\Result\PageFactory;
 
 class LoadBlock extends \Magento\Sales\Controller\Adminhtml\Order\Create
 {
@@ -55,10 +55,10 @@ class LoadBlock extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_initSession()->_processData();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->_reloadQuote();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_reloadQuote();
-            $this->messageManager->addException($e, $e->getMessage());
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
         }
 
         $asJson = $request->getParam('json');

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/Save.php
@@ -49,7 +49,7 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Create
                 ->createOrder();
 
             $this->_getSession()->clearStorage();
-            $this->messageManager->addSuccess(__('You created the order.'));
+            $this->messageManager->addSuccessMessage(__('You created the order.'));
             if ($this->_authorization->isAllowed('Magento_Sales::actions_view')) {
                 $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
             } else {
@@ -59,17 +59,17 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_getOrderCreateModel()->saveQuote();
             $message = $e->getMessage();
             if (!empty($message)) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $resultRedirect->setPath('sales/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $message = $e->getMessage();
             if (!empty($message)) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $resultRedirect->setPath('sales/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Order saving error: %1', $e->getMessage()));
+            $this->messageManager->addExceptionMessage($e, __('Order saving error: %1', $e->getMessage()));
             $resultRedirect->setPath('sales/*/');
         }
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Cancel.php
@@ -47,11 +47,11 @@ class Cancel extends \Magento\Backend\App\Action
                     \Magento\Sales\Api\CreditmemoManagementInterface::class
                 );
                 $creditmemoManagement->cancel($creditmemoId);
-                $this->messageManager->addSuccess(__('The credit memo has been canceled.'));
+                $this->messageManager->addSuccessMessage(__('The credit memo has been canceled.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Credit memo has not been canceled.'));
+                $this->messageManager->addErrorMessage(__('Credit memo has not been canceled.'));
             }
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('sales/*/view', ['creditmemo_id' => $creditmemoId]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
@@ -109,7 +109,7 @@ class Save extends \Magento\Backend\App\Action
                     $this->creditmemoSender->send($creditmemo);
                 }
 
-                $this->messageManager->addSuccess(__('You created the credit memo.'));
+                $this->messageManager->addSuccessMessage(__('You created the credit memo.'));
                 $this->_getSession()->getCommentText(true);
                 $resultRedirect->setPath('sales/order/view', ['order_id' => $creditmemo->getOrderId()]);
                 return $resultRedirect;
@@ -119,11 +119,11 @@ class Save extends \Magento\Backend\App\Action
                 return $resultForward;
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_getSession()->setFormData($data);
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError(__('We can\'t save the credit memo right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t save the credit memo right now.'));
         }
         $resultRedirect->setPath('sales/*/new', ['_current' => true]);
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/VoidAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/VoidAction.php
@@ -64,11 +64,11 @@ class VoidAction extends Action
                     $transactionSave->addObject($creditmemo->getInvoice());
                 }
                 $transactionSave->save();
-                $this->messageManager->addSuccess(__('You voided the credit memo.'));
+                $this->messageManager->addSuccessMessage(__('You voided the credit memo.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t void the credit memo.'));
+                $this->messageManager->addErrorMessage(__('We can\'t void the credit memo.'));
             }
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('sales/*/view', ['creditmemo_id' => $creditmemo->getId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/CreditmemoLoader.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/CreditmemoLoader.php
@@ -8,7 +8,7 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 
 use Magento\Framework\DataObject;
 use Magento\Sales\Api\CreditmemoRepositoryInterface;
-use \Magento\Sales\Model\Order\CreditmemoFactory;
+use Magento\Sales\Model\Order\CreditmemoFactory;
 
 /**
  * Class CreditmemoLoader
@@ -138,7 +138,7 @@ class CreditmemoLoader extends DataObject
          * Check order existing
          */
         if (!$order->getId()) {
-            $this->messageManager->addError(__('The order no longer exists.'));
+            $this->messageManager->addErrorMessage(__('The order no longer exists.'));
             return false;
         }
 
@@ -146,7 +146,7 @@ class CreditmemoLoader extends DataObject
          * Check creditmemo create availability
          */
         if (!$order->canCreditmemo()) {
-            $this->messageManager->addError(__('We can\'t create credit memo for the order.'));
+            $this->messageManager->addErrorMessage(__('We can\'t create credit memo for the order.'));
             return false;
         }
         return true;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Start.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Start.php
@@ -36,10 +36,10 @@ class Start extends \Magento\Sales\Controller\Adminhtml\Order\Create\Start
                 $resultRedirect->setPath('sales/order/');
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, $e->getMessage());
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
             $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         }
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Email.php
@@ -25,11 +25,11 @@ class Email extends \Magento\Sales\Controller\Adminhtml\Order
         if ($order) {
             try {
                 $this->orderManagement->notify($order->getEntityId());
-                $this->messageManager->addSuccess(__('You sent the order email.'));
+                $this->messageManager->addSuccessMessage(__('You sent the order email.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t send the email order right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t send the email order right now.'));
                 $this->logger->critical($e);
             }
             return $this->resultRedirectFactory->create()->setPath(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Hold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Hold.php
@@ -23,18 +23,18 @@ class Hold extends \Magento\Sales\Controller\Adminhtml\Order
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         if (!$this->isValidPostRequest()) {
-            $this->messageManager->addError(__('You have not put the order on hold.'));
+            $this->messageManager->addErrorMessage(__('You have not put the order on hold.'));
             return $resultRedirect->setPath('sales/*/');
         }
         $order = $this->_initOrder();
         if ($order) {
             try {
                 $this->orderManagement->hold($order->getEntityId());
-                $this->messageManager->addSuccess(__('You put the order on hold.'));
+                $this->messageManager->addSuccessMessage(__('You put the order on hold.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('You have not put the order on hold.'));
+                $this->messageManager->addErrorMessage(__('You have not put the order on hold.'));
             }
             $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
             return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Cancel.php
@@ -31,11 +31,11 @@ class Cancel extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice
             )->addObject(
                 $invoice->getOrder()
             )->save();
-            $this->messageManager->addSuccess(__('You canceled the invoice.'));
+            $this->messageManager->addSuccessMessage(__('You canceled the invoice.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice canceling error'));
+            $this->messageManager->addErrorMessage(__('Invoice canceling error'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Capture.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Capture.php
@@ -33,11 +33,11 @@ class Capture extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoic
             )->addObject(
                 $invoice->getOrder()
             )->save();
-            $this->messageManager->addSuccess(__('The invoice has been captured.'));
+            $this->messageManager->addSuccessMessage(__('The invoice has been captured.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice capturing error'));
+            $this->messageManager->addErrorMessage(__('Invoice capturing error'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/NewAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/NewAction.php
@@ -111,10 +111,10 @@ class NewAction extends \Magento\Backend\App\Action
             $resultPage->getConfig()->getTitle()->prepend(__('New Invoice'));
             return $resultPage;
         } catch (\Magento\Framework\Exception\LocalizedException $exception) {
-            $this->messageManager->addError($exception->getMessage());
+            $this->messageManager->addErrorMessage($exception->getMessage());
             return $this->_redirectToOrder($orderId);
         } catch (\Exception $exception) {
-            $this->messageManager->addException($exception, 'Cannot create an invoice.');
+            $this->messageManager->addExceptionMessage($exception, 'Cannot create an invoice.');
             return $this->_redirectToOrder($orderId);
         }
     }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -11,8 +11,8 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Registry;
 use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Magento\Sales\Model\Order\Email\Sender\ShipmentSender;
-use Magento\Sales\Model\Order\ShipmentFactory;
 use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Order\ShipmentFactory;
 use Magento\Sales\Model\Service\InvoiceService;
 
 /**
@@ -117,7 +117,7 @@ class Save extends \Magento\Backend\App\Action
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addError(__('We can\'t save the invoice right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t save the invoice right now.'));
             return $resultRedirect->setPath('sales/order/index');
         }
 
@@ -192,16 +192,16 @@ class Save extends \Magento\Backend\App\Action
             $transactionSave->save();
 
             if (isset($shippingResponse) && $shippingResponse->hasErrors()) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __(
                         'The invoice and the shipment  have been created. ' .
                         'The shipping label cannot be created now.'
                     )
                 );
             } elseif (!empty($data['do_shipment'])) {
-                $this->messageManager->addSuccess(__('You created the invoice and shipment.'));
+                $this->messageManager->addSuccessMessage(__('You created the invoice and shipment.'));
             } else {
-                $this->messageManager->addSuccess(__('The invoice has been created.'));
+                $this->messageManager->addSuccessMessage(__('The invoice has been created.'));
             }
 
             // send invoice/shipment emails
@@ -211,7 +211,7 @@ class Save extends \Magento\Backend\App\Action
                 }
             } catch (\Exception $e) {
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                $this->messageManager->addError(__('We can\'t send the invoice email right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t send the invoice email right now.'));
             }
             if ($shipment) {
                 try {
@@ -220,15 +220,15 @@ class Save extends \Magento\Backend\App\Action
                     }
                 } catch (\Exception $e) {
                     $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                    $this->messageManager->addError(__('We can\'t send the shipment right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t send the shipment right now.'));
                 }
             }
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->getCommentText(true);
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t save the invoice right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t save the invoice right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         return $resultRedirect->setPath('sales/*/new', ['order_id' => $orderId]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/VoidAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/VoidAction.php
@@ -34,11 +34,11 @@ class VoidAction extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInv
             )->addObject(
                 $invoice->getOrder()
             )->save();
-            $this->messageManager->addSuccess(__('The invoice has been voided.'));
+            $this->messageManager->addSuccessMessage(__('The invoice has been voided.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice voiding error'));
+            $this->messageManager->addErrorMessage(__('Invoice voiding error'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
@@ -48,13 +48,13 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
         $countNonCancelOrder = $collection->count() - $countCancelOrder;
 
         if ($countNonCancelOrder && $countCancelOrder) {
-            $this->messageManager->addError(__('%1 order(s) cannot be canceled.', $countNonCancelOrder));
+            $this->messageManager->addErrorMessage(__('%1 order(s) cannot be canceled.', $countNonCancelOrder));
         } elseif ($countNonCancelOrder) {
-            $this->messageManager->addError(__('You cannot cancel the order(s).'));
+            $this->messageManager->addErrorMessage(__('You cannot cancel the order(s).'));
         }
 
         if ($countCancelOrder) {
-            $this->messageManager->addSuccess(__('We canceled %1 order(s).', $countCancelOrder));
+            $this->messageManager->addSuccessMessage(__('We canceled %1 order(s).', $countCancelOrder));
         }
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath($this->getComponentRefererUrl());

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassHold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassHold.php
@@ -5,11 +5,11 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class MassHold
@@ -62,13 +62,13 @@ class MassHold extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAct
         $countNonHoldOrder = $collection->count() - $countHoldOrder;
 
         if ($countNonHoldOrder && $countHoldOrder) {
-            $this->messageManager->addError(__('%1 order(s) were not put on hold.', $countNonHoldOrder));
+            $this->messageManager->addErrorMessage(__('%1 order(s) were not put on hold.', $countNonHoldOrder));
         } elseif ($countNonHoldOrder) {
-            $this->messageManager->addError(__('No order(s) were put on hold.'));
+            $this->messageManager->addErrorMessage(__('No order(s) were put on hold.'));
         }
 
         if ($countHoldOrder) {
-            $this->messageManager->addSuccess(__('You have put %1 order(s) on hold.', $countHoldOrder));
+            $this->messageManager->addSuccessMessage(__('You have put %1 order(s) on hold.', $countHoldOrder));
         }
 
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
-use Magento\Ui\Component\MassAction\Filter;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 class MassUnhold extends AbstractMassAction
 {
@@ -52,15 +52,15 @@ class MassUnhold extends AbstractMassAction
         $countNonUnHoldOrder = $collection->count() - $countUnHoldOrder;
 
         if ($countNonUnHoldOrder && $countUnHoldOrder) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('%1 order(s) were not released from on hold status.', $countNonUnHoldOrder)
             );
         } elseif ($countNonUnHoldOrder) {
-            $this->messageManager->addError(__('No order(s) were released from on hold status.'));
+            $this->messageManager->addErrorMessage(__('No order(s) were released from on hold status.'));
         }
 
         if ($countUnHoldOrder) {
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('%1 order(s) have been released from on hold status.', $countUnHoldOrder)
             );
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/PdfDocumentsMassAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/PdfDocumentsMassAction.php
@@ -27,7 +27,7 @@ abstract class PdfDocumentsMassAction extends \Magento\Sales\Controller\Adminhtm
             $collection = $this->filter->getCollection($this->getOrderCollection()->create());
             return $this->massAction($collection);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfcreditmemos.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfcreditmemos.php
@@ -5,17 +5,16 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Sales\Model\Order\Pdf\Creditmemo;
-use Magento\Framework\Stdlib\DateTime\DateTime;
-use Magento\Framework\App\Response\Http\FileFactory;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Sales\Model\Order\Pdf\Creditmemo;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo\CollectionFactory;
-use Magento\Sales\Model\ResourceModel\Order\Collection as OrderCollection;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class Pdfcreditmemos
@@ -79,10 +78,9 @@ class Pdfcreditmemos extends \Magento\Sales\Controller\Adminhtml\Order\PdfDocume
      */
     protected function massAction(AbstractCollection $collection)
     {
-
         $creditmemoCollection = $this->collectionFactory->create()->setOrderFilter(['in' => $collection->getAllIds()]);
         if (!$creditmemoCollection->getSize()) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
         return $this->fileFactory->create(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfdocs.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfdocs.php
@@ -5,20 +5,20 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
-use Magento\Sales\Model\Order\Pdf\Invoice;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Response\Http\FileFactory;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Sales\Model\Order\Pdf\Shipment;
-use Magento\Sales\Model\Order\Pdf\Creditmemo;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Sales\Model\Order\Pdf\Creditmemo;
+use Magento\Sales\Model\Order\Pdf\Invoice;
+use Magento\Sales\Model\Order\Pdf\Shipment;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
-use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory as ShipmentCollectionFactory;
-use Magento\Sales\Model\ResourceModel\Order\Invoice\CollectionFactory as InvoiceCollectionFactory;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo\CollectionFactory as CreditmemoCollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Invoice\CollectionFactory as InvoiceCollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory as ShipmentCollectionFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * Class Pdfdocs
@@ -134,7 +134,7 @@ class Pdfdocs extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassActi
         }
 
         if (empty($documents)) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfinvoices.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfinvoices.php
@@ -5,17 +5,16 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Sales\Model\Order\Pdf\Invoice;
-use Magento\Framework\Stdlib\DateTime\DateTime;
-use Magento\Framework\App\Response\Http\FileFactory;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Sales\Model\Order\Pdf\Invoice;
 use Magento\Sales\Model\ResourceModel\Order\Invoice\CollectionFactory;
-use Magento\Sales\Model\ResourceModel\Order\Collection as OrderCollection;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -80,7 +79,7 @@ class Pdfinvoices extends \Magento\Sales\Controller\Adminhtml\Order\PdfDocuments
     {
         $invoicesCollection = $this->collectionFactory->create()->setOrderFilter(['in' => $collection->getAllIds()]);
         if (!$invoicesCollection->getSize()) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
         return $this->fileFactory->create(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfshipments.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfshipments.php
@@ -5,16 +5,16 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Response\Http\FileFactory;
-use Magento\Ui\Component\MassAction\Filter;
-use Magento\Sales\Model\Order\Pdf\Shipment;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Framework\Stdlib\DateTime\DateTime;
-use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory as ShipmentCollectionFactory;
+use Magento\Sales\Model\Order\Pdf\Shipment;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory as ShipmentCollectionFactory;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -84,7 +84,7 @@ class Pdfshipments extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMas
             ->create()
             ->setOrderFilter(['in' => $collection->getAllIds()]);
         if (!$shipmentsCollection->getSize()) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
         return $this->fileFactory->create(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/ReviewPayment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/ReviewPayment.php
@@ -53,15 +53,15 @@ class ReviewPayment extends \Magento\Sales\Controller\Adminhtml\Order
                         throw new \Exception(sprintf('Action "%s" is not supported.', $action));
                 }
                 $this->orderRepository->save($order);
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             } else {
                 $resultRedirect->setPath('sales/*/');
                 return $resultRedirect;
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update the payment right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update the payment right now.'));
             $this->logger->critical($e);
         }
         $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getEntityId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/AssignPost.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/AssignPost.php
@@ -26,18 +26,18 @@ class AssignPost extends \Magento\Sales\Controller\Adminhtml\Order\Status
             if ($status && $status->getStatus()) {
                 try {
                     $status->assignState($state, $isDefault, $visibleOnFront);
-                    $this->messageManager->addSuccess(__('You assigned the order status.'));
+                    $this->messageManager->addSuccessMessage(__('You assigned the order status.'));
                     return $resultRedirect->setPath('sales/*/');
                 } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                    $this->messageManager->addError($e->getMessage());
+                    $this->messageManager->addErrorMessage($e->getMessage());
                 } catch (\Exception $e) {
-                    $this->messageManager->addException(
+                    $this->messageManager->addExceptionMessage(
                         $e,
                         __('Something went wrong while assigning the order status.')
                     );
                 }
             } else {
-                $this->messageManager->addError(__('We can\'t find this order status.'));
+                $this->messageManager->addErrorMessage(__('We can\'t find this order status.'));
             }
             return $resultRedirect->setPath('sales/*/assign');
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Edit.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Edit.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order\Status;
 
-use Magento\Framework\Registry;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\Registry;
 use Magento\Framework\View\Result\PageFactory;
 
 class Edit extends \Magento\Sales\Controller\Adminhtml\Order\Status
@@ -48,7 +48,7 @@ class Edit extends \Magento\Sales\Controller\Adminhtml\Order\Status
             $resultPage->getConfig()->getTitle()->prepend(__('Edit Order Status'));
             return $resultPage;
         } else {
-            $this->messageManager->addError(__('We can\'t find this order status.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find this order status.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             return $resultRedirect->setPath('sales/');

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Save.php
@@ -12,6 +12,7 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Status
      * Save status form processing
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function execute()
     {
@@ -40,7 +41,9 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Status
             $status = $this->_objectManager->create(\Magento\Sales\Model\Order\Status::class)->load($statusCode);
             // check if status exist
             if ($isNew && $status->getStatus()) {
-                $this->messageManager->addError(__('We found another order status with the same order status code.'));
+                $this->messageManager->addErrorMessage(
+                    __('We found another order status with the same order status code.')
+                );
                 $this->_getSession()->setFormData($data);
                 return $resultRedirect->setPath('sales/*/new');
             }
@@ -49,12 +52,12 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Status
 
             try {
                 $status->save();
-                $this->messageManager->addSuccess(__('You saved the order status.'));
+                $this->messageManager->addSuccessMessage(__('You saved the order status.'));
                 return $resultRedirect->setPath('sales/*/');
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('We can\'t add the order status right now.')
                 );

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Unassign.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Unassign.php
@@ -18,17 +18,17 @@ class Unassign extends \Magento\Sales\Controller\Adminhtml\Order\Status
         if ($status) {
             try {
                 $status->unassignState($state);
-                $this->messageManager->addSuccess(__('You have unassigned the order status.'));
+                $this->messageManager->addSuccessMessage(__('You have unassigned the order status.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while unassigning the order.')
                 );
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find this order status.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find this order status.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Unhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Unhold.php
@@ -23,7 +23,7 @@ class Unhold extends \Magento\Sales\Controller\Adminhtml\Order
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         if (!$this->isValidPostRequest()) {
-            $this->messageManager->addError(__('Can\'t unhold order.'));
+            $this->messageManager->addErrorMessage(__('Can\'t unhold order.'));
             return $resultRedirect->setPath('sales/*/');
         }
         $order = $this->_initOrder();
@@ -33,11 +33,11 @@ class Unhold extends \Magento\Sales\Controller\Adminhtml\Order
                     throw new \Magento\Framework\Exception\LocalizedException(__('Can\'t unhold order.'));
                 }
                 $this->orderManagement->unhold($order->getEntityId());
-                $this->messageManager->addSuccess(__('You released the order from holding status.'));
+                $this->messageManager->addSuccessMessage(__('You released the order from holding status.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('The order was not on hold.'));
+                $this->messageManager->addErrorMessage(__('The order was not on hold.'));
             }
             $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
             return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/View.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order;
 
-use Magento\Backend\App\Action;
-
 class View extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
@@ -31,7 +29,7 @@ class View extends \Magento\Sales\Controller\Adminhtml\Order
                 $resultPage->getConfig()->getTitle()->prepend(__('Orders'));
             } catch (\Exception $e) {
                 $this->logger->critical($e);
-                $this->messageManager->addError(__('Exception occurred during order load'));
+                $this->messageManager->addErrorMessage(__('Exception occurred during order load'));
                 $resultRedirect->setPath('sales/order/index');
                 return $resultRedirect;
             }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/View/Giftmessage/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/View/Giftmessage/Save.php
@@ -18,9 +18,9 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\View\Giftmessage
                 $this->getRequest()->getParam('giftmessage')
             )->saveAllInOrder();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Something went wrong while saving the gift message.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while saving the gift message.'));
         }
 
         if ($this->getRequest()->getParam('type') == 'order_item') {

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/VoidPayment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/VoidPayment.php
@@ -21,11 +21,11 @@ class VoidPayment extends \Magento\Sales\Controller\Adminhtml\Order
                 // workaround for backwards compatibility
                 $order->getPayment()->void(new \Magento\Framework\DataObject());
                 $order->save();
-                $this->messageManager->addSuccess(__('The payment has been voided.'));
+                $this->messageManager->addSuccessMessage(__('The payment has been voided.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t void the payment right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t void the payment right now.'));
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             }
             $resultRedirect->setPath('sales/*/view', ['order_id' => $order->getId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
@@ -5,10 +5,9 @@
  */
 namespace Magento\Sales\Controller\Adminhtml;
 
-use Magento\Backend\App\Action;
 use Magento\Framework\Registry;
-use Magento\Framework\View\Result\PageFactory;
 use Magento\Framework\View\Result\LayoutFactory;
+use Magento\Framework\View\Result\PageFactory;
 use Magento\Sales\Api\OrderPaymentRepositoryInterface;
 
 /**
@@ -82,7 +81,7 @@ abstract class Transactions extends \Magento\Backend\App\Action
         );
 
         if (!$txn->getId()) {
-            $this->messageManager->addError(__('Please correct the transaction ID and try again.'));
+            $this->messageManager->addErrorMessage(__('Please correct the transaction ID and try again.'));
             $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
             return false;
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
@@ -38,11 +38,11 @@ class Fetch extends \Magento\Sales\Controller\Adminhtml\Transactions
                 ->setOrder($txn->getOrder())
                 ->importTransactionInfo($txn);
             $txn->save();
-            $this->messageManager->addSuccess(__('The transaction details have been updated.'));
+            $this->messageManager->addSuccessMessage(__('The transaction details have been updated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update the transaction details.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update the transaction details.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Sales/Helper/Guest.php
+++ b/app/code/Magento/Sales/Helper/Guest.php
@@ -10,7 +10,7 @@ use Magento\Framework\App as App;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Stdlib\Cookie\CookieSizeLimitReachedException;
 use Magento\Framework\Stdlib\Cookie\FailureToSendException;
-use \Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order;
 
 /**
  * Sales module base helper
@@ -128,7 +128,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
         $this->resultRedirectFactory = $resultRedirectFactory;
         $this->orderRepository = $orderRepository ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Sales\Api\OrderRepositoryInterface::class);
-        $this->searchCriteriaBuilder = $searchCriteria?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->searchCriteriaBuilder = $searchCriteria ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Api\SearchCriteriaBuilder::class);
         parent::__construct(
             $context
@@ -164,7 +164,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
             $this->coreRegistry->register('current_order', $order);
             return true;
         } catch (InputException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return $this->resultRedirectFactory->create()->setPath('sales/guest/form');
         }
     }

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1061,7 +1061,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             try {
                 $this->addProduct($productId, $config);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
                 return $e;
             }
@@ -1336,7 +1336,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         $data = isset($data['region']) && is_array($data['region']) ? array_merge($data, $data['region']) : $data;
 
         $addressForm = $this->_metadataFormFactory->create(
-            
+
             AddressMetadataInterface::ENTITY_TYPE_ADDRESS,
             'adminhtml_customer_address',
             $data,
@@ -1757,7 +1757,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
                 ->setWebsiteId($store->getWebsiteId())
                 ->setCreatedAt(null);
             $customer = $this->_validateCustomerData($customer);
-        } else if (!$customer->getId()) {
+        } elseif (!$customer->getId()) {
             /** Create new customer */
             $customerBillingAddressDataObject = $this->getBillingAddress()->exportCustomerAddress();
             $customer->setSuffix($customerBillingAddressDataObject->getSuffix())
@@ -1980,7 +1980,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         }
         if (!empty($this->_errors)) {
             foreach ($this->_errors as $error) {
-                $this->messageManager->addError($error);
+                $this->messageManager->addErrorMessage($error);
             }
             throw new \Magento\Framework\Exception\LocalizedException(__('Validation is failed.'));
         }

--- a/app/code/Magento/Sales/Model/AdminOrder/EmailSender.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/EmailSender.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Sales\Model\AdminOrder;
 
-use Psr\Log\LoggerInterface as Logger;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
+use Psr\Log\LoggerInterface as Logger;
 
 /**
  * Class EmailSender
@@ -55,7 +55,7 @@ class EmailSender
             $this->orderSender->send($order);
         } catch (\Magento\Framework\Exception\MailException $exception) {
             $this->logger->critical($exception);
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __('You did not email your customer. Please check your email settings.')
             );
             return false;

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/EmailTest.php
@@ -76,7 +76,9 @@ class EmailTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
-        $this->context = $this->createPartialMock(\Magento\Backend\App\Action\Context::class, [
+        $this->context = $this->createPartialMock(
+            \Magento\Backend\App\Action\Context::class,
+            [
                 'getRequest',
                 'getResponse',
                 'getMessageManager',
@@ -85,31 +87,32 @@ class EmailTest extends \PHPUnit\Framework\TestCase
                 'getSession',
                 'getActionFlag',
                 'getHelper',
-                'getResultRedirectFactory'
-            ]);
+                'getResultRedirectFactory',
+            ]
+        );
         $this->response = $this->createPartialMock(
             \Magento\Framework\App\ResponseInterface::class,
             ['setRedirect', 'sendResponse']
         );
 
-        $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
-            ->disableOriginalConstructor()->getMock();
+        $this->request =
+            $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)->disableOriginalConstructor()->getMock();
         $this->objectManager = $this->createPartialMock(
             \Magento\Framework\ObjectManager\ObjectManager::class,
             ['create']
         );
-        $this->messageManager = $this->createPartialMock(\Magento\Framework\Message\Manager::class, ['addSuccess']);
+        $this->messageManager =
+            $this->createPartialMock(\Magento\Framework\Message\Manager::class, ['addSuccessMessage']);
         $this->session = $this->createPartialMock(\Magento\Backend\Model\Session::class, ['setIsUrlNotice']);
         $this->actionFlag = $this->createPartialMock(\Magento\Framework\App\ActionFlag::class, ['get']);
         $this->helper = $this->createPartialMock(\Magento\Backend\Helper\Data::class, ['getUrl']);
         $this->resultRedirectFactoryMock = $this->getMockBuilder(
             \Magento\Backend\Model\View\Result\RedirectFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
-        $this->resultRedirectMock = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        )->disableOriginalConstructor()->setMethods(['create'])->getMock();
+        $this->resultRedirectMock =
+            $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
+                ->disableOriginalConstructor()
+                ->getMock();
         $this->context->expects($this->once())->method('getMessageManager')->willReturn($this->messageManager);
         $this->context->expects($this->once())->method('getRequest')->willReturn($this->request);
         $this->context->expects($this->once())->method('getResponse')->willReturn($this->response);
@@ -117,13 +120,13 @@ class EmailTest extends \PHPUnit\Framework\TestCase
         $this->context->expects($this->once())->method('getSession')->willReturn($this->session);
         $this->context->expects($this->once())->method('getActionFlag')->willReturn($this->actionFlag);
         $this->context->expects($this->once())->method('getHelper')->willReturn($this->helper);
-        $this->context->expects($this->once())
-            ->method('getResultRedirectFactory')
-            ->willReturn($this->resultRedirectFactoryMock);
+        $this->context->expects($this->once())->method('getResultRedirectFactory')->willReturn(
+            $this->resultRedirectFactoryMock
+        );
         $this->creditmemoEmail = $objectManagerHelper->getObject(
             \Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo\Email::class,
             [
-                'context' => $this->context
+                'context' => $this->context,
             ]
         );
     }
@@ -135,20 +138,12 @@ class EmailTest extends \PHPUnit\Framework\TestCase
         $cmManagementMock = $this->createMock($cmManagement);
         $this->prepareRedirect($cmId);
 
-        $this->request->expects($this->once())
-            ->method('getParam')
-            ->with('creditmemo_id')
-            ->willReturn($cmId);
-        $this->objectManager->expects($this->once())
-            ->method('create')
-            ->with($cmManagement)
-            ->willReturn($cmManagementMock);
-        $cmManagementMock->expects($this->once())
-            ->method('notify')
-            ->willReturn(true);
-        $this->messageManager->expects($this->once())
-            ->method('addSuccess')
-            ->with('You sent the message.');
+        $this->request->expects($this->once())->method('getParam')->with('creditmemo_id')->willReturn($cmId);
+        $this->objectManager->expects($this->once())->method('create')->with($cmManagement)->willReturn(
+            $cmManagementMock
+        );
+        $cmManagementMock->expects($this->once())->method('notify')->willReturn(true);
+        $this->messageManager->expects($this->once())->method('addSuccessMessage')->with('You sent the message.');
 
         $this->assertInstanceOf(
             \Magento\Backend\Model\View\Result\Redirect::class,
@@ -159,10 +154,9 @@ class EmailTest extends \PHPUnit\Framework\TestCase
 
     public function testEmailNoCreditmemoId()
     {
-        $this->request->expects($this->once())
-            ->method('getParam')
-            ->with('creditmemo_id')
-            ->will($this->returnValue(null));
+        $this->request->expects($this->once())->method('getParam')->with('creditmemo_id')->will(
+            $this->returnValue(null)
+        );
 
         $this->assertNull($this->creditmemoEmail->execute());
     }
@@ -172,12 +166,12 @@ class EmailTest extends \PHPUnit\Framework\TestCase
      */
     protected function prepareRedirect($cmId)
     {
-        $this->resultRedirectFactoryMock->expects($this->once())
-            ->method('create')
-            ->willReturn($this->resultRedirectMock);
-        $this->resultRedirectMock->expects($this->once())
-            ->method('setPath')
-            ->with('sales/order_creditmemo/view', ['creditmemo_id' => $cmId])
-            ->willReturnSelf();
+        $this->resultRedirectFactoryMock->expects($this->once())->method('create')->willReturn(
+            $this->resultRedirectMock
+        );
+        $this->resultRedirectMock->expects($this->once())->method('setPath')->with(
+            'sales/order_creditmemo/view',
+            ['creditmemo_id' => $cmId]
+        )->willReturnSelf();
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Invoice/AbstractInvoice/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Invoice/AbstractInvoice/EmailTest.php
@@ -6,10 +6,10 @@
 
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Invoice\AbstractInvoice;
 
-use \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\Email;
-
 use Magento\Framework\App\Action\Context;
+
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\Email;
 
 /**
  * Class EmailTest
@@ -196,7 +196,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->with($invoiceId)
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the message.');
 
         $this->resultRedirectFactory->expects($this->atLeastOnce())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/CancelTest.php
@@ -77,7 +77,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()->getMock();
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
         $this->orderRepositoryMock = $this->getMockBuilder(\Magento\Sales\Api\OrderRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -117,7 +117,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('You have not canceled the item.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ProcessDataTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ProcessDataTest.php
@@ -7,7 +7,6 @@
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Create;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-
 use Magento\Sales\Controller\Adminhtml\Order\Create\ProcessData;
 
 /**
@@ -87,7 +86,7 @@ class ProcessDataTest extends \PHPUnit\Framework\TestCase
                 'setDispatched',
                 'getModuleName',
                 'getActionName',
-                'getCookie'
+                'getCookie',
             ]
         );
         $response = $this->getMockForAbstractClass(
@@ -116,22 +115,20 @@ class ProcessDataTest extends \PHPUnit\Framework\TestCase
         $this->escaper = $this->createPartialMock(\Magento\Framework\Escaper::class, ['escapeHtml']);
 
         $this->resultForward = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Forward::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->getMock();
         $this->resultForwardFactory = $this->getMockBuilder(\Magento\Backend\Model\View\Result\ForwardFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
+                ->disableOriginalConstructor()
+                ->setMethods(['create'])
+                ->getMock();
 
-        $this->resultForwardFactory->expects($this->once())
-            ->method('create')
-            ->willReturn($this->resultForward);
+        $this->resultForwardFactory->expects($this->once())->method('create')->willReturn($this->resultForward);
 
         $this->processData = $objectManagerHelper->getObject(
             \Magento\Sales\Controller\Adminhtml\Order\Create\ProcessData::class,
             [
-                'context' => $context,
-                'escaper' => $this->escaper,
+                'context'              => $context,
+                'escaper'              => $this->escaper,
                 'resultForwardFactory' => $this->resultForwardFactory,
             ]
         );
@@ -155,13 +152,13 @@ class ProcessDataTest extends \PHPUnit\Framework\TestCase
         $paramReturnMap = [
             ['customer_id', null, null],
             ['store_id', null, null],
-            ['currency_id', null, null]
+            ['currency_id', null, null],
         ];
         $this->request->expects($this->atLeastOnce())->method('getParam')->willReturnMap($paramReturnMap);
 
         $objectManagerParamMap = [
             [\Magento\Sales\Model\AdminOrder\Create::class, $create],
-            [\Magento\Backend\Model\Session\Quote::class, $this->session]
+            [\Magento\Backend\Model\Session\Quote::class, $this->session],
         ];
         $this->objectManager->expects($this->atLeastOnce())->method('get')->willReturnMap($objectManagerParamMap);
 
@@ -226,12 +223,12 @@ class ProcessDataTest extends \PHPUnit\Framework\TestCase
         );
         $this->escaper->expects($this->once())->method('escapeHtml')->with($couponCode)->willReturn($couponCode);
 
-        $this->messageManager->expects($this->once())->method('addError')->with($errorMessageManager)->willReturnSelf();
-
-        $this->resultForward->expects($this->once())
-            ->method('forward')
-            ->with('index')
+        $this->messageManager->expects($this->once())
+            ->method('addErrorMessage')
+            ->with($errorMessageManager)
             ->willReturnSelf();
+
+        $this->resultForward->expects($this->once())->method('forward')->with('index')->willReturnSelf();
         $this->assertInstanceOf(\Magento\Backend\Model\View\Result\Forward::class, $this->processData->execute());
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/CancelTest.php
@@ -292,7 +292,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->method('cancel')
             ->with($creditmemoId);
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The credit memo has been canceled.');
         $this->resultRedirectFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
@@ -235,7 +235,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
      */
     protected function _setSaveActionExpectationForMageCoreException($data, $errorMessage)
     {
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($errorMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($errorMessage));
         $this->_sessionMock->expects($this->once())->method('setFormData')->with($this->equalTo($data));
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
@@ -335,7 +335,7 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->method('getInvoice')
             ->willReturn($invoiceMock);
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You voided the credit memo.');
         $this->resultRedirectFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/EmailTest.php
@@ -119,7 +119,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()->getMock();
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
 
         $this->orderMock = $this->getMockBuilder(\Magento\Sales\Api\Data\OrderInterface::class)
@@ -171,7 +171,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->with($orderId)
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the order email.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')
@@ -198,7 +198,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
                 new \Magento\Framework\Exception\NoSuchEntityException(__('Requested entity doesn\'t exist'))
             );
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('This order no longer exists.');
 
         $this->actionFlag->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/HoldTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/HoldTest.php
@@ -77,7 +77,7 @@ class HoldTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()->getMock();
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
         $this->orderRepositoryMock = $this->getMockBuilder(\Magento\Sales\Api\OrderRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -117,7 +117,7 @@ class HoldTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('You have not put the order on hold.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CancelTest.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Invoice;
 
-use Magento\Backend\App\Action;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
 
@@ -213,7 +212,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->method('save');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You canceled the invoice.');
 
         $this->invoiceRepository->expects($this->once())
@@ -295,7 +294,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->will($this->throwException($e));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())
@@ -343,7 +342,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->will($this->throwException($e));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CaptureTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CaptureTest.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Invoice;
 
-use Magento\Backend\App\Action;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
 
@@ -223,7 +222,7 @@ class CaptureTest extends \PHPUnit\Framework\TestCase
             ->method('save');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The invoice has been captured.');
 
         $invoiceMock->expects($this->once())
@@ -304,7 +303,7 @@ class CaptureTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())
@@ -355,7 +354,7 @@ class CaptureTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Invoice;
 
-use Magento\Backend\App\Action;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
@@ -121,7 +120,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t save the invoice right now.');
         $redirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
@@ -250,7 +250,7 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($transactionMock));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The invoice has been voided.');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
@@ -283,9 +283,9 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $resultForward = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Forward::class)
             ->disableOriginalConstructor()
@@ -334,7 +334,7 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->willReturn($invoiceMock);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassCancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassCancelTest.php
@@ -191,11 +191,11 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('1 order(s) cannot be canceled.');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('We canceled 1 order(s).');
 
         $this->resultRedirectMock->expects($this->once())
@@ -239,7 +239,7 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('You cannot cancel the order(s).');
 
         $this->resultRedirectMock->expects($this->once())
@@ -272,7 +272,7 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Can not cancel');
 
         $this->massAction->execute();

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassHoldTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassHoldTest.php
@@ -196,11 +196,11 @@ class MassHoldTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('1 order(s) were not put on hold.');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You have put 1 order(s) on hold.');
 
         $this->resultRedirectMock->expects($this->once())
@@ -240,7 +240,7 @@ class MassHoldTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('No order(s) were put on hold.');
 
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassUnholdTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassUnholdTest.php
@@ -188,11 +188,11 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('1 order(s) were not released from on hold status.');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 order(s) have been released from on hold status.');
 
         $this->resultRedirectMock->expects($this->once())
@@ -231,7 +231,7 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('No order(s) were released from on hold status.');
 
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ReviewPaymentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ReviewPaymentTest.php
@@ -75,7 +75,7 @@ class ReviewPaymentTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
         $this->messageManagerMock = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
 
         $this->resultRedirectFactoryMock = $this->createPartialMock(
@@ -137,7 +137,7 @@ class ReviewPaymentTest extends \PHPUnit\Framework\TestCase
         $this->paymentMock->expects($this->once())->method('update');
         $this->paymentMock->expects($this->any())->method('getIsTransactionApproved')->willReturn(true);
 
-        $this->messageManagerMock->expects($this->once())->method('addSuccess');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/UnholdTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/UnholdTest.php
@@ -77,7 +77,7 @@ class UnholdTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()->getMock();
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
         $this->orderRepositoryMock = $this->getMockBuilder(\Magento\Sales\Api\OrderRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -117,7 +117,7 @@ class UnholdTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Can\'t unhold order.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ViewTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ViewTest.php
@@ -248,7 +248,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
             ->method('critical')
             ->with($exception);
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Exception occurred during order load')
             ->willReturnSelf();
         $this->setPath('sales/order/index');
@@ -289,7 +289,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     protected function initOrderFail()
     {
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('This order no longer exists.')
             ->willReturnSelf();
         $this->actionFlagMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/PdfDocumentsMassActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/PdfDocumentsMassActionTest.php
@@ -46,7 +46,7 @@ class PdfDocumentsMassActionTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
 
         $this->orderCollectionMock = $this->createMock(\Magento\Sales\Model\ResourceModel\Order\Collection::class);
@@ -88,7 +88,7 @@ class PdfDocumentsMassActionTest extends \PHPUnit\Framework\TestCase
             ->method('getCollection')
             ->with($this->orderCollectionMock)
             ->willThrowException($exception);
-        $this->messageManager->expects($this->once())->method('addError');
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
 
         $this->resultRedirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->controller->execute($exception);

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/EmailSenderTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Sales\Test\Unit\Model\AdminOrder;
 
-use \Magento\Sales\Model\AdminOrder\EmailSender;
+use Magento\Sales\Model\AdminOrder\EmailSender;
 
 class EmailSenderTest extends \PHPUnit\Framework\TestCase
 {
@@ -57,7 +57,7 @@ class EmailSenderTest extends \PHPUnit\Framework\TestCase
             ->method('send')
             ->willThrowException(new \Magento\Framework\Exception\MailException(__('test message')));
         $this->messageManagerMock->expects($this->once())
-            ->method('addWarning');
+            ->method('addWarningMessage');
         $this->loggerMock->expects($this->once())
             ->method('critical');
 

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Delete.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Delete.php
@@ -21,13 +21,13 @@ class Delete extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $model = $this->_objectManager->create(\Magento\SalesRule\Model\Rule::class);
                 $model->load($id);
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the rule.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rule.'));
                 $this->_redirect('sales_rule/*/');
                 return;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete the rule right now. Please review the log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -35,7 +35,7 @@ class Delete extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a rule to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a rule to delete.'));
         $this->_redirect('sales_rule/*/');
     }
 }

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Edit.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Edit.php
@@ -51,7 +51,7 @@ class Edit extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
         if ($id) {
             $model->load($id);
             if (!$model->getRuleId()) {
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 $this->_redirect('sales_rule/*');
                 return;
             }

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Generate.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Generate.php
@@ -6,7 +6,6 @@
  */
 namespace Magento\SalesRule\Controller\Adminhtml\Promo\Quote;
 
-use Magento\Framework\App\ObjectManager;
 use Magento\SalesRule\Model\CouponGenerator;
 
 class Generate extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
@@ -64,7 +63,7 @@ class Generate extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
 
                 $couponCodes = $this->couponGenerator->generateCodes($data);
                 $generated = count($couponCodes);
-                $this->messageManager->addSuccess(__('%1 coupon(s) have been generated.', $generated));
+                $this->messageManager->addSuccessMessage(__('%1 coupon(s) have been generated.', $generated));
                 $this->_view->getLayout()->initMessages();
                 $result['messages'] = $this->_view->getLayout()->getMessagesBlock()->getGroupedHtml();
             } catch (\Magento\Framework\Exception\InputException $inputException) {

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
@@ -50,7 +50,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $validateResult = $model->validateData(new \Magento\Framework\DataObject($data));
                 if ($validateResult !== true) {
                     foreach ($validateResult as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                     $session->setPageData($data);
                     $this->_redirect('sales_rule/*/edit', ['id' => $model->getId()]);
@@ -82,7 +82,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $session->setPageData($model->getData());
 
                 $model->save();
-                $this->messageManager->addSuccess(__('You saved the rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rule.'));
                 $session->setPageData(false);
                 if ($this->getRequest()->getParam('back')) {
                     $this->_redirect('sales_rule/*/edit', ['id' => $model->getId()]);
@@ -91,7 +91,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $this->_redirect('sales_rule/*/');
                 return;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $id = (int)$this->getRequest()->getParam('rule_id');
                 if (!empty($id)) {
                     $this->_redirect('sales_rule/*/edit', ['id' => $id]);
@@ -100,7 +100,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 }
                 return;
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Something went wrong while saving the rule data. Please review the error log.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/SalesRule/Observer/CheckSalesRulesAvailability.php
+++ b/app/code/Magento/SalesRule/Observer/CheckSalesRulesAvailability.php
@@ -54,7 +54,7 @@ class CheckSalesRulesAvailability
         }
 
         if ($disabledRulesCount) {
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __(
                     '%1 Cart Price Rules based on "%2" attribute have been disabled.',
                     $disabledRulesCount,

--- a/app/code/Magento/SalesRule/Test/Unit/Controller/Adminhtml/Promo/Quote/GenerateTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Controller/Adminhtml/Promo/Quote/GenerateTest.php
@@ -143,7 +143,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
             ->with($requestData)
             ->willReturn(['some_data', 'some_data_2']);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->responseMock->expects($this->once())
             ->method('representJson')
             ->with();

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Delete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Delete.php
@@ -60,16 +60,18 @@ class Delete extends \Magento\Backend\App\Action
                 /** @var \Magento\Search\Model\SynonymGroup $synGroupModel */
                 $synGroupModel = $this->synGroupRepository->get($id);
                 $this->synGroupRepository->delete($synGroupModel);
-                $this->messageManager->addSuccess(__('The synonym group has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The synonym group has been deleted.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->logger->error($e);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('An error was encountered while performing delete operation.'));
+                $this->messageManager->addErrorMessage(
+                    __('An error was encountered while performing delete operation.')
+                );
                 $this->logger->error($e);
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find a synonym group to delete.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find a synonym group to delete.'));
         }
 
         return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Edit.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Edit.php
@@ -66,10 +66,10 @@ class Edit extends \Magento\Backend\App\Action
 
         // 2. Initial checking
         if ($groupId && (!$synGroup->getGroupId())) {
-                $this->messageManager->addError(__('This synonyms group no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This synonyms group no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultRedirectFactory->create();
-                return $resultRedirect->setPath('*/*/');
+            return $resultRedirect->setPath('*/*/');
         }
 
         // 3. Set entered data if was error when we do save

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/MassDelete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/MassDelete.php
@@ -72,17 +72,17 @@ class MassDelete extends \Magento\Backend\App\Action
                 $this->synGroupRepository->delete($synonymGroup);
                 $deletedItems++;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
         if ($deletedItems != 0) {
             if ($collectionSize != $deletedItems) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Failed to delete %1 synonym group(s).', $collectionSize - $deletedItems)
                 );
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 synonym group(s) have been deleted.', $deletedItems)
             );
         }

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Save.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Save.php
@@ -59,7 +59,7 @@ class Save extends \Magento\Backend\App\Action
             $synGroup = $this->synGroupRepository->get($synGroupId);
 
             if (!$synGroup->getGroupId() && $synGroupId) {
-                $this->messageManager->addError(__('This synonym group no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This synonym group no longer exists.'));
                 return $resultRedirect->setPath('*/*/');
             }
 

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Delete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Delete.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Search\Controller\Adminhtml\Term;
 
-use Magento\Search\Controller\Adminhtml\Term as TermController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Search\Controller\Adminhtml\Term as TermController;
 
 class Delete extends TermController
 {
@@ -23,16 +23,16 @@ class Delete extends TermController
                 $model = $this->_objectManager->create(\Magento\Search\Model\Query::class);
                 $model->setId($id);
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the search.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the search.'));
                 $resultRedirect->setPath('search/*/');
                 return $resultRedirect;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $resultRedirect->setPath('search/*/edit', ['id' => $this->getRequest()->getParam('id')]);
                 return $resultRedirect;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a search term to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a search term to delete.'));
         $resultRedirect->setPath('search/*/');
         return $resultRedirect;
     }

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Edit.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Edit.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Search\Controller\Adminhtml\Term;
 
-use Magento\Search\Controller\Adminhtml\Term as TermController;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\Registry;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Registry;
+use Magento\Search\Controller\Adminhtml\Term as TermController;
 
 class Edit extends TermController
 {
@@ -43,7 +43,7 @@ class Edit extends TermController
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This search no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This search no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
                 $resultRedirect->setPath('search/*');

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/MassDelete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/MassDelete.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Search\Controller\Adminhtml\Term;
 
-use Magento\Search\Controller\Adminhtml\Term as TermController;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Search\Controller\Adminhtml\Term as TermController;
 
 class MassDelete extends TermController
 {
@@ -17,16 +17,16 @@ class MassDelete extends TermController
     {
         $searchIds = $this->getRequest()->getParam('search');
         if (!is_array($searchIds)) {
-            $this->messageManager->addError(__('Please select searches.'));
+            $this->messageManager->addErrorMessage(__('Please select searches.'));
         } else {
             try {
                 foreach ($searchIds as $searchId) {
                     $model = $this->_objectManager->create(\Magento\Search\Model\Query::class)->load($searchId);
                     $model->delete();
                 }
-                $this->messageManager->addSuccess(__('Total of %1 record(s) were deleted.', count($searchIds)));
+                $this->messageManager->addSuccessMessage(__('Total of %1 record(s) were deleted.', count($searchIds)));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Save.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Save.php
@@ -7,9 +7,9 @@ namespace Magento\Search\Controller\Adminhtml\Term;
 
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Search\Model\QueryFactory;
-use Magento\Search\Controller\Adminhtml\Term as TermController;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Search\Controller\Adminhtml\Term as TermController;
+use Magento\Search\Model\QueryFactory;
 
 class Save extends TermController
 {
@@ -45,12 +45,15 @@ class Save extends TermController
                 $model->addData($data);
                 $model->setIsProcessed(0);
                 $model->save();
-                $this->messageManager->addSuccess(__('You saved the search term.'));
+                $this->messageManager->addSuccessMessage(__('You saved the search term.'));
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $this->proceedToEdit($data);
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while saving the search query.'));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __('Something went wrong while saving the search query.')
+                );
                 return $this->proceedToEdit($data);
             }
         }

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Synonyms/DeleteTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Synonyms/DeleteTest.php
@@ -107,10 +107,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         $this->repository->expects($this->once())->method('get')->with(10)->willReturn($this->synonymGroupMock);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The synonym group has been deleted.'));
 
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())->method('setPath')->with('*/*/')->willReturnSelf();
 
@@ -124,10 +124,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t find a synonym group to delete.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/MassDeleteTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/MassDeleteTest.php
@@ -6,8 +6,8 @@
 
 namespace Magento\Search\Test\Unit\Controller\Adminhtml\Term;
 
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 
 class MassDeleteTest extends \PHPUnit\Framework\TestCase
 {
@@ -54,7 +54,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
         $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess', 'addError'])
+            ->setMethods(['addSuccessMessage', 'addErrorMessage'])
             ->getMockForAbstractClass();
         $this->pageFactory = $this->getMockBuilder(\Magento\Framework\View\Result\PageFactory::class)
             ->setMethods([])
@@ -107,7 +107,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
         $this->createQuery(0, 1);
         $this->createQuery(1, 2);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->will($this->returnSelf());
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/SaveTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/SaveTest.php
@@ -75,7 +75,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess', 'addError', 'addException'])
+            ->setMethods(['addSuccessMessage', 'addErrorMessage', 'addExceptionMessage'])
             ->getMockForAbstractClass();
         $this->context->expects($this->any())
             ->method('getMessageManager')
@@ -143,7 +143,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('getId')->willReturn(false);
         $this->query->expects($this->once())->method('load')->with($queryId);
 
-        $this->messageManager->expects($this->once())->method('addSuccess');
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -161,7 +161,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
         $this->query->expects($this->any())->method('getId')->willReturn($queryId);
 
-        $this->messageManager->expects($this->once())->method('addSuccess');
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -180,7 +180,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->any())->method('getId')->willReturn(false);
         $this->query->expects($this->once())->method('load')->with($queryId);
 
-        $this->messageManager->expects($this->once())->method('addSuccess');
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -199,7 +199,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
         $this->query->expects($this->any())->method('getId')->willReturn($anotherQueryId);
 
-        $this->messageManager->expects($this->once())->method('addError');
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
         $this->session->expects($this->once())->method('setPageData');
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -216,7 +216,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('setStoreId');
         $this->query->expects($this->once())->method('loadByQueryText')->willThrowException(new \Exception());
 
-        $this->messageManager->expects($this->once())->method('addException');
+        $this->messageManager->expects($this->once())->method('addExceptionMessage');
         $this->session->expects($this->once())->method('setPageData');
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());

--- a/app/code/Magento/Security/Controller/Adminhtml/Session/LogoutAll.php
+++ b/app/code/Magento/Security/Controller/Adminhtml/Session/LogoutAll.php
@@ -38,11 +38,11 @@ class LogoutAll extends \Magento\Backend\App\Action
     {
         try {
             $this->sessionsManager->logoutOtherUserSessions();
-            $this->messageManager->addSuccess(__('All other open sessions for this account were terminated.'));
+            $this->messageManager->addSuccessMessage(__('All other open sessions for this account were terminated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __("We couldn't logout because of an error."));
+            $this->messageManager->addExceptionMessage($e, __("We couldn't logout because of an error."));
         }
         $this->_redirect('*/*/activity');
     }

--- a/app/code/Magento/Security/Model/Plugin/Auth.php
+++ b/app/code/Magento/Security/Model/Plugin/Auth.php
@@ -43,7 +43,7 @@ class Auth
     {
         $this->sessionsManager->processLogin();
         if ($this->sessionsManager->getCurrentSession()->isOtherSessionsTerminated()) {
-            $this->messageManager->addWarning(__('All other open sessions for this account were terminated.'));
+            $this->messageManager->addWarningMessage(__('All other open sessions for this account were terminated.'));
         }
     }
 

--- a/app/code/Magento/Security/Model/Plugin/AuthSession.php
+++ b/app/code/Magento/Security/Model/Plugin/AuthSession.php
@@ -82,7 +82,7 @@ class AuthSession
                 $this->sessionsManager->getCurrentSession()->getStatus()
             );
         } elseif ($message = $this->sessionsManager->getLogoutReasonMessage()) {
-            $this->messageManager->addError($message);
+            $this->messageManager->addErrorMessage($message);
         }
 
         return $this;

--- a/app/code/Magento/Security/Model/Plugin/LoginController.php
+++ b/app/code/Magento/Security/Model/Plugin/LoginController.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Security\Model\Plugin;
 
-use Magento\Security\Model\AdminSessionsManager;
 use Magento\Backend\Controller\Adminhtml\Auth\Login;
+use Magento\Security\Model\AdminSessionsManager;
 
 /**
  * Magento\Backend\Controller\Adminhtml\Auth\Login decorator
@@ -53,7 +53,7 @@ class LoginController
     {
         $logoutReasonCode = $this->securityCookie->getLogoutReasonCookie();
         if ($this->isLoginForm($login) && $logoutReasonCode >= 0) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 $this->sessionsManager->getLogoutReasonMessageByStatus($logoutReasonCode)
             );
             $this->securityCookie->deleteLogoutReasonCookie();

--- a/app/code/Magento/Security/Test/Unit/Controller/Adminhtml/Session/LogoutAllTest.php
+++ b/app/code/Magento/Security/Test/Unit/Controller/Adminhtml/Session/LogoutAllTest.php
@@ -74,7 +74,7 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess', 'addError', 'addException'])
+            ->setMethods(['addSuccessMessage', 'addErrorMessage', 'addExceptionMessage'])
             ->getMockForAbstractClass();
         $this->contextMock->expects($this->any())
             ->method('getMessageManager')
@@ -132,12 +132,12 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
         $this->sessionsManager->expects($this->once())
             ->method('logoutOtherUserSessions');
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($successMessage);
         $this->messageManager->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->messageManager->expects($this->never())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $this->responseMock->expects($this->once())
             ->method('setRedirect');
         $this->actionFlagMock->expects($this->once())
@@ -158,7 +158,7 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
             ->method('logoutOtherUserSessions')
             ->willThrowException(new LocalizedException($phrase));
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($phrase);
         $this->controller->execute();
     }
@@ -173,7 +173,7 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
             ->method('logoutOtherUserSessions')
             ->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with(new \Exception(), $phrase);
         $this->controller->execute();
     }

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthSessionTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthSessionTest.php
@@ -112,7 +112,7 @@ class AuthSessionTest extends \PHPUnit\Framework\TestCase
             ->willReturn($errorMessage);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage);
 
         $this->model->aroundProlong($this->authSessionMock, $proceed);

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthTest.php
@@ -58,7 +58,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager = $this->getMockForAbstractClass(
             \Magento\Framework\Message\ManagerInterface::class,
-            ['addWarning'],
+            ['addWarningMessage'],
             '',
             false
         );
@@ -94,7 +94,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             ->method('isOtherSessionsTerminated')
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addWarning')
+            ->method('addWarningMessage')
             ->with($warningMessage);
 
         $this->model->afterLogin($this->authMock);

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/LoginControllerTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/LoginControllerTest.php
@@ -103,7 +103,7 @@ class LoginControllerTest extends \PHPUnit\Framework\TestCase
             ->willReturn($errorMessage);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage);
 
         $this->securityCookieMock->expects($this->once())

--- a/app/code/Magento/SendFriend/Controller/Product/Send.php
+++ b/app/code/Magento/SendFriend/Controller/Product/Send.php
@@ -57,7 +57,7 @@ class Send extends \Magento\SendFriend\Controller\Product
         }
 
         if ($this->sendFriend->getMaxSendsToFriend() && $this->sendFriend->isExceedLimit()) {
-            $this->messageManager->addNotice(
+            $this->messageManager->addNoticeMessage(
                 __('You can\'t send messages more than %1 times an hour.', $this->sendFriend->getMaxSendsToFriend())
             );
         }

--- a/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
+++ b/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
@@ -6,8 +6,8 @@
 
 namespace Magento\SendFriend\Controller\Product;
 
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class Sendmail extends \Magento\SendFriend\Controller\Product
 {
@@ -91,23 +91,23 @@ class Sendmail extends \Magento\SendFriend\Controller\Product
             $validate = $this->sendFriend->validate();
             if ($validate === true) {
                 $this->sendFriend->send();
-                $this->messageManager->addSuccess(__('The link to a friend was sent.'));
+                $this->messageManager->addSuccessMessage(__('The link to a friend was sent.'));
                 $url = $product->getProductUrl();
                 $resultRedirect->setUrl($this->_redirect->success($url));
                 return $resultRedirect;
             } else {
                 if (is_array($validate)) {
                     foreach ($validate as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                 } else {
-                    $this->messageManager->addError(__('We found some problems with the data.'));
+                    $this->messageManager->addErrorMessage(__('We found some problems with the data.'));
                 }
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Some emails were not sent.'));
+            $this->messageManager->addExceptionMessage($e, __('Some emails were not sent.'));
         }
 
         // save form data

--- a/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendTest.php
+++ b/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendTest.php
@@ -128,7 +128,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addNotice');
+            ->method('addNoticeMessage');
 
         /** @var \Magento\Framework\View\Result\Page|\PHPUnit_Framework_MockObject_MockObject $pageMock */
         $pageMock = $this->getMockBuilder(\Magento\Framework\View\Result\Page::class)
@@ -217,7 +217,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addNotice');
+            ->method('addNoticeMessage');
 
         /** @var \Magento\Framework\View\Result\Page|\PHPUnit_Framework_MockObject_MockObject $pageMock */
         $pageMock = $this->getMockBuilder(\Magento\Framework\View\Result\Page::class)
@@ -293,7 +293,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn(true);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with(__('You can\'t send messages more than %1 times an hour.', 11))
             ->willReturnSelf();
 

--- a/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendmailTest.php
+++ b/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendmailTest.php
@@ -216,7 +216,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The link to a friend was sent.'))
             ->willReturnSelf();
 
@@ -338,7 +338,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Some error'))
             ->willReturnSelf();
 
@@ -465,7 +465,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We found some problems with the data.'))
             ->willReturnSelf();
 
@@ -592,7 +592,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Localized Exception.'))
             ->willReturnSelf();
 
@@ -720,7 +720,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('Some emails were not sent.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/CreateLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/CreateLabel.php
@@ -58,7 +58,7 @@ class CreateLabel extends \Magento\Backend\App\Action
             $shipment = $this->shipmentLoader->load();
             $this->labelGenerator->create($shipment, $this->_request);
             $shipment->save();
-            $this->messageManager->addSuccess(__('You created the shipping label.'));
+            $this->messageManager->addSuccessMessage(__('You created the shipping label.'));
             $response->setOk(true);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $response->setError(true);

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Email.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Email.php
@@ -57,12 +57,12 @@ class Email extends \Magento\Backend\App\Action
                 $this->_objectManager->create(\Magento\Shipping\Model\ShipmentNotifier::class)
                     ->notify($shipment);
                 $shipment->save();
-                $this->messageManager->addSuccess(__('You sent the shipment.'));
+                $this->messageManager->addSuccessMessage(__('You sent the shipment.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Cannot send shipment information.'));
+            $this->messageManager->addErrorMessage(__('Cannot send shipment information.'));
         }
 
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/MassPrintShippingLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/MassPrintShippingLabel.php
@@ -6,17 +6,16 @@
  */
 namespace Magento\Shipping\Controller\Adminhtml\Order\Shipment;
 
-use Magento\Backend\App\Action;
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Backend\App\Action\Context;
-use Magento\Shipping\Model\Shipping\LabelGenerator;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Response\Http\FileFactory;
-use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory as ShipmentCollectionFactory;
+use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory as ShipmentCollectionFactory;
+use Magento\Shipping\Model\Shipping\LabelGenerator;
+use Magento\Ui\Component\MassAction\Filter;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -105,7 +104,7 @@ class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\A
             );
         }
 
-        $this->messageManager->addError(__('There are no shipping labels related to selected orders.'));
+        $this->messageManager->addErrorMessage(__('There are no shipping labels related to selected orders.'));
         return $this->resultRedirectFactory->create()->setPath('sales/order/');
     }
 }

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintLabel.php
@@ -7,8 +7,8 @@
 namespace Magento\Shipping\Controller\Adminhtml\Order\Shipment;
 
 use Magento\Backend\App\Action;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResponseInterface;
 
 class PrintLabel extends \Magento\Backend\App\Action
 {
@@ -74,7 +74,7 @@ class PrintLabel extends \Magento\Backend\App\Action
                     $pdf = new \Zend_Pdf();
                     $page = $this->labelGenerator->createPdfPageFromImageString($labelContent);
                     if (!$page) {
-                        $this->messageManager->addError(
+                        $this->messageManager->addErrorMessage(
                             __(
                                 'We don\'t recognize or support the file extension in this shipment: %1.',
                                 $shipment->getIncrementId()
@@ -93,10 +93,10 @@ class PrintLabel extends \Magento\Backend\App\Action
                 );
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError(__('An error occurred while creating shipping label.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while creating shipping label.'));
         }
         $this->_redirect(
             'adminhtml/order_shipment/view',

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
@@ -6,7 +6,6 @@
  */
 namespace Magento\Shipping\Controller\Adminhtml\Order\Shipment;
 
-use Magento\Backend\App\Action;
 use Magento\Sales\Model\Order\Shipment\Validation\QuantityValidator;
 
 /**
@@ -97,7 +96,7 @@ class Save extends \Magento\Backend\App\Action
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addError(__('We can\'t save the shipment right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t save the shipment right now.'));
             return $resultRedirect->setPath('sales/order/index');
         }
 
@@ -134,7 +133,7 @@ class Save extends \Magento\Backend\App\Action
                 ->validate($shipment, [QuantityValidator::class]);
 
             if ($validationResult->hasMessages()) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __("Shipment Document Validation Error(s):\n" . implode("\n", $validationResult->getMessages()))
                 );
                 $this->_redirect('*/*/new', ['order_id' => $this->getRequest()->getParam('order_id')]);
@@ -159,7 +158,7 @@ class Save extends \Magento\Backend\App\Action
             $shipmentCreatedMessage = __('The shipment has been created.');
             $labelCreatedMessage = __('You created the shipping label.');
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 $isNeedCreateLabel ? $shipmentCreatedMessage . ' ' . $labelCreatedMessage : $shipmentCreatedMessage
             );
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->getCommentText(true);
@@ -168,7 +167,7 @@ class Save extends \Magento\Backend\App\Action
                 $responseAjax->setError(true);
                 $responseAjax->setMessage($e->getMessage());
             } else {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('*/*/new', ['order_id' => $this->getRequest()->getParam('order_id')]);
             }
         } catch (\Exception $e) {
@@ -177,7 +176,7 @@ class Save extends \Magento\Backend\App\Action
                 $responseAjax->setError(true);
                 $responseAjax->setMessage(__('An error occurred while creating shipping label.'));
             } else {
-                $this->messageManager->addError(__('Cannot save shipment.'));
+                $this->messageManager->addErrorMessage(__('Cannot save shipment.'));
                 $this->_redirect('*/*/new', ['order_id' => $this->getRequest()->getParam('order_id')]);
             }
         }

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
@@ -111,21 +111,21 @@ class ShipmentLoader extends DataObject
              * Check order existing
              */
             if (!$order->getId()) {
-                $this->messageManager->addError(__('The order no longer exists.'));
+                $this->messageManager->addErrorMessage(__('The order no longer exists.'));
                 return false;
             }
             /**
              * Check shipment is available to create separate from invoice
              */
             if ($order->getForcedShipmentWithInvoice()) {
-                $this->messageManager->addError(__('Cannot do shipment for the order separately from invoice.'));
+                $this->messageManager->addErrorMessage(__('Cannot do shipment for the order separately from invoice.'));
                 return false;
             }
             /**
              * Check shipment create availability
              */
             if (!$order->canShip()) {
-                $this->messageManager->addError(__('Cannot do shipment for the order.'));
+                $this->messageManager->addErrorMessage(__('Cannot do shipment for the order.'));
                 return false;
             }
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Shipment/MassPrintShippingLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Shipment/MassPrintShippingLabel.php
@@ -6,16 +6,15 @@
  */
 namespace Magento\Shipping\Controller\Adminhtml\Shipment;
 
-use Magento\Backend\App\Action;
-use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Backend\App\Action\Context;
-use Magento\Shipping\Model\Shipping\LabelGenerator;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory;
+use Magento\Shipping\Model\Shipping\LabelGenerator;
+use Magento\Ui\Component\MassAction\Filter;
 
 class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
@@ -87,7 +86,7 @@ class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\A
             );
         }
 
-        $this->messageManager->addError(__('There are no shipping labels related to selected shipments.'));
+        $this->messageManager->addErrorMessage(__('There are no shipping labels related to selected shipments.'));
         return $this->resultRedirectFactory->create()->setPath('sales/shipment/');
     }
 }

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/CreateLabelTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/CreateLabelTest.php
@@ -71,7 +71,7 @@ class CreateLabelTest extends \PHPUnit\Framework\TestCase
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
         $this->messageManagerMock = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError', '__wakeup']
+            ['addSuccessMessage', 'addErrorMessage', '__wakeup']
         );
         $this->labelGenerator = $this->createPartialMock(
             \Magento\Shipping\Model\Shipping\LabelGenerator::class,
@@ -155,7 +155,7 @@ class CreateLabelTest extends \PHPUnit\Framework\TestCase
             ->with($this->shipmentMock, $this->requestMock)
             ->will($this->returnValue(true));
         $this->shipmentMock->expects($this->once())->method('save')->will($this->returnSelf());
-        $this->messageManagerMock->expects($this->once())->method('addSuccess');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
         $this->responseMock->expects($this->once())->method('representJson');
 
         $this->assertNull($this->controller->execute());

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/EmailTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/EmailTest.php
@@ -122,7 +122,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
         );
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
         $this->session = $this->createPartialMock(\Magento\Backend\Model\Session::class, ['setIsUrlNotice']);
         $this->actionFlag = $this->createPartialMock(\Magento\Framework\App\ActionFlag::class, ['get']);
@@ -206,7 +206,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->with($orderShipment)
             ->will($this->returnValue(true));
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the shipment.');
         $path = '*/*/view';
         $arguments = ['shipment_id' => $shipmentId];

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/NewActionTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/NewActionTest.php
@@ -122,7 +122,7 @@ class NewActionTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()->getMock();
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
         $this->session = $this->createPartialMock(
             \Magento\Backend\Model\Session::class,

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/PrintLabelTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/PrintLabelTest.php
@@ -90,34 +90,40 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
             \Magento\Sales\Model\Order\Shipment::class,
             ['getIncrementId', 'getShippingLabel', '__wakeup']
         );
-        $this->messageManagerMock = $this->createPartialMock(\Magento\Framework\Message\Manager::class, ['addError']);
+        $this->messageManagerMock = $this->createPartialMock(
+            \Magento\Framework\Message\Manager::class,
+            ['addErrorMessage']
+        );
         $this->requestMock = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getParam']);
         $this->responseMock = $this->createMock(\Magento\Framework\App\Response\Http::class);
         $this->sessionMock = $this->createPartialMock(\Magento\Backend\Model\Session::class, ['setIsUrlNotice']);
         $this->actionFlag = $this->createPartialMock(\Magento\Framework\App\ActionFlag::class, ['get']);
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
         $this->helperMock = $this->createPartialMock(\Magento\Backend\Helper\Data::class, ['getUrl']);
-        $contextMock = $this->createPartialMock(\Magento\Backend\App\Action\Context::class, [
+        $contextMock = $this->createPartialMock(
+            \Magento\Backend\App\Action\Context::class,
+            [
                 'getRequest',
                 'getResponse',
                 'getMessageManager',
                 'getSession',
                 'getActionFlag',
                 'getObjectManager',
-                'getHelper'
-            ]);
+                'getHelper',
+            ]
+        );
 
         $contextMock->expects($this->any())->method('getRequest')->will($this->returnValue($this->requestMock));
         $contextMock->expects($this->any())->method('getResponse')->will($this->returnValue($this->responseMock));
         $contextMock->expects($this->any())->method('getSession')->will($this->returnValue($this->sessionMock));
         $contextMock->expects($this->any())->method('getActionFlag')->will($this->returnValue($this->actionFlag));
         $contextMock->expects($this->any())->method('getHelper')->will($this->returnValue($this->helperMock));
-        $contextMock->expects($this->any())
-            ->method('getMessageManager')
-            ->will($this->returnValue($this->messageManagerMock));
-        $contextMock->expects($this->any())
-            ->method('getObjectManager')
-            ->will($this->returnValue($this->objectManagerMock));
+        $contextMock->expects($this->any())->method('getMessageManager')->will(
+            $this->returnValue($this->messageManagerMock)
+        );
+        $contextMock->expects($this->any())->method('getObjectManager')->will(
+            $this->returnValue($this->objectManagerMock)
+        );
         $this->loadShipment();
 
         $this->controller = new \Magento\Shipping\Controller\Adminhtml\Order\Shipment\PrintLabel(
@@ -140,34 +146,22 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
         $shipment = [];
         $tracking = [];
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('order_id')
-            ->will($this->returnValue($orderId));
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('shipment_id')
-            ->will($this->returnValue($shipmentId));
-        $this->requestMock->expects($this->at(2))
-            ->method('getParam')
-            ->with('shipment')
-            ->will($this->returnValue($shipment));
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with('tracking')
-            ->will($this->returnValue($tracking));
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('setOrderId')
-            ->with($orderId);
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('setShipmentId')
-            ->with($shipmentId);
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('setShipment')
-            ->with($shipment);
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('setTracking')
-            ->with($tracking);
+        $this->requestMock->expects($this->at(0))->method('getParam')->with('order_id')->will(
+            $this->returnValue($orderId)
+        );
+        $this->requestMock->expects($this->at(1))->method('getParam')->with('shipment_id')->will(
+            $this->returnValue($shipmentId)
+        );
+        $this->requestMock->expects($this->at(2))->method('getParam')->with('shipment')->will(
+            $this->returnValue($shipment)
+        );
+        $this->requestMock->expects($this->at(3))->method('getParam')->with('tracking')->will(
+            $this->returnValue($tracking)
+        );
+        $this->shipmentLoaderMock->expects($this->once())->method('setOrderId')->with($orderId);
+        $this->shipmentLoaderMock->expects($this->once())->method('setShipmentId')->with($shipmentId);
+        $this->shipmentLoaderMock->expects($this->once())->method('setShipment')->with($shipment);
+        $this->shipmentLoaderMock->expects($this->once())->method('setTracking')->with($tracking);
     }
 
     /**
@@ -180,12 +174,8 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
         $resultContent = 'result-pdf-content';
         $incrementId = '1000001';
 
-        $this->shipmentMock->expects($this->once())
-            ->method('getIncrementId')
-            ->will($this->returnValue($incrementId));
-        $this->fileFactoryMock->expects($this->once())
-            ->method('create')
-            ->will($this->returnValue($resultContent));
+        $this->shipmentMock->expects($this->once())->method('getIncrementId')->will($this->returnValue($incrementId));
+        $this->fileFactoryMock->expects($this->once())->method('create')->will($this->returnValue($resultContent));
 
         return $resultContent;
     }
@@ -197,10 +187,10 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
      */
     protected function redirectSection()
     {
-        $this->actionFlag->expects($this->once())
-            ->method('get')
-            ->with('', \Magento\Backend\App\AbstractAction::FLAG_IS_URLS_CHECKED)
-            ->will($this->returnValue(true));
+        $this->actionFlag->expects($this->once())->method('get')->with(
+            '',
+            \Magento\Backend\App\AbstractAction::FLAG_IS_URLS_CHECKED
+        )->will($this->returnValue(true));
         $this->sessionMock->expects($this->once())->method('setIsUrlNotice')->with(true);
         $this->helperMock->expects($this->once())->method('getUrl')->will($this->returnValue('redirect-path'));
         $this->responseMock->expects($this->once())->method('setRedirect');
@@ -213,12 +203,12 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
     {
         $labelContent = '%PDF-label-content';
 
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('load')
-            ->will($this->returnValue($this->shipmentMock));
-        $this->shipmentMock->expects($this->once())
-            ->method('getShippingLabel')
-            ->will($this->returnValue($labelContent));
+        $this->shipmentLoaderMock->expects($this->once())->method('load')->will(
+            $this->returnValue($this->shipmentMock)
+        );
+        $this->shipmentMock->expects($this->once())->method('getShippingLabel')->will(
+            $this->returnValue($labelContent)
+        );
 
         $this->assertEquals($this->fileCreate(), $this->controller->execute());
     }
@@ -232,22 +222,18 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
         $pdfPageMock = $this->createPartialMock(\Zend_Pdf_Page::class, ['render', 'getPageDictionary']);
         $pageDictionaryMock = $this->createPartialMock(\Zend_Pdf_Element_Dictionary::class, ['touch', 'getObject']);
 
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('load')
-            ->will($this->returnValue($this->shipmentMock));
-        $this->shipmentMock->expects($this->once())
-            ->method('getShippingLabel')
-            ->will($this->returnValue($labelContent));
+        $this->shipmentLoaderMock->expects($this->once())->method('load')->will(
+            $this->returnValue($this->shipmentMock)
+        );
+        $this->shipmentMock->expects($this->once())->method('getShippingLabel')->will(
+            $this->returnValue($labelContent)
+        );
         $this->labelGenerator->expects($this->once())
             ->method('createPdfPageFromImageString')
             ->with($labelContent)
             ->will($this->returnValue($pdfPageMock));
-        $pdfPageMock->expects($this->any())
-            ->method('getPageDictionary')
-            ->will($this->returnValue($pageDictionaryMock));
-        $pageDictionaryMock->expects($this->any())
-            ->method('getObject')
-            ->will($this->returnSelf());
+        $pdfPageMock->expects($this->any())->method('getPageDictionary')->will($this->returnValue($pageDictionaryMock));
+        $pageDictionaryMock->expects($this->any())->method('getObject')->will($this->returnSelf());
 
         $this->assertEquals($this->fileCreate(), $this->controller->execute());
     }
@@ -262,37 +248,28 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
 
         $loggerMock = $this->createMock(\Psr\Log\LoggerInterface::class);
 
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('load')
-            ->will($this->returnValue($this->shipmentMock));
-        $this->shipmentMock->expects($this->once())
-            ->method('getShippingLabel')
-            ->will($this->returnValue($labelContent));
-        $this->shipmentMock->expects($this->once())
-            ->method('getIncrementId')
-            ->will($this->returnValue($incrementId));
+        $this->shipmentLoaderMock->expects($this->once())->method('load')->will(
+            $this->returnValue($this->shipmentMock)
+        );
+        $this->shipmentMock->expects($this->once())->method('getShippingLabel')->will(
+            $this->returnValue($labelContent)
+        );
+        $this->shipmentMock->expects($this->once())->method('getIncrementId')->will($this->returnValue($incrementId));
         $this->labelGenerator->expects($this->once())
             ->method('createPdfPageFromImageString')
             ->with($labelContent)
             ->will($this->returnValue(false));
-        $this->messageManagerMock->expects($this->at(0))
-            ->method('addError')
-            ->with(sprintf('We don\'t recognize or support the file extension in this shipment: %s.', $incrementId))
-            ->will($this->throwException(new \Exception()));
-        $this->messageManagerMock->expects($this->at(1))
-            ->method('addError')
-            ->with('An error occurred while creating shipping label.')
-            ->will($this->returnSelf());
-        $this->objectManagerMock->expects($this->once())
-            ->method('get')
-            ->with(\Psr\Log\LoggerInterface::class)
-            ->will($this->returnValue($loggerMock));
-        $loggerMock->expects($this->once())
-            ->method('critical');
-        $this->requestMock->expects($this->at(4))
-            ->method('getParam')
-            ->with('shipment_id')
-            ->will($this->returnValue(1));
+        $this->messageManagerMock->expects($this->at(0))->method('addErrorMessage')->with(
+            sprintf('We don\'t recognize or support the file extension in this shipment: %s.', $incrementId)
+        )->will($this->throwException(new \Exception()));
+        $this->messageManagerMock->expects($this->at(1))->method('addErrorMessage')->with(
+            'An error occurred while creating shipping label.'
+        )->will($this->returnSelf());
+        $this->objectManagerMock->expects($this->once())->method('get')->with(\Psr\Log\LoggerInterface::class)->will(
+            $this->returnValue($loggerMock)
+        );
+        $loggerMock->expects($this->once())->method('critical');
+        $this->requestMock->expects($this->at(4))->method('getParam')->with('shipment_id')->will($this->returnValue(1));
         $this->redirectSection();
 
         $this->assertNull($this->controller->execute());
@@ -303,10 +280,10 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecuteLoadShipmentFail()
     {
-        $this->shipmentLoaderMock->expects($this->once())
-            ->method('load')
-            ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
-        $this->messageManagerMock->expects($this->once())->method('addError')->will($this->returnSelf());
+        $this->shipmentLoaderMock->expects($this->once())->method('load')->willThrowException(
+            new \Magento\Framework\Exception\LocalizedException(__('message'))
+        );
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage')->will($this->returnSelf());
         $this->redirectSection();
 
         $this->assertNull($this->controller->execute());

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/SaveTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/SaveTest.php
@@ -7,11 +7,11 @@
 namespace Magento\Shipping\Test\Unit\Controller\Adminhtml\Order\Shipment;
 
 use Magento\Backend\App\Action;
-use Magento\Sales\Model\ValidatorResultInterface;
-use Magento\Sales\Model\Order\Email\Sender\ShipmentSender;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Sales\Model\Order\Email\Sender\ShipmentSender;
 use Magento\Sales\Model\Order\Shipment\ShipmentValidatorInterface;
 use Magento\Sales\Model\Order\Shipment\Validation\QuantityValidator;
+use Magento\Sales\Model\ValidatorResultInterface;
 
 /**
  * Class SaveTest
@@ -142,7 +142,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         );
         $this->messageManager = $this->createPartialMock(
             \Magento\Framework\Message\Manager::class,
-            ['addSuccess', 'addError']
+            ['addSuccessMessage', 'addErrorMessage']
         );
         $this->session = $this->createPartialMock(
             \Magento\Backend\Model\Session::class,
@@ -236,7 +236,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         if (!$formKeyIsValid || !$isPost) {
             $this->messageManager->expects($this->once())
-                ->method('addError');
+                ->method('addErrorMessage');
 
             $this->resultRedirect->expects($this->once())
                 ->method('setPath')

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Delete.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Delete.php
@@ -61,20 +61,20 @@ class Delete extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
                 }
                 $sitemap->delete();
                 // display success message
-                $this->messageManager->addSuccess(__('You deleted the sitemap.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the sitemap.'));
                 // go to grid
                 $this->_redirect('adminhtml/*/');
                 return;
             } catch (\Exception $e) {
                 // display error message
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 // go back to edit form
                 $this->_redirect('adminhtml/*/edit', ['sitemap_id' => $id]);
                 return;
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find a sitemap to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a sitemap to delete.'));
         // go to grid
         $this->_redirect('adminhtml/*/');
     }

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Edit.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Edit.php
@@ -41,7 +41,7 @@ class Edit extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This sitemap no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This sitemap no longer exists.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             }

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -25,16 +25,16 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             try {
                 $sitemap->generateXml();
 
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('The sitemap "%1" has been generated.', $sitemap->getSitemapFilename())
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t generate the sitemap right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t generate the sitemap right now.'));
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find a sitemap to generate.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find a sitemap to generate.'));
         }
 
         // go to grid

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
@@ -30,7 +30,7 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             $validator->setPaths($helper->getValidPaths());
             if (!$validator->isValid($path)) {
                 foreach ($validator->getMessages() as $message) {
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                 }
                 // save data in session
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($data);
@@ -83,13 +83,13 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             // save the data
             $model->save();
             // display success message
-            $this->messageManager->addSuccess(__('You saved the sitemap.'));
+            $this->messageManager->addSuccessMessage(__('You saved the sitemap.'));
             // clear previously saved data from session
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData(false);
             return $model->getId();
         } catch (\Exception $e) {
             // display error message
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             // save data in session
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($data);
         }

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/DeleteTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/DeleteTest.php
@@ -83,7 +83,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         $this->requestMock->expects($this->any())->method('getParam')->with('sitemap_id')->willReturn(0);
         $this->responseMock->expects($this->once())->method('setRedirect');
         $this->messageManagerMock->expects($this->any())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t find a sitemap to delete.');
 
         $this->deleteController->execute();
@@ -103,11 +103,11 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['load'])
             ->getMock();
 
-        $sitemapMock->expects($this->once())->method('load')->with($id)->willThrowException(new \Exception);
+        $sitemapMock->expects($this->once())->method('load')->with($id)->willThrowException(new \Exception());
         $this->sitemapFactoryMock->expects($this->once())->method('create')->willReturn($sitemapMock);
         $this->responseMock->expects($this->once())->method('setRedirect');
         $this->messageManagerMock->expects($this->any())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->deleteController->execute();
     }
@@ -142,7 +142,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
 
         $this->responseMock->expects($this->once())->method('setRedirect');
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->deleteController->execute();
     }

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Sitemap\Test\Unit\Controller\Adminhtml\Sitemap;
 
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 
 class SaveTest extends \PHPUnit\Framework\TestCase
 {
@@ -154,7 +154,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[$helperClass, $helper], [$sessionClass, $session]]);
 
         $this->messageManagerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->withConsecutive(
                 [$messages[0]],
                 [$messages[1]]

--- a/app/code/Magento/Store/Controller/Store/SwitchAction.php
+++ b/app/code/Magento/Store/Controller/Store/SwitchAction.php
@@ -14,8 +14,8 @@ use Magento\Store\Api\StoreCookieManagerInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreIsInactiveException;
-use Magento\Store\Model\StoreResolver;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\StoreResolver;
 
 /**
  * Switch current store view.
@@ -85,7 +85,7 @@ class SwitchAction extends Action
         }
 
         if (isset($error)) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl());
             return;
         }

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/Delete.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/Delete.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Tax\Controller\Adminhtml\Rate;
 
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class Delete extends \Magento\Tax\Controller\Adminhtml\Rate
 {
@@ -24,17 +24,17 @@ class Delete extends \Magento\Tax\Controller\Adminhtml\Rate
             try {
                 $this->_taxRateRepository->deleteById($rateId);
 
-                $this->messageManager->addSuccess(__('You deleted the tax rate.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the tax rate.'));
                 return $resultRedirect->setPath("*/*/");
             } catch (NoSuchEntityException $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete this rate because of an incorrect rate ID.')
                 );
                 return $resultRedirect->setPath("tax/*/");
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong deleting this rate.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong deleting this rate.'));
             }
 
             if ($this->getRequest()->getServer('HTTP_REFERER')) {

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/Save.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/Save.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Tax\Controller\Adminhtml\Rate;
 
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class Save extends \Magento\Tax\Controller\Adminhtml\Rate
 {
@@ -35,13 +35,13 @@ class Save extends \Magento\Tax\Controller\Adminhtml\Rate
                 $taxData = $this->_taxRateConverter->populateTaxRateData($ratePost);
                 $this->_taxRateRepository->save($taxData);
 
-                $this->messageManager->addSuccess(__('You saved the tax rate.'));
+                $this->messageManager->addSuccessMessage(__('You saved the tax rate.'));
                 return $resultRedirect->setPath('*/*/');
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($ratePost);
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
             return $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));
         }

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/Delete.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/Delete.php
@@ -20,15 +20,15 @@ class Delete extends \Magento\Tax\Controller\Adminhtml\Rule
         $ruleId = (int)$this->getRequest()->getParam('rule');
         try {
             $this->ruleService->deleteById($ruleId);
-            $this->messageManager->addSuccess(__('The tax rule has been deleted.'));
+            $this->messageManager->addSuccessMessage(__('The tax rule has been deleted.'));
             return $resultRedirect->setPath('tax/*/');
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $this->messageManager->addError(__('This rule no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
             return $resultRedirect->setPath('tax/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Something went wrong deleting this tax rule.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong deleting this tax rule.'));
         }
 
         return $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/Edit.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/Edit.php
@@ -25,7 +25,7 @@ class Edit extends \Magento\Tax\Controller\Adminhtml\Rule
                 $pageTitle = sprintf("%s", $taxRule->getCode());
             } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
                 $backendSession->unsRuleData();
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
                 return $resultRedirect->setPath('tax/*/');

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/Save.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/Save.php
@@ -24,16 +24,16 @@ class Save extends \Magento\Tax\Controller\Adminhtml\Rule
             try {
                 $taxRule = $this->ruleService->save($taxRule);
 
-                $this->messageManager->addSuccess(__('You saved the tax rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the tax rule.'));
 
                 if ($this->getRequest()->getParam('back')) {
                     return $resultRedirect->setPath('tax/*/edit', ['rule' => $taxRule->getId()]);
                 }
                 return $resultRedirect->setPath('tax/*/');
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t save this tax rule right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t save this tax rule right now.'));
             }
 
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setRuleData($postData);

--- a/app/code/Magento/Tax/Controller/Adminhtml/Tax/IgnoreTaxNotification.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Tax/IgnoreTaxNotification.php
@@ -46,7 +46,7 @@ class IgnoreTaxNotification extends \Magento\Tax\Controller\Adminhtml\Tax
                 $this->_objectManager->get(\Magento\Config\Model\ResourceModel\Config::class)
                     ->saveConfig($path, 1, ScopeConfigInterface::SCOPE_TYPE_DEFAULT, 0);
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate/ImportPost.php
+++ b/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate/ImportPost.php
@@ -24,14 +24,14 @@ class ImportPost extends \Magento\TaxImportExport\Controller\Adminhtml\Rate
                 );
                 $importHandler->importFromCsvFile($this->getRequest()->getFiles('import_rates_file'));
 
-                $this->messageManager->addSuccess(__('The tax rate has been imported.'));
+                $this->messageManager->addSuccessMessage(__('The tax rate has been imported.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Invalid file upload attempt'));
+                $this->messageManager->addErrorMessage(__('Invalid file upload attempt'));
             }
         } else {
-            $this->messageManager->addError(__('Invalid file upload attempt'));
+            $this->messageManager->addErrorMessage(__('Invalid file upload attempt'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Theme/Controller/Adminhtml/Design/Config/Save.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/Design/Config/Save.php
@@ -6,11 +6,11 @@
 namespace Magento\Theme\Controller\Adminhtml\Design\Config;
 
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Request\DataPersistorInterface;
-use Magento\Theme\Model\DesignConfigRepository;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Theme\Model\Data\Design\ConfigFactory;
+use Magento\Theme\Model\DesignConfigRepository;
 
 /**
  * Save action controller
@@ -73,7 +73,7 @@ class Save extends Action
         try {
             $designConfigData = $this->configFactory->create($scope, $scopeId, $data);
             $this->designConfigRepository->save($designConfigData);
-            $this->messageManager->addSuccess(__('You saved the configuration.'));
+            $this->messageManager->addSuccessMessage(__('You saved the configuration.'));
 
             $this->dataPersistor->clear('theme_design_config');
 
@@ -86,10 +86,10 @@ class Save extends Action
         } catch (LocalizedException $e) {
             $messages = explode("\n", $e->getMessage());
             foreach ($messages as $message) {
-                $this->messageManager->addError(__('%1', $message));
+                $this->messageManager->addErrorMessage(__('%1', $message));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while saving this configuration:') . ' ' . $e->getMessage()
             );

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Delete.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Delete.php
@@ -37,12 +37,12 @@ class Delete extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
                     );
                 }
                 $theme->delete();
-                $this->messageManager->addSuccess(__('You deleted the theme.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the theme.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We cannot delete the theme.'));
+            $this->messageManager->addExceptionMessage($e, __('We cannot delete the theme.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCss.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCss.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Theme\Controller\Adminhtml\System\Design\Theme;
 
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResponseInterface;
 
 /**
  * Class DownloadCss
@@ -48,7 +48,7 @@ class DownloadCss extends \Magento\Theme\Controller\Adminhtml\System\Design\Them
                 DirectoryList::ROOT
             );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('File not found: "%1".', $fileId));
+            $this->messageManager->addExceptionMessage($e, __('File not found: "%1".', $fileId));
             $this->getResponse()->setRedirect($this->_redirect->getRefererUrl());
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCustomCss.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCustomCss.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\Theme\Controller\Adminhtml\System\Design\Theme;
 
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResponseInterface;
 
 /**
  * Class DownloadCustomCss
@@ -44,7 +44,7 @@ class DownloadCustomCss extends \Magento\Theme\Controller\Adminhtml\System\Desig
                 );
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t find file.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t find file.'));
             $this->getResponse()->setRedirect($this->_redirect->getRefererUrl());
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Edit.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Edit.php
@@ -41,10 +41,10 @@ class Edit extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
             $this->_setActiveMenu('Magento_Theme::system_design_theme');
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('adminhtml/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We cannot find the theme.'));
+            $this->messageManager->addErrorMessage(__('We cannot find the theme.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             $this->_redirect('adminhtml/*/');
         }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Save.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Save.php
@@ -65,15 +65,15 @@ class Save extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
                 );
                 $customization->delete($removeJsFiles);
                 $singleFile->update($theme, $customCssData);
-                $this->messageManager->addSuccess(__('You saved the theme.'));
+                $this->messageManager->addSuccessMessage(__('You saved the theme.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_getSession()->setThemeData($themeData);
             $this->_getSession()->setThemeCustomCssData($customCssData);
             $redirectBack = true;
         } catch (\Exception $e) {
-            $this->messageManager->addError('The theme was not saved');
+            $this->messageManager->addErrorMessage('The theme was not saved');
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $redirectBack

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/Design/Config/SaveTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/Design/Config/SaveTest.php
@@ -138,7 +138,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('save')
             ->with($this->designConfig);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the configuration.'));
         $this->dataPersistor->expects($this->once())
             ->method('clear')
@@ -194,7 +194,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with($this->designConfig)
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('Exception message')));
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Exception message')->render());
 
         $this->dataPersistor->expects($this->once())
@@ -249,7 +249,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with($this->designConfig)
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'Something went wrong while saving this configuration: Exception message');
 
         $this->dataPersistor->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DeleteTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DeleteTest.php
@@ -141,7 +141,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->method('isVirtual')
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->willReturnSelf();
         $this->resultFactory->expects($this->once())
             ->method('create')
@@ -215,7 +215,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->with($path)
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $this->objectManager->expects($this->once())
             ->method('get')
             ->with(\Psr\Log\LoggerInterface::class)
@@ -258,7 +258,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->with($path)
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->assertInstanceOf(\Magento\Framework\Controller\Result\Redirect::class, $this->controller->execute());
     }

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCssTest.php
@@ -235,7 +235,7 @@ class DownloadCssTest extends \PHPUnit\Framework\TestCase
             ->method('getId')
             ->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $logger->expects($this->once())
             ->method('critical');
         $this->redirect->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCustomCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCustomCssTest.php
@@ -205,7 +205,7 @@ class DownloadCustomCssTest extends \PHPUnit\Framework\TestCase
             ->with($themeId)
             ->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $logger->expects($this->once())
             ->method('critical');
         $this->redirect->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/EditTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/EditTest.php
@@ -48,7 +48,7 @@ class EditTest extends \Magento\Theme\Test\Unit\Controller\Adminhtml\System\Desi
             ->with(\Magento\Framework\View\Design\ThemeInterface::class)
             ->willReturn($theme);
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->session->expects($this->once())
             ->method('setIsUrlNotice')
             ->with(true);
@@ -114,7 +114,7 @@ class EditTest extends \Magento\Theme\Test\Unit\Controller\Adminhtml\System\Desi
             ->willReturn($logger);
 
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->session->expects($this->once())
             ->method('setIsUrlNotice')
             ->with(true);

--- a/app/code/Magento/Theme/etc/adminhtml/di.xml
+++ b/app/code/Magento/Theme/etc/adminhtml/di.xml
@@ -30,6 +30,9 @@
                 <item name="default_message_identifier" xsi:type="array">
                     <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\EscapeRenderer::CODE</item>
                 </item>
+                <item name="addUnescapedMessage" xsi:type="array">
+                    <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\DefaultRenderer::CODE</item>
+                </item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/Theme/etc/frontend/di.xml
+++ b/app/code/Magento/Theme/etc/frontend/di.xml
@@ -20,6 +20,9 @@
                 <item name="default_message_identifier" xsi:type="array">
                     <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\EscapeRenderer::CODE</item>
                 </item>
+                <item name="addUnescapedMessage" xsi:type="array">
+                    <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\DefaultRenderer::CODE</item>
+                </item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Delete.php
+++ b/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Delete.php
@@ -18,9 +18,9 @@ class Delete extends \Magento\UrlRewrite\Controller\Adminhtml\Url\Rewrite
         if ($this->_getUrlRewrite()->getId()) {
             try {
                 $this->_getUrlRewrite()->delete();
-                $this->messageManager->addSuccess(__('You deleted the URL rewrite.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the URL rewrite.'));
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t delete URL Rewrite right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t delete URL Rewrite right now.'));
                 $this->_redirect('adminhtml/*/edit/', ['id' => $this->_getUrlRewrite()->getId()]);
                 return;
             }

--- a/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Save.php
+++ b/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Save.php
@@ -167,14 +167,14 @@ class Save extends \Magento\UrlRewrite\Controller\Adminhtml\Url\Rewrite
                 $this->_handleCmsPageUrlRewrite($model);
                 $model->save();
 
-                $this->messageManager->addSuccess(__('The URL Rewrite has been saved.'));
+                $this->messageManager->addSuccessMessage(__('The URL Rewrite has been saved.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $session->setUrlRewriteData($data);
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while saving URL Rewrite.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving URL Rewrite.'));
                 $session->setUrlRewriteData($data);
             }
         }

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
@@ -83,17 +83,17 @@ class Forgotpassword extends \Magento\User\Controller\Adminhtml\Auth
                     return $resultRedirect->setPath('admin');
                 }
                 // @codingStandardsIgnoreStart
-                $this->messageManager->addSuccess(__('We\'ll email you a link to reset your password.'));
+                $this->messageManager->addSuccessMessage(__('We\'ll email you a link to reset your password.'));
                 // @codingStandardsIgnoreEnd
                 $this->getResponse()->setRedirect(
                     $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
                 );
                 return;
             } else {
-                $this->messageManager->addError(__('Please correct this email address:'));
+                $this->messageManager->addErrorMessage(__('Please correct this email address:'));
             }
         } elseif (!empty($params)) {
-            $this->messageManager->addError(__('Please enter an email address.'));
+            $this->messageManager->addErrorMessage(__('Please enter an email address.'));
         }
         $this->_view->loadLayout();
         $this->_view->renderLayout();

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPassword.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPassword.php
@@ -31,7 +31,7 @@ class ResetPassword extends \Magento\User\Controller\Adminhtml\Auth
 
             $this->_view->renderLayout();
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Your password reset link has expired.'));
+            $this->messageManager->addErrorMessage(__('Your password reset link has expired.'));
             $this->_redirect('adminhtml/auth/forgotpassword', ['_nosecret' => true]);
             return;
         }

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -25,7 +25,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
         try {
             $this->_validateResetPasswordLinkToken($userId, $passwordResetToken);
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Your password reset link has expired.'));
+            $this->messageManager->addErrorMessage(__('Your password reset link has expired.'));
             $this->getResponse()->setRedirect(
                 $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
             );
@@ -43,7 +43,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
             $errors = $user->validate();
             if ($errors !== true && !empty($errors)) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addError($error);
+                    $this->messageManager->addErrorMessage($error);
                     $this->_redirect(
                         'adminhtml/auth/resetpassword',
                         ['_nosecret' => true, '_query' => ['id' => $userId, 'token' => $passwordResetToken]]
@@ -51,7 +51,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
                 }
             } else {
                 $user->save();
-                $this->messageManager->addSuccess(__('You updated your password.'));
+                $this->messageManager->addSuccessMessage(__('You updated your password.'));
                 $this->getResponse()->setRedirect(
                     $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
                 );

--- a/app/code/Magento/User/Controller/Adminhtml/Locks/MassUnlock.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Locks/MassUnlock.php
@@ -27,10 +27,10 @@ class MassUnlock extends \Magento\User\Controller\Adminhtml\Locks
                 $affectedUsers = $this->_objectManager
                     ->get(\Magento\User\Model\ResourceModel\User::class)
                     ->unlock($userIds);
-                $this->getMessageManager()->addSuccess(__('Unlocked %1 user(s).', $affectedUsers));
+                $this->getMessageManager()->addSuccessMessage(__('Unlocked %1 user(s).', $affectedUsers));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/User/Controller/Adminhtml/User/Delete.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Delete.php
@@ -6,8 +6,8 @@
  */
 namespace Magento\User\Controller\Adminhtml\User;
 
-use Magento\User\Block\User\Edit\Tab\Main as UserEdit;
 use Magento\Framework\Exception\AuthenticationException;
+use Magento\User\Block\User\Edit\Tab\Main as UserEdit;
 
 class Delete extends \Magento\User\Controller\Adminhtml\User
 {
@@ -22,7 +22,7 @@ class Delete extends \Magento\User\Controller\Adminhtml\User
 
         if ($userId) {
             if ($currentUser->getId() == $userId) {
-                $this->messageManager->addError(__('You cannot delete your own account.'));
+                $this->messageManager->addErrorMessage(__('You cannot delete your own account.'));
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $userId]);
                 return;
             }
@@ -36,16 +36,16 @@ class Delete extends \Magento\User\Controller\Adminhtml\User
                 $model = $this->_userFactory->create();
                 $model->setId($userId);
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the user.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the user.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $this->getRequest()->getParam('user_id')]);
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a user to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a user to delete.'));
         $this->_redirect('adminhtml/*/');
     }
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Edit.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Edit.php
@@ -22,7 +22,7 @@ class Edit extends \Magento\User\Controller\Adminhtml\User
         if ($userId) {
             $model->load($userId);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This user no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This user no longer exists.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             }

--- a/app/code/Magento/User/Controller/Adminhtml/User/InvalidateToken.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/InvalidateToken.php
@@ -45,16 +45,31 @@ class InvalidateToken extends \Magento\User\Controller\Adminhtml\User
         if ($userId = $this->getRequest()->getParam('user_id')) {
             try {
                 $this->tokenService->revokeAdminAccessToken($userId);
-                $this->messageManager->addSuccess(__('You have revoked the user\'s tokens.'));
+                $this->messageManager->addComplexSuccessMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => __('You have revoked the user\'s tokens.'),
+                    ]
+                );
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $userId]);
                 return;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $e->getMessage(),
+                    ]
+                );
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $userId]);
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a user to revoke.'));
+        $this->messageManager->addComplexErrorMessage(
+            'addUnescapedMessage',
+            [
+                'text' => __('We can\'t find a user to revoke.'),
+            ]
+        );
         $this->_redirect('adminhtml/*');
     }
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role/Delete.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role/Delete.php
@@ -24,15 +24,15 @@ class Delete extends \Magento\User\Controller\Adminhtml\User\Role
         $currentUser = $this->_userFactory->create()->setId($this->_authSession->getUser()->getId());
 
         if (in_array($rid, $currentUser->getRoles())) {
-            $this->messageManager->addError(__('You cannot delete self-assigned roles.'));
+            $this->messageManager->addErrorMessage(__('You cannot delete self-assigned roles.'));
             return $resultRedirect->setPath('adminhtml/*/editrole', ['rid' => $rid]);
         }
 
         try {
             $this->_initRole()->delete();
-            $this->messageManager->addSuccess(__('You deleted the role.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the role.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while deleting this role.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while deleting this role.'));
         }
 
         return $resultRedirect->setPath("*/*/");

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role/SaveRole.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role/SaveRole.php
@@ -85,7 +85,7 @@ class SaveRole extends \Magento\User\Controller\Adminhtml\User\Role
 
         $role = $this->_initRole('role_id');
         if (!$role->getId() && $rid) {
-            $this->messageManager->addError(__('This role no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This role no longer exists.'));
             return $resultRedirect->setPath('adminhtml/*/');
         }
 
@@ -109,7 +109,7 @@ class SaveRole extends \Magento\User\Controller\Adminhtml\User\Role
             foreach ($roleUsers as $nRuid) {
                 $this->_addUserToRole($nRuid, $role->getId());
             }
-            $this->messageManager->addSuccess(__('You saved the role.'));
+            $this->messageManager->addSuccessMessage(__('You saved the role.'));
         } catch (UserLockedException $e) {
             $this->_auth->logout();
             $this->getSecurityCookie()->setLogoutReasonCookie(
@@ -117,12 +117,12 @@ class SaveRole extends \Magento\User\Controller\Adminhtml\User\Role
             );
             return $resultRedirect->setPath('*');
         } catch (\Magento\Framework\Exception\AuthenticationException $e) {
-            $this->messageManager->addError(__('You have entered an invalid password for current user.'));
+            $this->messageManager->addErrorMessage(__('You have entered an invalid password for current user.'));
             return $this->saveDataToSessionAndRedirect($role, $this->getRequest()->getPostValue(), $resultRedirect);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while saving this role.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while saving this role.'));
         }
 
         return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/User/Controller/Adminhtml/User/Save.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Save.php
@@ -50,7 +50,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
         /** @var $model \Magento\User\Model\User */
         $model = $this->_userFactory->create()->load($userId);
         if ($userId && $model->isObjectNew()) {
-            $this->messageManager->addError(__('This user no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This user no longer exists.'));
             $this->_redirect('adminhtml/*/');
             return;
         }
@@ -86,7 +86,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
 
             $model->sendNotificationEmailsIfRequired();
 
-            $this->messageManager->addSuccess(__('You saved the user.'));
+            $this->messageManager->addSuccessMessage(__('You saved the user.'));
             $this->_getSession()->setUserData(false);
             $this->_redirect('adminhtml/*/');
         } catch (UserLockedException $e) {
@@ -96,7 +96,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
             );
             $this->_redirect('adminhtml/*/');
         } catch (\Magento\Framework\Exception\AuthenticationException $e) {
-            $this->messageManager->addError(__('You have entered an invalid password for current user.'));
+            $this->messageManager->addErrorMessage(__('You have entered an invalid password for current user.'));
             $this->redirectToEdit($model, $data);
         } catch (\Magento\Framework\Validator\Exception $e) {
             $messages = $e->getMessages();
@@ -104,7 +104,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
             $this->redirectToEdit($model, $data);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             if ($e->getMessage()) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
             $this->redirectToEdit($model, $data);
         }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Validate.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Validate.php
@@ -34,7 +34,12 @@ class Validate extends \Magento\User\Controller\Adminhtml\User
 
         if ($errors !== true && !empty($errors)) {
             foreach ($errors as $error) {
-                $this->messageManager->addError($error);
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $error,
+                    ]
+                );
             }
             $response->setError(1);
             $this->_view->getLayout()->initMessages();

--- a/app/code/Magento/User/Observer/Backend/AuthObserver.php
+++ b/app/code/Magento/User/Observer/Backend/AuthObserver.php
@@ -10,12 +10,12 @@ use Magento\Backend\Model\Auth\Session;
 use Magento\Backend\Model\UrlInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\State\UserLockedException;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\User\Model\Backend\Config\ObserverConfig;
 use Magento\User\Model\ResourceModel\User as ResourceUser;
 use Magento\User\Model\User;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\User\Model\UserFactory;
 
 /**
@@ -168,7 +168,7 @@ class AuthObserver implements ObserverInterface
 
         $newFirstFailureDate = false;
         $updateLockExpires = false;
-        $lockThreshInterval = new \DateInterval('PT' . $lockThreshold.'S');
+        $lockThreshInterval = new \DateInterval('PT' . $lockThreshold . 'S');
         // set first failure date when this is first failure or last first failure expired
         if (1 === $failuresNum || !$firstFailureDate || $now->diff($firstFailureDate) > $lockThreshInterval) {
             $newFirstFailureDate = $now;
@@ -195,7 +195,12 @@ class AuthObserver implements ObserverInterface
                 $myAccountUrl = $this->url->getUrl('adminhtml/system_account/');
                 $message = __('It\'s time to <a href="%1">change your password</a>.', $myAccountUrl);
             }
-            $this->messageManager->addNoticeMessage($message);
+            $this->messageManager->addComplexNoticeMessage(
+                'addUnescapedMessage',
+                [
+                    'text' => $message,
+                ]
+            );
             $message = $this->messageManager->getMessages()->getLastAddedMessage();
             if ($message) {
                 $message->setIdentifier('magento_user_password_expired')->setIsSticky(true);

--- a/app/code/Magento/User/Test/Unit/Controller/Adminhtml/User/DeleteTest.php
+++ b/app/code/Magento/User/Test/Unit/Controller/Adminhtml/User/DeleteTest.php
@@ -7,7 +7,6 @@
 namespace Magento\User\Test\Unit\Controller\Adminhtml\User;
 
 use Magento\Backend\Model\Auth\Session;
-use Magento\Framework\Exception\AuthenticationException;
 
 /**
  * Test class for \Magento\User\Controller\Adminhtml\User\Delete testing
@@ -193,19 +192,19 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
                 'currentUserPassword' => '123123q',
                 'userId'              => 1,
                 'currentUserId'       => 2,
-                'resultMethod'        => 'addSuccess',
+                'resultMethod'        => 'addSuccessMessage',
             ],
             [
                 'currentUserPassword' => '123123q',
                 'userId'              => 0,
                 'currentUserId'       => 2,
-                'resultMethod'        => 'addError',
+                'resultMethod'        => 'addErrorMessage',
             ],
             [
                 'currentUserPassword' => '123123q',
                 'userId'              => 1,
                 'currentUserId'       => 1,
-                'resultMethod'        => 'addError',
+                'resultMethod'        => 'addErrorMessage',
             ],
         ];
     }

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Delete.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Delete.php
@@ -21,9 +21,9 @@ class Delete extends \Magento\Variable\Controller\Adminhtml\System\Variable
         if ($variable->getId()) {
             try {
                 $variable->delete();
-                $this->messageManager->addSuccess(__('You deleted the custom variable.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the custom variable.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('adminhtml/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Save.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Save.php
@@ -31,7 +31,7 @@ class Save extends \Magento\Variable\Controller\Adminhtml\System\Variable
             $variable->setData($data);
             try {
                 $variable->save();
-                $this->messageManager->addSuccess(__('You saved the custom variable.'));
+                $this->messageManager->addSuccessMessage(__('You saved the custom variable.'));
                 if ($back) {
                     $resultRedirect->setPath(
                         'adminhtml/*/edit',
@@ -42,7 +42,7 @@ class Save extends \Magento\Variable\Controller\Adminhtml\System\Variable
                 }
                 return $resultRedirect;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('adminhtml/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Validate.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Validate.php
@@ -25,7 +25,7 @@ class Validate extends \Magento\Variable\Controller\Adminhtml\System\Variable
         $variable->addData($this->getRequest()->getPost('variable'));
         $result = $variable->validate();
         if ($result instanceof \Magento\Framework\Phrase) {
-            $this->messageManager->addError($result->getText());
+            $this->messageManager->addErrorMessage($result->getText());
             $layout = $this->layoutFactory->create();
             $layout->initMessages();
             $response->setError(true);

--- a/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
@@ -146,7 +146,7 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
 
         if ($result instanceof \Magento\Framework\Phrase) {
             $this->messageManagerMock->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with($result->getText());
             $this->layoutMock->expects($this->once())
                 ->method('initMessages');

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
@@ -104,7 +104,7 @@ abstract class Instance extends \Magento\Backend\App\Action
         if ($instanceId) {
             $widgetInstance->load($instanceId)->setCode($code);
             if (!$widgetInstance->getId()) {
-                $this->messageManager->addError(__('Please specify a correct widget.'));
+                $this->messageManager->addErrorMessage(__('Please specify a correct widget.'));
                 return false;
             }
         } else {

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Delete.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Delete.php
@@ -19,9 +19,9 @@ class Delete extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
         if ($widgetInstance) {
             try {
                 $widgetInstance->delete();
-                $this->messageManager->addSuccess(__('The widget instance has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The widget instance has been deleted.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
         $this->_redirect('adminhtml/*/');

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Save.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Save.php
@@ -33,7 +33,7 @@ class Save extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
         );
         try {
             $widgetInstance->save();
-            $this->messageManager->addSuccess(__('The widget instance has been saved.'));
+            $this->messageManager->addSuccessMessage(__('The widget instance has been saved.'));
             if ($this->getRequest()->getParam('back', false)) {
                 $this->_redirect(
                     'adminhtml/*/edit',
@@ -44,7 +44,7 @@ class Save extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
             }
             return;
         } catch (\Exception $exception) {
-            $this->messageManager->addError($exception->getMessage());
+            $this->messageManager->addErrorMessage($exception->getMessage());
             $this->_logger->critical($exception);
             $this->_redirect('adminhtml/*/edit', ['_current' => true]);
             return;

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Validate.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Validate.php
@@ -20,7 +20,7 @@ class Validate extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
         $widgetInstance = $this->_initWidgetInstance();
         $result = $widgetInstance->validate();
         if ($result !== true && is_string($result)) {
-            $this->messageManager->addError($result);
+            $this->messageManager->addErrorMessage($result);
             $this->_view->getLayout()->initMessages();
             $response->setError(true);
             $response->setHtmlMessage($this->_view->getLayout()->getMessagesBlock()->getGroupedHtml());

--- a/app/code/Magento/Wishlist/Controller/Index/Cart.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Cart.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Wishlist\Controller\Index;
 
-use Magento\Framework\App\Action;
 use Magento\Catalog\Model\Product\Exception as ProductException;
+use Magento\Framework\App\Action;
 use Magento\Framework\Controller\ResultFactory;
 
 /**
@@ -183,7 +183,7 @@ class Cart extends \Magento\Wishlist\Controller\AbstractIndex
                     'You added %1 to your shopping cart.',
                     $this->escaper->escapeHtml($item->getProduct()->getName())
                 );
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             }
 
             if ($this->cartHelper->getShouldRedirectToCart()) {
@@ -195,12 +195,12 @@ class Cart extends \Magento\Wishlist\Controller\AbstractIndex
                 }
             }
         } catch (ProductException $e) {
-            $this->messageManager->addError(__('This product(s) is out of stock.'));
+            $this->messageManager->addErrorMessage(__('This product(s) is out of stock.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addNotice($e->getMessage());
+            $this->messageManager->addNoticeMessage($e->getMessage());
             $redirectUrl = $configureUrl;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t add the item to the cart right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t add the item to the cart right now.'));
         }
 
         $this->helper->calculate();
@@ -211,7 +211,7 @@ class Cart extends \Magento\Wishlist\Controller\AbstractIndex
             $resultJson->setData(['backUrl' => $redirectUrl]);
             return $resultJson;
         }
-        
+
         $resultRedirect->setUrl($redirectUrl);
         return $resultRedirect;
     }

--- a/app/code/Magento/Wishlist/Controller/Index/Configure.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Configure.php
@@ -6,8 +6,8 @@
 namespace Magento\Wishlist\Controller\Index;
 
 use Magento\Framework\App\Action;
-use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NotFoundException;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -101,11 +101,11 @@ class Configure extends \Magento\Wishlist\Controller\AbstractIndex
 
             return $resultPage;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('*');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t configure the product right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t configure the product right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             $resultRedirect->setPath('*');
             return $resultRedirect;

--- a/app/code/Magento/Wishlist/Controller/Index/Remove.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Remove.php
@@ -6,9 +6,9 @@
 namespace Magento\Wishlist\Controller\Index;
 
 use Magento\Framework\App\Action;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Framework\Exception\NotFoundException;
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Wishlist\Controller\WishlistProviderInterface;
 
 /**
@@ -68,11 +68,11 @@ class Remove extends \Magento\Wishlist\Controller\AbstractIndex
             $item->delete();
             $wishlist->save();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('We can\'t delete the item from Wish List right now because of an error: %1.', $e->getMessage())
             );
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete the item from the Wish List right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete the item from the Wish List right now.'));
         }
 
         $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();

--- a/app/code/Magento/Wishlist/Controller/Index/Send.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Send.php
@@ -8,11 +8,11 @@ namespace Magento\Wishlist\Controller\Index;
 
 use Magento\Framework\App\Action;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Session\Generic as WishlistSession;
-use Magento\Store\Model\StoreManagerInterface;
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\View\Result\Layout as ResultLayout;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -164,7 +164,7 @@ class Send extends \Magento\Wishlist\Controller\AbstractIndex
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->wishlistSession->setSharingForm($this->getRequest()->getPostValue());
             $resultRedirect->setPath('*/*/share');
             return $resultRedirect;
@@ -230,12 +230,12 @@ class Send extends \Magento\Wishlist\Controller\AbstractIndex
             $this->inlineTranslation->resume();
 
             $this->_eventManager->dispatch('wishlist_share', ['wishlist' => $wishlist]);
-            $this->messageManager->addSuccess(__('Your wish list has been shared.'));
+            $this->messageManager->addSuccessMessage(__('Your wish list has been shared.'));
             $resultRedirect->setPath('*/*', ['wishlist_id' => $wishlist->getId()]);
             return $resultRedirect;
         } catch (\Exception $e) {
             $this->inlineTranslation->resume();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->wishlistSession->setSharingForm($this->getRequest()->getPostValue());
             $resultRedirect->setPath('*/*/share');
             return $resultRedirect;

--- a/app/code/Magento/Wishlist/Controller/Index/Update.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Update.php
@@ -6,8 +6,8 @@
 namespace Magento\Wishlist\Controller\Index;
 
 use Magento\Framework\App\Action;
-use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NotFoundException;
 
 class Update extends \Magento\Wishlist\Controller\AbstractIndex
 {
@@ -101,7 +101,7 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
                         $item->delete();
                     } catch (\Exception $e) {
                         $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                        $this->messageManager->addError(__('We can\'t delete item from Wish List right now.'));
+                        $this->messageManager->addErrorMessage(__('We can\'t delete item from Wish List right now.'));
                     }
                 }
 
@@ -113,7 +113,7 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
                     $item->setDescription($description)->setQty($qty)->save();
                     $updatedItems++;
                 } catch (\Exception $e) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __(
                             'Can\'t save description %1',
                             $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($description)
@@ -128,7 +128,7 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
                     $wishlist->save();
                     $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
                 } catch (\Exception $e) {
-                    $this->messageManager->addError(__('Can\'t update wish list'));
+                    $this->messageManager->addErrorMessage(__('Can\'t update wish list'));
                 }
             }
 

--- a/app/code/Magento/Wishlist/Controller/Index/UpdateItemOptions.php
+++ b/app/code/Magento/Wishlist/Controller/Index/UpdateItemOptions.php
@@ -8,9 +8,9 @@ namespace Magento\Wishlist\Controller\Index;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Wishlist\Controller\WishlistProviderInterface;
 
 /**
@@ -85,7 +85,7 @@ class UpdateItemOptions extends \Magento\Wishlist\Controller\AbstractIndex
         }
 
         if (!$product || !$product->isVisibleInCatalog()) {
-            $this->messageManager->addError(__('We can\'t specify a product.'));
+            $this->messageManager->addErrorMessage(__('We can\'t specify a product.'));
             $resultRedirect->setPath('*/');
             return $resultRedirect;
         }
@@ -114,11 +114,11 @@ class UpdateItemOptions extends \Magento\Wishlist\Controller\AbstractIndex
             $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
 
             $message = __('%1 has been updated in your Wish List.', $product->getName());
-            $this->messageManager->addSuccess($message);
+            $this->messageManager->addSuccessMessage($message);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update your Wish List right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update your Wish List right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $resultRedirect->setPath('*/*', ['wishlist_id' => $wishlist->getId()]);

--- a/app/code/Magento/Wishlist/Controller/Shared/Cart.php
+++ b/app/code/Magento/Wishlist/Controller/Shared/Cart.php
@@ -103,19 +103,19 @@ class Cart extends \Magento\Framework\App\Action\Action
                     'You added %1 to your shopping cart.',
                     $this->escaper->escapeHtml($item->getProduct()->getName())
                 );
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             }
 
             if ($this->cartHelper->getShouldRedirectToCart()) {
                 $redirectUrl = $this->cartHelper->getCartUrl();
             }
         } catch (ProductException $e) {
-            $this->messageManager->addError(__('This product(s) is out of stock.'));
+            $this->messageManager->addErrorMessage(__('This product(s) is out of stock.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addNotice($e->getMessage());
+            $this->messageManager->addNoticeMessage($e->getMessage());
             $redirectUrl = $item->getProductUrl();
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t add the item to the cart right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t add the item to the cart right now.'));
         }
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Wishlist/Controller/WishlistProvider.php
+++ b/app/code/Magento/Wishlist/Controller/WishlistProvider.php
@@ -85,10 +85,10 @@ class WishlistProvider implements WishlistProviderInterface
                 );
             }
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return false;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t create the Wish List right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t create the Wish List right now.'));
             return false;
         }
         $this->wishlist = $wishlist;

--- a/app/code/Magento/Wishlist/Model/ItemCarrier.php
+++ b/app/code/Magento/Wishlist/Model/ItemCarrier.php
@@ -12,10 +12,10 @@ use Magento\Checkout\Model\Cart;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Psr\Log\LoggerInterface as Logger;
 use Magento\Framework\Message\ManagerInterface as MessageManager;
 use Magento\Framework\UrlInterface;
 use Magento\Wishlist\Helper\Data as WishlistHelper;
+use Psr\Log\LoggerInterface as Logger;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -182,7 +182,12 @@ class ItemCarrier
 
         if ($messages) {
             foreach ($messages as $message) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addComplexErrorMessage(
+                    'addUnescapedMessage',
+                    [
+                        'text' => $message,
+                    ]
+                );
             }
             $redirectUrl = $indexUrl;
         }
@@ -192,7 +197,7 @@ class ItemCarrier
             try {
                 $wishlist->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t update the Wish List right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t update the Wish List right now.'));
                 $redirectUrl = $indexUrl;
             }
 
@@ -202,7 +207,7 @@ class ItemCarrier
                 $products[] = '"' . $product->getName() . '"';
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('%1 product(s) have been added to shopping cart: %2.', count($addedProducts), join(', ', $products))
             );
 

--- a/app/code/Magento/Wishlist/Observer/AddToCart.php
+++ b/app/code/Magento/Wishlist/Observer/AddToCart.php
@@ -105,7 +105,7 @@ class AddToCart implements ObserverInterface
             $this->checkoutSession->setWishlistPendingUrls($urls);
             $this->checkoutSession->setWishlistPendingMessages($messages);
 
-            $this->messageManager->addError($message);
+            $this->messageManager->addErrorMessage($message);
 
             $observer->getEvent()->getResponse()->setRedirect($url);
             $this->checkoutSession->setNoCartRedirect(true);

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Wishlist\Test\Unit\Controller\Index;
 
-use Magento\Wishlist\Controller\Index\Cart;
 use Magento\Catalog\Model\Product\Exception as ProductException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Wishlist\Controller\Index\Cart;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -172,7 +172,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManagerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess'])
+            ->setMethods(['addSuccessMessage'])
             ->getMockForAbstractClass();
 
         $this->urlMock = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
@@ -566,8 +566,8 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productName);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
-            ->with('You added '  . $productName . ' to your shopping cart.', null)
+            ->method('addSuccessMessage')
+            ->with('You added ' . $productName . ' to your shopping cart.', null)
             ->willReturnSelf();
 
         $this->cartHelperMock->expects($this->once())
@@ -581,7 +581,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $this->helperMock->expects($this->once())
             ->method('calculate')
             ->willReturnSelf();
-        
+
         return $refererUrl;
     }
 
@@ -735,7 +735,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new ProductException(__('Test Phrase')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('This product(s) is out of stock.', null)
             ->willReturnSelf();
 
@@ -901,7 +901,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('message', null)
             ->willReturnSelf();
 
@@ -1073,7 +1073,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('message', null)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
@@ -241,7 +241,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->with(\Magento\Wishlist\Model\Item::class)
             ->willReturn($item);
-        
+
         $this->wishlistProvider
             ->expects($this->once())
             ->method('getWishlist')
@@ -270,7 +270,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t delete the item from Wish List right now because of an error: Message.')
             ->willReturn(true);
 
@@ -355,7 +355,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t delete the item from the Wish List right now.')
             ->willReturn(true);
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
@@ -343,7 +343,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn($postValue);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage)
             ->willReturnSelf();
 
@@ -501,7 +501,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception($exceptionMessage));
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($exceptionMessage)
             ->willReturnSelf();
 
@@ -685,7 +685,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('Your wish list has been shared.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
@@ -249,7 +249,7 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t specify a product.')
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())
@@ -294,7 +294,7 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->never())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t specify a product.')
             ->willReturn(true);
 
@@ -433,12 +433,12 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('Test name has been updated in your Wish List.', null)
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('error-message')));
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('error-message', null)
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())
@@ -572,12 +572,12 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('Test name has been updated in your Wish List.', null)
             ->willThrowException($exception);
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t update your Wish List right now.', null)
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Shared/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Shared/CartTest.php
@@ -266,7 +266,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
 
         $successMessage = __('You added %1 to your shopping cart.', $productName);
         $this->messageManager->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($successMessage)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
@@ -37,7 +37,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
     protected $urlBuilderMock;
 
     /** @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject */
-    protected $managerMock;
+    protected $messageManager;
 
     /** @var \Magento\Framework\App\Response\RedirectInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $redirectMock;
@@ -63,7 +63,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $this->urlBuilderMock = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
             ->getMockForAbstractClass();
-        $this->managerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+        $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->getMockForAbstractClass();
         $this->redirectMock = $this->getMockBuilder(\Magento\Framework\App\Response\RedirectInterface::class)
             ->getMockForAbstractClass();
@@ -76,7 +76,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             $this->wishlistHelperMock,
             $this->cartHelperMock,
             $this->urlBuilderMock,
-            $this->managerMock,
+            $this->messageManager,
             $this->redirectMock
         );
     }
@@ -227,8 +227,8 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('getName')
             ->willReturn($productTwoName);
 
-        $this->managerMock->expects($this->once())
-            ->method('addSuccess')
+        $this->messageManager->expects($this->once())
+            ->method('addSuccessMessage')
             ->with(__('%1 product(s) have been added to shopping cart: %2.', 1, '"' . $productTwoName . '"'), null)
             ->willReturnSelf();
 
@@ -430,20 +430,18 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('getName')
             ->willReturn($productTwoName);
 
-        $this->managerMock->expects($this->at(0))
-            ->method('addError')
-            ->with(__('%1 for "%2".', 'Localized Exception', $productTwoName), null)
+        $this->messageManager->expects($this->at(0))
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => __('%1 for "%2".', 'Localized Exception', $productTwoName)])
             ->willReturnSelf();
 
-        $this->managerMock->expects($this->at(1))
-            ->method('addError')
-            ->with(
-                __(
-                    'We couldn\'t add the following product(s) to the shopping cart: %1.',
-                    '"' . $productOneName . '"'
-                ),
-                null
-            )->willReturnSelf();
+        $this->messageManager->expects($this->at(1))
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => __(
+                'We couldn\'t add the following product(s) to the shopping cart: %1.',
+                '"' . $productOneName . '"'
+            )])
+            ->willReturnSelf();
 
         $this->wishlistHelperMock->expects($this->once())
             ->method('calculate')
@@ -579,9 +577,9 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('critical')
             ->with($exception, []);
 
-        $this->managerMock->expects($this->at(0))
-            ->method('addError')
-            ->with(__('We can\'t add this item to your shopping cart right now.'), null)
+        $this->messageManager->expects($this->at(0))
+            ->method('addComplexErrorMessage')
+            ->with('addUnescapedMessage', ['text' => __('We can\'t add this item to your shopping cart right now.')])
             ->willReturnSelf();
 
         $this->wishlistHelperMock->expects($this->once())
@@ -602,8 +600,8 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('save')
             ->willThrowException(new \Exception());
 
-        $this->managerMock->expects($this->at(1))
-            ->method('addError')
+        $this->messageManager->expects($this->at(1))
+            ->method('addErrorMessage')
             ->with(__('We can\'t update the Wish List right now.'), null)
             ->willReturnSelf();
 
@@ -614,8 +612,8 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('getName')
             ->willReturn($productTwoName);
 
-        $this->managerMock->expects($this->once())
-            ->method('addSuccess')
+        $this->messageManager->expects($this->once())
+            ->method('addSuccessMessage')
             ->with(__('%1 product(s) have been added to shopping cart: %2.', 1, '"' . $productOneName . '"'), null)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Observer/AddToCartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Observer/AddToCartTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Wishlist\Test\Unit\Observer;
 
-use \Magento\Wishlist\Observer\AddToCart as Observer;
+use Magento\Wishlist\Observer\AddToCart as Observer;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -167,7 +167,7 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
             ->with([])
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message)
             ->willReturnSelf();
         $event->expects($this->once())

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1310,6 +1310,7 @@
             <argument name="renderers" xsi:type="array">
                 <item name="escape_renderer" xsi:type="object">Magento\Framework\View\Element\Message\Renderer\EscapeRenderer</item>
                 <item name="block_renderer" xsi:type="object">Magento\Framework\View\Element\Message\Renderer\BlockRenderer</item>
+                <item name="default_renderer" xsi:type="object">Magento\Framework\View\Element\Message\Renderer\DefaultRenderer</item>
             </argument>
         </arguments>
     </type>

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/Cart/Index/CouponPostTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/Cart/Index/CouponPostTest.php
@@ -12,11 +12,11 @@ namespace Magento\Checkout\Controller\Cart\Index;
 class CouponPostTest extends \Magento\TestFramework\TestCase\AbstractController
 {
     /**
-     * Test for \Magento\Checkout\Controller\Cart\CouponPost::execute() with simple product
+     * Test for \Magento\Checkout\Controller\Cart\CouponPost::execute() with invalid coupon
      *
      * @magentoDataFixture Magento/Checkout/_files/quote_with_virtual_product_and_address.php
      */
-    public function testExecute()
+    public function testExecuteInvalidCoupon()
     {
         /** @var $session \Magento\Checkout\Model\Session */
         $session = $this->_objectManager->create(\Magento\Checkout\Model\Session::class);
@@ -32,8 +32,42 @@ class CouponPostTest extends \Magento\TestFramework\TestCase\AbstractController
         );
 
         $this->assertSessionMessages(
-            $this->equalTo(['The coupon code "test" is not valid.']),
+            $this->equalTo(['The coupon code &quot;test&quot; is not valid.']),
             \Magento\Framework\Message\MessageInterface::TYPE_ERROR
+        );
+    }
+
+    /**
+     * Test for \Magento\Checkout\Controller\Cart\CouponPost::execute() with valid coupon
+     *
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_coupon_saved.php
+     */
+    public function testExecuteValidCoupon()
+    {
+        /** @var $session \Magento\Checkout\Model\Session */
+        $session = $this->_objectManager->create(\Magento\Checkout\Model\Session::class);
+        $quote = $session->getQuote();
+        $quote->setData('trigger_recollect', 1)->setTotalsCollectedFlag(true);
+
+        $salesRuleFactory = $this->_objectManager->get(\Magento\SalesRule\Model\RuleFactory::class);
+        $salesRule = $salesRuleFactory->create();
+        $salesRuleId = $this->_objectManager->get(\Magento\Framework\Registry::class)
+            ->registry('Magento/Checkout/_file/discount_10percent');
+        $salesRule->load($salesRuleId);
+        $couponCode = $salesRule->getPrimaryCoupon()->getCode();
+
+        $inputData = [
+            'remove' => 0,
+            'coupon_code' => $couponCode
+        ];
+        $this->getRequest()->setPostValue($inputData);
+        $this->dispatch(
+            'checkout/cart/couponPost/'
+        );
+
+        $this->assertSessionMessages(
+            $this->equalTo(['You used coupon code &quot;' . $couponCode . '&quot;.']),
+            \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
     }
 }

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Controller/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Controller/CartTest.php
@@ -91,7 +91,7 @@ class CartTest extends \Magento\TestFramework\TestCase\AbstractController
         );
 
         $this->assertSessionMessages(
-            $this->equalTo(['The coupon code "test" is not valid.']),
+            $this->equalTo(['The coupon code &quot;test&quot; is not valid.']),
             \Magento\Framework\Message\MessageInterface::TYPE_ERROR
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Contact/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Contact/Controller/IndexTest.php
@@ -24,7 +24,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractController
         $this->assertRedirect($this->stringContains('contact/index'));
         $this->assertSessionMessages(
             $this->contains(
-                "Thanks for contacting us with your comments and questions. We'll respond to you very soon."
+                "Thanks for contacting us with your comments and questions. We&#039;ll respond to you very soon."
             ),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );

--- a/dev/tests/integration/testsuite/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/FetchRatesTest.php
+++ b/dev/tests/integration/testsuite/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/FetchRatesTest.php
@@ -38,7 +38,7 @@ class FetchRatesTest extends \Magento\TestFramework\TestCase\AbstractBackendCont
         $this->dispatch('backend/admin/system_currency/fetchRates');
 
         $this->assertSessionMessages(
-            $this->contains('We can\'t initialize the import model.'),
+            $this->contains('We can&#039;t initialize the import model.'),
             \Magento\Framework\Message\MessageInterface::TYPE_ERROR
         );
     }
@@ -51,7 +51,7 @@ class FetchRatesTest extends \Magento\TestFramework\TestCase\AbstractBackendCont
         $this->runActionWithMockedImportService(['We can\'t retrieve a rate from url']);
 
         $this->assertSessionMessages(
-            $this->contains('Click "Save" to apply the rates we found.'),
+            $this->contains('Click &quot;Save&quot; to apply the rates we found.'),
             \Magento\Framework\Message\MessageInterface::TYPE_WARNING
         );
     }
@@ -64,7 +64,7 @@ class FetchRatesTest extends \Magento\TestFramework\TestCase\AbstractBackendCont
         $this->runActionWithMockedImportService();
 
         $this->assertSessionMessages(
-            $this->contains('Click "Save" to apply the rates we found.'),
+            $this->contains('Click &quot;Save&quot; to apply the rates we found.'),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Framework/Message/ManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Message/ManagerTest.php
@@ -94,11 +94,101 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     /**
      * @magentoAppIsolation enabled
      */
-    public function testAddError()
+    public function testAddErrorMessage()
     {
         $customGroup = 'custom-group';
-        $this->model->addError('some text');
-        $this->model->addError('some text 2', $customGroup);
+        $this->model->addErrorMessage('some text');
+        $this->model->addErrorMessage('some text 2', $customGroup);
+        $this->assertEquals(1, $this->model->getMessages()->getCount());
+        $this->assertEquals(1, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_ERROR));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_WARNING));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_NOTICE));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_SUCCESS));
+        $this->assertEquals('some text', $this->model->getMessages()->getLastAddedMessage()->getText());
+
+        $this->assertEquals(1, $this->model->getMessages(false, $customGroup)->getCount());
+        $this->assertEquals(
+            'some text 2',
+            $this->model->getMessages(false, $customGroup)->getLastAddedMessage()->getText()
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testAddWarningMessage()
+    {
+        $customGroup = 'custom-group';
+        $this->model->addWarningMessage('some text');
+        $this->model->addWarningMessage('some text 2', $customGroup);
+        $this->assertEquals(1, $this->model->getMessages()->getCount());
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_ERROR));
+        $this->assertEquals(1, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_WARNING));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_NOTICE));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_SUCCESS));
+        $this->assertEquals('some text', $this->model->getMessages()->getLastAddedMessage()->getText());
+
+        $this->assertEquals(1, $this->model->getMessages(false, $customGroup)->getCount());
+        $this->assertEquals(
+            'some text 2',
+            $this->model->getMessages(false, $customGroup)->getLastAddedMessage()->getText()
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testAddNoticeMessage()
+    {
+        $customGroup = 'custom-group';
+        $this->model->addNoticeMessage('some text');
+        $this->model->addNoticeMessage('some text 2', $customGroup);
+        $this->assertEquals(1, $this->model->getMessages()->getCount());
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_ERROR));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_WARNING));
+        $this->assertEquals(1, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_NOTICE));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_SUCCESS));
+        $this->assertEquals('some text', $this->model->getMessages()->getLastAddedMessage()->getText());
+
+        $this->assertEquals(1, $this->model->getMessages(false, $customGroup)->getCount());
+        $this->assertEquals(
+            'some text 2',
+            $this->model->getMessages(false, $customGroup)->getLastAddedMessage()->getText()
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testAddSuccessMessage()
+    {
+        $customGroup = 'custom-group';
+        $this->model->addSuccessMessage('some text');
+        $this->model->addSuccessMessage('some text 2', $customGroup);
+        $this->assertEquals(1, $this->model->getMessages()->getCount());
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_ERROR));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_WARNING));
+        $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_NOTICE));
+        $this->assertEquals(1, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_SUCCESS));
+        $this->assertEquals('some text', $this->model->getMessages()->getLastAddedMessage()->getText());
+
+        $this->assertEquals(1, $this->model->getMessages(false, $customGroup)->getCount());
+        $this->assertEquals(
+            'some text 2',
+            $this->model->getMessages(false, $customGroup)->getLastAddedMessage()->getText()
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testAddExceptionMessage()
+    {
+        $customGroup = 'custom-group';
+        $firstException = new \Exception('some text');
+        $secondException = new \Exception('some text 2');
+        $this->model->addExceptionMessage($firstException);
+        $this->model->addExceptionMessage($secondException, null, $customGroup);
         $this->assertEquals(1, $this->model->getMessages()->getCount());
         $this->assertEquals(1, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_ERROR));
         $this->assertEquals(0, $this->model->getMessages()->getCountByType(MessageInterface::TYPE_WARNING));

--- a/dev/tests/integration/testsuite/Magento/Paypal/Adminhtml/Paypal/ReportsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Adminhtml/Paypal/ReportsTest.php
@@ -23,7 +23,7 @@ class ReportsTest extends \Magento\TestFramework\TestCase\AbstractBackendControl
     {
         $this->dispatch('backend/paypal/paypal_reports/fetch');
         $this->assertSessionMessages(
-            $this->equalTo(['We can&#039;t fetch reports from &quot;login@127.0.0.1.&quot;']),
+            $this->equalTo(['We can\'t fetch reports from "login@127.0.0.1."']),
             \Magento\Framework\Message\MessageInterface::TYPE_ERROR
         );
     }

--- a/lib/internal/Magento/Framework/View/Element/Message/Renderer/DefaultRenderer.php
+++ b/lib/internal/Magento/Framework/View/Element/Message/Renderer/DefaultRenderer.php
@@ -5,29 +5,14 @@
  */
 namespace Magento\Framework\View\Element\Message\Renderer;
 
-use Magento\Framework\Escaper;
 use Magento\Framework\Message\MessageInterface;
 
-class EscapeRenderer implements RendererInterface
+class DefaultRenderer implements RendererInterface
 {
     /**
      * complex_renderer
      */
-    const CODE = 'escape_renderer';
-
-    /**
-     * @var Escaper
-     */
-    private $escaper;
-
-    /**
-     * @param Escaper $escaper
-     */
-    public function __construct(
-        Escaper $escaper
-    ) {
-        $this->escaper = $escaper;
-    }
+    const CODE = 'default_renderer';
 
     /**
      * Renders complex message
@@ -39,6 +24,6 @@ class EscapeRenderer implements RendererInterface
      */
     public function render(MessageInterface $message, array $initializationData)
     {
-        return $this->escaper->escapeHtml($message->getText());
+        return $message->getText();
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Message/Renderer/DefaultRendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Message/Renderer/DefaultRendererTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\View\Test\Unit\Element\Message\Renderer;
+
+use Magento\Framework\Message\MessageInterface;
+use Magento\Framework\View\Element\Message\Renderer\DefaultRenderer;
+
+class DefaultRendererTest extends \PHPUnit\Framework\TestCase
+{
+    public function testInterpret()
+    {
+        $messageText = 'Unescaped content';
+
+        /** @var MessageInterface | \PHPUnit_Framework_MockObject_MockObject $message */
+        $message = $this->createMock(\Magento\Framework\Message\MessageInterface::class);
+
+        $message->expects(static::once())
+            ->method('getText')
+            ->willReturn($messageText);
+
+        $renderer = new DefaultRenderer();
+        static::assertSame($messageText, $renderer->render($message, []));
+    }
+}


### PR DESCRIPTION
### Description
- Remove adminhtml message manager deprecated calls
- Proxy calls from deprecated methods to new ones in \Magento\Framework\Message\Manager
- Added complementary tests in \Magento\Framework\Message\ManagerTest
- Adapted unit tests, used addComplexMessages where needed to use new default renderer
- Optimized imports, phpcs-fixer for modified classes

### Fixed Issues (if relevant)
None, improvement

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
