### PR TITLE
#11936:required attribute set id filter on attribute group repository getList

### DIFF
--- a/app/code/Magento/Eav/Model/Attribute/GroupRepository.php
+++ b/app/code/Magento/Eav/Model/Attribute/GroupRepository.php
@@ -178,6 +178,7 @@ class GroupRepository implements \Magento\Eav\Api\AttributeGroupRepositoryInterf
     /**
      * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
      * @return null|string
+     * @deprecated
      */
     protected function retrieveAttributeSetIdFromSearchCriteria(
         \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria

--- a/app/code/Magento/Eav/Model/Attribute/GroupRepository.php
+++ b/app/code/Magento/Eav/Model/Attribute/GroupRepository.php
@@ -117,16 +117,6 @@ class GroupRepository implements \Magento\Eav\Api\AttributeGroupRepositoryInterf
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
-        $attributeSetId = $this->retrieveAttributeSetIdFromSearchCriteria($searchCriteria);
-        if (!$attributeSetId) {
-            throw InputException::requiredField('attribute_set_id');
-        }
-        try {
-            $this->setRepository->get($attributeSetId);
-        } catch (\Exception $exception) {
-            throw NoSuchEntityException::singleField('attributeSetId', $attributeSetId);
-        }
-
         /** @var \Magento\Eav\Model\ResourceModel\Entity\Attribute\Group\Collection $collection */
         $collection = $this->groupListFactory->create();
         $this->joinProcessor->process($collection);

--- a/app/code/Magento/Eav/Test/Unit/Model/Attribute/GroupRepositoryTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Attribute/GroupRepositoryTest.php
@@ -266,8 +266,6 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetList()
     {
-        $attributeSetId = 'filter';
-
         $filterInterfaceMock = $this->getMockBuilder(\Magento\Framework\Api\Search\FilterGroup::class)
             ->disableOriginalConstructor()
             ->setMethods([
@@ -275,24 +273,18 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
                 'getValue',
             ])
             ->getMock();
-        $filterInterfaceMock->expects($this->once())
-            ->method('getField')
-            ->willReturn('attribute_set_id');
-        $filterInterfaceMock->expects($this->once())
-            ->method('getValue')
-            ->willReturn($attributeSetId);
 
         $filterGroupMock = $this->getMockBuilder(\Magento\Framework\Api\Search\FilterGroup::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $filterGroupMock->expects($this->once())
+        $filterGroupMock->expects($this->any())
             ->method('getFilters')
             ->willReturn([$filterInterfaceMock]);
 
         $searchCriteriaMock = $this->getMockBuilder(\Magento\Framework\Api\SearchCriteriaInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $searchCriteriaMock->expects($this->once())
+        $searchCriteriaMock->expects($this->any())
             ->method('getFilterGroups')
             ->willReturn([$filterGroupMock]);
 
@@ -322,52 +314,6 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->assertEquals($searchResultsMock, $this->model->getList($searchCriteriaMock));
-    }
-
-    /**
-     * Test get list with invalid input exception
-     *
-     * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage attribute_set_id is a required field.
-     * @throws \Magento\Framework\Exception\InputException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @return void
-     */
-    public function testGetListWithInvalidInputException()
-    {
-        $searchCriteriaMock = $this->createMock(\Magento\Framework\Api\SearchCriteriaInterface::class);
-        $searchCriteriaMock->expects($this->once())->method('getFilterGroups')->willReturn([]);
-        $this->model->getList($searchCriteriaMock);
-    }
-
-    /**
-     * Test get list with no such entity exception
-     *
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage No such entity with attributeSetId = filter
-     * @throws \Magento\Framework\Exception\InputException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @return void
-     */
-    public function testGetListWithNoSuchEntityException()
-    {
-        $attributeSetId = 'filter';
-        $searchCriteriaMock = $this->createMock(\Magento\Framework\Api\SearchCriteriaInterface::class);
-        $filterGroupMock = $this->createMock(\Magento\Framework\Api\Search\FilterGroup::class);
-        $filterInterfaceMock = $this->createMock(\Magento\Framework\Api\Filter::class);
-
-        $searchCriteriaMock->expects($this->once())->method('getFilterGroups')->willReturn([$filterGroupMock]);
-
-        $filterGroupMock->expects($this->once())->method('getFilters')->willReturn([$filterInterfaceMock]);
-        $filterInterfaceMock->expects($this->once())->method('getField')->willReturn('attribute_set_id');
-        $filterInterfaceMock->expects($this->once())->method('getValue')->willReturn($attributeSetId);
-
-        $searchCriteriaMock->expects($this->once())->method('getFilterGroups')->willReturn([]);
-        $this->setRepositoryMock->expects($this->once())
-            ->method('get')
-            ->with($attributeSetId)
-            ->willThrowException(new \Exception());
-        $this->model->getList($searchCriteriaMock);
     }
 
     /**


### PR DESCRIPTION
### Description
This PR removes the need for an attribute_set_id filter in the method `Magento\Eav\Model\Attribute\GroupRepository::getList`
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11936: required attribute set id filter on attribute group repository getList

### Manual testing scenarios
1. There aren't any since this is more of a technical task than a user facing issue fix

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
