### PR TITLE
Fixes #8009

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock/AbstractAction.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock/AbstractAction.php
@@ -248,7 +248,7 @@ abstract class AbstractAction
             }
         }
         
-        $this->cacheContext->registerEntities(Product::CACHE_TAG, $productIds);
+        $this->cacheContext->registerEntities(Product::CACHE_TAG, $processIds);
         $this->eventManager->dispatch('clean_cache_by_tags', ['object' => $this->cacheContext]);
         
         return $this;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Flush full page cache for all products that have been reindexed. Not only the child products, but also parent products. This is already the case in 2.2-develop.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8009: Magento 2.1.3 out of stock associated products to configurable are not full page cache cleaned

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
preconditions: set indexers to scheduled and install sample data for configurable products
1. buy all available simples of a configurable product, so they become out of stock
2. run the indexer_update_all_views cron job
3. refresh the product detail page
4. the product should now be out of stock

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
