### PR TITLE
Fix search field incorrect position on storefront in Safari

### DIFF
--- a/lib/web/css/source/lib/_dropdowns.less
+++ b/lib/web/css/source/lib/_dropdowns.less
@@ -253,6 +253,7 @@
         .lib-css(z-index, @_dropdown-list-z-index);
         box-sizing: border-box;
         display: none;
+        position: absolute;
 
         ._lib-dropdown-list-position(
             @_dropdown-list-position-top,
@@ -291,7 +292,6 @@
 
         @{_options-selector} {
             display: block;
-            position: absolute;
         }
     }
 }


### PR DESCRIPTION
### Description
Good description with screenshots you can find in https://github.com/magento/magento2/issues/8178

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/8178: Safari & minicart

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Click the minicart icon to open the dropdown in Safary (both iOS and MacOS)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
