### PR TITLE
[Backport for 2.1 of #9904] #8069: Saving Category with existing imag…

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -53,6 +53,11 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     private $imageUploader;
 
     /**
+     * @var string
+     */
+    private $additionalData = '_additional_data_';
+
+    /**
      * Image constructor.
      *
      * @param \Psr\Log\LoggerInterface $logger
@@ -80,9 +85,9 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     {
         $attributeName = $this->getAttribute()->getName();
         $value = $object->getData($attributeName);
-        $imageName = $this->getUploadedImageName($value);
 
-        if ($imageName) {
+        if ($imageName = $this->getUploadedImageName($value)) {
+            $object->setData($this->additionalData . $attributeName, $value);
             $object->setData($attributeName, $imageName);
         } else if (!is_string($value)) {
             $object->setData($attributeName, '');
@@ -125,15 +130,27 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     }
 
     /**
-     * Save uploaded file and set its name to category.
+     * Check if temporary file is available for new image upload.
+     *
+     * @param array $value
+     * @return bool
+     */
+    private function isTmpFileAvailable($value)
+    {
+        return is_array($value) && isset($value[0]['tmp_name']);
+    }
+
+    /**
+     * Save uploaded file and set its name to category
      *
      * @param \Magento\Framework\DataObject $object
      * @return \Magento\Catalog\Model\Category\Attribute\Backend\Image
      */
     public function afterSave($object)
     {
-        $imageName = $object->getData($this->getAttribute()->getName(), null);
-        if ($imageName) {
+        $value = $object->getData($this->additionalData . $this->getAttribute()->getName());
+
+        if ($this->isTmpFileAvailable($value) && $imageName = $this->getUploadedImageName($value)) {
             try {
                 $this->getImageUploader()->moveFileFromTmp($imageName);
             } catch (\Exception $e) {

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -164,7 +164,8 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
         $object = new \Magento\Framework\DataObject(
             [
-                'test_attribute' => 'test1234.jpg'
+                'test_attribute' => 'test1234.jpg',
+                '_additional_data_test_attribute' => [['name' => 'test1234.jpg', 'tmp_name' => 'test-test-1234']]
             ]
         );
         $model->afterSave($object);
@@ -207,7 +208,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($exception));
         $object = new \Magento\Framework\DataObject(
             [
-                'test_attribute' => 'test1234.jpg'
+                '_additional_data_test_attribute' => [['name' => 'test1234.jpg', 'tmp_name' => 'test-test-1234']]
             ]
         );
         $model->afterSave($object);


### PR DESCRIPTION
### Description
Exception triggered every time a category that has an image is saved.
This PR is backport of #9904

### Fixed Issues
1. magento/magento2#8069: Saving Category with existing image causes an exception

### Manual testing scenarios
1. Create a new category an add an image
2. Edit category and save, without change any attributes
3. Observer logs

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
