### PR TITLE
Issue #12500: Fix productRepository getList caches product without ga…

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -694,6 +694,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $collection->load();
 
         $collection->addCategoryIds();
+        $collection->addMediaGalleryData();
         $searchResult = $this->searchResultsFactory->create();
         $searchResult->setSearchCriteria($searchCriteria);
         $searchResult->setItems($collection->getItems());


### PR DESCRIPTION
…llery images data

### Description
Using productRepository getList caches product without gallery images data

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12500: Using productRepository getList caches product without gallery images data

### Manual testing scenarios
1. Use code supplied in module 'ReachDigital_GetListIssue'. See: https://github.com/magento/magento2/issues/12500
2. Add a configurable with visual swatch configured for the 'color' attribute. Add some simple products who have a media gallery and set visual swatch with option 'Update Product Preview Image' to Yes.
3. Go to the category page with the configurable and choose a swatch color.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
