### PR TITLE
Correctly provide list of swatch attributes for product #11703

### DIFF
--- a/app/code/Magento/Swatches/Helper/Attribute.php
+++ b/app/code/Magento/Swatches/Helper/Attribute.php
@@ -7,6 +7,7 @@ namespace Magento\Swatches\Helper;
 
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Swatches\Model\Swatch;
 
 /**
  * Provide list of swatch attributes for product.
@@ -35,7 +36,7 @@ class Attribute
     public function getEavAttributeAdditionalDataKeys()
     {
         return [
-            \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY,
+            Swatch::SWATCH_INPUT_TYPE_KEY,
             'update_product_preview_image',
             'use_product_image_for_swatch'
         ];
@@ -113,10 +114,10 @@ class Attribute
      */
     public function isVisualSwatch(AbstractAttribute $attribute)
     {
-        if (!$attribute->hasData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY)) {
+        if (!$attribute->hasData(Swatch::SWATCH_INPUT_TYPE_KEY)) {
             $this->populateAdditionalDataEavAttribute($attribute);
         }
-        return $attribute->getData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY) == \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_VISUAL;
+        return $attribute->getData(Swatch::SWATCH_INPUT_TYPE_KEY) == Swatch::SWATCH_INPUT_TYPE_VISUAL;
     }
 
     /**
@@ -130,6 +131,6 @@ class Attribute
         if (!$attribute->hasData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY)) {
             $this->populateAdditionalDataEavAttribute($attribute);
         }
-        return $attribute->getData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY) == \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_TEXT;
+        return $attribute->getData(Swatch::SWATCH_INPUT_TYPE_KEY) == Swatch::SWATCH_INPUT_TYPE_TEXT;
     }
 }

--- a/app/code/Magento/Swatches/Helper/Attribute.php
+++ b/app/code/Magento/Swatches/Helper/Attribute.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Swatches\Helper;
+
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+
+/**
+ * Provide list of swatch attributes for product.
+ */
+class Attribute
+{
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+
+    /**
+     * @param SerializerInterface $serializer
+     */
+    public function __construct(
+        SerializerInterface $serializer
+    ) {
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Get data key which should populated to attribute entity from "additional_data" field
+     *
+     * @return array
+     */
+    public function getEavAttributeAdditionalDataKeys()
+    {
+        return [
+            \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY,
+            'update_product_preview_image',
+            'use_product_image_for_swatch'
+        ];
+    }
+
+    /**
+     * @param AbstractAttribute $attribute
+     * @return $this
+     */
+    public function assembleAdditionalDataEavAttribute(AbstractAttribute $attribute)
+    {
+        $initialAdditionalData = [];
+        $additionalData = (string) $attribute->getData('additional_data');
+        if (!empty($additionalData)) {
+            $additionalData = $this->serializer->unserialize($additionalData);
+            if (is_array($additionalData)) {
+                $initialAdditionalData = $additionalData;
+            }
+        }
+
+        $dataToAdd = [];
+        foreach ($this->getEavAttributeAdditionalDataKeys() as $key) {
+            $dataValue = $attribute->getData($key);
+            if (null !== $dataValue) {
+                $dataToAdd[$key] = $dataValue;
+            }
+        }
+        $additionalData = array_merge($initialAdditionalData, $dataToAdd);
+        $attribute->setData('additional_data', $this->serializer->serialize($additionalData));
+        return $this;
+    }
+
+    /**
+     * Populate eav attribute with additional data from "additional_data" field
+     *
+     * @param AbstractAttribute $attribute
+     * @return $this
+     */
+    public function populateAdditionalDataEavAttribute(AbstractAttribute $attribute)
+    {
+        $serializedAdditionalData = $attribute->getData('additional_data');
+
+        if ($serializedAdditionalData) {
+            $additionalData = $this->serializer->unserialize($serializedAdditionalData);
+
+            if (isset($additionalData) && is_array($additionalData)) {
+                foreach ($this->getEavAttributeAdditionalDataKeys() as $key) {
+                    if (isset($additionalData[$key])) {
+                        $attribute->setData($key, $additionalData[$key]);
+                    }
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if an attribute is Swatch
+     *
+     * @param AbstractAttribute $attribute
+     * @return bool
+     */
+    public function isSwatchAttribute(AbstractAttribute $attribute)
+    {
+        $result = $this->isVisualSwatch($attribute) || $this->isTextSwatch($attribute);
+        return $result;
+    }
+
+    /**
+     * Is attribute Visual Swatch
+     *
+     * @param AbstractAttribute $attribute
+     * @return bool
+     */
+    public function isVisualSwatch(AbstractAttribute $attribute)
+    {
+        if (!$attribute->hasData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY)) {
+            $this->populateAdditionalDataEavAttribute($attribute);
+        }
+        return $attribute->getData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY) == \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_VISUAL;
+    }
+
+    /**
+     * Is attribute Textual Swatch
+     *
+     * @param AbstractAttribute $attribute
+     * @return bool
+     */
+    public function isTextSwatch(AbstractAttribute $attribute)
+    {
+        if (!$attribute->hasData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY)) {
+            $this->populateAdditionalDataEavAttribute($attribute);
+        }
+        return $attribute->getData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY) == \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_TEXT;
+    }
+}

--- a/app/code/Magento/Swatches/Model/SwatchAttributesProvider.php
+++ b/app/code/Magento/Swatches/Model/SwatchAttributesProvider.php
@@ -8,6 +8,8 @@ namespace Magento\Swatches\Model;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 
 /**
  * Provide list of swatch attributes for product.
@@ -31,15 +33,23 @@ class SwatchAttributesProvider
     private $attributesPerProduct;
 
     /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+
+    /**
      * @param Configurable $typeConfigurable
      * @param SwatchAttributeCodes $swatchAttributeCodes
+     * @param SerializerInterface $serializer
      */
     public function __construct(
         Configurable $typeConfigurable,
-        SwatchAttributeCodes $swatchAttributeCodes
+        SwatchAttributeCodes $swatchAttributeCodes,
+        SerializerInterface $serializer
     ) {
         $this->typeConfigurable = $typeConfigurable;
         $this->swatchAttributeCodes = $swatchAttributeCodes;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -61,12 +71,95 @@ class SwatchAttributesProvider
             $swatchAttributes = [];
             foreach ($configurableAttributes as $configurableAttribute) {
                 if (array_key_exists($configurableAttribute->getAttributeId(), $swatchAttributeCodeMap)) {
-                    $swatchAttributes[$configurableAttribute->getAttributeId()]
-                        = $configurableAttribute->getProductAttribute();
+                    $productAttribute = $configurableAttribute->getProductAttribute();
+
+                    // Check if product attribute is actually an swatch attribute
+                    if ($productAttribute && $this->isSwatchAttribute($productAttribute)) {
+                        $swatchAttributes[$configurableAttribute->getAttributeId()] = $productAttribute;
+                    }
                 }
             }
             $this->attributesPerProduct[$product->getId()] = $swatchAttributes;
         }
         return $this->attributesPerProduct[$product->getId()];
+    }
+
+    /**
+     * Get data key which should populated to attribute entity from "additional_data" field
+     *
+     * @return array
+     */
+    public function getEavAttributeAdditionalDataKeys()
+    {
+        return [
+            \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY,
+            'update_product_preview_image',
+            'use_product_image_for_swatch'
+        ];
+    }
+
+    /**
+     * Populate eav attribute with additional data from "additional_data" field
+     *
+     * @param AbstractAttribute $attribute
+     * @return $this
+     */
+    public function populateAdditionalDataEavAttribute(AbstractAttribute $attribute)
+    {
+        $serializedAdditionalData = $attribute->getData('additional_data');
+
+        if ($serializedAdditionalData) {
+            $additionalData = $this->serializer->unserialize($serializedAdditionalData);
+
+            if (isset($additionalData) && is_array($additionalData)) {
+                foreach ($this->getEavAttributeAdditionalDataKeys() as $key) {
+                    if (isset($additionalData[$key])) {
+                        $attribute->setData($key, $additionalData[$key]);
+                    }
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if an attribute is Swatch
+     *
+     * @param AbstractAttribute $attribute
+     * @return bool
+     */
+    public function isSwatchAttribute(AbstractAttribute $attribute)
+    {
+        $result = $this->isVisualSwatch($attribute) || $this->isTextSwatch($attribute);
+        return $result;
+    }
+
+    /**
+     * Is attribute Visual Swatch
+     *
+     * @param AbstractAttribute $attribute
+     * @return bool
+     */
+    public function isVisualSwatch(AbstractAttribute $attribute)
+    {
+        if (!$attribute->hasData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY)) {
+            $this->populateAdditionalDataEavAttribute($attribute);
+        }
+        return $attribute->getData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY) == \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_VISUAL;
+    }
+
+    /**
+     * Is attribute Textual Swatch
+     *
+     * @param AbstractAttribute $attribute
+     * @return bool
+     */
+    public function isTextSwatch(AbstractAttribute $attribute)
+    {
+        if (!$attribute->hasData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY)) {
+            $this->populateAdditionalDataEavAttribute($attribute);
+        }
+        return $attribute->getData(\Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_KEY) == \Magento\Swatches\Model\Swatch::SWATCH_INPUT_TYPE_TEXT;
     }
 }

