### PR TITLE
Move isAllowed method from AccessChangeQuoteControl to separate service

### DIFF
--- a/app/code/Magento/Quote/Api/ChangeQuoteControlInterface.php
+++ b/app/code/Magento/Quote/Api/ChangeQuoteControlInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Api;
+
+use Magento\Quote\Api\Data\CartInterface;
+
+/**
+ * Service checks if the user has ability to change the quote.
+ */
+interface ChangeQuoteControlInterface
+{
+    /**
+     * Checks if user is allowed to change the quote.
+     *
+     * @param CartInterface $quote
+     * @return bool
+     */
+    public function isAllowed(CartInterface $quote): bool;
+}

--- a/app/code/Magento/Quote/Model/ChangeQuoteControl.php
+++ b/app/code/Magento/Quote/Model/ChangeQuoteControl.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Model;
+
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Quote\Api\ChangeQuoteControlInterface;
+use Magento\Quote\Api\Data\CartInterface;
+
+/**
+ * {@inheritdoc}
+ */
+class ChangeQuoteControl implements ChangeQuoteControlInterface
+{
+    /**
+     * @var UserContextInterface $userContext
+     */
+    private $userContext;
+
+    /**
+     * @param UserContextInterface $userContext
+     */
+    public function __construct(UserContextInterface $userContext)
+    {
+        $this->userContext = $userContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAllowed(CartInterface $quote): bool
+    {
+        switch ($this->userContext->getUserType()) {
+            case UserContextInterface::USER_TYPE_CUSTOMER:
+                $isAllowed = ($quote->getCustomerId() == $this->userContext->getUserId());
+                break;
+            case UserContextInterface::USER_TYPE_GUEST:
+                $isAllowed = ($quote->getCustomerId() === null);
+                break;
+            case UserContextInterface::USER_TYPE_ADMIN:
+            case UserContextInterface::USER_TYPE_INTEGRATION:
+                $isAllowed = true;
+                break;
+            default:
+                $isAllowed = false;
+        }
+
+        return $isAllowed;
+    }
+}

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AccessChangeQuoteControlTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AccessChangeQuoteControlTest.php
@@ -3,9 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Quote\Test\Unit\Model\QuoteRepository\Plugin;
 
 use Magento\Authorization\Model\UserContextInterface;
+use Magento\Quote\Model\ChangeQuoteControl;
 use Magento\Quote\Model\QuoteRepository\Plugin\AccessChangeQuoteControl;
 use Magento\Quote\Model\Quote;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -34,6 +36,11 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
      */
     private $quoteRepositoryMock;
 
+    /**
+     * @var ChangeQuoteControl|MockObject
+     */
+    private $changeQuoteControlMock;
+
     protected function setUp()
     {
         $this->userContextMock = $this->getMockBuilder(UserContextInterface::class)
@@ -50,15 +57,19 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->changeQuoteControlMock = $this->getMockBuilder(ChangeQuoteControl::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $objectManagerHelper = new ObjectManager($this);
         $this->accessChangeQuoteControl = $objectManagerHelper->getObject(
             AccessChangeQuoteControl::class,
-            ['userContext' => $this->userContextMock]
+            ['changeQuoteControl' => $this->changeQuoteControlMock]
         );
     }
 
     /**
-     * User with role Customer and customer_id much with context user_id.
+     * User with role Customer and customer_id matches context user_id.
      */
     public function testBeforeSaveForCustomer()
     {
@@ -67,6 +78,9 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
 
         $this->userContextMock->method('getUserType')
             ->willReturn(UserContextInterface::USER_TYPE_CUSTOMER);
+
+        $this->changeQuoteControlMock->method('isAllowed')
+            ->willReturn(true);
 
         $result = $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
 
@@ -81,10 +95,14 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
      */
     public function testBeforeSaveException()
     {
-        $this->userContextMock->method('getUserType')
-            ->willReturn(UserContextInterface::USER_TYPE_CUSTOMER);
         $this->quoteMock->method('getCustomerId')
             ->willReturn(2);
+
+        $this->userContextMock->method('getUserType')
+            ->willReturn(UserContextInterface::USER_TYPE_CUSTOMER);
+
+        $this->changeQuoteControlMock->method('isAllowed')
+            ->willReturn(false);
 
         $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
@@ -99,6 +117,9 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
 
         $this->userContextMock->method('getUserType')
             ->willReturn(UserContextInterface::USER_TYPE_ADMIN);
+
+        $this->changeQuoteControlMock->method('isAllowed')
+            ->willReturn(true);
 
         $result = $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
 
@@ -115,6 +136,9 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
 
         $this->userContextMock->method('getUserType')
             ->willReturn(UserContextInterface::USER_TYPE_GUEST);
+
+        $this->changeQuoteControlMock->method('isAllowed')
+            ->willReturn(true);
 
         $result = $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
 
@@ -135,6 +159,9 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
         $this->userContextMock->method('getUserType')
             ->willReturn(UserContextInterface::USER_TYPE_GUEST);
 
+        $this->changeQuoteControlMock->method('isAllowed')
+            ->willReturn(false);
+
         $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
 
@@ -151,6 +178,9 @@ class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
 
         $this->userContextMock->method('getUserType')
             ->willReturn(10);
+
+        $this->changeQuoteControlMock->method('isAllowed')
+            ->willReturn(false);
 
         $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }

--- a/app/code/Magento/Quote/etc/di.xml
+++ b/app/code/Magento/Quote/etc/di.xml
@@ -22,6 +22,7 @@
     <preference for="Magento\Quote\Api\CouponManagementInterface" type="Magento\Quote\Model\CouponManagement" />
     <preference for="Magento\Quote\Api\CartManagementInterface" type="Magento\Quote\Model\QuoteManagement" />
     <preference for="Magento\Quote\Api\CartTotalRepositoryInterface" type="Magento\Quote\Model\Cart\CartTotalRepository" />
+    <preference for="Magento\Quote\Api\ChangeQuoteControlInterface" type="Magento\Quote\Model\ChangeQuoteControl" />
     <preference for="Magento\Quote\Api\CartTotalManagementInterface" type="Magento\Quote\Model\Cart\CartTotalManagement" />
     <preference for="Magento\Quote\Api\Data\TotalsInterface" type="Magento\Quote\Model\Cart\Totals" />
     <preference for="Magento\Quote\Api\Data\TotalSegmentInterface" type="Magento\Quote\Model\Cart\TotalSegment" />


### PR DESCRIPTION
### Description
We are using recurring payments in combination with pre-order products. A small amount of the final price is payed and with the shipment, the remaining amount. In order to do this we always need a customer. We therefore automatically convert guest to shadow customers. This isn't an account the customer can use but we need it for the recurring payment.

In Magento v2.2 a plugin of `QuoteManagement::submit()` is introduced, `AccessChangeQuoteControl` which now prevents guests from placing orders since `$quote->getCustomerId()` isn't `null` anymore.

Moved logic to separate service so we can create a plugin.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Convert guests to customers by making a plugin of `QuoteManagement::submit()`
2. In frontend as guest, add an item to your quote in proceed to checkout.
3. Complete checkout, make sure plugin to convert guest to shadow customer is triggered.
4. API call will return following exception: `Invalid state change requested`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

2.3 Port: https://github.com/magento/magento2/pull/13776