### PR TITLE
10058: Tablerate->getCsvFile() fails with non-default PHP upload_tmp_dir 

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate.php
+++ b/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate.php
@@ -12,7 +12,6 @@
 namespace Magento\OfflineShipping\Model\ResourceModel\Carrier;
 
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\DirectoryList;
 use Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate\Import;
 use Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate\RateQuery;
 use Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate\RateQueryFactory;
@@ -321,9 +320,13 @@ class Tablerate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     private function getCsvFile($filePath)
     {
-        $tmpDirectory = $this->filesystem->getDirectoryRead(DirectoryList::SYS_TMP);
-        $path = $tmpDirectory->getRelativePath($filePath);
-        return $tmpDirectory->openFile($path);
+        $pathInfo = pathInfo($filePath);
+        $dirName = isset($pathInfo['dirname']) ? $pathInfo['dirname'] : '';
+        $fileName = isset($pathInfo['basename']) ? $pathInfo['basename'] : '';
+
+        $directoryRead = $this->filesystem->getDirectoryReadByPath($dirName);
+
+        return $directoryRead->openFile($fileName);
     }
 
     /**

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/TablerateTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/TablerateTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\OfflineShipping\Test\Unit\Model\ResourceModel\Carrier;
+
+use Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate;
+use Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate\Import;
+use Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate\RateQueryFactory;
+
+/**
+ * Unit test for Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class TablerateTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Tablerate
+     */
+    private $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $filesystemMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resource;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $importMock;
+
+    protected function setUp()
+    {
+        $contextMock = $this->createMock(\Magento\Framework\Model\ResourceModel\Db\Context::class);
+        $loggerMock = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $coreConfigMock = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
+        $carrierTablerateMock = $this->createMock(\Magento\OfflineShipping\Model\Carrier\Tablerate::class);
+        $this->filesystemMock = $this->createMock(\Magento\Framework\Filesystem::class);
+        $this->importMock = $this->createMock(Import::class);
+        $rateQueryFactoryMock = $this->createMock(RateQueryFactory::class);
+        $this->resource = $this->createMock(\Magento\Framework\App\ResourceConnection::class);
+
+        $contextMock->expects($this->once())->method('getResources')->willReturn($this->resource);
+
+        $this->model = new Tablerate(
+            $contextMock,
+            $loggerMock,
+            $coreConfigMock,
+            $this->storeManagerMock,
+            $carrierTablerateMock,
+            $this->filesystemMock,
+            $this->importMock,
+            $rateQueryFactoryMock
+        );
+    }
+
+    public function testUploadAndImport()
+    {
+        $_FILES['groups']['tmp_name']['tablerate']['fields']['import']['value'] = 'some/path/to/file';
+        $object = $this->createPartialMock(
+            \Magento\OfflineShipping\Model\Config\Backend\Tablerate::class,
+            ['getScopeId']
+        );
+
+        $websiteMock = $this->createMock(\Magento\Store\Api\Data\WebsiteInterface::class);
+        $directoryReadMock = $this->createMock(\Magento\Framework\Filesystem\Directory\ReadInterface::class);
+        $fileReadMock = $this->createMock(\Magento\Framework\Filesystem\File\ReadInterface::class);
+        $connectionMock = $this->createMock(\Magento\Framework\DB\Adapter\AdapterInterface::class);
+
+        $this->storeManagerMock->expects($this->once())->method('getWebsite')->willReturn($websiteMock);
+        $object->expects($this->once())->method('getScopeId')->willReturn(1);
+        $websiteMock->expects($this->once())->method('getId')->willReturn(1);
+
+        $this->filesystemMock->expects($this->once())->method('getDirectoryReadByPath')
+            ->with('some/path/to')->willReturn($directoryReadMock);
+        $directoryReadMock->expects($this->once())->method('openFile')
+            ->with('file')->willReturn($fileReadMock);
+
+        $this->resource->expects($this->once())->method('getConnection')->willReturn($connectionMock);
+
+        $connectionMock->expects($this->once())->method('beginTransaction');
+        $connectionMock->expects($this->once())->method('delete');
+        $connectionMock->expects($this->once())->method('commit');
+
+        $this->importMock->expects($this->once())->method('getColumns')->willReturn([]);
+        $this->importMock->expects($this->once())->method('getData')->willReturn([]);
+
+        $this->model->uploadAndImport($object);
+        unset($_FILES['groups']);
+    }
+}

--- a/lib/internal/Magento/Framework/Filesystem.php
+++ b/lib/internal/Magento/Framework/Filesystem.php
@@ -71,6 +71,20 @@ class Filesystem
     }
 
     /**
+     * Create an instance of directory with read permissions by path.
+     *
+     * @param string $path
+     * @param string $driverCode
+     *
+     * @return \Magento\Framework\Filesystem\Directory\ReadInterface
+     *
+     */
+    public function getDirectoryReadByPath($path, $driverCode = DriverPool::FILE)
+    {
+        return $this->readFactory->create($path, $driverCode);
+    }
+
+    /**
      * Create an instance of directory with write permissions
      *
      * @param string $directoryCode

--- a/lib/internal/Magento/Framework/Test/Unit/FilesystemTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/FilesystemTest.php
@@ -43,6 +43,14 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($dirReadMock, $this->_filesystem->getDirectoryRead(DirectoryList::ROOT));
     }
 
+    public function testGetDirectoryReadByPath()
+    {
+        /** @var \Magento\Framework\Filesystem\Directory\ReadInterface $dirReadMock */
+        $dirReadMock = $this->createMock(\Magento\Framework\Filesystem\Directory\ReadInterface::class);
+        $this->_dirReadFactoryMock->expects($this->once())->method('create')->will($this->returnValue($dirReadMock));
+        $this->assertEquals($dirReadMock, $this->_filesystem->getDirectoryReadByPath('path/to/some/file'));
+    }
+
     public function testGetDirectoryWrite()
     {
         /** @var \Magento\Framework\Filesystem\Directory\WriteInterface $dirWriteMock */


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Now path for upload_tmp_dir can be any.
2.3 pr: https://github.com/magento/magento2/pull/12376

### Fixed Issues (if relevant)
1. magento/magento2#10058: Tablerate->getCsvFile() fails with non-default PHP upload_tmp_dir 

### Manual testing scenarios
1. Make a new directory for uploads, eg mkdir -p /var/lib/php/uploads && chmod 1777 /var/lib/php/uploads
2. Set PHP upload_tmp_dir to this directory. eg, add upload_tmp_dir = /var/lib/php/uploads to /etc/php.ini
3. Login to Magento Admin
4. Go to Stores > Configuration > Sales > Shipping Methods
5. Select Table Rates, and enable
6. Click "Import"
7. Choose a file, click save.

Expected result
Table rates are updated

Actual result
Receive an error, eg The file “/tmp/var/lib/php/uploads/phphEpJe5” doesn’t exist

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
