### PR TITLE
Webshop throws an exception when sharing wishlist with RSS enabled

### DIFF
--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_email_rss.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_email_rss.xml
@@ -7,8 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="root">
-            <block class="Magento\Wishlist\Block\Rss\EmailLink" name="wishlist.email.rss" cacheable="false"/>
-        </referenceContainer>
+        <block class="Magento\Wishlist\Block\Rss\EmailLink" name="wishlist.email.rss" cacheable="false"/>
     </body>
 </page>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
In this pull request a bug that was discovered while the "Share Wishlist" functionality was executed. When a logged in user adds products to the wishlist and then tries to share them using RSS, an exception is thrown: `report.INFO: Broken reference: the 'wishlist.email.rss' element cannot be added as child to 'root', because the latter doesn't exist []`

### Manual testing scenarios
0. Enable the RSS feed from wishlist in the backend
1. Open the front-end of a magento 2 installation.
2. Log in a user on the frontend
3. Add one or more products to the wishlist
4. Go to My Account -> My wishlist
5. Click on the "Share wishlist" button
6. Ensure the RSS feed checkbox is checked
7. Click on Share wishlist
