### PR TITLE
Fixed 'Non-numeric value' warning on account create/save when DOB field is visible

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Filter/Date.php
+++ b/lib/internal/Magento/Framework/Data/Form/Filter/Date.php
@@ -54,6 +54,10 @@ class Date implements \Magento\Framework\Data\Form\Filter\FilterInterface
      */
     public function inputFilter($value)
     {
+        if (!$value) {
+            return $value;
+        }
+
         $filterInput = new \Zend_Filter_LocalizedToNormalized(
             ['date_format' => $this->_dateFormat, 'locale' => $this->localeResolver->getLocale()]
         );
@@ -74,6 +78,10 @@ class Date implements \Magento\Framework\Data\Form\Filter\FilterInterface
      */
     public function outputFilter($value)
     {
+        if (!$value) {
+            return $value;
+        }
+
         $filterInput = new \Zend_Filter_LocalizedToNormalized(
             ['date_format' => DateTime::DATE_INTERNAL_FORMAT, 'locale' => $this->localeResolver->getLocale()]
         );


### PR DESCRIPTION
### Description
This commit fixes:

 - broken customer registration page when "Date of Birth" field is visible on the frontend.
 - not working customer save method when DOB is visible

### Related Issues

- https://github.com/magento/magento2/issues/12146

### Manual testing scenarios
1. Navigate to _Stores > Configuration > Customer Configuration > Name and Address Options_ and make DOB field visible.
2. Navigate to frontend Customer Registration page. An exception with warning will appear:

    Trace:

    ```
    Exception #0 (Exception): Warning: A non-numeric value encountered in vendor/magento/zendframework1/library/Zend/Locale/Math/PhpMath.php on line 94
    #0 vendor/magento/zendframework1/library/Zend/Locale/Math/PhpMath.php(94): Magento\Framework\App\ErrorHandler->handler(2, 'A non-numeric v...', '...', 94, Array)
    #1 vendor/magento/zendframework1/library/Zend/Locale/Format.php(385): Zend_Locale_Math_PhpMath::Sub('0', '', 0)
    #2 vendor/magento/zendframework1/library/Zend/Locale/Format.php(662): Zend_Locale_Format::toNumber('', Array)
    #3 vendor/magento/zendframework1/library/Zend/Filter/NormalizedToLocalized.php(106): Zend_Locale_Format::toFloat(NULL, Array)
    #4 lib/internal/Magento/Framework/Data/Form/Filter/Date.php(85): Zend_Filter_NormalizedToLocalized->filter(NULL)
    #5 app/code/Magento/Customer/Block/Widget/Dob.php(131): Magento\Framework\Data\Form\Filter\Date->outputFilter(NULL)
    #6 app/code/Magento/Customer/Block/Widget/Dob.php(97): Magento\Customer\Block\Widget\Dob->applyOutputFilter(NULL)
    #7 app/code/Magento/Customer/view/frontend/templates/form/register.phtml(32): Magento\Customer\Block\Widget\Dob->setDate(NULL)
    ```

3. Navigate to the backend, open existing customer and try to save it with empty DOB field. The page reloads with an error message "Something went wrong while saving the customer.".

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
