### PR TITLE
11552: Admin orders account information showing guest for customer name.

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteRepository/Plugin/AddCustomerInfo.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository/Plugin/AddCustomerInfo.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Model\QuoteRepository\Plugin;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Add to quote all necessary customer information.
+ */
+class AddCustomerInfo
+{
+    /**
+     * List of necessary fields.
+     *
+     * @var array
+     */
+    private $fields = [
+        OrderInterface::CUSTOMER_EMAIL,
+        OrderInterface::CUSTOMER_FIRSTNAME,
+        OrderInterface::CUSTOMER_LASTNAME,
+        OrderInterface::CUSTOMER_GROUP_ID,
+    ];
+
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
+     * AddCustomerInfo constructor.
+     *
+     * @param CustomerRepositoryInterface $customerRepository
+     */
+    public function __construct(CustomerRepositoryInterface $customerRepository)
+    {
+        $this->customerRepository = $customerRepository;
+    }
+
+    /**
+     * Add to quote customer necessary information, if needed.
+     *
+     * @param CartRepositoryInterface $subject
+     * @param CartInterface $quote
+     * @return null
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeSave(CartRepositoryInterface $subject, CartInterface $quote)
+    {
+        if ($quote->getCustomerId() !== null) {
+            foreach ($this->fields as $property) {
+                if (!$quote->getData($property)) {
+                    $customer = $this->customerRepository->getById($quote->getCustomerId());
+                    $quote->setCustomer($customer);
+                    $quote->setCustomerIsGuest(false);
+                    break;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/code/Magento/Quote/Model/QuoteRepository/Plugin/AddCustomerInfo.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository/Plugin/AddCustomerInfo.php
@@ -79,7 +79,7 @@ class AddCustomerInfo
     {
         $result = '';
         switch ($property) {
-            case OrderInterface::CUSTOMER_EMAIL :
+            case OrderInterface::CUSTOMER_EMAIL:
                 $result = $customer->getEmail();
                 break;
             case OrderInterface::CUSTOMER_FIRSTNAME:

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AddCustomerInfoTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AddCustomerInfoTest.php
@@ -53,12 +53,28 @@ class AddCustomerInfoTest extends TestCase
      */
     public function testBeforeSave()
     {
-        $customerId = 1;
+        $customerId = '1';
+        $customerEmail = 'customer@exampel.com';
+        $customerFirstName = 'John';
+        $customerLastName = 'Doe';
+        $customerGroupId = 1;
 
         /** @var CustomerInterface|\PHPUnit_Framework_MockObject_MockObject $customer */
         $customer = $this->getMockBuilder(CustomerInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
+        $customer->expects(self::once())
+            ->method('getEmail')
+            ->willReturn($customerEmail);
+        $customer->expects(self::once())
+            ->method('getFirstName')
+            ->willReturn($customerFirstName);
+        $customer->expects(self::once())
+            ->method('getLastName')
+            ->willReturn($customerLastName);
+        $customer->expects(self::once())
+            ->method('getGroupId')
+            ->willReturn($customerGroupId);
 
         $this->customerRepository->expects(self::once())
             ->method('getById')
@@ -73,21 +89,30 @@ class AddCustomerInfoTest extends TestCase
         /** @var CartInterface|\PHPUnit_Framework_MockObject_MockObject $cart */
         $cart = $this->getMockBuilder(CartInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCustomerIsGuest', 'getCustomerId', 'getData', 'setCustomer', 'setCustomerIsGuest'])
+            ->setMethods(['getCustomerId', 'getData', 'setCustomerIsGuest', 'setData', 'setCustomerGroupId'])
             ->getMockForAbstractClass();
-        $cart->expects(self::once())
-            ->method('getCustomerIsGuest')
-            ->willReturn(false);
         $cart->expects(self::exactly(2))
             ->method('getCustomerId')
             ->willReturn($customerId);
-        $cart->expects(self::once())
+        $cart->expects(self::exactly(3))
             ->method('getData')
-            ->with(self::identicalTo(OrderInterface::CUSTOMER_EMAIL))
+            ->withConsecutive(
+                self::identicalTo(OrderInterface::CUSTOMER_EMAIL),
+                self::identicalTo(OrderInterface::CUSTOMER_FIRSTNAME),
+                self::identicalTo(OrderInterface::CUSTOMER_LASTNAME)
+            )
             ->willReturn(null);
+        $cart->expects(self::exactly(3))
+            ->method('setData')
+            ->withConsecutive(
+                self::identicalTo(OrderInterface::CUSTOMER_EMAIL),
+                self::identicalTo(OrderInterface::CUSTOMER_FIRSTNAME),
+                self::identicalTo(OrderInterface::CUSTOMER_LASTNAME)
+            )
+            ->willReturnSelf();
         $cart->expects(self::once())
-            ->method('setCustomer')
-            ->with(self::identicalTo($customer))
+            ->method('setCustomerGroupId')
+            ->with($customerGroupId)
             ->willReturnSelf();
         $cart->expects(self::once())
             ->method('setCustomerIsGuest')

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AddCustomerInfoTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AddCustomerInfoTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Test\Unit\Model\QuoteRepository\Plugin;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\QuoteRepository\Plugin\AddCustomerInfo;
+use Magento\Sales\Api\Data\OrderInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provide test for AddCustomerInfoPlugin.
+ */
+class AddCustomerInfoTest extends TestCase
+{
+    /**
+     * @var AddCustomerInfo
+     */
+    private $testSubject;
+
+    /**
+     * @var CustomerRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $customerRepository;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->customerRepository = $this->getMockBuilder(CustomerRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getById'])
+            ->getMockForAbstractClass();
+        $objectManager = new ObjectManager($this);
+        $this->testSubject = $objectManager->getObject(
+            AddCustomerInfo::class,
+            ['customerRepository' => $this->customerRepository]
+        );
+    }
+
+    /**
+     * Test all necessary customer info will be added to cart, if absent.
+     *
+     * @return void
+     */
+    public function testBeforeSave()
+    {
+        $customerId = 1;
+
+        /** @var CustomerInterface|\PHPUnit_Framework_MockObject_MockObject $customer */
+        $customer = $this->getMockBuilder(CustomerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->customerRepository->expects(self::once())
+            ->method('getById')
+            ->with(self::identicalTo($customerId))
+            ->willReturn($customer);
+
+        /** @var CartRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject $cartRepository */
+        $cartRepository = $this->getMockBuilder(CartRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        /** @var CartInterface|\PHPUnit_Framework_MockObject_MockObject $cart */
+        $cart = $this->getMockBuilder(CartInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCustomerIsGuest', 'getCustomerId', 'getData', 'setCustomer', 'setCustomerIsGuest'])
+            ->getMockForAbstractClass();
+        $cart->expects(self::once())
+            ->method('getCustomerIsGuest')
+            ->willReturn(false);
+        $cart->expects(self::exactly(2))
+            ->method('getCustomerId')
+            ->willReturn($customerId);
+        $cart->expects(self::once())
+            ->method('getData')
+            ->with(self::identicalTo(OrderInterface::CUSTOMER_EMAIL))
+            ->willReturn(null);
+        $cart->expects(self::once())
+            ->method('setCustomer')
+            ->with(self::identicalTo($customer))
+            ->willReturnSelf();
+        $cart->expects(self::once())
+            ->method('setCustomerIsGuest')
+            ->with(self::identicalTo(false))
+            ->willReturnSelf();
+
+        $this->testSubject->beforeSave($cartRepository, $cart);
+    }
+}

--- a/app/code/Magento/Quote/etc/webapi_rest/di.xml
+++ b/app/code/Magento/Quote/etc/webapi_rest/di.xml
@@ -11,5 +11,6 @@
     </type>
     <type name="Magento\Quote\Model\QuoteRepository">
         <plugin name="accessControl" type="Magento\Quote\Model\QuoteRepository\Plugin\AccessChangeQuoteControl" />
+        <plugin name="add_customer_info" type="Magento\Quote\Model\QuoteRepository\Plugin\AddCustomerInfo" />
     </type>
 </config>

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
@@ -319,6 +319,55 @@ class CartRepositoryTest extends WebapiAbstract
     }
 
     /**
+     * Saving quote without full customer information, just customer id.
+     *
+     * @magentoApiDataFixture Magento/Sales/_files/quote.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @return void
+     */
+    public function testSaveQuoteWithMinimalCustomerInfo()
+    {
+        $this->_markTestAsRestOnly();
+        $token = $this->getToken();
+        /** @var Quote $quote */
+        $quote = $this->getCart('test01');
+        $requestData['quote'] = [
+            'id' => $quote->getId(),
+            'customer' => [
+                'id' => 1,
+            ],
+        ];
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::$mineCartUrl,
+                'httpMethod'   => Request::HTTP_METHOD_PUT,
+                'token'        => $token
+            ],
+            'soap' => [
+                'service'        => 'quoteCartRepositoryV1',
+                'serviceVersion' => 'V1',
+                'operation'      => 'quoteCartRepositoryV1Save',
+                'token'          => $token
+            ]
+        ];
+
+        $this->_webApiCall($serviceInfo, $requestData);
+
+        // Reload target quote
+        $quote = $this->getCart('test01');
+        /** @var $repository \Magento\Customer\Api\CustomerRepositoryInterface */
+        $repository = $this->objectManager->create(\Magento\Customer\Api\CustomerRepositoryInterface::class);
+        /** @var $customer \Magento\Customer\Api\Data\CustomerInterface */
+        $customer = $repository->get('customer@example.com');
+        $this->assertEquals(0, $quote->getCustomerIsGuest());
+        $this->assertEquals($customer->getId(), $quote->getCustomerId());
+        $this->assertEquals($customer->getFirstname(), $quote->getCustomerFirstname());
+        $this->assertEquals($customer->getLastname(), $quote->getCustomerLastname());
+        $this->assertEquals($customer->getEmail(), $quote->getCustomerEmail());
+        $this->assertEquals($customer->getGroupId(), $quote->getCustomerGroupId());
+    }
+
+    /**
      * Request to api for the current user token.
      *
      * @return string

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
@@ -327,6 +327,7 @@ class CartRepositoryTest extends WebapiAbstract
      */
     public function testSaveQuoteWithMinimalCustomerInfo()
     {
+        //for SOAP all necessary fields for customer are mandatory.
         $this->_markTestAsRestOnly();
         $token = $this->getToken();
         /** @var Quote $quote */
@@ -342,12 +343,6 @@ class CartRepositoryTest extends WebapiAbstract
                 'resourcePath' => self::$mineCartUrl,
                 'httpMethod'   => Request::HTTP_METHOD_PUT,
                 'token'        => $token
-            ],
-            'soap' => [
-                'service'        => 'quoteCartRepositoryV1',
-                'serviceVersion' => 'V1',
-                'operation'      => 'quoteCartRepositoryV1Save',
-                'token'          => $token
             ]
         ];
 

--- a/dev/tests/integration/testsuite/Magento/Quote/Model/QuoteRepository/Plugin/AddCustomerInfoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Quote/Model/QuoteRepository/Plugin/AddCustomerInfoTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Model\QuoteRepository\Plugin;
+
+use Magento\Authorization\Model\CompositeUserContext;
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\App\Area;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\TestFramework\App\State;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Interception\PluginList;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provide tests for AddCustomerInfo plugin.
+ */
+class AddCustomerInfoTest extends TestCase
+{
+    /**
+     * Test AddCustomerInfo plugin is registered for Rest Api area.
+     */
+    public function testAddCustomerInfoIsRegistered()
+    {
+        /** @var State $state */
+        $state = Bootstrap::getObjectManager()->get(State::class);
+        $state->setAreaCode(Area::AREA_WEBAPI_REST);
+        $pluginInfo = Bootstrap::getObjectManager()->get(PluginList::class)->get(QuoteRepository::class, []);
+        self::assertSame(AddCustomerInfo::class, $pluginInfo['add_customer_info']['instance']);
+    }
+
+    /**
+     * Test AddCustomerInfo plugin adds all necessary customer information, if quote has customer id.
+     *
+     * @magentoDataFixture Magento/Sales/_files/quote.php
+     * @magentoDataFixture Magento/Customer/_files/customer.php
+     */
+    public function testAfterSave()
+    {
+        /** @var State $state */
+        $state = Bootstrap::getObjectManager()->get(State::class);
+        $state->setAreaCode(Area::AREA_WEBAPI_REST);
+        /** @var CustomerRepositoryInterface $customerRepository */
+        $customerRepository = Bootstrap::getObjectManager()->get(CustomerRepositoryInterface::class);
+        /** @var CustomerInterface $customer */
+        $customer = $customerRepository->get('customer@example.com');
+        $this->mockUserContext($customer->getId());
+        /** @var QuoteRepository $quoteRepository */
+        $quoteRepository = Bootstrap::getObjectManager()->create(QuoteRepository::class);
+        $quote = $this->loadQuote();
+        $quote->setCustomerId($customer->getId());
+        $quoteRepository->save($quote);
+        $quote = $this->loadQuote();
+        self::assertEquals(0, $quote->getCustomerIsGuest());
+        self::assertEquals($customer->getId(), $quote->getCustomerId());
+        self::assertEquals($customer->getFirstname(), $quote->getCustomerFirstname());
+        self::assertEquals($customer->getLastname(), $quote->getCustomerLastname());
+        self::assertEquals($customer->getEmail(), $quote->getCustomerEmail());
+        self::assertEquals($customer->getGroupId(), $quote->getCustomerGroupId());
+    }
+
+    /**
+     * @return \Magento\Quote\Model\Quote
+     */
+    private function loadQuote()
+    {
+        /** @var $quote \Magento\Quote\Model\Quote */
+        $quote = Bootstrap::getObjectManager()->get(\Magento\Quote\Model\Quote::class);
+        $quote->load('test01', 'reserved_order_id');
+
+        return $quote;
+    }
+
+    /**
+     * Mock User context to bypass AccessChangeQuoteControl plugin.
+     *
+     * @param string $customerId
+     * @return void
+     */
+    private function mockUserContext(string $customerId)
+    {
+        Bootstrap::getObjectManager()->removeSharedInstance(CompositeUserContext::class);
+        /** @var UserContextInterface|\PHPUnit_Framework_MockObject_MockObject $userContext */
+        $userContext = $this->getMockBuilder(CompositeUserContext::class)
+            ->setMethods(['getUserType', 'getUserId'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $userContext->expects(self::any())
+            ->method('getUserType')
+            ->willReturn(UserContextInterface::USER_TYPE_CUSTOMER);
+        $userContext->expects(self::any())
+            ->method('getUserId')
+            ->willReturn($customerId);
+        Bootstrap::getObjectManager()->addSharedInstance($userContext, CompositeUserContext::class);
+    }
+}


### PR DESCRIPTION
### Description
Fix for : Admin orders account information showing guest for customer name.

### Fixed Issues (if relevant)
1. magento/magento2#11552: Admin orders account information showing guest for customer name.

### Manual testing scenarios
1. Register customer.
2. Create simple product.
3. Create guest cart with  POST rest/V1/guest-carts.
4. Add simple product to cart with POST rest/V1/guest-carts/{cart_id_form_previous_step}/items.
body ex:
```
{
  "cartItem": {
    "sku": "{your_simple_product_sku}",
    "qty": 1,
    "name": "{your_simple_product_name}",
    "product_type": "simple",
    "quote_id": "{cart_id_form_previous_step}"
  }
}
```
5. Assign cart to registered customer with PUT rest/V1/carts/mine.
Set only customer id field for customer information:
```
{
  "quote": {
    "id": "{quote_id_from_previous_step_response_body}",
    "is_active": true,
    "customer": {
      "id": "{registered_customer_id_from_first_step}",
    }
  }
}
```
6. Login as customer from 1-st step(customer should have cart with 1 item. If not, try to remove all previous quotes from magento db, table "quote").
7. Complete checkout process.
8. Navigate to admin Sales > Orders.
9. Check newly created order, section "Account Information". "Customer Name", "Email", "Customer Group" should be presented and has correct values(same as registered customer from step1).



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
