### PR TITLE
9990: Product import doesn't allow empty attribute values for non-static attributes(backport to 2.2)

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -533,11 +533,6 @@ abstract class AbstractType
      */
     public function clearEmptyData(array $rowData)
     {
-        foreach ($this->_getProductAttributes($rowData) as $attrCode => $attrParams) {
-            if (!$attrParams['is_static'] && !isset($rowData[$attrCode])) {
-                unset($rowData[$attrCode]);
-            }
-        }
         return $rowData;
     }
 

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
@@ -225,6 +225,60 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
                     'price' => 10,
                 ],
             ],
+            [
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'price' => 0,
+                ],
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'price' => 0,
+                ],
+            ],
+            [
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'weight' => '',
+                ],
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'weight' => '',
+                ],
+            ],
+            [
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'description' => '',
+                ],
+                [
+                    'sku' => '',
+                    'store_view_code' => 'German',
+                    '_attribute_set' => 'Default',
+                    'product_type' => '',
+                    'name' => 'Simple 01 German',
+                    'description' => '',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Backport from https://github.com/magento/magento2/pull/11935.
### Description

### Fixed Issues (if relevant)
1. magento/magento2#9990: Product import doesn't allow empty attribute values for non-static attributes

### Manual testing scenarios
1. Change value to empty for some attribute in csv.
2. Run product import.
3. Check this attribute for value. It should be empty.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
