### PR TITLE
Duplicate array key

### DIFF
--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
@@ -143,7 +143,6 @@ class Extend extends \Magento\Catalog\Block\Adminhtml\Form\Renderer\Fieldset\Ele
             [
                 'name' => "product[{$switchAttributeCode}]",
                 'values' => $this->getOptions(),
-                'value' => $switchAttributeCode,
                 'class' => 'required-entry next-toinput',
                 'no_span' => true,
                 'disabled' => $this->isDisabledField(),

--- a/app/code/Magento/Downloadable/Helper/File.php
+++ b/app/code/Magento/Downloadable/Helper/File.php
@@ -765,7 +765,6 @@ class File extends \Magento\Framework\App\Helper\AbstractHelper
         'xxyz' => 'chemical/x-xyz',
         'xzaz' => 'application/vnd.zzazz.deck+xml',
         'xzip' => 'application/zip',
-        'xzmm' => 'application/vnd.handheld-entertainment+xml',
-        'xodt' => 'application/x-vnd.oasis.opendocument.spreadsheet',
+        'xzmm' => 'application/vnd.handheld-entertainment+xml'
     ];
 }


### PR DESCRIPTION
Duplicate array key

### Description
File: app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
Correct is 'value' => $this->getProduct()->getData($switchAttributeCode)

File: app/code/Magento/Downloadable/Helper/File.php
Correct is 'xodt' => 'application/vnd.oasis.opendocument.text'

### Fixed Issues (if relevant)
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
