### PR TITLE
[Backport 2.2] MAGETWO-71697: Fix possible bug when saving address with empty street line #10582

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -269,7 +269,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     {
         if (is_array($key)) {
             $key = $this->_implodeArrayField($key);
-        } elseif (is_array($value) && !empty($value) && $this->isAddressMultilineAttribute($key)) {
+        } elseif (is_array($value) && $this->isAddressMultilineAttribute($key)) {
             $value = $this->_implodeArrayValues($value);
         }
         return parent::setData($key, $value);
@@ -309,7 +309,11 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
      */
     protected function _implodeArrayValues($value)
     {
-        if (is_array($value) && count($value)) {
+        if (is_array($value)) {
+            if (!count($value)) {
+                return '';
+            }
+
             $isScalar = false;
             foreach ($value as $val) {
                 if (is_scalar($val)) {

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -367,6 +367,15 @@ class AbstractAddressTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @dataProvider getStreetFullDataProvider
+     */
+    public function testSetDataStreetAlwaysConvertedToString($expectedResult, $street)
+    {
+        $this->model->setData('street', $street);
+        $this->assertEquals($expectedResult, $this->model->getData('street'));
+    }
+
+    /**
      * @return array
      */
     public function getStreetFullDataProvider()

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
@@ -34,6 +34,7 @@ use Magento\Framework\Serialize\Serializer\Json;
  * Test class for sales quote address model
  *
  * @see \Magento\Quote\Model\Quote\Address
+ * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class AddressTest extends \PHPUnit\Framework\TestCase
@@ -47,6 +48,11 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Quote\Model\Quote | \PHPUnit_Framework_MockObject_MockObject
      */
     private $quote;
+
+    /**
+     * @var \Magento\Quote\Model\Quote\Address\CustomAttributeListInterface | \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $attributeList;
 
     /**
      * @var \Magento\Framework\App\Config | \PHPUnit_Framework_MockObject_MockObject
@@ -166,9 +172,13 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->attributeList = $this->createMock(\Magento\Quote\Model\Quote\Address\CustomAttributeListInterface::class);
+        $this->attributeList->method('getAttributes')->willReturn([]);
+
         $this->address = $objectManager->getObject(
             \Magento\Quote\Model\Quote\Address::class,
             [
+                'attributeList' => $this->attributeList,
                 'scopeConfig' => $this->scopeConfig,
                 'serializer' => $this->serializer,
                 'storeManager' => $this->storeManager,


### PR DESCRIPTION
Cherry-pick of https://github.com/magento/magento2/commit/5858ca59f2b3ed8d799c6914978210867035fb4c
Original PR: https://github.com/magento/magento2/pull/10582

### Description
The changes affect address street data preparation to guarantee that street array will be converted to the string.

### Manual testing scenarios
1. Make the street address as an optional field (third-party extension is required or edit DB properties of the field)
2. Save the address without street
3. `exception 'Exception' with message 'Notice: Array to string conversion on line 2903 in
lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php ` will be raised.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
