### PR TITLE
Category page X-Magento-Tags headers contains product cache identities even which category display mode is set to "Static block only"

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -334,13 +334,21 @@ class ListProduct extends AbstractProduct implements IdentityInterface
     public function getIdentities()
     {
         $identities = [];
-        foreach ($this->_getProductCollection() as $item) {
-            $identities = array_merge($identities, $item->getIdentities());
-        }
+
         $category = $this->getLayer()->getCurrentCategory();
         if ($category) {
             $identities[] = Product::CACHE_PRODUCT_CATEGORY_TAG . '_' . $category->getId();
         }
+
+        //Check if category page shows only static block (No products)
+        if ($category->getData('display_mode') == Category::DM_PAGE) {
+            return $identities;
+        }
+
+        foreach ($this->_getProductCollection() as $item) {
+            $identities = array_merge($identities, $item->getIdentities());
+        }
+
         return $identities;
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ListProductTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ListProductTest.php
@@ -192,7 +192,7 @@ class ListProductTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($this->toolbarMock));
 
         $this->assertEquals(
-            [$productTag, $categoryTag],
+            [$categoryTag, $productTag],
             $this->block->getIdentities()
         );
         $this->assertEquals(


### PR DESCRIPTION
## Description
When varnish is selected as the cache engine, If there are products associated to a respective category, and the category `display mode` is set to `Static block only`, on the category page `X-Magento-Tags` headers contains product item cache identities even when no product is displayed for the page.

<img width="927" alt="screenshot_2" src="https://user-images.githubusercontent.com/2647377/33316624-930ef2f8-d45a-11e7-8b2c-515a199f632b.png">

This PR will:

- Prevent the `Magento\Catalog\Model\Product::CACHE_TAG` cache identities to be generated if the category page `Display Mode` is set to `Static block only`

<img width="846" alt="screenshot_3" src="https://user-images.githubusercontent.com/2647377/33316733-fc98de1e-d45a-11e7-91b6-0097434f2ebb.png">


## Fixed Issues (if relevant)

None, code improvement

## Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds on Travis CI are green)