### PR TITLE
WYSIWYG JS - Directive URL not always properly detected #7167

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -461,10 +461,10 @@ define([
         decodeDirectives: function (content) {
             // escape special chars in directives url to use it in regular expression
             var url = this.makeDirectiveUrl('%directive%').replace(/([$^.?*!+:=()\[\]{}|\\])/g, '\\$1'),
-                reg = new RegExp(url.replace('%directive%', '([a-zA-Z0-9,_-]+)'));
+                reg = new RegExp(url.replace('%directive%', '([a-zA-Z0-9%,_-]+)'));
 
             return content.gsub(reg, function (match) { //eslint-disable-line no-extra-bind
-                return Base64.mageDecode(match[1]);
+                return Base64.mageDecode(decodeURIComponent(match[1]));
             });
         },
 


### PR DESCRIPTION
WYSIWYG JS - Directive URL not always properly detected

See issue #7167

### Description

When the CMS WYSIWYG Editor inserts a new image from the media browser, the server will return the image path not as ``{{media url=""}}`` but as a directive url for showing the correct preview image.

The actual ``{{media url=""}}``-directive is encoded within that URL and gets extracted by JavaScript upon change.



The issue here, sometimes the encoded directive includes special characters which are getting url encoded by the call to ``$this->_backendData->getUrl()`` in ``\Magento\Cms\Helper\Wysiwyg\Images::getImageHtmlDeclaration()`` end result in a finals string containing url encoded characters (e.g.  "pwZyJ9fQ,," => "pwZyJ9fQ%2C%2C")

Those URLs are note detected by the ``decodeDirectives()``



### Fixed Issues (if relevant)

1. magento/magento2#7167: 2.2.0-dev - cms images are being added as __directive for path


### Manual testing scenarios

Upload a file such as "downloads.jpg" to your media browser and place it on a cms page and save.
The full ___directive URL is saved as content and also visible to the frontend.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
