### PR TITLE
#12450: Set Current Store from Store Code if isUseStoreInUrl

### DIFF
--- a/app/code/Magento/Store/App/Request/PathInfoProcessor.php
+++ b/app/code/Magento/Store/App/Request/PathInfoProcessor.php
@@ -44,7 +44,7 @@ class PathInfoProcessor implements \Magento\Framework\App\Request\PathInfoProces
 
         if ($store->isUseStoreInUrl()) {
             if (!$request->isDirectAccessFrontendName($storeCode) && $storeCode != Store::ADMIN_CODE) {
-                $this->storeManager->setCurrentStore($storeCode);
+                $this->storeManager->setCurrentStore($store->getCode());
                 $pathInfo = '/' . (isset($pathParts[1]) ? $pathParts[1] : '');
                 return $pathInfo;
             } elseif (!empty($storeCode)) {

--- a/app/code/Magento/Store/Test/Unit/App/Request/PathInfoProcessorTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Request/PathInfoProcessorTest.php
@@ -47,6 +47,7 @@ class PathInfoProcessorTest extends \PHPUnit\Framework\TestCase
         )->with(
             'storeCode'
         )->willReturn($store);
+        $store->expects($this->once())->method('getCode')->will($this->returnValue('storeCode'));
         $store->expects($this->once())->method('isUseStoreInUrl')->will($this->returnValue(true));
         $this->_requestMock->expects(
             $this->once()


### PR DESCRIPTION
Set Current Store from Store Code
### Description
If use Store Code in Url but for some reason is empty after process, set Store_Code from Store

### Fixed Issues (if relevant)
1. magento/magento2#12450: Store not found when adding a ? to site URL

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Turn on "Add storecode to URL's" in "Configuration > General > Web"
1. Navigate in browser to `{BASE_URL}/?`
1. Error thrown

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
