### PR TITLE
CASE in select broken the collection query

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -574,7 +574,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
             $fullExpression = str_replace('{{' . $attributeItem . '}}', $attrField, $fullExpression);
         }
 
-        $this->getSelect()->columns([$alias => $fullExpression]);
+        $this->getSelect()->columns([$alias => new \Zend_Db_Expr($fullExpression)]);
 
         $this->_joinFields[$alias] = ['table' => false, 'field' => $fullExpression];
 


### PR DESCRIPTION
addExpressionAttributeToSelect result in SQL statement error if we send CASE statement to it. Added Zend_Db_Expr to escape that.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Online to escape adding back tick incase of SELECT statement with CASE in there.  

### Fixed Issues (if relevant)
I don't thinks there are open issues

### Manual testing scenarios
1. Create product collection object and add a CASE statement in the that using addExpressionToSelect will result in query error.
