### PR TITLE
Dissociate data and schema version

### DIFF
--- a/lib/internal/Magento/Framework/Module/Declaration/Converter/Dom.php
+++ b/lib/internal/Magento/Framework/Module/Declaration/Converter/Dom.php
@@ -32,6 +32,19 @@ class Dom implements \Magento\Framework\Config\ConverterInterface
                 throw new \Exception("Attribute 'setup_version' is missing for module '{$name}'.");
             }
             $moduleData['setup_version'] = $versionNode->nodeValue;
+
+            $schemaVersionNode = $moduleAttributes->getNamedItem('schema_version');
+
+            if ($schemaVersionNode !== null) {
+                $moduleData['schema_version'] = $schemaVersionNode->nodeValue;
+            }
+
+            $dataVersionNode = $moduleAttributes->getNamedItem('data_version');
+
+            if ($dataVersionNode !== null) {
+                $moduleData['data_version'] = $dataVersionNode->nodeValue;
+            }
+
             $moduleData['sequence'] = [];
             /** @var $childNode \DOMNode */
             foreach ($moduleNode->childNodes as $childNode) {

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -843,7 +843,8 @@ class Installer
         $moduleContextList = $this->generateListOfModuleContext($resource, $verType);
         foreach ($moduleNames as $moduleName) {
             $this->log->log("Module '{$moduleName}':");
-            $configVer = $this->moduleList->getOne($moduleName)['setup_version'];
+            $module = $this->moduleList->getOne($moduleName);
+            $configVer = (isset($module[$type . '_version'])) ? $module[$type . '_version'] : $module['setup_version'];
             $currentVersion = $moduleContextList[$moduleName]->getVersion();
             // Schema/Data is installed
             if ($currentVersion !== '') {


### PR DESCRIPTION
### Description
Adding ability to use different version for data and schema parts (see…setup_module table).
In current version, Magento use setup_version for these two different versions (data and schema) in setup_module table.

### Manual testing scenarios
Create a module with following module.xml file :

```<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
    <module name="Synolia_Example" data_version="1.0.0" schema_version="1.0.5">
    </module>
</config>
```

Obviously, this code still work:
```<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
    <module name="Synolia_Example" setup_version="1.0.0">
    </module>
</config>
```
Maybe it's unnecessary but if so, we don't undestand the purpose of two colums in setup_module table (maybe Magento 1 residue ? ;-)).

Thanx in advance.

Josselin

