### PR TITLE
Fix js error when disable/enable wysiwyg editor

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -45,7 +45,8 @@ define([
                 component: this,
                 selector: 'button'
             }, function (element) {
-                this.$wysiwygEditorButton = $(element);
+                this.$wysiwygEditorButton = this.$wysiwygEditorButton ?
+                    this.$wysiwygEditorButton.add($(element)) : $(element);
             }.bind(this));
 
             return this;

--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -94,7 +94,7 @@ define([
             this.$wysiwygEditorButton.attr('disabled', status);
 
             /* eslint-disable no-undef */
-            if (tinyMCE) {
+            if (tinyMCE && tinyMCE.activeEditor) {
                 _.each(tinyMCE.activeEditor.controlManager.controls, function (property, index, controls) {
                     controls[property.id].setDisabled(status);
                 });


### PR DESCRIPTION
### Description
This PR fixes two issues when disable/enable WYSIWYG editor with `ui/form/element/helper/service` checkbox:

 - Js error in console: `Uncaught TypeError: Cannot read property 'controlManager' of null at UiClass.setDisabled (wysiwyg.js:98)`
 - Only the last WYSIWYG button will be disabled

### Manual testing scenarios
1. Open `app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml`
2. Replace description field with the following code:

    ```xml
    <field name="description" template="ui/form/field" sortOrder="50" formElement="wysiwyg">
        <argument name="data" xsi:type="array">
            <item name="config" xsi:type="array">
                <!--<item name="wysiwygConfigData" xsi:type="array">
                    <item name="settings" xsi:type="array">
                        <item name="theme_advanced_buttons1" xsi:type="string">bold,italic,|,justifyleft,justifycenter,justifyright,|,fontselect,fontsizeselect,|,forecolor,backcolor,|,link,unlink,image,|,bullist,numlist,|,code</item>
                        <item name="theme_advanced_buttons2" xsi:type="boolean">false</item>
                        <item name="theme_advanced_buttons3" xsi:type="boolean">false</item>
                        <item name="theme_advanced_buttons4" xsi:type="boolean">false</item>
                        <item name="theme_advanced_statusbar_location" xsi:type="boolean">false</item>
                    </item>
                    <item name="files_browser_window_url" xsi:type="boolean">false</item>
                    <item name="height" xsi:type="string">100px</item>
                    <item name="toggle_button" xsi:type="boolean">false</item>
                    <item name="add_variables" xsi:type="boolean">false</item>
                    <item name="add_widgets" xsi:type="boolean">false</item>
                    <item name="add_images" xsi:type="boolean">false</item>
                    <item name="add_directives" xsi:type="boolean">true</item>
                </item>-->
                <item name="source" xsi:type="string">category</item>
                <item name="service" xsi:type="array">
                    <item name="template" xsi:type="string">ui/form/element/helper/service</item>
                </item>
            </item>
        </argument>
        <settings>
            <label translate="true">Description</label>
            <dataScope>description</dataScope>
        </settings>
        <formElements>
            <wysiwyg class="Magento\Catalog\Ui\Component\Category\Form\Element\Wysiwyg">
                <settings>
                    <rows>8</rows>
                    <wysiwyg>true</wysiwyg>
                </settings>
            </wysiwyg>
        </formElements>
    </field>
    ```

3. Navigate to category edit form and try to use "Use Default Value" checkbox below description field.
4. Js error will be logged to the console and the last button will be disabled only.
5. Apply the patch to fix js error and all buttons will be disabled.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
