### PR TITLE
10210: Transport variable can not be altered in email_invoice_set_template_vars_before Event (backport MAGETWO-69482 to 2.1).

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Sender/EmailSender.php
@@ -7,9 +7,12 @@ namespace Magento\Sales\Model\Order\Creditmemo\Sender;
 
 use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\Order\Creditmemo\SenderInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Email notification sender for Creditmemo.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class EmailSender extends Sender implements SenderInterface
 {
@@ -106,13 +109,17 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
+            $transportObject = new DataObject($transport);
 
+            /**
+             * Event argument `transport` is @deprecated. Use `transportObject` instead.
+             */
             $this->eventManager->dispatch(
                 'email_creditmemo_set_template_vars_before',
-                ['sender' => $this, 'transport' => $transport]
+                ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transportObject->getData());
 
             if ($this->checkAndSend($order)) {
                 $creditmemo->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order\Email\Container\Template;
 use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class CreditmemoCommentSender
@@ -71,13 +72,17 @@ class CreditmemoCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transportObject = new DataObject($transport);
 
+        /**
+         * Event argument `transport` is @deprecated. Use `transportObject` instead.
+         */
         $this->eventManager->dispatch(
             'email_creditmemo_comment_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transport]
+            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transportObject->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo as CreditmemoResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class CreditmemoSender
@@ -102,7 +103,7 @@ class CreditmemoSender extends Sender
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
             $order = $creditmemo->getOrder();
-            
+
             $transport = [
                 'order' => $order,
                 'creditmemo' => $creditmemo,
@@ -113,13 +114,17 @@ class CreditmemoSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
+            $transportObject = new DataObject($transport);
 
+            /**
+             * Event argument `transport` is @deprecated. Use `transportObject` instead.
+             */
             $this->eventManager->dispatch(
                 'email_creditmemo_set_template_vars_before',
-                ['sender' => $this, 'transport' => $transport]
+                ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transportObject->getData());
 
             if ($this->checkAndSend($order)) {
                 $creditmemo->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class InvoiceCommentSender
@@ -71,13 +72,17 @@ class InvoiceCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transportObject = new DataObject($transport);
 
+        /**
+         * Event argument `transport` is @deprecated. Use `transportObject` instead.
+         */
         $this->eventManager->dispatch(
             'email_invoice_comment_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transport]
+            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transportObject->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\ResourceModel\Order\Invoice as InvoiceResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class InvoiceSender
@@ -113,13 +114,17 @@ class InvoiceSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
+            $transportObject = new DataObject($transport);
 
+            /**
+             * Event argument `transport` is @deprecated. Use `transportObject` instead.
+             */
             $this->eventManager->dispatch(
                 'email_invoice_set_template_vars_before',
-                ['sender' => $this, 'transport' => $transport]
+                ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transportObject->getData());
 
             if ($this->checkAndSend($order)) {
                 $invoice->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
@@ -11,6 +11,7 @@ use Magento\Sales\Model\Order\Email\Container\Template;
 use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class OrderCommentSender
@@ -68,13 +69,17 @@ class OrderCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transportObject = new DataObject($transport);
 
+        /**
+         * Event argument `transport` is @deprecated. Use `transportObject` instead.
+         */
         $this->eventManager->dispatch(
             'email_order_comment_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transport]
+            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transportObject->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Shipment;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class ShipmentCommentSender
@@ -71,13 +72,17 @@ class ShipmentCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transportObject = new DataObject($transport);
 
+        /**
+         * Event argument `transport` is @deprecated. Use `transportObject` instead.
+         */
         $this->eventManager->dispatch(
             'email_shipment_comment_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transport]
+            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transportObject->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Shipment;
 use Magento\Sales\Model\ResourceModel\Order\Shipment as ShipmentResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class ShipmentSender
@@ -102,7 +103,7 @@ class ShipmentSender extends Sender
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
             $order = $shipment->getOrder();
-            
+
             $transport = [
                 'order' => $order,
                 'shipment' => $shipment,
@@ -113,13 +114,17 @@ class ShipmentSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
+            $transportObject = new DataObject($transport);
 
+            /**
+             * Event argument `transport` is @deprecated. Use `transportObject` instead.
+             */
             $this->eventManager->dispatch(
                 'email_shipment_set_template_vars_before',
-                ['sender' => $this, 'transport' => $transport]
+                ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transportObject->getData());
 
             if ($this->checkAndSend($order)) {
                 $shipment->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
@@ -7,9 +7,12 @@ namespace Magento\Sales\Model\Order\Invoice\Sender;
 
 use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\Order\Invoice\SenderInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Email notification sender for Invoice.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class EmailSender extends Sender implements SenderInterface
 {
@@ -104,15 +107,19 @@ class EmailSender extends Sender implements SenderInterface
                 'payment_html' => $this->getPaymentHtml($order),
                 'store' => $order->getStore(),
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
-                'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
+                'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
+            $transportObject = new DataObject($transport);
 
+            /**
+             * Event argument `transport` is @deprecated. Use `transportObject` instead.
+             */
             $this->eventManager->dispatch(
                 'email_invoice_set_template_vars_before',
-                ['sender' => $this, 'transport' => $transport]
+                ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transportObject->getData());
 
             if ($this->checkAndSend($order)) {
                 $invoice->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
@@ -7,9 +7,12 @@ namespace Magento\Sales\Model\Order\Shipment\Sender;
 
 use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\Order\Shipment\SenderInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Email notification sender for Shipment.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class EmailSender extends Sender implements SenderInterface
 {
@@ -106,13 +109,17 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
+            $transportObject = new DataObject($transport);
 
+            /**
+             * Event argument `transport` is @deprecated. Use `transportObject` instead.
+             */
             $this->eventManager->dispatch(
                 'email_shipment_set_template_vars_before',
-                ['sender' => $this, 'transport' => $transport]
+                ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transportObject->getData());
 
             if ($this->checkAndSend($order)) {
                 $shipment->setEmailSent(true);

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Sender/EmailSenderTest.php
@@ -262,6 +262,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                 'formattedShippingAddress' => 'Formatted address',
                 'formattedBillingAddress' => 'Formatted address',
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManagerMock->expects($this->once())
                 ->method('dispatch')
@@ -269,13 +270,14 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                     'email_creditmemo_set_template_vars_before',
                     [
                         'sender' => $this->subject,
-                        'transport' => $transport,
+                        'transport' => $transport->getData(),
+                        'transportObject' => $transport
                     ]
                 );
 
             $this->templateContainerMock->expects($this->once())
                 ->method('setTemplateVars')
-                ->with($transport);
+                ->with($transport->getData());
 
             $this->identityContainerMock->expects($this->once())
                 ->method('isEnabled')

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Invoice/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Invoice/Sender/EmailSenderTest.php
@@ -258,8 +258,9 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                 'payment_html' => 'Payment Info Block',
                 'store' => $this->storeMock,
                 'formattedShippingAddress' => 'Formatted address',
-                'formattedBillingAddress' => 'Formatted address'
+                'formattedBillingAddress' => 'Formatted address',
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManagerMock->expects($this->once())
                 ->method('dispatch')
@@ -267,13 +268,14 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                     'email_invoice_set_template_vars_before',
                     [
                         'sender' => $this->subject,
-                        'transport' => $transport
+                        'transport' => $transport->getData(),
+                        'transportObject' => $transport,
                     ]
                 );
 
             $this->templateContainerMock->expects($this->once())
                 ->method('setTemplateVars')
-                ->with($transport);
+                ->with($transport->getData());
 
             $this->identityContainerMock->expects($this->once())
                 ->method('isEnabled')
@@ -353,7 +355,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
             'Successful sync sending without comment' => [0, false, false, true],
             'Failed sync sending with comment' => [0, false, true, false],
             'Successful forced sync sending with comment' => [1, true, true, true],
-            'Async sending' => [1, false, false, false]
+            'Async sending' => [1, false, false, false],
         ];
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/Sender/EmailSenderTest.php
@@ -262,6 +262,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                 'formattedShippingAddress' => 'Formatted address',
                 'formattedBillingAddress' => 'Formatted address',
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManagerMock->expects($this->once())
                 ->method('dispatch')
@@ -269,13 +270,14 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                     'email_shipment_set_template_vars_before',
                     [
                         'sender' => $this->subject,
-                        'transport' => $transport,
+                        'transport' => $transport->getData(),
+                        'transportObject' => $transport,
                     ]
                 );
 
             $this->templateContainerMock->expects($this->once())
                 ->method('setTemplateVars')
-                ->with($transport);
+                ->with($transport->getData());
 
             $this->identityContainerMock->expects($this->once())
                 ->method('isEnabled')


### PR DESCRIPTION
Backport MAGETWO-69482.

### Fixed Issues (if relevant)
1. magento/magento2#10210: Transport variable can not be altered in email_invoice_set_template_vars_before Event (backport MAGETWO-69482 to 2.1).

### Manual testing scenarios
1. Declare the event
```
<event name="email_invoice_set_template_vars_before">
        <observer name="mod_mail_variables_of_Invoice" instance="Vendor\Module\Observer\ChangePaymentHtml" />
    </event>
```

2. Alter variable payment_html in Vendor\Module\Observer\ChangePaymentHtml like
```
<?php

namespace Venoor\Module\Observer;

use Magento\Framework\Event\ObserverInterface;
use Magento\Framework\Event\Observer;
use Magento\Framework\App\Request\DataPersistorInterface;
use Magento\Framework\App\ObjectManager;
use Vendor\Module\Helper\Data as PaymentHelper;
use Magento\Sales\Model\Order;

class ChangePaymentHtml implements ObserverInterface
{
    public function execute(\Magento\Framework\Event\Observer $observer)
    {
         $transport = $observer->getEvent()->getData('transportObject');

        $transport['payment_html'] = '<div>SOME PAYMENT INFO</div>';
        $observer->setData('transportObject', $transport);
    }
}
```
3. Create order -> create Invoice.
4. Open invoice.
5. Press Send email.
6. Open email. Payment method should be "SOME PAYMENT INFO" .

### Expected result
1. Email should be modified and new or changed variables should be output in email. 

### Actual result
1. Email is unchanged, and $transport variable seems not to be changed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