--- a/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
@@ -58,6 +58,11 @@ class DataTest extends \PHPUnit\Framework\TestCase
      */
     private $swatchAttributesProvider;
 
+    /**
+     * @var \Magento\Swatches\Helper\Attribute|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $attributeHelper;
+
     protected function setUp()
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -115,6 +120,10 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->swatchAttributesProvider = $this->getMockBuilder(SwatchAttributesProvider::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->attributeHelper = $this->objectManager->getObject(
+            \Magento\Swatches\Helper\Attribute::class,
+            ['serializer' => $serializer]
+        );
 
         $this->swatchHelperObject = $this->objectManager->getObject(
             \Magento\Swatches\Helper\Data::class,
@@ -127,6 +136,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
                 'imageHelper' => $this->imageHelperMock,
                 'serializer' => $serializer,
                 'swatchAttributesProvider' => $this->swatchAttributesProvider,
+                'attributeHelper' => $this->attributeHelper
             ]
         );
         $this->objectManager->setBackwardCompatibleProperty(

--- a/app/code/Magento/Swatches/Test/Unit/Model/SwatchAttributesProviderTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Model/SwatchAttributesProviderTest.php
@@ -94,8 +94,7 @@ class SwatchAttributesProviderTest extends \PHPUnit\Framework\TestCase
         $expected = [];
 
         // Test cases where swatchAttributeCodes::getCodes returns attribute codes which are no longer swatch attributes
-        foreach ($dataForIsSwatchAttribute as $attributeId => $isSwatchAttribute)
-        {
+        foreach ($dataForIsSwatchAttribute as $attributeId => $isSwatchAttribute) {
             $productAttributeMock = $this->createPartialMock(
                 \Magento\Eav\Model\Entity\Attribute\AbstractAttribute::class,
                 ['setData', 'hasData', 'getData']

--- a/app/code/Magento/Swatches/Test/Unit/Model/SwatchAttributesProviderTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Model/SwatchAttributesProviderTest.php
@@ -32,6 +32,11 @@ class SwatchAttributesProviderTest extends \PHPUnit\Framework\TestCase
      */
     private $productMock;
 
