### PR TITLE
Unable to find product with slash character in name

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
@@ -6,11 +6,12 @@
 namespace Magento\Catalog\Ui\DataProvider\Product;
 
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Ui\DataProvider\AbstractDataProvider;
 
 /**
  * Class ProductDataProvider
  */
-class ProductDataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
+class ProductDataProvider extends AbstractDataProvider
 {
     /**
      * Product collection
@@ -101,7 +102,7 @@ class ProductDataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
                 ->addFilter(
                     $this->getCollection(),
                     $filter->getField(),
-                    [$filter->getConditionType() => $filter->getValue()]
+                    [$filter->getConditionType() => $this->getFilterValue($filter)]
                 );
         } else {
             parent::addFilter($filter);

--- a/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
+++ b/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Ui\DataProvider;
 
+use Magento\Framework\Api\Filter;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface;
 
@@ -76,6 +77,7 @@ abstract class AbstractDataProvider implements DataProviderInterface
     {
         return $this->collection;
     }
+
     /**
      * Get Data Provider name
      *
@@ -149,13 +151,14 @@ abstract class AbstractDataProvider implements DataProviderInterface
     /**
      * @inheritdoc
      */
-    public function addFilter(\Magento\Framework\Api\Filter $filter)
+    public function addFilter(Filter $filter)
     {
         $this->getCollection()->addFieldToFilter(
             $filter->getField(),
             [$filter->getConditionType() => $this->getFilterValue($filter)]
         );
     }
+
     /**
      * Returns search criteria
      *
@@ -281,10 +284,10 @@ abstract class AbstractDataProvider implements DataProviderInterface
     /**
      * You need to escape backslashes twice in LIKE statement.
      *
-     * @param $filter
+     * @param Filter $filter
      * @return string
      */
-    protected function getFilterValue($filter)
+    protected function getFilterValue(Filter $filter)
     {
         if ($filter->getConditionType() === "like" &&
             strpos($filter->getValue(), "\\") !== false) {

--- a/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
+++ b/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Ui\DataProvider;
 
-use Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface;
 
 abstract class AbstractDataProvider implements DataProviderInterface
 {
@@ -153,7 +153,7 @@ abstract class AbstractDataProvider implements DataProviderInterface
     {
         $this->getCollection()->addFieldToFilter(
             $filter->getField(),
-            [$filter->getConditionType() => $filter->getValue()]
+            [$filter->getConditionType() => $this->getFilterValue($filter)]
         );
     }
     /**
@@ -276,5 +276,21 @@ abstract class AbstractDataProvider implements DataProviderInterface
     public function setConfigData($config)
     {
         $this->data['config'] = $config;
+    }
+
+    /**
+     * You need to escape backslashes twice in LIKE statement.
+     *
+     * @param $filter
+     * @return string
+     */
+    protected function getFilterValue(&$filter)
+    {
+        if ($filter->getConditionType() === "like" &&
+            strpos($filter->getValue(), "\\") !== false &&
+            strpos($filter->getValue(), "\\\\") === false) {
+            $filter->setValue(str_replace("\\", "\\\\", $filter->getValue()));
+        }
+        return $filter->getValue();
     }
 }

--- a/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
+++ b/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
@@ -284,12 +284,11 @@ abstract class AbstractDataProvider implements DataProviderInterface
      * @param $filter
      * @return string
      */
-    protected function getFilterValue(&$filter)
+    protected function getFilterValue($filter)
     {
         if ($filter->getConditionType() === "like" &&
-            strpos($filter->getValue(), "\\") !== false &&
-            strpos($filter->getValue(), "\\\\") === false) {
-            $filter->setValue(str_replace("\\", "\\\\", $filter->getValue()));
+            strpos($filter->getValue(), "\\") !== false) {
+            return str_replace("\\", "\\\\", $filter->getValue());
         }
         return $filter->getValue();
     }


### PR DESCRIPTION
Unable to find product with slash character in name

### Description
Is necessary  to escape backslashes twice in LIKE statement.

### Fixed Issues (if relevant)
1. magento/magento2#9817: Unable to find product with slash character in name


### Manual testing scenarios

1. Create product with slash in name (e.g. "Concealer Circle\Delete") and remember SKU
2. Try to search it through admin panel by filtering by name

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
