### PR TITLE
Fixed invalid parameter type in phpdoc block in Topmenu class

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -331,7 +331,7 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Add identity
      *
-     * @param array $identity
+     * @param string $identity
      * @return void
      */
     public function addIdentity($identity)

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -331,7 +331,7 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Add identity
      *
-     * @param string $identity
+     * @param string|array $identity
      * @return void
      */
     public function addIdentity($identity)


### PR DESCRIPTION
### Description
`addIdentity` method accepts strings, not an array.

See the usage: 

1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/Plugin/Block/Topmenu.php#L119
2. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/Plugin/Block/Topmenu.php#L129

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
