### PR TITLE
magento/magento2#12083: Cannot import zero (0) value into custom attribute

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -534,7 +534,7 @@ abstract class AbstractType
     public function clearEmptyData(array $rowData)
     {
         foreach ($this->_getProductAttributes($rowData) as $attrCode => $attrParams) {
-            if (!$attrParams['is_static'] && empty($rowData[$attrCode])) {
+            if (!$attrParams['is_static'] && !isset($rowData[$attrCode])) {
                 unset($rowData[$attrCode]);
             }
         }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
@@ -28,9 +28,15 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
         $this->_model = $this->getMockForAbstractClass(
             \Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::class,
             [
-                $this->objectManager->get(\Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory::class),
-                $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory::class),
-                $this->objectManager->get(\Magento\Framework\App\ResourceConnection::class),
+                $this->objectManager->get(
+                    \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory::class
+                ),
+                $this->objectManager->get(
+                    \Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory::class
+                ),
+                $this->objectManager->get(
+                    \Magento\Framework\App\ResourceConnection::class
+                ),
                 $params
             ]
         );

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractTest.php
@@ -13,19 +13,24 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
     protected $_model;
 
     /**
+     * @var \Magento\TestFramework\ObjectManager
+     */
+    private $objectManager;
+
+    /**
      * On product import abstract class methods level it doesn't matter what product type is using.
      * That is why current tests are using simple product entity type by default
      */
     protected function setUp()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $params = [$objectManager->create(\Magento\CatalogImportExport\Model\Import\Product::class), 'simple'];
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $params = [$this->objectManager->create(\Magento\CatalogImportExport\Model\Import\Product::class), 'simple'];
         $this->_model = $this->getMockForAbstractClass(
             \Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::class,
             [
-                $objectManager->get(\Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory::class),
-                $objectManager->get(\Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory::class),
-                $objectManager->get(\Magento\Framework\App\ResourceConnection::class),
+                $this->objectManager->get(\Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory::class),
+                $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory::class),
+                $this->objectManager->get(\Magento\Framework\App\ResourceConnection::class),
                 $params
             ]
         );
@@ -130,6 +135,11 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test cleaning imported attribute data from empty values (note '0' is not empty).
+     *
+     * @magentoDbIsolation enabled
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture Magento/CatalogImportExport/Model/Import/_files/custom_attributes.php
      * @dataProvider clearEmptyDataDataProvider
      */
     public function testClearEmptyData($rowData, $expectedAttributes)
@@ -141,8 +151,14 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * Data provider for testClearEmptyData.
+     *
+     * @return array
+     */
     public function clearEmptyDataDataProvider()
     {
+        // We use sku attribute to test static attributes.
         return [
             [
                 [
@@ -152,6 +168,7 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
                     'product_type' => 'simple',
                     'name' => 'Simple 01',
                     'price' => 10,
+                    'test_attribute' => '1',
                 ],
                 [
                     'sku' => 'simple1',
@@ -159,26 +176,49 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
                     '_attribute_set' => 'Default',
                     'product_type' => 'simple',
                     'name' => 'Simple 01',
-                    'price' => 10
+                    'price' => 10,
+                    'test_attribute' => '1',
                 ],
             ],
             [
                 [
-                    'sku' => '',
-                    'store_view_code' => 'German',
+                    'sku' => '0',
+                    'store_view_code' => '',
                     '_attribute_set' => 'Default',
-                    'product_type' => '',
-                    'name' => 'Simple 01 German',
-                    'price' => '',
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                    'test_attribute' => '0',
                 ],
                 [
-                    'sku' => '',
-                    'store_view_code' => 'German',
+                    'sku' => '0',
+                    'store_view_code' => '',
                     '_attribute_set' => 'Default',
-                    'product_type' => '',
-                    'name' => 'Simple 01 German'
-                ]
-            ]
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                    'test_attribute' => '0',
+                ],
+            ],
+            [
+                [
+                    'sku' => null,
+                    'store_view_code' => '',
+                    '_attribute_set' => 'Default',
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                    'test_attribute' => null,
+                ],
+                [
+                    'sku' => null,
+                    'store_view_code' => '',
+                    '_attribute_set' => 'Default',
+                    'product_type' => 'simple',
+                    'name' => 'Simple 01',
+                    'price' => 10,
+                ],
+            ],
         ];
     }
 }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/custom_attributes.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/custom_attributes.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+/** @var \Magento\Eav\Model\Entity\Type $entityType */
+$entityType = $objectManager->create(\Magento\Eav\Model\Entity\Type::class);
+$entityType->loadByCode('catalog_product');
+$entityTypeId = $entityType->getId();
+
+/** @var \Magento\Eav\Model\Entity\Attribute\Set $attributeSet */
+$attributeSet = $objectManager->create(\Magento\Eav\Model\Entity\Attribute\Set::class);
+$attributeSet->load('default', 'attribute_set_name');
+$attributeSetId = $attributeSet->getId();
+
+$attributeGroupId = $attributeSet->getDefaultGroupId($entityType->getDefaultAttributeSetId());
+
+$attributeData = [
+    [
+        'attribute_code' => 'test_attribute',
+        'entity_type_id' => $entityTypeId,
+        'backend_type' => 'varchar',
+        'is_required' => 1,
+        'is_user_defined' => 1,
+        'is_unique' => 0,
+        'attribute_set_id' => $attributeSetId,
+        'attribute_group_id' => $attributeGroupId,
+    ],
+];
+
+foreach ($attributeData as $data) {
+    /** @var \Magento\Eav\Model\Entity\Attribute $attribute */
+    $attribute = $objectManager->create(\Magento\Eav\Model\Entity\Attribute::class);
+    $attribute->setData($data);
+    $attribute->setIsStatic(true);
+    $attribute->save();
+}

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/custom_attributes_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/custom_attributes_rollback.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+$attributeCodes = [
+    'test_attribute',
+    ];
+
+foreach ($attributeCodes as $attributeCode) {
+    /** @var \Magento\Eav\Model\Entity\Attribute $attribute */
+    $attribute = $objectManager->create(\Magento\Eav\Model\Entity\Attribute::class);
+    $attribute->loadByCode('catalog_product', $attributeCode);
+    if ($attribute->getId()) {
+        $attribute->delete();
+    }
+}


### PR DESCRIPTION
### Description
Product import now is not ignoring zero values.

### Fixed Issues (if relevant)
1. magento/magento2#12083: Cannot import zero (0) value into custom attribute

### Manual testing scenarios
1. Create Custom Attribute using Text Field input type set its code to 'custom_attribute_code'.
2. Assign Custom Attribute to default product attribute set.
3. Create a Product, set some value to its Custom Attribute.
4. Export Product.
5. Edit received CSV file, set its 'additional_attributes' column to 'custom_attribute_code=0'
6. Import CSV file, use behavior 'Add/Update'.
7. Check Product created in step 3. Its Custom Attribute must be 0.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
