### PR TITLE
Fix "Undefined variable: responseAjax" notice when trying to save a shipment package

### DIFF
--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
@@ -109,6 +109,8 @@ class Save extends \Magento\Backend\App\Action
 
         $isNeedCreateLabel = isset($data['create_shipping_label']) && $data['create_shipping_label'];
 
+        $responseAjax = new \Magento\Framework\DataObject();
+
         try {
             $this->shipmentLoader->setOrderId($this->getRequest()->getParam('order_id'));
             $this->shipmentLoader->setShipmentId($this->getRequest()->getParam('shipment_id'));
@@ -143,7 +145,6 @@ class Save extends \Magento\Backend\App\Action
             $shipment->register();
 
             $shipment->getOrder()->setCustomerNoteNotify(!empty($data['send_email']));
-            $responseAjax = new \Magento\Framework\DataObject();
 
             if ($isNeedCreateLabel) {
                 $this->labelGenerator->create($shipment, $this->_request);


### PR DESCRIPTION
### Description
When creating a shipping label and the post to /admin/order_shipment/save/order_id/<orderid>/?isAjax=true fails, the real error is obscured because of a NOTICE about responseAjax being undefined at line 168 of vendor/magento/module-shipping/Controller/Adminhtml/Order/Shipment/Save.php. There is no reason the responseAjax object needs to be defined inside the try/catch block.  Moving this up before the try/catch will resolve the issue of it not being defined prior to an exception being thrown.

### Manual testing scenarios
1. Create an order
2. Click the "Ship" button when viewing the order in the admin
3. Check the box for "Create Shipping Label"
4. Click "Submit Shipment"
5. Click "Add products to shipment"
6. Select products to add and then click "Add selected products to package"
7. Click "Save"
8. View browser console to see that AJAX request has failed. Go to network tab and select request to see the exception thrown.

In my specific case, the following message was prevented from being displayed:
"We don't have enough information to create shipping labels. Please make sure your store information and settings are complete."

This message isn't relevant for this pull request but demonstrates what the expected result was 
