### PR TITLE
12180 Remove unnecessary use operator for Context, causes 503 error i…

### DIFF
--- a/app/code/Magento/Customer/Model/AttributeChecker.php
+++ b/app/code/Magento/Customer/Model/AttributeChecker.php
@@ -8,7 +8,6 @@ namespace Magento\Customer\Model;
 use Magento\Customer\Api\AddressMetadataInterface;
 use Magento\Customer\Api\AddressMetadataManagementInterface;
 use Magento\Customer\Model\Metadata\AttributeResolver;
-use Magento\Framework\App\Helper\Context;
 
 /**
  * Customer attribute checker.


### PR DESCRIPTION
…n account address book.

Removing an unnecessary "use" to prevent a 503 error in account address book page.

### Description
Remove the unnecessary "use".

### Fixed Issues (if relevant)

1. magento/magento2#12180: M2.2.1 Unable to open Address book after account creation

### Manual testing scenarios

- Set up a Magento v2.2.1 environment (prod mode + composer dump-autoload -o)
- Create an account as a customer.
- Immediately after creating your customer, try to open your address book.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
