### PR TITLE
Format generated config files using the short array syntax

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -76,7 +76,8 @@ class PhpFormatter implements FormatterInterface
      * @param integer $depth
      * @return string
      */
-    private function varExportShort($var, $depth=0) {
+    private function varExportShort($var, $depth = 0)
+    {
         if (gettype($var) === 'array') {
             $indexed = array_keys($var) === range(0, count($var) - 1);
             $r = [];
@@ -88,6 +89,6 @@ class PhpFormatter implements FormatterInterface
             return sprintf("[\n%s\n%s]", implode(",\n", $r), str_repeat(self::INDENT, $depth - 1));
         }
 
-        return var_export($var, TRUE);
+        return var_export($var, true);
     }
 }

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -23,7 +23,7 @@ class PhpFormatter implements FormatterInterface
     public function format($data, array $comments = [])
     {
         if (!empty($comments) && is_array($data)) {
-            return "<?php\nreturn array (\n" . $this->formatData($data, $comments) . "\n);\n";
+            return "<?php\nreturn [\n" . $this->formatData($data, $comments) . "\n];\n";
         }
         return "<?php\nreturn " . $this->varExportShort($data, true) . ";\n";
     }
@@ -53,13 +53,13 @@ class PhpFormatter implements FormatterInterface
                     $elements[] = $prefix . " */";
                 }
 
-                $elements[] = $prefix . var_export($key, true) . ' => ' .
-                    (!is_array($value) ? var_export($value, true) . ',' : '');
+                $elements[] = $prefix . $this->varExportShort($key) . ' => ' .
+                    (!is_array($value) ? $this->varExportShort($value) . ',' : '');
 
                 if (is_array($value)) {
-                    $elements[] = $prefix . 'array (';
+                    $elements[] = $prefix . '[';
                     $elements[] = $this->formatData($value, [], '  ' . $prefix);
-                    $elements[] = $prefix . '),';
+                    $elements[] = $prefix . '],';
                 }
             }
             return implode("\n", $elements);

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -11,6 +11,9 @@ namespace Magento\Framework\App\DeploymentConfig\Writer;
  */
 class PhpFormatter implements FormatterInterface
 {
+    /**
+     * 2 space indentation for array formatting
+     */
     const INDENT = '  ';
 
     /**
@@ -76,19 +79,20 @@ class PhpFormatter implements FormatterInterface
      * @param integer $depth
      * @return string
      */
-    private function varExportShort($var, $depth = 0)
+    private function varExportShort($var, int $depth = 0): string
     {
-        if (gettype($var) === 'array') {
-            $indexed = array_keys($var) === range(0, count($var) - 1);
-            $r = [];
-            foreach ($var as $key => $value) {
-                $r[] = str_repeat(self::INDENT, $depth)
-                    . ($indexed ? '' : $this->varExportShort($key) . ' => ')
-                    . $this->varExportShort($value, $depth + 1);
-            }
-            return sprintf("[\n%s\n%s]", implode(",\n", $r), str_repeat(self::INDENT, $depth - 1));
+        if (!is_array($var)) {
+            return var_export($var, true);
         }
 
-        return var_export($var, true);
+        $indexed = array_keys($var) === range(0, count($var) - 1);
+        $expanded = [];
+        foreach ($var as $key => $value) {
+            $expanded[] = str_repeat(self::INDENT, $depth)
+                . ($indexed ? '' : $this->varExportShort($key) . ' => ')
+                . $this->varExportShort($value, $depth + 1);
+        }
+
+        return sprintf("[\n%s\n%s]", implode(",\n", $expanded), str_repeat(self::INDENT, $depth - 1));
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -55,68 +55,68 @@ class PhpFormatterTest extends \PHPUnit\Framework\TestCase
         ];
         $expectedResult1 = <<<TEXT
 <?php
-return array (
+return [
   'ns1' => 
-  array (
+  [
     's1' => 
-    array (
+    [
       0 => 's11',
       1 => 's12',
-    ),
+    ],
     's2' => 
-    array (
+    [
       0 => 's21',
       1 => 's22',
-    ),
-  ),
+    ],
+  ],
   /**
    * For the section: ns2
    * comment for namespace 2
    */
   'ns2' => 
-  array (
+  [
     's1' => 
-    array (
+    [
       0 => 's11',
-    ),
-  ),
+    ],
+  ],
   'ns3' => 'just text',
   'ns4' => 'just text',
-);
+];
 
 TEXT;
         $expectedResult2 = <<<TEXT
 <?php
-return array (
+return [
   /**
    * For the section: ns1
    * comment for' namespace 1
    */
   'ns1' => 
-  array (
+  [
     's1' => 
-    array (
+    [
       0 => 's11',
       1 => 's12',
-    ),
+    ],
     's2' => 
-    array (
+    [
       0 => 's21',
       1 => 's22',
-    ),
-  ),
+    ],
+  ],
   /**
    * For the section: ns2
    * comment for namespace 2.
    * Next comment for' namespace 2
    */
   'ns2' => 
-  array (
+  [
     's1' => 
-    array (
+    [
       0 => 's11',
-    ),
-  ),
+    ],
+  ],
   /**
    * For the section: ns3
    * comment for" namespace 3
@@ -127,7 +127,7 @@ return array (
    * comment for namespace 4
    */
   'ns4' => 'just text',
-);
+];
 
 TEXT;
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -130,12 +130,36 @@ return array (
 );
 
 TEXT;
+
+        $expectedResult3 = <<<TEXT
+<?php
+return [
+  'ns1' => [
+    's1' => [
+      's11',
+      's12'
+    ],
+    's2' => [
+      's21',
+      's22'
+    ]
+  ],
+  'ns2' => [
+    's1' => [
+      's11'
+    ]
+  ],
+  'ns3' => 'just text',
+  'ns4' => 'just text'
+];
+
+TEXT;
         return [
             ['string', [], "<?php\nreturn 'string';\n"],
             ['string', ['comment'], "<?php\nreturn 'string';\n"],
-            [$array, [], "<?php\nreturn " . var_export($array, true) . ";\n"],
             [$array, $comments1, $expectedResult1],
             [$array, $comments2, $expectedResult2],
+            [$array, [], $expectedResult3],
         ];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
1. Magento is following a standard of new code using short array syntax (https://github.com/magento/magento2/issues/758).
2. Magento has an automated checker to enforce the short array syntax precommit (https://github.com/magento/magento2/blob/2.2/.php_cs.dist#L31). 
3. Magento recommends checking in `app/etc/config.php` (http://devdocs.magento.com/guides/v2.2/config-guide/config/config-php.html)
>Check this file in to source control and use it in your development, staging, and production systems.
4. Magento's auto-generated `app/etc/config.php` uses the long array syntax.

Put that all together and the auto-generated config doesn't match the required standards to be checked in. The change made in this PR is to modify `PhpFormatter` to recursively return the array representation using short array syntax `[]` instead of long `array()`. If the given variable is not an array, it uses the standard `var_export` behavior.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. bin/magento setup:upgrade
2. app/etc/config.php should use the short array syntax

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
