### PR TITLE
Fix "Undefined variable: responseAjax" notice when trying to save a shipment package (backport fix to 2.1)

### DIFF
--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
@@ -109,6 +109,8 @@ class Save extends \Magento\Backend\App\Action
 
         $isNeedCreateLabel = isset($data['create_shipping_label']) && $data['create_shipping_label'];
 
+        $responseAjax = new \Magento\Framework\DataObject();
+
         try {
             $this->shipmentLoader->setOrderId($this->getRequest()->getParam('order_id'));
             $this->shipmentLoader->setShipmentId($this->getRequest()->getParam('shipment_id'));
@@ -143,7 +145,6 @@ class Save extends \Magento\Backend\App\Action
             $shipment->register();
 
             $shipment->getOrder()->setCustomerNoteNotify(!empty($data['send_email']));
-            $responseAjax = new \Magento\Framework\DataObject();
 
             if ($isNeedCreateLabel) {
                 $this->labelGenerator->create($shipment, $this->_request);


### PR DESCRIPTION
This is a backport of PR #12091 to 2.1