### PR TITLE
8022: Uncaught Error: Call to a member function addItem() on array in app/code/Magento/Sales/Model/Order/Shipment.php(backport to 2.2)

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Shipment.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment.php
@@ -94,6 +94,11 @@ class Shipment extends AbstractModel implements EntityInterface, ShipmentInterfa
     protected $orderRepository;
 
     /**
+     * @var \Magento\Sales\Model\ResourceModel\Order\Shipment\Track\Collection|null
+     */
+    private $tracksCollection = null;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -331,16 +336,11 @@ class Shipment extends AbstractModel implements EntityInterface, ShipmentInterfa
      */
     public function getTracksCollection()
     {
-        if (!$this->hasData(ShipmentInterface::TRACKS)) {
-            $this->setTracks($this->_trackCollectionFactory->create()->setShipmentFilter($this->getId()));
-
-            if ($this->getId()) {
-                foreach ($this->getTracks() as $track) {
-                    $track->setShipment($this);
-                }
-            }
+        if ($this->tracksCollection === null) {
+            $this->tracksCollection = $this->_trackCollectionFactory->create()->setShipmentFilter($this->getId());
         }
-        return $this->getTracks();
+
+        return $this->tracksCollection;
     }
 
     /**

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Shipment/Relation.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Shipment/Relation.php
@@ -62,8 +62,8 @@ class Relation implements RelationInterface
                 $this->shipmentItemResource->save($item);
             }
         }
-        if (null !== $object->getTracks()) {
-            foreach ($object->getTracks() as $track) {
+        if (null !== $object->getTracksCollection()) {
+            foreach ($object->getTracksCollection() as $track) {
                 $track->setParentId($object->getId());
                 $this->shipmentTrackResource->save($track);
             }

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Shipment/RelationTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Shipment/RelationTest.php
@@ -86,7 +86,8 @@ class RelationTest extends \PHPUnit\Framework\TestCase
                     'getId',
                     'getItems',
                     'getTracks',
-                    'getComments'
+                    'getComments',
+                    'getTracksCollection',
                 ]
             )
             ->getMock();
@@ -123,7 +124,7 @@ class RelationTest extends \PHPUnit\Framework\TestCase
             ->method('getComments')
             ->willReturn([$this->commentMock]);
         $this->shipmentMock->expects($this->exactly(2))
-            ->method('getTracks')
+            ->method('getTracksCollection')
             ->willReturn([$this->trackMock]);
         $this->itemMock->expects($this->once())
             ->method('setParentId')

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ShipmentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ShipmentTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Sales\Model\Order;
 
 /**
@@ -46,5 +47,36 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $shipment->save();
         $shipment->load($shipment->getId());
         $this->assertEquals($packages, $shipment->getPackages());
+    }
+
+    /**
+     * Check that getTracksCollection() always return collection instance.
+     *
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testAddTrack()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+        $order = $objectManager->create(\Magento\Sales\Model\Order::class);
+        $order->loadByIncrementId('100000001');
+
+        /** @var \Magento\Sales\Model\Order\Shipment $shipment */
+        $shipment = $objectManager->create(\Magento\Sales\Model\Order\Shipment::class);
+        $shipment->setOrder($order);
+
+        $shipment->addItem($objectManager->create(\Magento\Sales\Model\Order\Shipment\Item::class));
+        $shipment->save();
+
+        /** @var $track \Magento\Sales\Model\Order\Shipment\Track */
+        $track = $objectManager->get(\Magento\Sales\Model\Order\Shipment\Track::class);
+        $track->setNumber('Test Number')->setTitle('Test Title')->setCarrierCode('Test CODE');
+
+        $this->assertEmpty($shipment->getTracks());
+        $shipment->addTrack($track)->save();
+
+        //to empty cache
+        $shipment->setTracks(null);
+        $this->assertNotEmpty($shipment->getTracks());
     }
 }


### PR DESCRIPTION
### Description
Backport from https://github.com/magento/magento2/pull/11680.
Method getTracksCollection() was able to return different types of data: collection or array. Now it will always return tracks collection object.

### Fixed Issues (if relevant)
1. magento/magento2#8022: Uncaught Error: Call to a member function addItem() on array in app/code/Magento/Sales/Model/Order/Shipment.php

### Manual testing scenarios
1. Load or create a Shipment model

```
/*** @var $shipment \Magento\Sales\Model\Order\Shipment **/
$shipmentCollection = $this->_objectManager->get(
    'Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory'
)->create();
$shipment = $shipmentCollection->getFirstItem();
{code}
		
2. Make a call
`$shipment->getTracks();`
		
3. Create a Track model and try to add it to the Shipment

{code}
/*** @var $track \Magento\Sales\Model\Order\Shipment\Track **/
$track = $this->_objectManager->get(
    'Magento\Sales\Model\Order\Shipment\TrackFactory'
)->create();
$track->setNumber('Test Number')
          ->setTitle('Test Title')
          ->setCarrierCode('Test CODE');

$shipment->addTrack($track)->save();
```
### Expected result
1. Successfull save

### Actual result

You will receive an error **Call to a member function addItem() on array* because the method *getTracksCollection()** in Shipment model will return an array instead of Collection Object.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
