### PR TITLE
Shipping method fixtures not compatible with getShippingMethod(true) in OrderCreateTest

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderCreateTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderCreateTest.php
@@ -140,7 +140,7 @@ class OrderCreateTest extends WebapiAbstract
                 [
                     'shipping' => [
                         'address' => $address,
-                        'method' => 'Flat Rate - Fixed'
+                        'method' => 'flatrate_flatrate'
                     ],
                     'items' => [$orderItem->getData()],
                     'stock_id' => null,
@@ -232,6 +232,9 @@ class OrderCreateTest extends WebapiAbstract
         $this->assertEquals($order['grand_total'], $model->getGrandTotal());
         $this->assertNotNull($model->getShippingAddress());
         $this->assertTrue((bool)$model->getShippingAddress()->getId());
-        $this->assertEquals('Flat Rate - Fixed', $model->getShippingMethod());
+        $this->assertEquals('Flat Rate - Fixed', $model->getShippingDescription());
+        $shippingMethod = $model->getShippingMethod(true);
+        $this->assertEquals('flatrate', $shippingMethod['carrier_code']);
+        $this->assertEquals('flatrate', $shippingMethod['method']);
     }
 }


### PR DESCRIPTION
### Description
Test `Magento\Sales\Service\V1\OrderCreateTest` has an incorrect shipping method fixture which produces an error when ever something tries to get the orders shipping method as an object.
e.g.
`$order->getShippingMethod(true);`
`Notice: Undefined offset: 1 in /magento2/app/code/Magento/Sales/Model/Order.php on line 1194`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. In any order extension or test have `$order->getShippingMethod(true);`
2. Current OrderCreateTest produces an error `Notice: Undefined offset: 1 in /magento2/app/code/Magento/Sales/Model/Order.php on line 1194`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
