### PR TITLE
Clear `mage-cache-sessid` cookie on Ajax Login

### DIFF
--- a/app/code/Magento/Customer/Controller/Ajax/Login.php
+++ b/app/code/Magento/Customer/Controller/Ajax/Login.php
@@ -98,8 +98,10 @@ class Login extends \Magento\Framework\App\Action\Action
         $this->customerAccountManagement = $customerAccountManagement;
         $this->resultJsonFactory = $resultJsonFactory;
         $this->resultRawFactory = $resultRawFactory;
-        $this->cookieManager = $cookieManager ?: ObjectManager::getInstance()->get(CookieManagerInterface::class);
-        $this->cookieMetadataFactory = $cookieMetadataFactory ?: ObjectManager::getInstance()->get(CookieMetadataFactory::class);
+        $this->cookieManager = $cookieManager ?:
+            ObjectManager::getInstance()->get(CookieManagerInterface::class);
+        $this->cookieMetadataFactory = $cookieMetadataFactory ?:
+            ObjectManager::getInstance()->get(CookieMetadataFactory::class);
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Controller/Ajax/LoginTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Ajax/LoginTest.php
@@ -73,6 +73,21 @@ class LoginTest extends \PHPUnit\Framework\TestCase
      */
     protected $redirectMock;
 
+    /**
+     * @var \Magento\Framework\Stdlib\CookieManagerInterface| \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cookieManager;
+
+    /**
+     * @var \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory| \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cookieMetadataFactory;
+
+    /**
+     * @var \Magento\Framework\Stdlib\Cookie\CookieMetadata| \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cookieMetadata;
+
     protected function setUp()
     {
         $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
@@ -98,6 +113,16 @@ class LoginTest extends \PHPUnit\Framework\TestCase
         $this->resultJsonFactory = $this->getMockBuilder(\Magento\Framework\Controller\Result\JsonFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
+            ->getMock();
+
+        $this->cookieManager = $this->getMockBuilder(\Magento\Framework\Stdlib\CookieManagerInterface::class)
+            ->setMethods(['getCookie', 'deleteCookie'])
+            ->getMockForAbstractClass();
+        $this->cookieMetadataFactory = $this->getMockBuilder(\Magento\Framework\Stdlib\Cookie\CookieMetadataFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->cookieMetadata = $this->getMockBuilder(\Magento\Framework\Stdlib\Cookie\CookieMetadata::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->resultRaw = $this->getMockBuilder(\Magento\Framework\Controller\Result\Raw::class)
@@ -128,6 +153,8 @@ class LoginTest extends \PHPUnit\Framework\TestCase
                 'resultJsonFactory' => $this->resultJsonFactory,
                 'objectManager' => $this->objectManager,
                 'customerAccountManagement' => $this->customerAccountManagementMock,
+                'cookieManager' => $this->cookieManager,
+                'cookieMetadataFactory' => $this->cookieMetadataFactory
             ]
         );
     }
@@ -178,6 +205,22 @@ class LoginTest extends \PHPUnit\Framework\TestCase
         $redirectMock = $this->createMock(\Magento\Customer\Model\Account\Redirect::class);
         $this->object->setAccountRedirect($redirectMock);
         $redirectMock->expects($this->once())->method('getRedirectCookie')->willReturn('some_url1');
+
+        $this->cookieManager->expects($this->once())
+            ->method('getCookie')
+            ->with('mage-cache-sessid')
+            ->willReturn(true);
+        $this->cookieMetadataFactory->expects($this->once())
+            ->method('createCookieMetadata')
+            ->willReturn($this->cookieMetadata);
+        $this->cookieMetadata->expects($this->once())
+            ->method('setPath')
+            ->with('/')
+            ->willReturnSelf();
+        $this->cookieManager->expects($this->once())
+            ->method('deleteCookie')
+            ->with('mage-cache-sessid', $this->cookieMetadata)
+            ->willReturnSelf();
 
         $scopeConfigMock = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
         $this->object->setScopeConfig($scopeConfigMock);


### PR DESCRIPTION
This PR is a port of https://github.com/magento-partners/magento2ce/pull/74

### Description
This PR adds code based on `Magento\Customer\Controller\Account\LoginPost::execute` to clear the `mage-cache-sessid` cookie on login. This triggers a refresh of the customer data in localStorage. The primary purpose is to make sure the customer cart is properly loaded after a successful login.

### Fixed Issues (if relevant)
When a customer with existing cart items logs in using the authentication-popup the mini-cart does not display their cart items after login.

### Manual testing scenarios
1. Login in using customer/account/login route
2. Add items to customer cart
3. Logout
4. Add virtual product to cart
5. Open mini-cart and click 'Checkout' to open the authentication-popup
6. Login using the authentication-popup
7. The last item cart item will correctly appear merged with the existing quote items in the mini-cart when the page reloads. (Previously only the items from the guest cart would be visible until another action invalidated the cart data in localStorage.)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
