### PR TITLE
[2.3] Correct flat indexing with staging and > 500 cats

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -369,15 +369,19 @@ class AbstractAction
         }
         $values = [];
 
+        foreach ($entityIds as $entityId) {
+            $values[$entityId] = [];
+        }
+
         $attributes = $this->getAttributes();
         $attributesType = ['varchar', 'int', 'decimal', 'text', 'datetime'];
         foreach ($attributesType as $type) {
             foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
-                if (isset($row['entity_id']) && isset($row['attribute_id'])) {
+                if (isset($row[$this->getCategoryMetadata()->getLinkField()]) && isset($row['attribute_id'])) {
                     $attributeId = $row['attribute_id'];
                     if (isset($attributes[$attributeId])) {
                         $attributeCode = $attributes[$attributeId]['attribute_code'];
-                        $values[$row['entity_id']][$attributeCode] = $row['value'];
+                        $values[$row[$this->getCategoryMetadata()->getLinkField()]][$attributeCode] = $row['value'];
                     }
                 }
             }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -376,13 +376,14 @@ class AbstractAction
 
         $attributes = $this->getAttributes();
         $attributesType = ['varchar', 'int', 'decimal', 'text', 'datetime'];
+        $linkField = $this->getCategoryMetadata()->getLinkField();
         foreach ($attributesType as $type) {
             foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
-                if (isset($row[$this->getCategoryMetadata()->getLinkField()]) && isset($row['attribute_id'])) {
+                if (isset($row[$linkField]) && isset($row['attribute_id'])) {
                     $attributeId = $row['attribute_id'];
                     if (isset($attributes[$attributeId])) {
                         $attributeCode = $attributes[$attributeId]['attribute_code'];
-                        $values[$row[$this->getCategoryMetadata()->getLinkField()]][$attributeCode] = $row['value'];
+                        $values[$row[$linkField]][$attributeCode] = $row['value'];
                     }
                 }
             }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
@@ -64,18 +64,22 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
             }
             /** @TODO Do something with chunks */
             $categoriesIdsChunks = array_chunk($categoriesIds[$store->getRootCategoryId()], 500);
+
             foreach ($categoriesIdsChunks as $categoriesIdsChunk) {
                 $attributesData = $this->getAttributeValues($categoriesIdsChunk, $store->getId());
+                $linkField = $this->categoryMetadata->getLinkField();
+
                 $data = [];
                 foreach ($categories[$store->getRootCategoryId()] as $category) {
-                    if (!isset($attributesData[$category[$this->categoryMetadata->getLinkField()]])) {
+                    if (!isset($attributesData[$category[$linkField]])) {
                         continue;
                     }
                     $category['store_id'] = $store->getId();
                     $data[] = $this->prepareValuesToInsert(
-                        array_merge($category, $attributesData[$category[$this->categoryMetadata->getLinkField()]])
+                        array_merge($category, $attributesData[$category[$linkField]])
                     );
                 }
+
                 $this->connection->insertMultiple(
                     $this->addTemporaryTableSuffix($this->getMainStoreTable($store->getId())),
                     $data

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Rows.php
@@ -175,7 +175,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
 
                 $categoryAttributesData = [];
                 if (isset($attributesData[$linkId]) && is_array($attributesData[$linkId])) {
-                    $categoryAttributesData = $attributesData[$categoryId];
+                    $categoryAttributesData = $attributesData[$linkId];
                 }
                 $categoryIndexData = $this->buildCategoryIndexData(
                     $store,

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Rows.php
@@ -164,16 +164,22 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
      */
     private function buildIndexData(Store $store, $categoriesIdsChunk, $attributesData)
     {
+        $linkField = $this->categoryMetadata->getLinkField();
+
         $data = [];
         foreach ($categoriesIdsChunk as $categoryId) {
             try {
+                $category = $this->categoryRepository->get($categoryId);
+                $categoryData = $category->getData();
+                $linkId = $categoryData[$linkField];
+
                 $categoryAttributesData = [];
-                if (isset($attributesData[$categoryId]) && is_array($attributesData[$categoryId])) {
+                if (isset($attributesData[$linkId]) && is_array($attributesData[$linkId])) {
                     $categoryAttributesData = $attributesData[$categoryId];
                 }
                 $categoryIndexData = $this->buildCategoryIndexData(
                     $store,
-                    $categoryId,
+                    $categoryData,
                     $categoryAttributesData
                 );
                 $data[] = $categoryIndexData;
@@ -186,18 +192,16 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
 
     /**
      * @param Store $store
-     * @param int $categoryId
+     * @param array $categoryData
      * @param array $categoryAttributesData
      * @return array
      * @throws NoSuchEntityException
      */
-    private function buildCategoryIndexData(Store $store, $categoryId, array $categoryAttributesData)
+    private function buildCategoryIndexData(Store $store, array $categoryData, array $categoryAttributesData)
     {
-        $category = $this->categoryRepository->get($categoryId);
-        $categoryAttributesData = [];
         $data = $this->prepareValuesToInsert(
             array_merge(
-                $category->getData(),
+                $categoryData,
                 $categoryAttributesData,
                 ['store_id' => $store->getId()]
             )


### PR DESCRIPTION
### Description

In a past change, entity_id was used for mapping.  However, since the index stores things by entity id (not link id), this prevents it from selecting the correct row.

Additionally, there was a spurious `$categoryAttributesData = [];` in `buildCategoryIndexData()` which looks like a mistake, so the argument was ignored.

Please see magento-partners/magento2ce#65 for more detail with regard to Magento Commerce.

### Manual testing scenarios
For Magento Open Source:
1. Start with a fresh DB and create 10 categories.
2. Create another 500 categories (ideally via script.)
3. Enable flat category indexing.
4. Reindex flat category.
5. Modify the name of certain categories.
6. Reindex flat category again.

Expected results:
Reindex runs successfully.  All rows have correct updates.

Actual results:
Data may not update properly.

Please see magento-partners/magento2ce#65 for the Magento Commerce test scenario.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
