### PR TITLE
Removed FileClassScannerTest dependency to "Magento_Catalog"

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/FileClassScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/FileClassScannerTest.php
@@ -204,13 +204,38 @@ PHP
         self::assertContains('This\Is\Not\My\Ns\ThisIsNotMyTest', $result);
     }
 
-    public function testClassKeywordInMiddleOfFile()
+    public function testMultipleClassKeywordsInMiddleOfFileWithStringVariableParsing()
     {
-        $filename = __DIR__
-            . '/../../../../../../../../../..'
-            . '/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php';
-        $filename = realpath($filename);
-        $scanner = new FileClassScanner($filename);
+        $scanner = $this->getMockBuilder(FileClassScanner::class)->disableOriginalConstructor()->setMethods([
+            'getFileContents'
+        ])->getMock();
+        $scanner->expects(self::once())->method('getFileContents')->willReturn(<<<'PHP'
+<?php
+
+namespace This\Is\My\Ns;
+
+use stdClass;
+
+class ThisIsMyTest
+{
+    protected function firstMethod()
+    {
+        $test = 1;
+        $testString = "foo {$test}";
+        $className = stdClass::class;
+        $testString2 = "bar {$test}";
+    }
+
+    protected function secondMethod()
+    {
+        $this->doMethod(stdClass::class)->runAction();
+    }
+}
+
+PHP
+        );
+
+        /* @var $scanner FileClassScanner */
         $result = $scanner->getClassNames();
 
         self::assertCount(1, $result);


### PR DESCRIPTION

### Description
Code optimization that makes a current test `testClassKeywordInMiddleOfFile` stand on its own since is the only test in `FileClassScannerTest`  to not include its own test data.

### Process
Looked at the original error fixed by 4e8d1d612a98cbe35e7782faba5c0609935a1c2a and reproduced what it needed from app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
to test for the problem "FileClassScannerTest not liking one case when the word "class" was in a class" as described in commit message 4e8d1d612a98cbe35e7782faba5c0609935a1c2a. Found the problem to only be triggered when string variable interpolation was also being used in the class.
On this basis, the name of the test was changed to `testMultipleClassKeywordsInMiddleOfFileWithStringVariableParsing`

Motivation behind this change came from experiencing the issue magento/magento2#11230

### To test this code
1. `git checkout 4e8d1d612a98cbe35e7782faba5c0609935a1c2a~1`
2. `composer install`
3.  Insert new method `\Magento\Setup\Test\Unit\Module\Di\Code\Reader\FileClassScannerTest::testMultipleClassKeywordsInMiddleOfFileWithStringVariableParsing()` found in 6cf723a945fe7e490fc223b8092ffdc8e3dff910 (the commit from this pull requst) into [`setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/FileClassScannerTest.php`](setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/FileClassScannerTest.php)
4. Run the unit test to see that it fails as expected (example `./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist --filter testMultipleClassKeywordsInMiddleOfFileWithStringVariableParsing setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/FileClassScannerTest.php`)

### Fixes Issue
* magento/magento2#11230

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)