### PR TITLE
Enable using URI segments that do not belong to a key-value pair.

### DIFF
--- a/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
@@ -75,7 +75,7 @@ class RequestPreprocessor
                 $uri = parse_url($baseUrl);
                 if (!$this->getBaseUrlChecker()->execute($uri, $request)) {
                     $redirectUrl = $this->_url->getRedirectUrl(
-                        $this->_url->getUrl(ltrim($request->getPathInfo(), '/'), ['_nosid' => true])
+                        $this->_url->getUrl(ltrim($request->getPathInfo(), '/'), ['_nosid' => true, '_base_url_redirection' => true])
                     );
                     $redirectCode = (int)$this->_scopeConfig->getValue(
                         'web/url/redirect_to_base',

--- a/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
@@ -75,7 +75,10 @@ class RequestPreprocessor
                 $uri = parse_url($baseUrl);
                 if (!$this->getBaseUrlChecker()->execute($uri, $request)) {
                     $redirectUrl = $this->_url->getRedirectUrl(
-                        $this->_url->getUrl(ltrim($request->getPathInfo(), '/'), ['_nosid' => true, '_base_url_redirection' => true])
+                        $this->_url->getUrl(
+                            ltrim($request->getPathInfo(), '/'),
+                            ['_nosid' => true, '_base_url_redirection' => true]
+                        )
                     );
                     $redirectCode = (int)$this->_scopeConfig->getValue(
                         'web/url/redirect_to_base',

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -844,8 +844,9 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             return $routePath;
         }
 
-        // Remove empty parameters.
-        $routeParams = array_filter($routeParams);
+        if (!is_null($routeParams)) {
+            $routeParams = array_filter($routeParams);
+        }
 
         $routeParams = $this->routeParamsPreprocessor
             ->execute($this->_scopeResolver->getAreaCode(), $routePath, $routeParams);

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -531,10 +531,11 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
         if (!empty($routePieces)) {
             while (!empty($routePieces)) {
                 $key = array_shift($routePieces);
+                $value = '';
                 if (!empty($routePieces)) {
                     $value = array_shift($routePieces);
-                    $this->getRouteParamsResolver()->setRouteParam($key, $value);
                 }
+                $this->getRouteParamsResolver()->setRouteParam($key, $value);
             }
         }
 
@@ -588,9 +589,10 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             if ($this->_getRouteParams()) {
                 foreach ($this->_getRouteParams() as $key => $value) {
                     if ($value === null || false === $value || '' === $value || !is_scalar($value)) {
-                        continue;
+                        $routePath .= $key . '/';
+                    } else {
+                        $routePath .= $key . '/' . $value . '/';
                     }
-                    $routePath .= $key . '/' . $value . '/';
                 }
             }
             $this->setData('route_path', $routePath);

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -844,6 +844,9 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             return $routePath;
         }
 
+        // Remove empty parameters.
+        $routeParams = array_filter($routeParams);
+
         $routeParams = $this->routeParamsPreprocessor
             ->execute($this->_scopeResolver->getAreaCode(), $routePath, $routeParams);
 

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -531,11 +531,10 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
         if (!empty($routePieces)) {
             while (!empty($routePieces)) {
                 $key = array_shift($routePieces);
-                $value = '';
                 if (!empty($routePieces)) {
                     $value = array_shift($routePieces);
+                    $this->getRouteParamsResolver()->setRouteParam($key, $value);
                 }
-                $this->getRouteParamsResolver()->setRouteParam($key, $value);
             }
         }
 
@@ -589,10 +588,9 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             if ($this->_getRouteParams()) {
                 foreach ($this->_getRouteParams() as $key => $value) {
                     if ($value === null || false === $value || '' === $value || !is_scalar($value)) {
-                        $routePath .= $key . '/';
-                    } else {
-                        $routePath .= $key . '/' . $value . '/';
+                        continue;
                     }
+                    $routePath .= $key . '/' . $value . '/';
                 }
             }
             $this->setData('route_path', $routePath);
@@ -842,10 +840,6 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
     {
         if (filter_var($routePath, FILTER_VALIDATE_URL)) {
             return $routePath;
-        }
-
-        if (!is_null($routeParams)) {
-            $routeParams = array_filter($routeParams);
         }
 
         $routeParams = $this->routeParamsPreprocessor

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -748,6 +748,11 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             return $this->getBaseUrl() . $routeParams['_direct'];
         }
 
+        if (isset($routeParams['_base_url_redirection']) && $routeParams['_base_url_redirection'] === true) {
+            unset($routeParams['_base_url_redirection']);
+            return $this->getBaseUrl() . $routePath;
+        }
+
         $this->_setRoutePath($routePath);
         if (is_array($routeParams)) {
             $this->_setRouteParams($routeParams, false);


### PR DESCRIPTION
### Description
You can find description here => https://github.com/magento/magento2/issues/12242

### Fixed Issues (if relevant)
1. magento/magento2#12242: Fourth URI segment is lost during redirection

### Manual testing scenarios
1. Make a request to http://example.com/test-1/test-2/test-3/test-4.html
2. Magento redirects to https://example.com/test-1/test-2/test-3/test-4.html as expected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
