### PR TITLE
[FIX] Magento_Ui: Return empty string when the given date column is undefined

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -37,8 +37,14 @@ define([
          * @returns {String} Formatted date.
          */
         getLabel: function (value, format) {
-            var date = moment(this._super());
+            var superValue = this._super(),
+                date;
 
+            if (superValue === undefined) {
+                return '';
+            }
+
+            date = moment(superValue);
             date = date.isValid() && value[this.index] ?
                 date.format(format || this.dateFormat) :
                 '';


### PR DESCRIPTION

### Description
Return empty string when the given date column is undefined in a grid

### Fixed Issues (if relevant)
1. magento/magento2#12461: Undefined Date Columns in Grid Default to current date / time

### Manual testing scenarios
1. Select a date column that has undefined values in a grid
2. Verify that undefined values are showing up as empty string and not the current date and time

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)