+    /**
+     * @var \Magento\Catalog\Model\Product|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $attributeHelperMock;
+
     protected function setUp()
     {
         $this->typeConfigurable = $this->createPartialMock(
@@ -43,45 +48,92 @@ class SwatchAttributesProviderTest extends \PHPUnit\Framework\TestCase
 
         $this->productMock = $this->createPartialMock(\Magento\Catalog\Model\Product::class, ['getId', 'getTypeId']);
 
+        $this->attributeHelperMock = $this->createMock(\Magento\Swatches\Helper\Attribute::class);
+
         $this->swatchAttributeProvider = (new ObjectManager($this))->getObject(SwatchAttributesProvider::class, [
             'typeConfigurable' => $this->typeConfigurable,
             'swatchAttributeCodes' => $this->swatchAttributeCodes,
+            'attributeHelper' => $this->attributeHelperMock
         ]);
     }
 
-    public function testProvide()
+    public function dataForIsSwatchAttribute()
+    {
+        return [
+            [
+                [false]
+            ],
+            [
+                [true]
+            ],
+            [
+                [false, false]
+            ],
+            [
+                [false, true]
+            ],
+            [
+                [true, false]
+            ],
+            [
+                [true, true]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataForIsSwatchAttribute
+     */
+    public function testProvide(array $dataForIsSwatchAttribute)
     {
         $this->productMock->method('getId')->willReturn(1);
         $this->productMock->method('getTypeId')
             ->willReturn(Configurable::TYPE_CODE);
 
-        $productAttributeMock = $this->getMockForAbstractClass(
-            \Magento\Framework\Interception\InterceptorInterface::class
-        );
+        $configurableAttributes = [];
+        $expected = [];
 
-        $configAttributeMock = $this->createPartialMock(
-            Configurable\Attribute::class,
-            ['getAttributeId', 'getProductAttribute']
-        );
-        $configAttributeMock
-            ->method('getAttributeId')
-            ->willReturn(1);
+        // Test cases where swatchAttributeCodes::getCodes returns attribute codes which are no longer swatch attributes
+        foreach ($dataForIsSwatchAttribute as $attributeId => $isSwatchAttribute)
+        {
+            $productAttributeMock = $this->createPartialMock(
+                \Magento\Eav\Model\Entity\Attribute\AbstractAttribute::class,
+                ['setData', 'hasData', 'getData']
+            );
 
-        $configAttributeMock
-            ->method('getProductAttribute')
-            ->willReturn($productAttributeMock);
+            $this->attributeHelperMock
+                ->expects($this->at($attributeId))
+                ->method('isSwatchAttribute')
+                ->with($productAttributeMock)
+                ->willReturn($isSwatchAttribute);
+
+            $configAttributeMock = $this->createPartialMock(
+                Configurable\Attribute::class,
+                ['getAttributeId', 'getProductAttribute']
+            );
+            $configAttributeMock
+                ->method('getAttributeId')
+                ->willReturn($attributeId);
+            $configAttributeMock
+                ->method('getProductAttribute')
+                ->willReturn($productAttributeMock);
+
+            $configurableAttributes[] = $configAttributeMock;
+
+            if ($isSwatchAttribute) {
+                $expected[$attributeId] = $productAttributeMock;
+            }
+        }
 
         $this->typeConfigurable
             ->method('getConfigurableAttributes')
             ->with($this->productMock)
-            ->willReturn([$configAttributeMock]);
+            ->willReturn($configurableAttributes);
 
-        $swatchAttributes = [1 => 'text_swatch'];
         $this->swatchAttributeCodes
             ->method('getCodes')
-            ->willReturn($swatchAttributes);
+            ->willReturn($dataForIsSwatchAttribute);
 
-        $expected = [1 => $productAttributeMock];
         $result = $this->swatchAttributeProvider->provide($this->productMock);
 
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Correctly provide list of swatch attributes for product. This is an fix for #11703

The `populateAdditionalDataEavAttribute`, `isSwatchAttribute`, `isVisualSwatch`, `isTextSwatch` method definitions moved from `Magento\Swatches\Helper\Data` class to `Magento\Swatches\Model\SwatchAttributesProvider` class but methods are still callable from `Magento\Swatches\Helper\Data` which just calls the `Magento\Swatches\Model\SwatchAttributesProvider` methods instead so the backward compatibility is preserved. Method definitions are moved so they can be used in the `Magento\Swatches\Model\SwatchAttributesProvider::provide` method to correctly list of swatch attributes for product.

### Fixed Issues (if relevant)
1. magento/magento2#11703: Changing Swatches to Drop-down does not remove swatches from existing products

### Manual testing scenarios
1. Create swatch text attribute
1. Create configurable product using this attribute
1. Open product on frontend - attribute is being outputted as swatch attribute and you can select all the product configurations which is ok
1. Change the swatch attribute back to dropdown
1. Open product on the frontend - attribute is being still outputted as swatch attribute which is wrong but you still can select the product configurations
1. Add additional option for the dropdown attribute and add additional configuration for this option to the configurable product
1. Open the product on the frontend - the attribute is still being still outputted as swatch attribute and the newly added configuration can't be selected on the frontend because the added attribute does not contain necessary data for it to be rendered as swatch option as the attribute should be rendered as dropdown option instead of swatch.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
