### PR TITLE
Overselling items in situations of high load and high concurrency on a singe item

### DIFF
--- a/app/code/Magento/CatalogInventory/Api/Data/StockItemInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockItemInterface.php
@@ -401,4 +401,11 @@ interface StockItemInterface extends ExtensibleDataInterface
     public function setExtensionAttributes(
         \Magento\CatalogInventory\Api\Data\StockItemExtensionInterface $extensionAttributes
     );
+
+    /**
+     * Synchronize object's stored data with the actual data
+     *
+     * @return $this
+     */
+    public function resetStoredData();
 }

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -834,5 +834,16 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
         return $this->_setExtensionAttributes($extensionAttributes);
     }
 
+    /**
+     * Synchronize object's stored data with the actual data
+     *
+     * @return $this
+     */
+    public function resetStoredData()
+    {
+        $this->updateStoredData();
+        return $this;
+    }
+
     //@codeCoverageIgnoreEnd
 }

--- a/app/code/Magento/CatalogInventory/Model/StockManagement.php
+++ b/app/code/Magento/CatalogInventory/Model/StockManagement.php
@@ -109,6 +109,7 @@ class StockManagement implements StockManagementInterface
             }
             if ($this->canSubtractQty($stockItem)) {
                 $stockItem->setQty($stockItem->getQty() - $orderedQty);
+                $stockItem->resetStoredData();
             }
             $registeredItems[$productId] = $orderedQty;
             if (!$this->stockState->verifyStock($productId, $stockItem->getWebsiteId())


### PR DESCRIPTION
### Description
This pull requests attempts to address the issue mentioned in issue #12287. The solution put forward to to mark the qty field as unchanged so that when the Stock Item object is saved later in the `sales_model_service_quote_submit_success` event the value stored in the "stale" object does not override the already modified record in the database.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12287: Overselling items in situations of high load and high concurrency on a singe item

### Manual testing scenarios
1. Please see test's mentioned in open issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
