### PR TITLE
Prevent empty label when element has no label set

### DIFF
--- a/app/code/Magento/Ui/view/frontend/web/templates/form/field.html
+++ b/app/code/Magento/Ui/view/frontend/web/templates/form/field.html
@@ -6,9 +6,9 @@
 -->
 <div class="field" data-bind="visible: visible, attr: {'name': element.dataScope}, css: additionalClasses">
 
-    <!-- ko if: element.label -->
-        <label class="label" data-bind="attr: { for: element.uid }"><span translate="element.label"></span></label>
-    <!-- /ko -->
+    <label if="element.label" class="label" data-bind="attr: { for: element.uid }">
+        <span translate="element.label"></span>
+    </label>
 
     <div class="control" data-bind="css: {'_with-tooltip': element.tooltip}">
         <!-- ko ifnot: element.hasAddons() -->

--- a/app/code/Magento/Ui/view/frontend/web/templates/form/field.html
+++ b/app/code/Magento/Ui/view/frontend/web/templates/form/field.html
@@ -6,11 +6,9 @@
 -->
 <div class="field" data-bind="visible: visible, attr: {'name': element.dataScope}, css: additionalClasses">
 
-    <label class="label" data-bind="attr: { for: element.uid }">
-        <!-- ko if: element.label -->
-        <span translate="element.label"></span>
-        <!-- /ko -->
-    </label>
+    <!-- ko if: element.label -->
+        <label class="label" data-bind="attr: { for: element.uid }"><span translate="element.label"></span></label>
+    <!-- /ko -->
 
     <div class="control" data-bind="css: {'_with-tooltip': element.tooltip}">
         <!-- ko ifnot: element.hasAddons() -->


### PR DESCRIPTION
### Description
Knockout checks if element has a label. When it has not a label set, the emtpy <label></label> tags are still generated in the dom. This is unnecessary, so the knockout if statement can be placed around the label itself.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
