### PR TITLE
12111: Missing cascade into attribute set deletion.[port]

### DIFF
--- a/app/code/Magento/Catalog/Plugin/Model/AttributeSetRepository/RemoveProducts.php
+++ b/app/code/Magento/Catalog/Plugin/Model/AttributeSetRepository/RemoveProducts.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Plugin\Model\AttributeSetRepository;
+
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Eav\Api\AttributeSetRepositoryInterface;
+use Magento\Eav\Api\Data\AttributeSetInterface;
+
+/**
+ * Delete related products after attribute set successfully removed.
+ */
+class RemoveProducts
+{
+    /**
+     * Retrieve products related to specific attribute set.
+     *
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * RemoveProducts constructor.
+     *
+     * @param CollectionFactory $collectionFactory
+     */
+    public function __construct(CollectionFactory $collectionFactory)
+    {
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * Delete related to specific attribute set products, if attribute set was removed successfully.
+     *
+     * @param AttributeSetRepositoryInterface $subject
+     * @param bool $result
+     * @param AttributeSetInterface $attributeSet
+     * @return bool
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterDelete(
+        AttributeSetRepositoryInterface $subject,
+        bool $result,
+        AttributeSetInterface $attributeSet
+    ) {
+        /** @var Collection $productCollection */
+        $productCollection = $this->collectionFactory->create();
+        $productCollection->addFieldToFilter('attribute_set_id', ['eq' => $attributeSet->getId()]);
+        $productCollection->delete();
+
+        return $result;
+    }
+}

--- a/app/code/Magento/Catalog/Test/Unit/Plugin/Model/AttributeSetRepository/RemoveProductsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Plugin/Model/AttributeSetRepository/RemoveProductsTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Test\Unit\Plugin\Model\AttributeSetRepository;
+
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Catalog\Plugin\Model\AttributeSetRepository\RemoveProducts;
+use Magento\Eav\Api\AttributeSetRepositoryInterface;
+use Magento\Eav\Api\Data\AttributeSetInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provide tests for RemoveProducts plugin.
+ */
+class RemoveProductsTest extends TestCase
+{
+    /**
+     * @var RemoveProducts
+     */
+    private $testSubject;
+
+    /**
+     * @var CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $collectionFactory;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $objectManager = new ObjectManager($this);
+        $this->collectionFactory = $this->getMockBuilder(CollectionFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->testSubject = $objectManager->getObject(
+            RemoveProducts::class,
+            [
+                'collectionFactory' => $this->collectionFactory,
+            ]
+        );
+    }
+
+    /**
+     * Test plugin will delete all related products for given attribute set.
+     */
+    public function testAfterDelete()
+    {
+        $attributeSetId = '1';
+
+        /** @var Collection|\PHPUnit_Framework_MockObject_MockObject $collection */
+        $collection = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects(self::once())
+            ->method('addFieldToFilter')
+            ->with(self::identicalTo('attribute_set_id'), self::identicalTo(['eq' => $attributeSetId]));
+        $collection->expects(self::once())
+            ->method('delete');
+
+        $this->collectionFactory->expects(self::once())
+            ->method('create')
+            ->willReturn($collection);
+
+        /** @var AttributeSetRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject $attributeSetRepository */
+        $attributeSetRepository = $this->getMockBuilder(AttributeSetRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        /** @var AttributeSetInterface|\PHPUnit_Framework_MockObject_MockObject $attributeSet */
+        $attributeSet = $this->getMockBuilder(AttributeSetInterface::class)
+            ->setMethods(['getId'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $attributeSet->expects(self::once())
+            ->method('getId')
+            ->willReturn($attributeSetId);
+
+        self::assertTrue($this->testSubject->afterDelete($attributeSetRepository, true, $attributeSet));
+    }
+}

--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -184,4 +184,7 @@
             <argument name="scopeOverriddenValue" xsi:type="object">Magento\Catalog\Model\Attribute\ScopeOverriddenValue</argument>
         </arguments>
     </type>
+    <type name="Magento\Eav\Api\AttributeSetRepositoryInterface">
+        <plugin name="remove_products" type="Magento\Catalog\Plugin\Model\AttributeSetRepository\RemoveProducts"/>
+    </type>
 </config>

--- a/app/code/Magento/Catalog/etc/module.xml
+++ b/app/code/Magento/Catalog/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Catalog" setup_version="2.2.3">
+    <module name="Magento_Catalog" setup_version="2.2.4">
         <sequence>
             <module name="Magento_Eav"/>
             <module name="Magento_Cms"/>

--- a/dev/tests/integration/testsuite/Magento/Catalog/Plugin/Model/AttributeSetRepository/RemoveProductsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Plugin/Model/AttributeSetRepository/RemoveProductsTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Plugin\Model\AttributeSetRepository;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Eav\Api\AttributeSetRepositoryInterface;
+use Magento\Eav\Model\Entity\Attribute\Set;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Interception\PluginList;
+use Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provide tests for RemoveProducts plugin.
+ * @magentoAppArea adminhtml
+ */
+class RemoveProductsTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testRemoveProductsIsRegistered()
+    {
+        $pluginInfo = Bootstrap::getObjectManager()->get(PluginList::class)
+            ->get(AttributeSetRepositoryInterface::class, []);
+        self::assertSame(RemoveProducts::class, $pluginInfo['remove_products']['instance']);
+    }
+
+    /**
+     * Test related to given attribute set products will be removed, if attribute set will be deleted.
+     *
+     * @magentoDataFixture Magento/Catalog/_files/attribute_set_with_product.php
+     */
+    public function testAfterDelete()
+    {
+        $attributeSet = Bootstrap::getObjectManager()->get(Set::class);
+        $attributeSet->load('empty_attribute_set', 'attribute_set_name');
+
+        $productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
+        $product = $productRepository->get('simple');
+
+        $productCollection = Bootstrap::getObjectManager()->get(CollectionFactory::class)->create();
+        $productCollection->addIdFilter($product->getId());
+        $urlRewriteCollection = Bootstrap::getObjectManager()->get(UrlRewriteCollectionFactory::class)->create();
+        $urlRewriteCollection->addFieldToFilter('entity_type', 'product');
+        $urlRewriteCollection->addFieldToFilter('entity_id', $product->getId());
+
+        self::assertSame(1, $urlRewriteCollection->getSize());
+        self::assertSame(1, $productCollection->getSize());
+
+        $attributeSetRepository = Bootstrap::getObjectManager()->get(AttributeSetRepositoryInterface::class);
+        $attributeSetRepository->deleteById($attributeSet->getAttributeSetId());
+
+        $productCollection = Bootstrap::getObjectManager()->get(CollectionFactory::class)->create();
+        $productCollection->addIdFilter($product->getId());
+        $urlRewriteCollection = Bootstrap::getObjectManager()->get(UrlRewriteCollectionFactory::class)->create();
+        $urlRewriteCollection->addFieldToFilter('entity_type', 'product');
+        $urlRewriteCollection->addFieldToFilter('entity_id', $product->getId());
+
+        self::assertSame(0, $urlRewriteCollection->getSize());
+        self::assertSame(0, $productCollection->getSize());
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/attribute_set_with_product.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/attribute_set_with_product.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+require __DIR__ . '/../../Eav/_files/empty_attribute_set.php';
+require __DIR__ . '/../../Catalog/_files/product_simple.php';
+
+$product->setAttributeSetId($attributeSet->getId());
+$product->save();

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/attribute_set_with_product_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/attribute_set_with_product_rollback.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+require __DIR__ . '/../../Catalog/_files/product_simple_rollback.php';
+require __DIR__ . '/../../Eav/_files/empty_attribute_set_rollback.php';


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
https://github.com/magento/magento2/pull/12167 port on 2.3.0

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12110: Missing cascade into attribute set deletion

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a custom attributes set.
2. Attach some products to this attributes set.
3. Got to attributes set admin page.
4. Delete your custom attributes set.
5. Confirm you want to remove attached products also.
6. Check, table url_rewrite should be cleaned from references to removed products.
7. Check, that new product named like an old one from removed attribute set can be created via API or admin interface.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
