### PR TITLE
Infinite redirect issue for admin : Resolved

### DIFF
--- a/app/code/Magento/Backend/Controller/Adminhtml/Auth/Login.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Auth/Login.php
@@ -44,7 +44,16 @@ class Login extends \Magento\Backend\Controller\Adminhtml\Auth
             }
             return $this->getRedirect($this->_backendUrl->getStartupPageUrl());
         }
-
+        
+        return $this->resultPageFactory->create();
+        
+        /** 
+         * No need to check further here as this will never pass because
+         * 1) Magento\Backend\App\Action\Plugin\Authentication::_processNotLoggedInUser is redirecting user to adminhtml/auth/login and here we cant compare this with adminhtml/index/index
+         * 2) refreshed ACL URL key will always change
+         */
+        
+        /*
         $requestUrl = $this->getRequest()->getUri();
         $backendUrl = $this->getUrl('*');
         // redirect according to rewrite rule
@@ -53,6 +62,7 @@ class Login extends \Magento\Backend\Controller\Adminhtml\Auth
         } else {
             return $this->resultPageFactory->create();
         }
+        */
     }
 
     /**


### PR DESCRIPTION
Resolution for Infinite redirect issue for admin

<!--- Provide a general summary of the Pull Request in the Title above -->

Magento2 Admin having a Redirect Loop Issue because of compassion again with different URLs 
so this is not going to pass with this compassion
we already have a check for login & refresh ACL on Magento\Backend\App\Action\Plugin\Authentication::_processNotLoggedInUser
so here we do not need any further compassion for URLs 

also Magento\Backend\App\Action\Plugin\Authentication::_processNotLoggedInUser
will always redirect User to URL: **adminhtml/auth/login** 
and in this action, we are comparing this with **adminhtml/index/index** 

in this action, we just need a login check that is already there on the top of it 

<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11355: Infinite redirects in magento

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. cache clear 
2. compile & deployed 
3. successful login into admin 
4. successfully add a new product & customer etc.

### Contribution checklist

 Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
