### PR TITLE
12073: ProductRepository fails to load product with camelcase SKU

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -251,6 +251,11 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         if (!isset($this->instances[$sku])) {
             $sku = trim($sku);
         }
+
+        if (!isset($this->instances[$sku])) {
+            throw new NoSuchEntityException(__('Requested product doesn\'t exist'));
+        }
+
         return $this->instances[$sku][$cacheKey];
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -527,6 +527,25 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->productMock, $this->model->get($productSku));
     }
 
+    /**
+     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testGetBySkuWithCamelCaseException()
+    {
+        $productId = 22;
+        $fakeProductSku = 'testproduct';
+        $realProductSku = 'testProduct';
+        $this->productFactoryMock->expects($this->once())->method('create')
+            ->will($this->returnValue($this->productMock));
+        $this->resourceModelMock->expects($this->once())->method('getIdBySku')
+            ->with($fakeProductSku)->willReturn($productId);
+        $this->productMock->expects($this->once())->method('load')->with($productId);
+        $this->productMock->expects($this->atLeastOnce())->method('getId')->willReturn($productId);
+        $this->productMock->expects($this->once())->method('getSku')->willReturn($realProductSku);
+
+        $this->assertEquals($this->productMock, $this->model->get($fakeProductSku));
+    }
+
     public function testSaveExisting()
     {
         $this->storeManagerMock->expects($this->any())->method('getWebsites')->willReturn([1 => 'default']);

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Model;
+
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Test for Magento\Catalog\Model\ProductRepository
+ */
+class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ProductRepository
+     */
+    protected $model;
+
+    protected function setUp()
+    {
+        $this->model = Bootstrap::getObjectManager()->create(ProductRepository::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_camel_case_sku.php
+     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testGet()
+    {
+        $product = $this->model->get('camelcaseproduct');
+
+        $this->assertEquals('CamelCaseProduct', $product->getSku());
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_camel_case_sku.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_camel_case_sku.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->reinitialize();
+
+/** @var \Magento\TestFramework\ObjectManager $objectManager */
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+$product->isObjectNew(true);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setId(1)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Simple Product')
+    ->setSku('CamelCaseProduct')
+    ->setPrice(10)
+    ->setWeight(1)
+    ->setShortDescription("Short description")
+    ->setTaxClassId(0)
+    ->setDescription('Description with <b>html tag</b>')
+    ->setMetaTitle('meta title')
+    ->setMetaKeyword('meta keyword')
+    ->setMetaDescription('meta description')
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->setStockData(
+        [
+            'use_config_manage_stock' => 1,
+            'qty' => 100,
+            'is_qty_decimal' => 0,
+            'is_in_stock' => 1,
+        ]
+    );
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepositoryFactory */
+$productRepository = $objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+$productRepository->save($product);

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_camel_case_sku_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_camel_case_sku_rollback.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Framework\Exception\NoSuchEntityException;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->getInstance()->reinitialize();
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+try {
+    $product = $productRepository->get('CamelCaseProduct', false, null, true);
+    $productRepository->delete($product);
+} catch (NoSuchEntityException $e) {
+}
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);


### PR DESCRIPTION
ProductRepository fails to load product with camelcase SKU

### Fixed Issues (if relevant)
1. magento/magento2#12073: ProductRepository fails to load product with camelcase SKU

### Manual testing scenarios
1. Create a simple product with the camel case sku (for example "Test")
2. Use get() method of \Magento\Catalog\Model\ProductRepository to get this product by sku, and specify the sku in lower case.

### Expected result
1. NoSuchEntityException is returned

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
