### PR TITLE
Missed extension_attributes into [GET] catalogCategoryLinkManagement

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryProductLink.php
+++ b/app/code/Magento/Catalog/Model/CategoryProductLink.php
@@ -6,11 +6,13 @@
 
 namespace Magento\Catalog\Model;
 
+use Magento\Framework\Api\AbstractExtensibleObject;
+use Magento\Catalog\Api\Data\CategoryProductLinkInterface;
 /**
  * @codeCoverageIgnore
  */
-class CategoryProductLink extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Catalog\Api\Data\CategoryProductLinkInterface
+class CategoryProductLink extends AbstractExtensibleObject implements
+    CategoryProductLinkInterface
 {
     /**#@+
      * Constant for confirmation status
@@ -80,7 +82,11 @@ class CategoryProductLink extends \Magento\Framework\Api\AbstractExtensibleObjec
      */
     public function getExtensionAttributes()
     {
-        return $this->_getExtensionAttributes();
+        $extensionAttributes = $this->_getExtensionAttributes();
+        if (!$extensionAttributes) {
+            return $this->extensionFactory->create(CategoryProductLinkInterface::class);
+        }
+        return $extensionAttributes;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/CategoryProductLink.php
+++ b/app/code/Magento/Catalog/Model/CategoryProductLink.php
@@ -8,6 +8,7 @@ namespace Magento\Catalog\Model;
 
 use Magento\Framework\Api\AbstractExtensibleObject;
 use Magento\Catalog\Api\Data\CategoryProductLinkInterface;
+
 /**
  * @codeCoverageIgnore
  */


### PR DESCRIPTION
I was working to manipulate information of a category with there products based on position information. When I wanted to add some edtra information into catalogCategoryLinkManagement, I don't see the extension_attribute.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you calling the REST API /V1/categories/:categoryId/products extension_attributes field is missed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
