### PR TITLE
Missing dependency of Google AdWords

### DIFF
--- a/app/code/Magento/GoogleAdwords/composer.json
+++ b/app/code/Magento/GoogleAdwords/composer.json
@@ -5,8 +5,8 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/module-store": "100.2.*",
         "magento/module-sales": "101.0.*",
-        "magento/module-google-analytics": "100.2.*",
-        "magento/framework": "101.0.*"
+        "magento/framework": "101.0.*",
+        "magento/module-google-analytics": "100.2.*"
     },
     "type": "magento2-module",
     "version": "100.2.0",

--- a/app/code/Magento/GoogleAdwords/composer.json
+++ b/app/code/Magento/GoogleAdwords/composer.json
@@ -5,6 +5,7 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/module-store": "100.2.*",
         "magento/module-sales": "101.0.*",
+        "magento/module-google-analytics": "100.2.*",
         "magento/framework": "101.0.*"
     },
     "type": "magento2-module",


### PR DESCRIPTION
If you disable Magento Google Analytics (bin/magento module:disable Magento_GoogleAnalytics) the configuration section "Google API" is missing the Magento backend and Google AdWords can't be configured. However, Magento_GoogleAnalytics is not a dependency of Magento_GoogleAdWords.
To fix this Magento_GoogleAnalytics should be declared as dependency of Magento_GoogleAdWords so that the configuration is possible.