### PR TITLE
Added correction for og:type content value

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
@@ -9,7 +9,7 @@
 /** @var $block \Magento\Catalog\Block\Product\View */
 ?>
 
-<meta property="og:type" content="og:product" />
+<meta property="og:type" content="product" />
 <meta property="og:title" content="<?= $block->escapeHtmlAttr($block->stripTags($block->getProduct()->getName())) ?>" />
 <meta property="og:image" content="<?= $block->escapeUrl($block->getImage($block->getProduct(), 'product_base_image')->getImageUrl()) ?>" />
 <meta property="og:description" content="<?= $block->escapeHtmlAttr($block->stripTags($block->getProduct()->getShortDescription())) ?>" />


### PR DESCRIPTION
## Description

Added correction to the og:type meta tag content value.

Before:
`<meta property="og:type" content="og:product" />`

After:
`<meta property="og:type" content="product" />`

References:
[Facebook Open Graph](https://developers.facebook.com/docs/reference/opengraph/object-type/product/)
[Pinterest](https://developers.pinterest.com/docs/rich-pins/products/)

## Fixed Issues (if relevant)

None, code improvement

## Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds on Travis CI are green)