### PR TITLE
[Backport 2.2-develop] Fix swagger-ui on instances of Magento running on a non-standard port

### DIFF
--- a/app/code/Magento/Webapi/Controller/Rest.php
+++ b/app/code/Magento/Webapi/Controller/Rest.php
@@ -303,7 +303,7 @@ class Rest implements \Magento\Framework\App\FrontControllerInterface
         $responseBody = $this->swaggerGenerator->generate(
             $requestedServices,
             $this->_request->getScheme(),
-            $this->_request->getHttpHost(),
+            $this->_request->getHttpHost(false),
             $this->_request->getRequestUri()
         );
         $this->_response->setBody($responseBody)->setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
### Description
Backport of https://github.com/magento/magento2/pull/10504.

### Manual testing scenarios
1. Run Magento on non-standard port (8082).
2. Try to execute API methods using swagger UI.
3. Base url without port is used.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
