### PR TITLE
9764: exception message is wrong and misleading in findAccessorMethodName() of Magento\Framework\Reflection\NameFinder

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/NameFinder.php
+++ b/lib/internal/Magento/Framework/Reflection/NameFinder.php
@@ -99,8 +99,9 @@ class NameFinder
         } else {
             throw new \LogicException(
                 sprintf(
-                    'Property "%s" does not have corresponding setter in class "%s".',
+                    'Property "%s" does not have accessor method "%s" in class "%s".',
                     $camelCaseProperty,
+                    $accessorName,
                     $class->getName()
                 )
             );

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/NameFinderTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/NameFinderTest.php
@@ -27,7 +27,7 @@ class NameFinderTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSetterMethodName()
     {
-        $class = new ClassReflection("\\Magento\\Framework\\Reflection\\Test\\Unit\\DataObject");
+        $class = new ClassReflection(\Magento\Framework\Reflection\Test\Unit\DataObject::class);
         $setterName = $this->nameFinder->getSetterMethodName($class, 'AttrName');
         $this->assertEquals("setAttrName", $setterName);
 
@@ -43,7 +43,7 @@ class NameFinderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetSetterMethodNameInvalidAttribute()
     {
-        $class = new ClassReflection("\\Magento\\Framework\\Reflection\\Test\\Unit\\DataObject");
+        $class = new ClassReflection(\Magento\Framework\Reflection\Test\Unit\DataObject::class);
         $this->nameFinder->getSetterMethodName($class, 'InvalidAttribute');
     }
 
@@ -55,7 +55,7 @@ class NameFinderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetSetterMethodNameWrongCamelCasedAttribute()
     {
-        $class = new ClassReflection("\\Magento\\Framework\\Reflection\\Test\\Unit\\DataObject");
+        $class = new ClassReflection(\Magento\Framework\Reflection\Test\Unit\DataObject::class);
         $this->nameFinder->getSetterMethodName($class, 'ActivE');
     }
 

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/NameFinderTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/NameFinderTest.php
@@ -37,7 +37,9 @@ class NameFinderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /Property "InvalidAttribute" does not have corresponding setter in class (.*?)/
+     * @codingStandardsIgnoreStart
+     * @expectedExceptionMessage Property "InvalidAttribute" does not have accessor method "setInvalidAttribute" in class "Magento\Framework\Reflection\Test\Unit\DataObject"
+     * @codingStandardsIgnoreEnd
      */
     public function testGetSetterMethodNameInvalidAttribute()
     {
@@ -47,11 +49,31 @@ class NameFinderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /Property "ActivE" does not have corresponding setter in class (.*?)/
+     * @codingStandardsIgnoreStart
+     * @expectedExceptionMessage Property "ActivE" does not have accessor method "setActivE" in class "Magento\Framework\Reflection\Test\Unit\DataObject"
+     * @codingStandardsIgnoreEnd
      */
     public function testGetSetterMethodNameWrongCamelCasedAttribute()
     {
         $class = new ClassReflection("\\Magento\\Framework\\Reflection\\Test\\Unit\\DataObject");
         $this->nameFinder->getSetterMethodName($class, 'ActivE');
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Property "Property" does not have accessor method "getProperty" in class "className".
+     */
+    public function testFindAccessorMethodName()
+    {
+        $reflectionClass = $this->createMock(\Zend\Code\Reflection\ClassReflection::class);
+        $reflectionClass->expects($this->atLeastOnce())->method('hasMethod')->willReturn(false);
+        $reflectionClass->expects($this->atLeastOnce())->method('getName')->willReturn('className');
+
+        $this->nameFinder->findAccessorMethodName(
+            $reflectionClass,
+            'Property',
+            'getProperty',
+            'isProperty'
+        );
     }
 }


### PR DESCRIPTION
Exception message is wrong and misleading in findAccessorMethodName() of Magento\Framework\Reflection\NameFinder

### Fixed Issues (if relevant)
1. magento/magento2#9764: exception message is wrong and misleading in findAccessorMethodName() of Magento\Framework\Reflection\NameFinder

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. This function gets getter name and It call findAccessorMethodName()

```public function getGetterMethodName(ClassReflection $class, $camelCaseProperty)
{
$getterName = 'get' . $camelCaseProperty;
$boolGetterName = 'is' . $camelCaseProperty;
return $this->findAccessorMethodName($class, $camelCaseProperty, $getterName, $boolGetterName);
}
```
In my case,
```
$getterName = getIsDefaultBilling
$class->name = "Magento\Customer\Api\Data\AddressInterface"
```
 Expected result:
Exception: 'Property "IsDefaultBilling" does not have accessor method "getIsDefaultBilling" in class "Magento\Customer\Api\Data\AddressInterface.',

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
