### PR TITLE
Add attribute folder as an allowed resource

### DIFF
--- a/app/code/Magento/Swatches/etc/config.xml
+++ b/app/code/Magento/Swatches/etc/config.xml
@@ -26,5 +26,12 @@
                 <swatch_image_position>stretch</swatch_image_position>
             </watermark>
         </design>
+        <system>
+            <media_storage_configuration>
+                <allowed_resources>
+                    <attribute_image_folder>attribute</attribute_image_folder>
+                </allowed_resources>
+            </media_storage_configuration>
+        </system>
     </default>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Swatches aren't yet configured to be an allowed resource so we can't access them when we switch over to use the database file storage system. This change configures swatches to be an allowed resource.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set up a product to use an image-based swatch
2. Switch over to using database file storage
3. Delete the pub/media folder
3. Visit the product page
4. You should not be able to download the image from the database into the pub/media folder (if the patch it not applied)
5. You should be able to download the image from the database into the pub/media folder (if the patch is applied)

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
