### PR TITLE
Add configurable Monolog configuration

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -7,7 +7,9 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="DateTimeInterface" type="DateTime" />
-    <preference for="Psr\Log\LoggerInterface" type="Magento\Framework\Logger\Monolog" />
+    <preference for="Psr\Log\LoggerInterface" type="Magento\Framework\Logger\MainLogchannel" />
+    <preference for="Magento\Framework\Logger\Configuration\ChannelConfigurationParserInterface" type="Magento\Framework\Logger\Configuration\ChannelConfigurationParser" />
+    <preference for="Magento\Framework\Logger\Configuration\LogConfigurationProviderInterface" type="Magento\Framework\Logger\Configuration\LogConfigurationProvider" />
     <preference for="Magento\Framework\EntityManager\EntityMetadataInterface" type="Magento\Framework\EntityManager\EntityMetadata" />
     <preference for="Magento\Framework\EntityManager\HydratorInterface" type="Magento\Framework\EntityManager\Hydrator" />
     <preference for="Magento\Framework\View\Template\Html\MinifierInterface" type="Magento\Framework\View\Template\Html\Minifier" />
@@ -689,6 +691,7 @@
                 <item name="searchResults" xsi:type="string">\Magento\Framework\Api\Code\Generator\SearchResults</item>
                 <item name="extensionInterface" xsi:type="string">\Magento\Framework\Api\Code\Generator\ExtensionAttributesInterfaceGenerator</item>
                 <item name="extension" xsi:type="string">\Magento\Framework\Api\Code\Generator\ExtensionAttributesGenerator</item>
+                <item name="logchannel" xsi:type="string">\Magento\Framework\Logger\Code\Generator\Logchannel</item>
             </argument>
         </arguments>
     </type>

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/Payflow/SilentPostTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/Payflow/SilentPostTest.php
@@ -9,7 +9,6 @@ use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Logger\Monolog;
 use Magento\Paypal\Model\Payflow\Service\Gateway;
 use Magento\Paypal\Model\Payflowlink;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -18,6 +17,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\TestFramework\TestCase\AbstractController;
 use PHPUnit\Framework\MockObject_MockObject as MockObject;
