### PR TITLE
Fixed missing 'size' and 'type' props on a third-party category images [Backport 2.2]

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/DataProvider.php
+++ b/app/code/Magento/Catalog/Model/Category/DataProvider.php
@@ -494,8 +494,8 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
 
                     $categoryData[$attributeCode][0]['name'] = $fileName;
                     $categoryData[$attributeCode][0]['url'] = $category->getImageUrl($attributeCode);
-                    $categoryData['image'][0]['size'] = isset($stat) ? $stat['size'] : 0;
-                    $categoryData['image'][0]['type'] = $mime;
+                    $categoryData[$attributeCode][0]['size'] = isset($stat) ? $stat['size'] : 0;
+                    $categoryData[$attributeCode][0]['type'] = $mime;
                 }
             }
         }


### PR DESCRIPTION
### Description
This PR is a cherry pick of https://github.com/magento/magento2/commit/3541d8d87e414fec2bb6502aeb4501110415dcb4
Original PR: https://github.com/magento/magento2/pull/11541

### Description
Fixes hardcoded 'image' key when processing `ImageBackendModel` attribute.

### Manual testing scenarios
1. In order to test the issue, you need to create custom `ImageBackendModel` attribute and add it to the category edit form
    1. This is a code to create an attribute. You can use it in any action without writing an upgrade:

        ```php
        $setup = $this->_objectManager->get(\Magento\Framework\Setup\ModuleDataSetupInterface::class);
        $categorySetupFactory = $this->_objectManager->get(\Magento\Catalog\Setup\CategorySetupFactory::class);
        $setup->startSetup();
        $categorySetup = $categorySetupFactory->create(['setup' => $setup]);
        $categorySetup->addAttribute(
            \Magento\Catalog\Model\Category::ENTITY,
            'thumbnail_test',
            [
                'type' => 'varchar',
                'label' => 'Thumbnail test',
                'input' => 'image',
                'backend' => 'Magento\Catalog\Model\Category\Attribute\Backend\Image',
                'required' => false,
                'sort_order' => 4,
                'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_STORE,
                'group' => 'General Information',
            ]
        );
        $setup->endSetup();
        ```

    2. Add this code to `Magento/Catalog/view/adminhtml/ui_component/category_form.xml` above the image field:

        ```xml
        <field name="thumbnail_test" sortOrder="30" formElement="fileUploader">
            <argument name="data" xsi:type="array">
                <item name="config" xsi:type="array">
                    <item name="source" xsi:type="string">category</item>
                </item>
            </argument>
            <settings>
                <elementTmpl>ui/form/element/uploader/uploader</elementTmpl>
                <dataType>string</dataType>
                <label translate="true">Category Thumbnail</label>
                <visible>true</visible>
                <required>false</required>
            </settings>
            <formElements>
                <fileUploader>
                    <settings>
                        <required>false</required>
                        <uploaderConfig>
                            <param xsi:type="url" name="url" path="catalog/category_image/upload"/>
                        </uploaderConfig>
                        <previewTmpl>Magento_Catalog/image-preview</previewTmpl>
                    </settings>
                </fileUploader>
            </formElements>
        </field>
        ```
2. Upload third-party image (leave the image field empty) and save category
3. Third-party image will not have required 'size' and 'type' properties during page rendering.
    The main image will have 'size' and 'type' properties of third-party image:

    ![image](https://user-images.githubusercontent.com/306080/31758503-686b1e50-b4b6-11e7-9549-187009094d32.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

