### PR TITLE
Making possible to define configuration by environment

### DIFF
--- a/lib/internal/Magento/Framework/Config/File/ConfigFilePool.php
+++ b/lib/internal/Magento/Framework/Config/File/ConfigFilePool.php
@@ -13,6 +13,7 @@ namespace Magento\Framework\Config\File;
 class ConfigFilePool
 {
     const APP_CONFIG = 'app_config';
+    const APP_CONFIG_ENV = 'app_config_env';
     const APP_ENV = 'app_env';
 
     /**
@@ -32,6 +33,7 @@ class ConfigFilePool
      */
     private $applicationConfigFiles = [
         self::APP_CONFIG => 'config.php',
+        self::APP_CONFIG_ENV => 'config_env.php',
         self::APP_ENV => 'env.php',
     ];
 

--- a/lib/internal/Magento/Framework/Config/Test/Unit/File/ConfigFilePoolTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/File/ConfigFilePoolTest.php
@@ -27,6 +27,7 @@ class ConfigFilePoolTest extends \PHPUnit\Framework\TestCase
     {
         $expected['new_key'] = 'new_config.php';
         $expected[ConfigFilePool::APP_CONFIG] = 'config.php';
+        $expected[ConfigFilePool::APP_CONFIG_ENV] = 'config_env.php';
         $expected[ConfigFilePool::APP_ENV] = 'env.php';
 
         $this->assertEquals($expected, $this->configFilePool->getPaths());


### PR DESCRIPTION
### Description

Add new file `config_env.php` into the config pool:

* `config_env.php` can be in VCS and add specific configurations by environment. This file updates values in `config.php` but `env.php` has still the highest priority

Add `CONFIG_ENV_MODE` in `env.php` to be able to specify the system environment:
* `CONFIG_ENV_MODE` can be set into the `env.php` to specify the config environment mode to load the config settings.

### Fixed Issues

The new deployment pipeline added on 2.2 makes possible to propagate configuration to a live server. However, that introduces new issues as it is not possible to specify such configuration by environment. See following example:

**Situation**
* On `config.php` we specify `dev/js/merge_files = 1` and `dev/css/merge_css_files = 1`
* We need that on `config.php` because is the only configuration file under VCS and same configuration is needed on the `build` system.
* That works great on our `build` and `PROD` environments as they need same configuration

**Problem**
* If I install the project locally, I do not want the files to be merged.
* As this configuration is now present on `config.php` the only way to modify that on my local is by manually adding the corresponding configuration on `env.php`.
* Imho it is a big limitation that the only way to do that is by manually editing the `env.php` (or executing command `config:set --lock path value`)
    * `env.php` is not in VCS, so you need to manually edit the `env.php` every time you install a project locally
    * Working on a team, if someone adds changes on `config.php` for production and build server. He has no way to add the corresponding for local env to ensure that those changes will not break the local installations of his colleagues. For example enabling varnish cache on `config.php`. Next time the other developers checkout the latest version of the project, it will break their local installation as they do not have Varnish.

**Alternatives Solutions that do not work**
Discussing that in Slack, Anton Kril suggested to use condition statements inside `config.php` that  return different configurations depending on `env` variables. Although that works, these statements are gone as soon as you execute any command that edits the `config.php`. That is the case for `app:config:dump` or `module:disable/enable`. Because of that, it is not possible to properly maintain those condition statements inside `config.php`. 

### Manual testing scenarios

These changes allow keeping configuration by environment like that:

Possible to define in `env.php` type of environment for config settings
```
<?php
# etc/env.php
return array(
//...  
'CONFIG_ENV_MODE' => 'LOCAL',
//...
);
```

Use environment type inside `config_env.php` to overwrite default settings in `config.php`
```
<?php
# etc/config_env.php
$config = [];

if (strtoupper(getenv('CONFIG_ENV_MODE')) == 'LOCAL') {
    $configLocal = array(
        'system' =>
            array(
                'default' =>
                    array(
                        'dev' =>
                            array(
                                'js' =>
                                    array(
                                        'merge_files' => '0',
                                    ),
                                'css' =>
                                    array(
                                        'merge_css_files' => '0',
                                    ),
                                'static' =>
                                    array(
                                        'sign' => '0',
                                    ),
                            ),
                        # Disable Varnish
                        'system' =>
                            array(
                                'full_page_cache' =>
                                    array(
                                        'caching_application' => '1',
                                    ),
                            ),
                    ),
            ),
    );
    $config = array_replace_recursive($config, $configLocal);
}

if (in_array(strtoupper(getenv('CONFIG_ENV_MODE')), ['LOCAL', 'JENKINS'])) {
    $configLocal = array(
        'modules' =>
            array (
                'TddWizard_Fixtures' => 1,
            ),
    );
    $config = array_replace_recursive($config, $configLocal);
}

return $config;
```

As you can see in this example, thanks to that, we can assure that all developers will have `merge_files = 0` and `TddWizard_Fixtures` module enabled on their local environments. That modifies the `config.php` which is meant for `PROD` and `BUILD` systems but it is shared among all environments.

```
<?php
# etc/config_php
return array(
    'modules' =>
        array(
          //....
           'TddWizard_Fixtures' => 0,
          //...
         ),
     'system' =>
            array(
                'default' =>
                    array(
                        'dev' =>
                            array(
                                'js' =>
                                    array(
                                        'merge_files' => '1',
                                    ),
                                'css' =>
                                    array(
                                        'merge_css_files' => '1',
                                    ),
                                'static' =>
                                    array(
                                        'sign' => '1',
                                    ),
                            ),
                    ),
            ),
);
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
