### PR TITLE
Fix coupon code failing to apply discount to shipping amount (2.1-develop)

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -417,6 +417,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         }
 
         if ($this->_needCollect) {
+            $this->getQuote()->getShippingAddress()->unsCachedItemsAll();
+            $this->getQuote()->setTotalsCollectedFlag(false);
             $this->getQuote()->collectTotals();
         }
 

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1413,11 +1413,14 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             $tmpAddress->unsAddressId()->unsAddressType();
             $data = $tmpAddress->getData();
             $data['save_in_address_book'] = 0;
+            // Don't lose the shipping method
+            unset($data['shipping_method']);
             // Do not duplicate address (billing address will do saving too)
             $this->getShippingAddress()->addData($data);
         }
         $this->getShippingAddress()->setSameAsBilling($flag);
-        $this->setRecollect(true);
+        // Recalculate the address shipping amounts
+        $this->collectShippingRates();
         return $this;
     }
 


### PR DESCRIPTION
### Issue

Create new coupon code that applies to shipping amount, has fixed discount, and has a product condition that is never met (qty>999 for example) so it only ever applies to shipping.
This is a "£5 off shipping for all orders".
Use table rates to apply a cost to shipping of more than £5 or exactly £5.
Create new backend order with this coupon code and apply to an order, so it should only discount the shipping. You will see the totals update correspondingly.
Ensure "Set shipping as billing" is ticked.

Submit the order.

### Expected

Order is created with same totals and the £5 discount to shipping.

### Actual

Order is created and there is no discount. The shipping is charged full and the total amount charged to the customer is higher than what was on the previous screen.

### Reason

When the order is submitted, the Magento\Sales\Model\AdminOrder\Create::setShippingAsBilling function overwrites the shipping amounts in the shipping address. It copies billing to shipping but the data contains not only a blank method but also 0 against all shipping amounts. This data is not recalculated. When Magento\SalesRule\Model\Quote\Discount comes along to calculate discount it sees 0 shipping amounts on the address and fails to apply any discount.

### Fix

Inside Magento\Sales\Model\AdminOrder\Create::setShippingAsBilling trigger a recollect of shipping rates.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