+use Psr\Log\LoggerInterface;
 
 class SilentPostTest extends AbstractController
 {
@@ -111,10 +111,12 @@ class SilentPostTest extends AbstractController
         $this->withRequest($orderIncrementId, $resultCode);
         $this->withGatewayResponse($orderIncrementId, $resultCode);
 
-        $logger = $this->getMockBuilder(Monolog::class)
+        $this->_objectManager->get(LoggerInterface::class);
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->_objectManager->addSharedInstance($logger, Monolog::class);
+        $this->_objectManager->addSharedInstance($logger, 'Magento\Framework\Logger\MainLogchannel');
 
         $exception = new LocalizedException(__('Response message from PayPal gateway'));
         $logger->expects(self::once())
@@ -125,7 +127,7 @@ class SilentPostTest extends AbstractController
 
         self::assertEquals(200, $this->getResponse()->getStatusCode());
 
-        $this->_objectManager->removeSharedInstance(Monolog::class);
+        $this->_objectManager->removeSharedInstance(LoggerInterface::class);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Logger/Code/Generator/Logchannel.php
+++ b/lib/internal/Magento/Framework/Logger/Code/Generator/Logchannel.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Code\Generator;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Code\Generator\ClassGenerator;
+use Magento\Framework\Code\Generator\CodeGeneratorInterface;
+use Magento\Framework\Code\Generator\Io;
+use Magento\Framework\Filesystem\Driver\File;
+use Magento\Framework\Logger\Monolog;
+use \Magento\Framework\Logger\Logchannel as LogchannelBaseClass;
+use Zend\Code\Generator\PropertyGenerator;
+
+/**
+ * Logchannel Code Generator
+ *
+ * Responsible for generating ...Logchannel classed automatically.
+ *
+ * Classes are instantiated from \Magento\Framework\Logger\Monolog when there is no specific configuration (For BC)
+ * Classed are instantiated from \Magento\Framework\Logger\Logchannel when there is channel specific configuration
+ */
+class Logchannel
+{
+    /**
+     * @var string[]
+     */
+    private $_errors = [];
+
+    /**
+     * Source model class name
+     *
+     * @var string
+     */
+    private $sourceClassName;
+
+    /**
+     * Result model class name
+     *
+     * @var string
+     */
+    private $resultClassName;
+
+    /**
+     * @var string
+     */
+    private $channelName;
+
+    /**
+     * @var Io
+     */
+    private $ioObject;
+
+    /**
+     * @var CodeGeneratorInterface
+     */
+    private $classGenerator;
+
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @param null|string $sourceClassName
+     * @param null|string $resultClassName
+     * @param null|Io $ioObject
+     * @param null|CodeGeneratorInterface $classGenerator
+     */
+    public function __construct(
+        $sourceClassName,
+        $resultClassName,
+        Io $ioObject = null,
+        CodeGeneratorInterface $classGenerator = null
+    ) {
+        $this->sourceClassName = $this->getFullyQualifiedClassName($sourceClassName);
+        $this->resultClassName = $this->getFullyQualifiedClassName($resultClassName);
+        $this->ioObject = $ioObject !== null ? $ioObject : new Io(new File());
+        $this->classGenerator = $classGenerator !== null ? $classGenerator : new ClassGenerator();
+        $this->deploymentConfig = ObjectManager::getInstance()->get(DeploymentConfig::class);
+
+        $this->channelName = strtolower(preg_replace(
+            '/([A-Z]+)/',
+            '-$1',
+            lcfirst(substr($sourceClassName, strrpos($sourceClassName, '\\') + 1))
+        ));
+    }
+
+    /**
+     * Generation template method
+     *
+     * @return bool
+     */
+    public function generate()
+    {
+        try {
+            $sourceCode = $this->generateCode();
+            $fileName = $this->ioObject->generateResultFileName($this->resultClassName);
+            $this->ioObject->makeResultFileDirectory($this->resultClassName);
+            $this->ioObject->writeResultFile($fileName, $sourceCode);
+
+            return $fileName;
+        } catch (\Exception $e) {
+            $this->addError($e->getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * Get full source class name, with namespace
+     *
+     * @return string
+     */
+    public function getSourceClassName()
+    {
+        return class_exists($this->sourceClassName) ? $this->sourceClassName : Monolog::class;
+    }
+
+    /**
+     * List of occurred generation errors
+     *
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->_errors;
+    }
+
+    /**
+     * Generate code
+     *
+     * @return string
+     */
+    private function generateCode(): string
+    {
+        $logChannelConfig = $this->deploymentConfig->get('logging');
+
+        $this->classGenerator->setName($this->resultClassName);
+
+        if ($logChannelConfig === null ||
+            !isset($logChannelConfig['channels']) ||
+            !isset($logChannelConfig['channels'][$this->channelName])
+        ) {
+            return $this->classGenerator
+                ->setExtendedClass(Monolog::class)
+                ->generate();
+        }
+
+        $this->classGenerator
+            ->setExtendedClass(
+                class_exists($this->sourceClassName) ? $this->sourceClassName : LogchannelBaseClass::class
+            )
+            ->addProperty(
+                'channelName',
+                $this->channelName,
+                PropertyGenerator::FLAG_PROTECTED
+            )
+            ->addProperty(
+                'channelConfiguration',
+                $logChannelConfig['channels'][$this->channelName],
+                PropertyGenerator::FLAG_PROTECTED
+            );
+
+        return $this->classGenerator->generate();
+    }
+
+    /**
+     * Add error message
+     *
+     * @param string $message
+     */
+    private function addError(string $message)
+    {
+        $this->_errors[] = $message;
+    }
+
+    /**
+     * Get fully qualified class name
+     *
+     * @param string $className
+     * @return string
+     */
+    private function getFullyQualifiedClassName($className)
+    {
+        $className = ltrim($className, '\\');
+        return $className ? '\\' . $className : '';
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Configuration/ChannelConfigurationParser.php
+++ b/lib/internal/Magento/Framework/Logger/Configuration/ChannelConfigurationParser.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Configuration;
+
+/**
+ * Parse configuration for a specific logging channel.
+ *
+ * Channel specific configuration is dependend on the global logging configuration
+ * from LogConfigurationProviderInterface
+ */
+class ChannelConfigurationParser implements ChannelConfigurationParserInterface
+{
+    /**
+     * @var LogConfigurationProviderInterface
+     */
+    private $logConfigProvider;
+
+    /**
+     * @param LogConfigurationProviderInterface $logConfigProvider
+     */
+    public function __construct(LogConfigurationProviderInterface $logConfigProvider)
+    {
+        $this->logConfigProvider = $logConfigProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseConfiguration(array $channelConfig): ParsedChannelConfiguration
+    {
+        $handlers = [];
+        $processors = [];
+
+        if (isset($channelConfig['handlers'])) {
+            foreach ($channelConfig['handlers'] as $key) {
+                $handlers[] = $this->logConfigProvider->getHandlerByKey($key);
+            }
+        }
+
+        if (isset($channelConfig['processors'])) {
+            foreach ($channelConfig['processors'] as $key) {
+                $processors[] = $this->logConfigProvider->getProcessorByKey($key);
+            }
+        }
+
+        return new ParsedChannelConfiguration($handlers, $processors);
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Configuration/ChannelConfigurationParserInterface.php
+++ b/lib/internal/Magento/Framework/Logger/Configuration/ChannelConfigurationParserInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Configuration;
+
+/**
+ * Parse channel specific configuration from deployment configuration. This does not
+ * include the global logging configuration, that is handled by LogConfigurationProviderInterface
+ */
+interface ChannelConfigurationParserInterface
+{
+    /**
+     * Get Configured Handlers
+     *
+     * @param array $channelConfig
+     * @return ParsedChannelConfiguration
+     */
+    public function parseConfiguration(array $channelConfig): ParsedChannelConfiguration;
+}

--- a/lib/internal/Magento/Framework/Logger/Configuration/LogConfigurationProvider.php
+++ b/lib/internal/Magento/Framework/Logger/Configuration/LogConfigurationProvider.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Configuration;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\HandlerInterface;
+
+/**
+ * Log Configuration Provider
+ *
+ * Reads Log configuration from deployment (env.php) and instantiates the required
+ * objects on demand.
+ *
+ * Configuration format is inspired by MonologCascade (https://github.com/theorchard/monolog-cascade)
+ * Implementation is made specific for Magento (e.g. it uses the ObjectManager to instantiate objects allowing DI)
+ */
+class LogConfigurationProvider implements LogConfigurationProviderInterface
+{
+    const TYPE_FORMATTER = 'formatter';
+    const TYPE_HANDLER = 'handler';
+    const TYPE_PROCESSOR = 'processor';
+    const TYPE_OTHER = 'other';
+
+    /**
+     * @var array
+     */
+    private $formattersByKey = [];
+
+    /**
+     * @var array
+     */
+    private $handlersByKey = [];
+
+    /**
+     * @var array
+     */
+    private $processorsByKey = [];
+
+    /**
+     * @var array
+     */
+    private $logConfiguration;
+
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var Utility\ObjectInstantiator
+     */
+    private $objectInstantiator;
+
+    /**
+     * @param DeploymentConfig $deploymentConfig
+     * @param Utility\ObjectInstantiator $objectInstantiator
+     */
+    public function __construct(DeploymentConfig $deploymentConfig, Utility\ObjectInstantiator $objectInstantiator)
+    {
+        $this->deploymentConfig = $deploymentConfig;
+        $this->objectInstantiator = $objectInstantiator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandlerByKey(string $key): HandlerInterface
+    {
+        if ($this->logConfiguration === null) {
+            $this->logConfiguration = $this->deploymentConfig->get('logging');
+        }
+
+        return $this->getOrInstantiateHandlerByKey($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProcessorByKey(string $key)
+    {
+        if ($this->logConfiguration === null) {
+            $this->logConfiguration = $this->deploymentConfig->get('logging');
+        }
+
+        return $this->getOrInstantiateProcessorByKey($key);
+    }
+
+    /**
+     * Get or instantiate formatter by key
+     *
+     * @param string $key
+     * @return FormatterInterface
+     */
+    private function getOrInstantiateFormatterByKey(string $key): FormatterInterface
+    {
+        if (isset($this->formattersByKey[$key])) {
+            return $this->formattersByKey[$key];
+        }
+
+        if (!isset($this->logConfiguration['formatters']) || !isset($this->logConfiguration['formatters'][$key])) {
+            throw new \RuntimeException('Log formatter with not found with key: ' . $key);
+        }
+
+        $this->formattersByKey[$key] = $this->instantiateItem(
+            $this->logConfiguration['formatters'][$key],
+            self::TYPE_FORMATTER
+        );
+
+        return $this->formattersByKey[$key];
+    }
+
+    /**
+     * Get or instantiate processor by key
+     *
+     * @param string $key
+     * @return mixed
+     */
+    private function getOrInstantiateProcessorByKey(string $key)
+    {
+        if (isset($this->processorsByKey[$key])) {
+            return $this->processorsByKey[$key];
+        }
+
+        if (!isset($this->logConfiguration['processors']) || !isset($this->logConfiguration['processors'][$key])) {
+            throw new \RuntimeException('Log processor not found with key: ' . $key);
+        }
+
+        $this->processorsByKey[$key] = $this->instantiateItem(
+            $this->logConfiguration['processors'][$key],
+            self::TYPE_PROCESSOR
+        );
+
+        return $this->processorsByKey[$key];
+    }
+
+    /**
+     * Get or instantiate handler by key
+     *
+     * @param string $key
+     * @return HandlerInterface
+     */
+    private function getOrInstantiateHandlerByKey(string $key): HandlerInterface
+    {
+        if (isset($this->handlersByKey[$key])) {
+            return $this->handlersByKey[$key];
+        }
+
+        if (!isset($this->logConfiguration['handlers']) || !isset($this->logConfiguration['handlers'][$key])) {
+            throw new \RuntimeException('Log handlers not found with key: ' . $key);
+        }
+
+        $this->handlersByKey[$key] = $this->instantiateItem(
+            $this->logConfiguration['handlers'][$key],
+            self::TYPE_HANDLER
+        );
+
+        return $this->handlersByKey[$key];
+    }
+
+    /**
+     * Instantiate item (formatter, processor, handler) from configuration
+     *
+     * @param array|string $item
+     * @param string $type
+     * @return array|mixed
+     */
+    private function instantiateItem($item, string $type)
+    {
+        $item = $this->unifyItemConfigurationFormat($item);
+
+        $arguments = $this->getArguments($item, $type);
+        $object = $this->objectInstantiator->createInstance($item['class'], $arguments);
+
+        if ($type === self::TYPE_HANDLER && isset($item['formatter'])) {
+            $object->setFormatter($this->getOrInstantiateFormatterByKey($item['formatter']));
+        }
+        if ($type === self::TYPE_HANDLER && isset($item['processors']) && is_array($item['processors'])) {
+            foreach ($item['processors'] as $processorKey) {
+                $object->pushProcessor($this->getOrInstantiateProcessorByKey($processorKey));
+            }
+        }
+
+        return $object;
+    }
+
+    /**
+     * Configuration of items can be done using string and array.
+     * Unify them to a constant array format
+     *
+     * @param array|string $item
+     * @return array
+     */
+    private function unifyItemConfigurationFormat($item): array
+    {
+        if (is_string($item)) {
+            $item = [ 'class' => $item ];
+        }
+
+        if (!is_array($item) || !isset($item['class'])) {
+            throw new \InvalidArgumentException('Cannot instantiate object for item of type: ' . gettype($item));
+        }
+
+        return $item;
+    }
+
+    /**
+     * Get arguments for constructor
+     *
+     * @param array $item
+     * @param string $type
+     * @return array
+     */
+    private function getArguments(array $item, string $type): array
+    {
+        $arguments = $item;
+        if ($type === self::TYPE_HANDLER) {
+            $arguments = $this->processHandlerArguments($arguments);
+        }
+
+        foreach (array_keys($arguments) as $argumentKey) {
+            if (substr($argumentKey, 0, 1) !== '@') {
+                continue;
+            }
+            $arguments[substr($argumentKey, 1)] = $this->instantiateItem(
+                $arguments[$argumentKey],
+                self::TYPE_OTHER
+            );
+            unset($arguments[$argumentKey]);
+        }
+
+        unset($arguments['class']);
+        return $arguments;
+    }
+
+    /**
+     * Handlers allow some specific arguments to be passed. Process them
+     *
+     * @param array $arguments
+     * @return array
+     */
+    private function processHandlerArguments(array $arguments): array
+    {
+        if (array_key_exists('handler', $arguments)) {
+            $arguments['handler'] = $this->getOrInstantiateHandlerByKey($arguments['handler']);
+        }
+        if (array_key_exists('handlers', $arguments) && is_array($arguments['handlers'])) {
+            $handlers = [];
+            foreach ($arguments['handlers'] as $handlerKey) {
+                $handlers[] = $this->getOrInstantiateHandlerByKey($handlerKey);
+            }
+            $arguments['handlers'] = $handlers;
+        }
+
+        unset($arguments['formatter']);
+        unset($arguments['processors']);
+
+        return $arguments;
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Configuration/LogConfigurationProviderInterface.php
+++ b/lib/internal/Magento/Framework/Logger/Configuration/LogConfigurationProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Configuration;
+
+use Monolog\Handler\HandlerInterface;
+
+/**
+ * Provides global logging Configuration (e.g. non channel specific)
+ */
+interface LogConfigurationProviderInterface
+{
+    /**
+     * Get Handler By Name
+     *
+     * @param string $key
+     * @return HandlerInterface
+     */
+    public function getHandlerByKey(string $key): HandlerInterface;
+
+    /**
+     * Get Processor By Name
+     *
+     * @param string $key
+     * @return object
+     */
+    public function getProcessorByKey(string $key);
+}

--- a/lib/internal/Magento/Framework/Logger/Configuration/ParsedChannelConfiguration.php
+++ b/lib/internal/Magento/Framework/Logger/Configuration/ParsedChannelConfiguration.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Configuration;
+
+/**
+ * Value object for parsed channel configuration
+ */
+class ParsedChannelConfiguration
+{
+    /**
+     * @var array
+     */
+    private $handlers;
+
+    /**
+     * @var array
+     */
+    private $processors;
+
+    /**
+     * ParsedChannelConfiguration constructor.
+     * @param array $handlers
+     * @param array $processors
+     */
+    public function __construct(array $handlers, array $processors)
+    {
+        $this->handlers = $handlers;
+        $this->processors = $processors;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHandlers(): array
+    {
+        return $this->handlers;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProcessors(): array
+    {
+        return $this->processors;
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Configuration/Utility/ObjectInstantiator.php
+++ b/lib/internal/Magento/Framework/Logger/Configuration/Utility/ObjectInstantiator.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Configuration\Utility;
+
+use Magento\Framework\App\ObjectManager;
+
+/**
+ * Object Instantiator
+ *
+ * Wrapper around static ObjectManager usage. Used where we cannot inject
+ * ObjectManager directly as the object instantiation is done before the
+ * ObjectManager is ready
+ */
+class ObjectInstantiator
+{
+    /**
+     * Create Object Instance
+     *
+     * @param string $class
+     * @param array $arguments
+     * @return mixed
+     */
+    public function createInstance(string $class, array $arguments = [])
+    {
+        return ObjectManager::getInstance()->create($class, $arguments);
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Logchannel.php
+++ b/lib/internal/Magento/Framework/Logger/Logchannel.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger;
+
+use Magento\Framework\Logger\Configuration\ChannelConfigurationParserInterface;
+use Monolog\Logger;
+
+/**
+ * Monolog instance specifically configured with a specific channel name and configuration
+ * Configuration is provided trough ChannelConfigurationParserInterface
+ *
+ * You should not instantiate this class directly. The preferred method is to include an instance of
+ * Magento\Framework\Logger\...Logchannel where the ... stand for the specific channel name.
+ * An example of this could be \Magento\Framework\Logger\MainLogchannel
+ *
+ * This class is used from \Magento\Framework\Logger\Code\Generator\Logchannel to generate specific Logchannel
+ * instances.
+ */
+class Logchannel extends Logger
+{
+    /**
+     * @var string
+     */
+    protected $channelName = 'main';
+
+    /**
+     * @var array
+     */
+    protected $channelConfiguration = [];
+
+    /**
+     * @param ChannelConfigurationParserInterface $channelConfigParser
+     */
+    public function __construct(ChannelConfigurationParserInterface $channelConfigParser)
+    {
+        $parsedConfiguration = $channelConfigParser->parseConfiguration($this->channelConfiguration);
+        parent::__construct(
+            $this->channelName,
+            $parsedConfiguration->getHandlers(),
+            $parsedConfiguration->getProcessors()
+        );
+    }
+
+    /**
+     * Adds a log record.
+     *
+     * @param integer $level The logging level
+     * @param string $message The log message
+     * @param array $context The log context
+     * @return Boolean Whether the record has been processed
+     */
+    public function addRecord($level, $message, array $context = [])
+    {
+        /**
+         * To preserve compatibility with Exception messages.
+         * And support PSR-3 context standard.
+         *
+         * @link http://www.php-fig.org/psr/psr-3/#context PSR-3 context standard
+         */
+        if ($message instanceof \Exception && !isset($context['exception'])) {
+            $context['exception'] = $message;
+        }
+
+        $message = $message instanceof \Exception ? $message->getMessage() : $message;
+
+        return parent::addRecord($level, $message, $context);
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Monolog.php
+++ b/lib/internal/Magento/Framework/Logger/Monolog.php
@@ -12,6 +12,8 @@ class Monolog extends Logger
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Use generated LogChannel instances (e.g. \Magento\Framework\Logger\MainMagentoLogchannel)
      */
     public function __construct($name, array $handlers = [], array $processors = [])
     {

--- a/lib/internal/Magento/Framework/Logger/Test/Unit/Configuration/ChannelConfigurationParserTest.php
+++ b/lib/internal/Magento/Framework/Logger/Test/Unit/Configuration/ChannelConfigurationParserTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Logger\Test\Unit\Configuration;
+
+use Magento\Framework\Logger\Configuration\ChannelConfigurationParser;
+use Magento\Framework\Logger\Configuration\LogConfigurationProviderInterface;
+use Monolog\Handler\TestHandler;
+use Monolog\Processor\UidProcessor;
+
+class ChannelConfigurationParserTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCorrectFetchingOfHandlersByKey()
+    {
+        $handler = new TestHandler();
+
+        $logConfigProvider = $this->createMock(LogConfigurationProviderInterface::class);
+        $logConfigProvider
+            ->method('getHandlerByKey')
+            ->with($this->equalTo('test'))
+            ->willReturn($handler);
+
+        $channelConfigParser = new ChannelConfigurationParser($logConfigProvider);
+
+        $parsedConfiguration = $channelConfigParser->parseConfiguration(
+            [
+                'handlers' => [ 'test' ]
+            ]
+        );
+
+        $this->assertCount(1, $parsedConfiguration->getHandlers());
+        $this->assertInstanceOf(TestHandler::class, $parsedConfiguration->getHandlers()[0]);
+    }
+
+    public function testCorrectFetchingOfProcessorsByKey()
+    {
+        $processor = new UidProcessor();
+
+        $logConfigProvider = $this->createMock(LogConfigurationProviderInterface::class);
+        $logConfigProvider
+            ->method('getProcessorByKey')
+            ->with($this->equalTo('uid'))
+            ->willReturn($processor);
+
+        $channelConfigParser = new ChannelConfigurationParser($logConfigProvider);
+
+        $parsedConfiguration = $channelConfigParser->parseConfiguration(
+            [
+                'processors' => [ 'uid' ]
+            ]
+        );
+
+        $this->assertCount(1, $parsedConfiguration->getProcessors());
+        $this->assertInstanceOf(UidProcessor::class, $parsedConfiguration->getProcessors()[0]);
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Test/Unit/Configuration/LogConfigurationProviderTest.php
+++ b/lib/internal/Magento/Framework/Logger/Test/Unit/Configuration/LogConfigurationProviderTest.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Test\Unit\Configuration;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Logger\Configuration\LogConfigurationProvider;
+use Magento\Framework\Logger\Configuration\Utility\ObjectInstantiator;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\HandlerInterface;
+
+class LogConfigurationProviderTest extends \PHPUnit\Framework\TestCase
+{
+    public function testInstantiationOfHandlerWithOnlyAClassName()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'handlers' => [
+                    'test' => 'TestHandler'
+                ]
+            ]
+        );
+
+        $testHandler = $this->createMock(HandlerInterface::class);
+
+        $objectInstantiator = $this->createMock(ObjectInstantiator::class);
+        $objectInstantiator
+            ->method('createInstance')
+            ->with($this->equalTo('TestHandler'))
+            ->willReturn($testHandler);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    public function testInstantiationOfProcessorWithOnlyAClassName()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'processors' => [
+                    'test' => 'TestProcessor'
+                ]
+            ]
+        );
+
+        $testProcessor = (object) [];
+
+        $objectInstantiator = $this->createMock(ObjectInstantiator::class);
+        $objectInstantiator
+            ->method('createInstance')
+            ->with($this->equalTo('TestProcessor'))
+            ->willReturn($testProcessor);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testProcessor),
+            spl_object_hash($logConfigProvider->getProcessorByKey('test')),
+            'Expected to get exact testProcessor back'
+        );
+    }
+
+    public function testSimpleConstructorArgumentInConfiguration()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'handlers' => [
+                    'test' => [
+                        'class' => 'TestHandler',
+                        'level' => 300
+                    ]
+                ]
+            ]
+        );
+
+        $testHandler = $this->createMock(HandlerInterface::class);
+
+        $objectInstantiator = $this->createObjectInstantiatorMock([
+            [$this->equalTo('TestHandler'), $this->equalTo(['level' => 300]), $testHandler]
+        ]);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    public function testObjectInstanceConstructorArgumentInConfiguration()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'handlers' => [
+                    'test' => [
+                        'class' => 'TestHandler',
+                        '@random' => [
+                            'class' => 'RandomObject'
+                        ]
+                    ]
+                ]
+            ]
+        );
+
+        $randomObject = (object)[];
+        $testHandler = $this->createMock(HandlerInterface::class);
+
+        $objectInstantiator = $this->createObjectInstantiatorMock([
+            [$this->equalTo('RandomObject'), null, $randomObject],
+            [$this->equalTo('TestHandler'), $this->equalTo(['random' => $randomObject]), $testHandler]
+        ]);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    public function testHandlerReferenceArgumentForHandlerInConfiguration()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'handlers' => [
+                    'test' => [
+                        'class' => 'TestHandler',
+                        'handler' => 'test2'
+                    ],
+                    'test2' => [
+                        'class' => 'RefHandler'
+                    ]
+                ]
+            ]
+        );
+
+        $refHandler = $this->createMock(HandlerInterface::class);
+        $testHandler = $this->createMock(HandlerInterface::class);
+
+        $objectInstantiator = $this->createObjectInstantiatorMock([
+            [$this->equalTo('RefHandler'), $this->equalTo([]), $refHandler],
+            [$this->equalTo('TestHandler'), $this->equalTo(['handler' => $refHandler]), $testHandler]
+        ]);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    public function testHandlersReferenceArgumentForHandlerInConfiguration()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'handlers' => [
+                    'test' => [
+                        'class' => 'TestHandler',
+                        'handlers' => ['test2', 'test3']
+                    ],
+                    'test2' => [
+                        'class' => 'RefHandler1'
+                    ],
+                    'test3' => [
+                        'class' => 'RefHandler2'
+                    ]
+                ]
+            ]
+        );
+
+        $refHandler1 = $this->createMock(HandlerInterface::class);
+        $refHandler2 = $this->createMock(HandlerInterface::class);
+        $testHandler = $this->createMock(HandlerInterface::class);
+
+        $objectInstantiator = $this->createObjectInstantiatorMock([
+            [$this->equalTo('RefHandler1'), $this->equalTo([]), $refHandler1],
+            [$this->equalTo('RefHandler2'), $this->equalTo([]), $refHandler2],
+            [$this->equalTo('TestHandler'), $this->equalTo(['handlers' => [$refHandler1, $refHandler2]]), $testHandler]
+        ]);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    public function testSetFormatterByFormatterReferenceForHandlerInConfiguration()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'formatters' => [
+                    'test' => [
+                        'class' => 'TestFormatter'
+                    ]
+                ],
+                'handlers' => [
+                    'test' => [
+                        'class' => 'TestHandler',
+                        'formatter' => 'test'
+                    ]
+                ]
+            ]
+        );
+
+        $testFormatter = $this->createMock(FormatterInterface::class);
+        $testHandler = $this->createMock(HandlerInterface::class);
+        $testHandler
+            ->expects($this->once())
+            ->method('setFormatter')
+            ->with($this->equalTo($testFormatter));
+
+        $objectInstantiator = $this->createObjectInstantiatorMock([
+            [$this->equalTo('TestFormatter'), $this->equalTo([]), $testFormatter],
+            [$this->equalTo('TestHandler'), $this->equalTo([]), $testHandler]
+        ]);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    public function testPushProcessorByProcessorsReferenceForHandlerInConfiguration()
+    {
+        $deploymentConfig = $this->createDeployConfigMock(
+            [
+                'processors' => [
+                    'test' => [
+                        'class' => 'TestProcessor'
+                    ],
+                    'test2' => [
+                        'class' => 'TestProcessor'
+                    ]
+                ],
+                'handlers' => [
+                    'test' => [
+                        'class' => 'TestHandler',
+                        'processors' => ['test', 'test2']
+                    ]
+                ]
+            ]
+        );
+
+        $testProcessor = (object)[];
+        $testHandler = $this->createMock(HandlerInterface::class);
+        $testHandler
+            ->expects($this->exactly(2))
+            ->method('pushProcessor')
+            ->with($this->equalTo($testProcessor));
+
+        $objectInstantiator = $this->createObjectInstantiatorMock([
+            [$this->equalTo('TestProcessor'), $this->equalTo([]), $testProcessor],
+            [$this->equalTo('TestHandler'), $this->equalTo([]), $testHandler]
+        ]);
+
+        $logConfigProvider = new LogConfigurationProvider($deploymentConfig, $objectInstantiator);
+
+        $this->assertEquals(
+            spl_object_hash($testHandler),
+            spl_object_hash($logConfigProvider->getHandlerByKey('test')),
+            'Expected to get exact testHandler back'
+        );
+    }
+
+    /**
+     * Create DeploymentConfig Mock
+     *
+     * logConfiguration is the configuration given back when get('logging') is called
+     *
+     * @param array $logConfiguration
+     * @return DeploymentConfig
+     */
+    private function createDeployConfigMock(array $logConfiguration)
+    {
+        $deploymentConfig = $this->createMock(DeploymentConfig::class);
+        $deploymentConfig
+            ->method('get')
+            ->with($this->equalTo('logging'))
+            ->willReturn($logConfiguration);
+
+        return $deploymentConfig;
+    }
+
+    /**
+     * Create ObjectInstantiator Mock
+     *
+     * The instanceConfigs follow the same pattern as returnValueMap but instead of comparing values
+     * use PHPUnit constraints. A null value for a constraint ignores that argument value
+     *
+     * Examples:
+     * [ $this->equalTo('Tester'), $this->equalTo([ 'level' => 300 ]), $testMock ]
+     * [ $this->equalTo('Tester'), null, $testMock ]
+     *
+     * @param array $instanceConfigs
+     * @return ObjectInstantiator
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function createObjectInstantiatorMock(array $instanceConfigs)
+    {
+        $objectInstantiator = $this->createMock(ObjectInstantiator::class);
+        $objectInstantiator
+            ->method('createInstance')
+            ->will($this->returnCallback(function (string $class, array $arguments = []) use ($instanceConfigs) {
+                foreach ($instanceConfigs as $instanceConfig) {
+                    if ($instanceConfig[0] !== null && !$instanceConfig[0]->evaluate($class, '', true)) {
+                        continue;
+                    }
+                    if ($instanceConfig[1] !== null && !$instanceConfig[1]->evaluate($arguments, '', true)) {
+                        continue;
+                    }
+                    return $instanceConfig[2];
+                }
+
+                throw new \RuntimeException(
+                    'Unexpected ObjectInstance: ' . var_export($class, true) . ' / ' . var_export($arguments, true)
+                );
+            }));
+
+        return $objectInstantiator;
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Test/Unit/LogchannelTest.php
+++ b/lib/internal/Magento/Framework/Logger/Test/Unit/LogchannelTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Logger\Test\Unit;
+
+use Magento\Framework\Logger\Configuration\ChannelConfigurationParserInterface;
+use Magento\Framework\Logger\Configuration\ParsedChannelConfiguration;
+use Magento\Framework\Logger\Logchannel;
+use Monolog\Handler\TestHandler;
+use Monolog\Processor\UidProcessor;
+
+class LogchannelTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCorrectHandlerAssigned()
+    {
+        $handler = new TestHandler();
+
+        $channelConfigParser = $this->createMock(ChannelConfigurationParserInterface::class);
+        $channelConfigParser
+            ->method('parseConfiguration')
+            ->willReturn(new ParsedChannelConfiguration([$handler], []));
+
+        $logger = new Logchannel($channelConfigParser);
+
+        $handlers = $logger->getHandlers();
+
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf(TestHandler::class, $handlers[0]);
+    }
+
+    public function testCorrectProcessorAssigned()
+    {
+        $processor = new UidProcessor();
+
+        $channelConfigParser = $this->createMock(ChannelConfigurationParserInterface::class);
+        $channelConfigParser
+            ->method('parseConfiguration')
+            ->willReturn(new ParsedChannelConfiguration([], [$processor]));
+
+        $logger = new Logchannel($channelConfigParser);
+
+        $processors = $logger->getProcessors();
+
+        $this->assertCount(1, $processors);
+        $this->assertInstanceOf(UidProcessor::class, $processors[0]);
+    }
+
+    /**
+     * @depends testCorrectHandlerAssigned
+     * @depends testCorrectProcessorAssigned
+     */
+    public function testAddRecord()
+    {
+        $handler = new TestHandler();
+
+        $channelConfigParser = $this->createMock(ChannelConfigurationParserInterface::class);
+        $channelConfigParser
+            ->method('parseConfiguration')
+            ->willReturn(new ParsedChannelConfiguration([$handler], []));
+
+        $logger = new Logchannel($channelConfigParser);
+
+        $logger->addError('test');
+        list($record) = $handler->getRecords();
+
+        $this->assertSame('test', $record['message']);
+    }
+
+    /**
+     * @depends testAddRecord
+     */
+    public function testAddRecordAsException()
+    {
+        $handler = new TestHandler();
+
+        $channelConfigParser = $this->createMock(ChannelConfigurationParserInterface::class);
+        $channelConfigParser
+            ->method('parseConfiguration')
+            ->willReturn(new ParsedChannelConfiguration([$handler], []));
+
+        $logger = new Logchannel($channelConfigParser);
+
+        $logger->addError(new \Exception('Some exception'));
+        list($record) = $handler->getRecords();
+
+        $this->assertInstanceOf(\Exception::class, $record['context']['exception']);
+        $this->assertSame('Some exception', $record['message']);
+    }
+}


### PR DESCRIPTION
The Magento Log setup is made so that it is similar to Magento 1. In the cases where you want to extend this functionality or change the way logging is configured you have to write a custom module.

This change makes it possible to add custom log channels and configuration in env.php without adding an extra module.

### Description
For multiple clients we implement custom logging, we do this now using a custom module as it requires changing preferences in the DI configuration.

This pull request introduces the possibility of configuring your log from `env.php`. It also implements the concept of log channels but in this initial version there is only one channel "main" as there was before.

The configuration of logging is done in the `logging` array key in `env.php`. The format is very close to a popular package called Monolog Cascade. Here is an example configuration:

```
'logging' => array(
    'formatters' => array(
        'only_extra' => array(
            'class' => '\Monolog\Formatter\LineFormatter',
            'format' => "[%datetime%] %channel%.%level_name%: %extra%\n"
        )
    ),    
    'handlers' => array(
        'system_group' => array(
            'class' => '\Monolog\Handler\GroupHandler',
            'handlers' => array('system', 'screen'),
            'formatter' => 'only_extra',
            'processors' => array('introspect')
        ),
        'system' => array(
            'class' => '\Magento\Framework\Logger\Handler\System'
        ),
        'screen' => array(
            'class' => '\Monolog\Handler\StreamHandler',
            'stream' => 'php://stderr',
            'level' => \Monolog\Logger::DEBUG
        ),
        'debug' => array(
            'class' => '\Magento\Framework\Logger\Handler\Debug'
        )
    ),
    'processors' => array(
        'uid' => '\Monolog\Processor\UidProcessor',
        'introspect' => array(
            'class' => '\Monolog\Processor\IntrospectionProcessor',
            'level' => \Monolog\Logger::DEBUG
        )
    ),
    'channels' => array(
        'main' => array(
            'handlers' => array('system_group', 'debug'),
            'processors' => array('uid')
        )
    )
),
```
**formatters**, **handlers** and **processors** are all configuration items for there respectable types. The array keys of each item are also they keys/identifiers they can be mapped with. Every item in those type arrays can either be an string which is then interpreted as a class name (example: `'uid' => '\Monolog\Processor\UidProcessor'` and loaded from DI or an array.

This array has one required key and that is `class`. This is the class name that should be instantiated. This instantiation is done trough the ObjectManager so preferences are correctly used. The rest of the values are as-is passed to the constructor. With the exception of the following keys:

* `class`: Contains the class name.
* `handlers` (only for handlers): Every item in the array is looked up from the list of defined handlers by there key name. 
* `handler` (only for handlers): The corresponding handler is resolved by the given key name
* `processors` (only for handlers): The corresponding processor is loaded by the given key name. Processors are added after instantiation to the handler with `pushProcessor`.
* `formatter` (only for handlers): The corresponding formatter is resolved by the given key name.
* Every key that starts with `@` is seen as a class instantiation. The allowed values are a string with a class name or an array that contains the `class` key with optional other constructor arguments. When given as a constructor argument the `@` character is stripped of.

**channels** contain the different channel configurations. The default channel is called `main`. A channel can contain a list of handlers and processors. 

With code generation it is automatically possible to load a LoggerInterface for a specific channel. An example of this is `Magento\Framework\Logger\MainLogchannel` that gives a logger for the `main` channel or `Magento\Framework\Logger\DatabaseLogchannel` that will give a logger for the `database` channel. 

When a channel is requested that is not available in the channel configuration will give an instance of `\Magento\Framework\Logger\Monolog` for backwards compatibility. 

### Manual testing scenarios
1. Clear all generated files, etc. On `cache:flush` it should trigger some log lines as it clears some keys. 
2. Add the given configuration above to `env.php` and again clear all generated files. On `cache:flush` it not only should still write to the original files but also show some log lines on the screen containing a random `uid` (from the `UidProcessor`) and without any message due to the format in the configured `LineFormatter`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
