### PR TITLE
[Magento 2.2] - Do not allow to see the version of magento in production mode

### DIFF
--- a/app/code/Magento/Version/Controller/Index/Index.php
+++ b/app/code/Magento/Version/Controller/Index/Index.php
@@ -24,20 +24,20 @@ class Index extends Action
     /**
      * @var State
      */
-    protected $state;
+    private $state;
 
     /**
      * @param Context $context
      * @param ProductMetadataInterface $productMetadata
-     * @param State $state
+     * @param State|null $state
      */
     public function __construct(
         Context $context,
         ProductMetadataInterface $productMetadata,
-        State $state
+        State $state = null
     ) {
         $this->productMetadata = $productMetadata;
-        $this->state = $state;
+        $this->state = $state ?: \Magento\Framework\App\ObjectManager::getInstance()->get(State::class);
         parent::__construct($context);
     }
 
@@ -49,7 +49,7 @@ class Index extends Action
      */
     public function execute()
     {
-        if ($this->state->getMode() == State::MODE_PRODUCTION) {
+        if ($this->state->getMode() === State::MODE_PRODUCTION) {
             $this->_forward('index', 'noroute', 'cms');
             return;
         }


### PR DESCRIPTION
### Description
When an user enter to domain.com/magento_version can see magento version.

### Manual testing scenarios
1. Set Magento to Production mode.
2. Enter to domain.com/magento_version

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
