### PR TITLE
Trying to get data from non existent products

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Quote/Item/Collection.php
@@ -220,8 +220,10 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $orderData = $this->getOrdersData($productIds);
         foreach ($items as $item) {
             $item->setId($item->getProductId());
-            $item->setPrice($productData[$item->getProductId()]['price'] * $item->getBaseToGlobalRate());
-            $item->setName($productData[$item->getProductId()]['name']);
+            if (isset($productData[$item->getProductId()])) {
+                $item->setPrice($productData[$item->getProductId()]['price'] * $item->getBaseToGlobalRate());
+                $item->setName($productData[$item->getProductId()]['name']);
+            }
             $item->setOrders(0);
             if (isset($orderData[$item->getProductId()])) {
                 $item->setOrders($orderData[$item->getProductId()]['orders']);


### PR DESCRIPTION
As requested in #12321 

When calling Products in Cart report, it called data of deleted products resulting in exception trying to access $productData[$item->getProductId()]

### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Magento 2.1.10

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Delete a product recently sold
1. Open Reports > Marketing > Products in Cart

### Expected result
<!--- Tell us what should happen -->
1. List of products

### Actual result
<!--- Tell us what happens instead -->
1. Blank list