### PR TITLE
magento/magento2#11880: Configurable::getUsedProducts returns a different array after product collections is cached

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -1296,7 +1296,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
                 if ($salableOnly) {
                     $collection = $this->salableProcessor->process($collection);
                 }
-                $usedProducts = $collection->getItems();
+                $usedProducts = array_values($collection->getItems());
                 $this->saveUsedProductsCacheData($product, $usedProducts, $cacheKey);
             }
             $product->setData($dataFieldName, $usedProducts);

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
@@ -237,6 +237,26 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * Test getUsedProducts returns array with same indexes regardless collections was cache or not.
+     *
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/product_configurable.php
+     */
+    public function testGetUsedProductsCached()
+    {
+        /** @var  \Magento\Framework\App\Cache\StateInterface $cacheState */
+        $cacheState = Bootstrap::getObjectManager()->get(\Magento\Framework\App\Cache\StateInterface::class);
+        $cacheState->setEnabled(\Magento\Framework\App\Cache\Type\Collection::TYPE_IDENTIFIER, true);
+
+        $products = $this->getUsedProducts();
+        $productsCached = $this->getUsedProducts();
+        self::assertEquals(
+            array_keys($products),
+            array_keys($productsCached)
+        );
+    }
+
     public function testGetUsedProductCollection()
     {
         $this->assertInstanceOf(
@@ -570,5 +590,15 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         $this->model->prepareForCart($buyRequest, $product);
 
         return $product;
+    }
+
+    /**
+     * @return ProductInterface[]
+     */
+    protected function getUsedProducts()
+    {
+        $product = Bootstrap::getObjectManager()->create(Product::class);
+        $product->load(1);
+        return $this->model->getUsedProducts($product);
     }
 }


### PR DESCRIPTION
### Description
Magento\ConfigurableProduct\Model\Product\Type\Configurable:::loadUsedProducts is now ignoring array keys returned by collection.

### Fixed Issues (if relevant)
1. magento/magento2#11880: Configurable::getUsedProducts returns a different array after product collections is cached

### Manual testing scenarios
1. See the magento/magento2#11880 steps to reproduce.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
