### PR TITLE
Fix for issue 12127: Single quotation marks are now decoded properly in admin attribute option input fields

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -88,7 +88,9 @@ $stores = $block->getStoresSortedBySortOrder();
     $values = [];
     foreach($block->getOptionValues() as $value) {
         $value = $value->getData();
-        $values[] = is_array($value) ? array_map("htmlspecialchars_decode", $value) : $value;
+        $values[] = is_array($value) ? array_map(function($str) {
+            return htmlspecialchars_decode($str, ENT_QUOTES);
+        }, $value) : $value;
     }
     ?>
     <script type="text/x-magento-init">


### PR DESCRIPTION
### Description
Single quotation marks are now decoded properly in admin attribute option input fields.

It sort of feels like this is a workaround though. I think the right fix would be to not escape the output by PHP in the first place, and let Underscore's templating engine handle the escaping.

As it stands now, the attribute option value is first escaped in `Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options::_prepareUserDefinedAttributeOptionValues`, and then it's decoded (improperly) in `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml::91`, and then it's escaped again by the Underscore templating engine: `<%- %>`.

The problem is that the first escapes includes single quotes, but the decode doesn't (which I've added in this PR). So, I've fixed the bad decode, but why the first encode/decode is happening, I'm not sure.

### Fixed Issues
Fixes issue magento/magento2#12127.

### Manual testing scenarios
1. As an admin, go to Stores -> Attributes -> Products -> Manufacturer
2. Add a new attribute option called "Nature's Way Supplements"
3. Hit "Save and continue"
4. Hit "Save and continue" again

#### Result
 * Text input value now shows `Nature's Way Supplements`, instead of  `Nature&#039;s Way Supplements`.
 * Database entry (`eav_attribute_option_value`) correctly stores `Nature's Way Supplements`, instead of  `Nature&#039;s Way Supplements`.