### PR TITLE
[Backport-2.1] Added namespace to product videos fotorama events

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
@@ -175,10 +175,10 @@ define([
          */
         clearEvents: function () {
             this.fotoramaItem.off(
-                'fotorama:show ' +
-                'fotorama:showend ' +
-                'fotorama:fullscreenenter ' +
-                'fotorama:fullscreenexit'
+                'fotorama:show.' + this.PV +
+                ' fotorama:showend.' + this.PV +
+                ' fotorama:fullscreenenter.' + this.PV +
+                ' fotorama:fullscreenexit.' + this.PV
             );
         },
 
@@ -232,11 +232,11 @@ define([
          * @private
          */
         _listenForFullscreen: function () {
-            this.fotoramaItem.on('fotorama:fullscreenenter', $.proxy(function () {
+            this.fotoramaItem.on('fotorama:fullscreenenter.' + this.PV, $.proxy(function () {
                 this.isFullscreen = true;
             }, this));
 
-            this.fotoramaItem.on('fotorama:fullscreenexit', $.proxy(function () {
+            this.fotoramaItem.on('fotorama:fullscreenexit.' + this.PV, $.proxy(function () {
                 this.isFullscreen = false;
                 this._hideVideoArrows();
             }, this));
@@ -468,7 +468,7 @@ define([
                 t;
 
             if (!fotorama.activeFrame.$navThumbFrame) {
-                this.fotoramaItem.on('fotorama:showend', $.proxy(function (evt, fotoramaData) {
+                this.fotoramaItem.on('fotorama:showend.' + this.PV, $.proxy(function (evt, fotoramaData) {
                     $(fotoramaData.activeFrame.$stageFrame).removeAttr('href');
                 }, this));
 
@@ -486,7 +486,7 @@ define([
                 this._checkForVideo(e, fotorama, t + 1);
             }
 
-            this.fotoramaItem.on('fotorama:showend', $.proxy(function (evt, fotoramaData) {
+            this.fotoramaItem.on('fotorama:showend.' + this.PV, $.proxy(function (evt, fotoramaData) {
                 $(fotoramaData.activeFrame.$stageFrame).removeAttr('href');
             }, this));
         },
@@ -528,15 +528,15 @@ define([
          * @private
          */
         _attachFotoramaEvents: function () {
-            this.fotoramaItem.on('fotorama:showend', $.proxy(function (e, fotorama) {
+            this.fotoramaItem.on('fotorama:showend.' + this.PV, $.proxy(function (e, fotorama) {
                 this._startPrepareForPlayer(e, fotorama);
             }, this));
 
-            this.fotoramaItem.on('fotorama:show', $.proxy(function (e, fotorama) {
+            this.fotoramaItem.on('fotorama:show.' + this.PV, $.proxy(function (e, fotorama) {
                 this._unloadVideoPlayer(fotorama.activeFrame.$stageFrame.parent(), fotorama, true);
             }, this));
 
-            this.fotoramaItem.on('fotorama:fullscreenexit', $.proxy(function (e, fotorama) {
+            this.fotoramaItem.on('fotorama:fullscreenexit.' + this.PV, $.proxy(function (e, fotorama) {
                 fotorama.activeFrame.$stageFrame.find('.' + this.PV).remove();
                 this._startPrepareForPlayer(e, fotorama);
             }, this));

--- a/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
@@ -207,7 +207,7 @@ define([
                 if (options.dataMergeStrategy === 'prepend') {
                     this.options.videoData = [].concat(
                         this.options.optionsVideoData[options.selectedOption],
-                        this.options.videoData
+                        this.defaultVideoData
                     );
                 } else {
                     this.options.videoData = this.options.optionsVideoData[options.selectedOption];


### PR DESCRIPTION
### Description
This pull request fixes issue with ignored gallery config in view.xml on configurable products.
It happens because `clearEvents` function removes all fotorama event listeners. 
I added event namespace to only remove product videos related events.
Please check #12268 for more details.

### Fixed Issues (if relevant)
1. magento/magento2#12268: Gallery issues on configurable product page

### Manual testing scenarios
1. Open `app/design/frontend/Magento/luma/etc/view.xml` and change `navdir` to `vertical` on line 216.
2. Open configurable product and select size and color.
3. Click on the image to open full screen view.

### Backport
#12469 Added namespace to product videos fotorama events

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
