### PR TITLE
Match flexible static file version in nginx sample config

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -100,7 +100,7 @@ location /static/ {
 
     # Remove signature of the static files that is used to overcome the browser cache
     location ~ ^/static/version {
-        rewrite ^/static/(version\d*/)?(.*)$ /static/$2 last;
+        rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
     }
 
     location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2)$ {


### PR DESCRIPTION
### Description
Magento 2.2 allows you to specify a custom version for static files being deployed. That means it may not necessarily be numeric like it is when using the default timestamp version numbers. This generalizes the nginx sample config to match custom versions as well.