### PR TITLE
9742: Default welcome message returns after being deleted #9742

### DIFF
--- a/app/code/Magento/Theme/Model/Design/Config/Storage.php
+++ b/app/code/Magento/Theme/Model/Design/Config/Storage.php
@@ -87,10 +87,13 @@ class Storage
                 $scopeId,
                 $fieldData->getFieldConfig()
             );
-            if ($value !== null) {
-                $fieldData->setValue($value);
+
+            if ($value === null) {
+                $value = '';
             }
+            $fieldData->setValue($value);
         }
+
         return $designConfig;
     }
 

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/Design/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/Design/ConfigTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Theme\Model\Design;
+
+/**
+ * Test for \Magento\Theme\Model\Design\Config\Storage.
+ */
+class ConfigTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Theme\Model\Design\Config\Storage
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        $this->storage = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Theme\Model\Design\Config\Storage::class
+        );
+    }
+
+    /**
+     * Test design/header/welcome if it is saved in db as empty(null) it should be shown on backend as empty.
+     *
+     * @magentoDataFixture Magento/Theme/_files/config_data.php
+     */
+    public function testLoad()
+    {
+        $data = $this->storage->load('stores', 1);
+        foreach ($data->getExtensionAttributes()->getDesignConfigData() as $configData) {
+            if ($configData->getPath() == 'design/header/welcome') {
+                $this->assertSame('', $configData->getValue());
+            }
+        }
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Theme/_files/config_data.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/_files/config_data.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Config\Model\Config\Factory;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var Factory $configFactory */
+$configFactory = $objectManager->create(Factory::class);
+/** @var \Magento\Config\Model\Config $config */
+$config = $configFactory->create();
+$config->setScope('stores');
+$config->setStore('default');
+$config->setDataByPath('design/header/welcome', null);
+$config->save();

--- a/dev/tests/integration/testsuite/Magento/Theme/_files/config_data_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/_files/config_data_rollback.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+/** @var \Magento\Framework\App\ResourceConnection $resource */
+$resource = $objectManager->get(\Magento\Framework\App\ResourceConnection::class);
+$connection = $resource->getConnection();
+$tableName = $resource->getTableName('core_config_data');
+
+$connection->query("DELETE FROM $tableName WHERE path = 'design/header/welcome';");


### PR DESCRIPTION
Default welcome message returns after being deleted #9742

### Description
Column value in core_config_data was nullable. When we saved '' as column was nullable in lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php line 3001 the value became null, so it was null in db. If value is null it will take the default value, so we couldn't save '' and see '' at the form.
Now column value isn't nullable, so when we save '' it will save in db as '' and show at the form as ''.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9742:Default welcome message returns after being deleted

### Manual testing scenarios
1. Go to Content -> Configuration -> Click Edit on theme being used.
2. Open header tab -> clear Welcome Text.
3. Click save and continue.
4. Open header tab -> Welcome Text field should be empty.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
