### PR TITLE
Issue: 3596. Resolve Notice with undefined index 'value'

### DIFF
--- a/app/code/Magento/Payment/Helper/Data.php
+++ b/app/code/Magento/Payment/Helper/Data.php
@@ -290,6 +290,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             foreach ($methods as $code => $title) {
                 if (isset($groups[$code])) {
                     $labelValues[$code]['label'] = $title;
+                    $labelValues[$code]['value'] = null;
                 } elseif (isset($groupRelations[$code])) {
                     unset($labelValues[$code]);
                     $labelValues[$groupRelations[$code]]['value'][$code] = ['value' => $code, 'label' => $title];


### PR DESCRIPTION
Fix for issue: https://github.com/magento/magento2/issues/3596

### Description
If you have a custom **offline** payment method it automatically falls in exception group used while fetching all payment methods this cause that payment method don't have **value** key in the definition and as the result - undefined index on order view page in admin panel. My fix adds key **value** as null and it fixes the notice.

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#3596: Notice: Undefined index: value in /app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Select.php on line 72

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add custom offline payment method
2. Create an order with instantly payable payment method (like PayPal, PayPal, ... not the bank transfer)
3. Got to order view in admin panel and you should PHP notice.

### Contribution checklist
 - [ + ] Pull request has a meaningful description of its purpose
 - [ + ] All commits are accompanied by meaningful commit messages
 - [ + ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ + ] All automated tests passed successfully (all builds on Travis CI are green)
