### PR TITLE
Fixes #12218

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -35,8 +35,9 @@ class Tax extends AbstractTotal
             $orderItemTax = (double)$orderItem->getTaxInvoiced();
             $baseOrderItemTax = (double)$orderItem->getBaseTaxInvoiced();
             $orderItemQty = (double)$orderItem->getQtyInvoiced();
+            $orderItemTaxCompensation = (double)$orderItem->getDiscountTaxCompensationInvoiced();
 
-            if ($orderItemTax && $orderItemQty) {
+            if (($orderItemTaxCompensation || $orderItemTax) && $orderItemQty) {
                 /**
                  * Check item tax amount
                  */

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -35,9 +35,9 @@ class Tax extends AbstractTotal
             $orderItemTax = (double)$orderItem->getTaxInvoiced();
             $baseOrderItemTax = (double)$orderItem->getBaseTaxInvoiced();
             $orderItemQty = (double)$orderItem->getQtyInvoiced();
-            $orderItemTaxCompensation = (double)$orderItem->getDiscountTaxCompensationInvoiced();
+            $taxCompensation = (double)$orderItem->getDiscountTaxCompensationInvoiced();
 
-            if (($orderItemTaxCompensation || $orderItemTax) && $orderItemQty) {
+            if (($taxCompensation || $orderItemTax) && $orderItemQty) {
                 /**
                  * Check item tax amount
                  */


### PR DESCRIPTION
Prevent omitting discount tax compensation handling on orders with 100% discount

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12218: Creditmemo total is negative on a 100% discounted order

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. see https://github.com/magento/magento2/issues/12218

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
