### PR TITLE
Added missing dependencies of the Magento_Config module.

### DIFF
--- a/app/code/Magento/Config/etc/module.xml
+++ b/app/code/Magento/Config/etc/module.xml
@@ -6,5 +6,16 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Config" setup_version="2.0.0"/>
+    <module name="Magento_Config" setup_version="2.0.0">
+        <sequence>
+            <module name="Magento_Backend"/>
+            <module name="Magento_Cron"/>
+            <module name="Magento_Deploy"/>
+            <module name="Magento_Directory"/>
+            <module name="Magento_Email"/>
+            <module name="Magento_MediaStorage"/>
+            <module name="Magento_Store"/>
+            <module name="Magento_User"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
### Description
This was discovered in scope of https://github.com/magento/magento2/issues/12405 (which I closed because the initial post didn't contain the correct steps to reproduce, the correct ones are listed below).

I took the liberty of including more then only the `Magento_Store` module in the dependencies, because the `Magento_Config` module uses 8 other modules, so I think they should all be defined. These are the same dependencies as defined in the [`composer.json` file](https://github.com/magento/magento2/blob/2.2.1/app/code/Magento/Config/composer.json#L7-L13), but the `composer.json` file doesn't list `Magento_User`. This is I think correct, since `Magento_User` is only used in the tests. So it shouldn't be a hard dependency in the `composer.json` file, but still needs to be included in the `module.xml` file I think?

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/12405: Magento 2.2.1 - Impossible to create a new storeview

### Manual testing scenarios
1. Setup a clean Magento 2.2.1
2. Install https://github.com/baldwin-agency/magento2-module-less-js-compiler
3. After running `setup:upgrade` check your `app/etc/config.php` file, it will have `Magento_Config` as a higher priority to load then `Magento_Store`
4. Login into the backend
5. Go to Stores => All Stores
6. Click 'Create Store View'
7. Enter some dummy content in the fields and click 'Save Store View'
8. An error `Requested store is not found` is shown and no storeview is added.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
