### PR TITLE
Fix Configurable attribute options are not sorted #7441

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
@@ -81,6 +81,10 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
                 ]
             ),
             []
+        )->joinInner(
+            ['attribute_opt' => $this->attributeResource->getTable('eav_attribute_option')],
+            'attribute_opt.option_id = entity_value.value',
+            []
         )->joinLeft(
             ['attribute_label' => $this->attributeResource->getTable('catalog_product_super_attribute_label')],
             implode(
@@ -97,6 +101,8 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
         )->where(
             'attribute.attribute_id = ?',
             $superAttribute->getAttributeId()
+        )->order(
+            'attribute_opt.sort_order ASC'
         );
 
         if (!$superAttribute->getSourceModel()) {


### PR DESCRIPTION
Bugfix for #7441 - Configurable attribute options are not sorted

**Steps to reproduce**
Create a configurable attribute and add two options at least.
Create a configurable product for these options.
Go to the product page and see the configurable attribute select (options).
Change attribute options sort order and flush all caches.
Go to the product page and see the configurable attribute select (options) looks like before.

**Expected result:**

Configurable options HAVE been reordered.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
