### PR TITLE
Update CAPTCHA labels to reflect the symbols in the CAPTCHA image

### DIFF
--- a/app/code/Magento/Captcha/i18n/en_US.csv
+++ b/app/code/Magento/Captcha/i18n/en_US.csv
@@ -4,10 +4,10 @@ Always,Always
 "Incorrect CAPTCHA","Incorrect CAPTCHA"
 "Incorrect CAPTCHA.","Incorrect CAPTCHA."
 "The account is locked. Please wait and try again or contact %1.","The account is locked. Please wait and try again or contact %1."
-"Please enter the letters from the image","Please enter the letters from the image"
+"Please enter the letters and numbers from the image","Please enter the letters and numbers from the image"
 "<strong>Attention</strong>: Captcha is case sensitive.","<strong>Attention</strong>: Captcha is case sensitive."
 "Reload captcha","Reload captcha"
-"Please type the letters below","Please type the letters below"
+"Please type the letters and numbers below","Please type the letters and numbers below"
 "Attention: Captcha is case sensitive.","Attention: Captcha is case sensitive."
 CAPTCHA,CAPTCHA
 "Enable CAPTCHA in Admin","Enable CAPTCHA in Admin"

--- a/app/code/Magento/Captcha/view/adminhtml/templates/default.phtml
+++ b/app/code/Magento/Captcha/view/adminhtml/templates/default.phtml
@@ -13,7 +13,7 @@ $captcha = $block->getCaptchaModel();
 ?>
 <div class="admin__field _required">
     <label for="captcha" class="admin__field-label">
-        <span><?= $block->escapeHtml(__('Please enter the letters from the image')) ?></span>
+        <span><?= $block->escapeHtml(__('Please enter the letters and numbers from the image')) ?></span>
     </label>
     <div class="admin__field-control">
         <input

--- a/app/code/Magento/Captcha/view/frontend/templates/default.phtml
+++ b/app/code/Magento/Captcha/view/frontend/templates/default.phtml
@@ -12,7 +12,7 @@
 $captcha = $block->getCaptchaModel();
 ?>
 <div class="field captcha required" role="<?= $block->escapeHtmlAttr($block->getFormId()) ?>">
-    <label for="captcha_<?= $block->escapeHtmlAttr($block->getFormId()) ?>" class="label"><span><?= $block->escapeHtml(__('Please type the letters below')) ?></span></label>
+    <label for="captcha_<?= $block->escapeHtmlAttr($block->getFormId()) ?>" class="label"><span><?= $block->escapeHtml(__('Please type the letters and numbers below')) ?></span></label>
     <div class="control captcha">
         <input name="<?= $block->escapeHtmlAttr(\Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE) ?>[<?= $block->escapeHtmlAttr($block->getFormId()) ?>]" type="text" class="input-text required-entry" data-validate="{required:true}" id="captcha_<?= $block->escapeHtmlAttr($block->getFormId()) ?>" />
         <div class="nested">
@@ -23,7 +23,7 @@ $captcha = $block->getCaptchaModel();
                                             "imageLoader": "<?= $block->escapeUrl($block->getViewFileUrl('images/loader-2.gif')) ?>",
                                              "type": "<?= $block->escapeHtmlAttr($block->getFormId()) ?>"}}'>
                 <div class="control captcha-image">
-                    <img alt="<?= $block->escapeHtmlAttr(__('Please type the letters below')) ?>" class="captcha-img" height="<?= /* @noEscape */ (float) $block->getImgHeight() ?>" src="<?= $block->escapeUrl($captcha->getImgSrc()) ?>"/>
+                    <img alt="<?= $block->escapeHtmlAttr(__('Please type the letters and numbers below')) ?>" class="captcha-img" height="<?= /* @noEscape */ (float) $block->getImgHeight() ?>" src="<?= $block->escapeUrl($captcha->getImgSrc()) ?>"/>
                     <button type="button" class="action reload captcha-reload" title="<?= $block->escapeHtmlAttr(__('Reload captcha')) ?>"><span><?= $block->escapeHtml(__('Reload captcha')) ?></span></button>
                 </div>
             </div>

--- a/app/code/Magento/Captcha/view/frontend/web/template/checkout/captcha.html
+++ b/app/code/Magento/Captcha/view/frontend/web/template/checkout/captcha.html
@@ -6,7 +6,7 @@
 -->
 <!-- ko if: (isRequired() && getIsVisible())-->
 <div class="field captcha required" data-bind="blockLoader: getIsLoading()">
-    <label data-bind="attr: {for: 'captcha_' + formId}" class="label"><span data-bind="i18n: 'Please type the letters below'"></span></label>
+    <label data-bind="attr: {for: 'captcha_' + formId}" class="label"><span data-bind="i18n: 'Please type the letters and numbers below'"></span></label>
     <div class="control captcha">
         <input name="captcha_string" type="text" class="input-text required-entry" data-bind="value: captchaValue(), attr: {id: 'captcha_' + formId, 'data-scope': dataScope}" />
         <input name="captcha_form_id" type="hidden" data-bind="value: formId,  attr: {'data-scope': dataScope}" />
@@ -14,7 +14,7 @@
             <div class="field captcha no-label">
                 <div class="control captcha-image">
                     <img data-bind="attr: {
-                                        alt: $t('Please type the letters below'),
+                                        alt: $t('Please type the letters and numbers below'),
                                         height: imageHeight(),
                                         src: getImageSource(),
                                         }"


### PR DESCRIPTION
### Description
The text labels referring to the CAPTCHA image only refer to letters, when there are also numbers in the CAPTCHA images.  Meaning the instruction to the user is ambiguous.  The message implies to NOT enter the numbers, thus the CAPTCHA doesn't match.

I've changed the labels in a few places and updated the dictionary file

### Manual testing scenarios
1. As a customer visit the sign-in page and enter the wrong password for the same email address several times until the captcha image & label appears
2. As a merchant visit the admin login page and enter the wrong password for the same user account several times until the captcha image & label appears
3. Install a language pack which includes a dictionary key for the new phrases, change the language of the store and repeat steps 1 & 2 ensuring the phrases appear in their translated forms.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
