### PR TITLE
9684: No ACL set for integrations

### DIFF
--- a/app/code/Magento/Integration/etc/acl.xml
+++ b/app/code/Magento/Integration/etc/acl.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::system">
+                    <resource id="Magento_Integration::extensions" title="System Extensions" translate="title" sortOrder="30">
+                        <resource id="Magento_Integration::integrations" title="System Integrations" translate="title" sortOrder="40" />
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9684: No ACL set for integrations

### Manual testing scenarios
1. Create admin role.
2. Set custom role resources.
3. Select all resources.
4. Add a user to the role.
5. Login as this user.
6. Search for 'System > Extentions > Integrations.

Expected result:
Extentions > Integrations is present on the System tab.
Actual result:
Extentions > Integrations is absent on the System tab

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
