### PR TITLE
MAGETWO-84525 Send newsletter subscription success email after confirmation

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -621,6 +621,8 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             $this->setStatus(self::STATUS_SUBSCRIBED)
                 ->setStatusChanged(true)
                 ->save();
+
+            $this->sendConfirmationSuccessEmail();
             return true;
         }
 

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
@@ -12,11 +12,11 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
     /**
      * @var Subscriber
      */
-    protected $_model;
+    private $model;
 
     protected function setUp()
     {
-        $this->_model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+        $this->model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Newsletter\Model\Subscriber::class
         );
     }
@@ -27,17 +27,17 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmailConfirmation()
     {
-        $this->_model->subscribe('customer_confirm@example.com');
+        $this->model->subscribe('customer_confirm@example.com');
         /** @var TransportBuilderMock $transportBuilder */
         $transportBuilder = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
             ->get(\Magento\TestFramework\Mail\Template\TransportBuilderMock::class);
         // confirmationCode 'ysayquyajua23iq29gxwu2eax2qb6gvy' is taken from fixture
         $this->assertContains(
-            '/newsletter/subscriber/confirm/id/' . $this->_model->getSubscriberId()
+            '/newsletter/subscriber/confirm/id/' . $this->model->getSubscriberId()
             . '/code/ysayquyajua23iq29gxwu2eax2qb6gvy',
             $transportBuilder->getSentMessage()->getRawMessage()
         );
-        $this->assertEquals(Subscriber::STATUS_NOT_ACTIVE, $this->_model->getSubscriberStatus());
+        $this->assertEquals(Subscriber::STATUS_NOT_ACTIVE, $this->model->getSubscriberStatus());
     }
 
     /**
@@ -45,8 +45,8 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
      */
     public function testLoadByCustomerId()
     {
-        $this->assertSame($this->_model, $this->_model->loadByCustomerId(1));
-        $this->assertEquals('customer@example.com', $this->_model->getSubscriberEmail());
+        $this->assertSame($this->model, $this->model->loadByCustomerId(1));
+        $this->assertEquals('customer@example.com', $this->model->getSubscriberEmail());
     }
 
     /**
@@ -56,13 +56,13 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
     public function testUnsubscribeSubscribe()
     {
         // Unsubscribe and verify
-        $this->assertSame($this->_model, $this->_model->loadByCustomerId(1));
-        $this->assertEquals($this->_model, $this->_model->unsubscribe());
-        $this->assertEquals(Subscriber::STATUS_UNSUBSCRIBED, $this->_model->getSubscriberStatus());
+        $this->assertSame($this->model, $this->model->loadByCustomerId(1));
+        $this->assertEquals($this->model, $this->model->unsubscribe());
+        $this->assertEquals(Subscriber::STATUS_UNSUBSCRIBED, $this->model->getSubscriberStatus());
 
         // Subscribe and verify
-        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->_model->subscribe('customer@example.com'));
-        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->_model->getSubscriberStatus());
+        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->model->subscribe('customer@example.com'));
+        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->model->getSubscriberStatus());
     }
 
     /**
@@ -72,11 +72,32 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
     public function testUnsubscribeSubscribeByCustomerId()
     {
         // Unsubscribe and verify
-        $this->assertSame($this->_model, $this->_model->unsubscribeCustomerById(1));
-        $this->assertEquals(Subscriber::STATUS_UNSUBSCRIBED, $this->_model->getSubscriberStatus());
+        $this->assertSame($this->model, $this->model->unsubscribeCustomerById(1));
+        $this->assertEquals(Subscriber::STATUS_UNSUBSCRIBED, $this->model->getSubscriberStatus());
 
         // Subscribe and verify
-        $this->assertSame($this->_model, $this->_model->subscribeCustomerById(1));
-        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->_model->getSubscriberStatus());
+        $this->assertSame($this->model, $this->model->subscribeCustomerById(1));
+        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->model->getSubscriberStatus());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Newsletter/_files/subscribers.php
+     * @magentoConfigFixture current_store newsletter/subscription/confirm 1
+     */
+    public function testConfirm()
+    {
+        $customerEmail = 'customer_confirm@example.com';
+        $this->model->subscribe($customerEmail);
+        $this->model->loadByEmail($customerEmail);
+        $this->model->confirm($this->model->getSubscriberConfirmCode());
+
+        $transportBuilder = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\TestFramework\Mail\Template\TransportBuilderMock::class
+        );
+
+        $this->assertContains(
+            'You have been successfully subscribed to our newsletter.',
+            $transportBuilder->getSentMessage()->getRawMessage()
+        );
     }
 }


### PR DESCRIPTION
### Description
Fix Issue #12439 
Send newsletter subscription success after user clicks on confirmation link in email

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/12439 
Newsletter subscription success email not sent after confirmation #12439


### Manual testing scenarios

1. Change configuration under Stores > Configuration > Customers > Newsletter > Subscription Options > Need to Confirm to Yes
2. Sign up for Newsletter on frontend
3. Follow confirmation link in email
4. Check email inbox for subscription success email

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
