### PR TITLE
7691: address with saveInAddressBook 0 are still being added to the address book for new customers(backport to 2.2)

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -475,6 +475,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                     'email' => $quote->getCustomerEmail()
                 ]
             );
+            $shippingAddress->setData('quote_address_id', $quote->getShippingAddress()->getId());
             $addresses[] = $shippingAddress;
             $order->setShippingAddress($shippingAddress);
             $order->setShippingMethod($quote->getShippingAddress()->getShippingMethod());
@@ -486,6 +487,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                 'email' => $quote->getCustomerEmail()
             ]
         );
+        $billingAddress->setData('quote_address_id', $quote->getBillingAddress()->getId());
         $addresses[] = $billingAddress;
         $order->setBillingAddress($billingAddress);
         $order->setAddresses($addresses);

--- a/app/code/Magento/Sales/etc/module.xml
+++ b/app/code/Magento/Sales/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Sales" setup_version="2.0.7">
+    <module name="Magento_Sales" setup_version="2.0.8">
         <sequence>
             <module name="Magento_Rule"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -325,12 +325,12 @@ define([
                 data = this.serializeData(this.billingAddressContainer);
             } else {
                 data = this.serializeData(this.shippingAddressContainer);
-                areasToLoad.push('shipping_method');
             }
+            areasToLoad.push('shipping_method');
             data = data.toObject();
             data['shipping_as_billing'] = flag ? 1 : 0;
             data['reset_shipping'] = 1;
-            this.loadArea( areasToLoad, true, data);
+            this.loadArea(areasToLoad, true, data);
         },
 
         resetShippingMethod : function(data){

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/Shipping/Method.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/Shipping/Method.php
@@ -44,9 +44,13 @@ class Method extends Block
     public function selectShippingMethod(array $shippingMethod)
     {
         $this->waitFormLoading();
-        if ($this->_rootElement->find($this->shippingMethodsLink)->isVisible()) {
-            $this->_rootElement->find($this->shippingMethodsLink)->click();
-        }
+        $this->_rootElement->waitUntil(
+            function () {
+                return $this->_rootElement->find($this->shippingMethodsLink)->isVisible() ? true : null;
+            }
+        );
+
+        $this->_rootElement->find($this->shippingMethodsLink)->click();
         $selector = sprintf(
             $this->shippingMethod,
             $shippingMethod['shipping_service'],


### PR DESCRIPTION
Backport from https://github.com/magento/magento2/pull/11903.

If you place an order as a guest and set the save_in_address_book for an address on 0, that address will still be copied to the customer address book when registering as a new customer on the checkout success page.

### Fixed Issues (if relevant)
1. magento/magento2#7691: address with saveInAddressBook 0 are still being added to the address book for new customers.

### Manual testing scenarios
1. Place an order as a guest and set the save_in_address_book for your shipping address to 0 
2. Click the register link on the checkout success page
3. Addresses with save_in_address_book set to 0 should not be copied to the new customer address book.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
