### PR TITLE
Attribute with "Catalog Input Type for Store Owner" equal "Fixed Product Tax" for Multi-store

### DIFF
--- a/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Manager/Website.php
+++ b/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Manager/Website.php
@@ -68,7 +68,7 @@ class Website
         if ($storeId = $this->locator->getStore()->getId()) {
             /** @var WebsiteInterface $website */
             $website = $this->storeManager->getStore($storeId)->getWebsite();
-            $websites[$website->getId()] = [
+            $websites[] = [
                 'value' => $website->getId(),
                 'label' => $this->formatLabel(
                     $website->getName(),
@@ -81,7 +81,7 @@ class Website
                 if (!in_array($website->getId(), $product->getWebsiteIds())) {
                     continue;
                 }
-                $websites[$website->getId()] = [
+                $websites[] = [
                     'value' => $website->getId(),
                     'label' => $this->formatLabel(
                         $website->getName(),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Attribute with "Catalog Input Type for Store Owner" equal "Fixed Product Tax" did not work correctly for multi-stores.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12393: Attribute with "Catalog Input Type for Store Owner" equal "Fixed Product Tax" for Multi-store

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create two websites website1 (website_id = 1),  website2 (website_id =2)
2. Create new product SKU=product1 and check for "Product in Websites" only website2. 
3. Create new product attribute "attribute1" with "Catalog Input Type for Store Owner" equal "Fixed Product Tax".
4. Assign attribute1 to default attribute set.
5. Open product "product1" and find attribute1 and click the button "add" near "attribute1".

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
