### PR TITLE
Allow "order" attribute on the "css" element in layout files

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/head.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/head.xsd
@@ -19,6 +19,7 @@
         <xs:attribute name="target" type="xs:string"/>
         <xs:attribute name="type" type="xs:string"/>
         <xs:attribute name="src_type" type="xs:string"/>
+        <xs:attribute name="order" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="metaType">


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->
As the attributes for the `css` element are looked up in the `xs:complexType linkType`, I have added the attribute order there. This ensures that the schema will be valid for the XML layout files.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12188: Magento 2.2 Upgrade - Element 'css', attribute 'order': The attribute 'order' is not allowed.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Setup a Magento 2.2 instance
2. In a theme layout file include 2 css files with different order atribute
3. Check in browser that the files are included in corect order
4. Change the order attribute between the files
5. Check that thefiles are included correctly in browser

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
