### PR TITLE
[Backport 2.3] Added Visibility and Status filter to category product grid

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tab/Product.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tab/Product.php
@@ -14,6 +14,9 @@ namespace Magento\Catalog\Block\Adminhtml\Category\Tab;
 use Magento\Backend\Block\Widget\Grid;
 use Magento\Backend\Block\Widget\Grid\Column;
 use Magento\Backend\Block\Widget\Grid\Extended;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\App\ObjectManager;
 
 class Product extends \Magento\Backend\Block\Widget\Grid\Extended
 {
@@ -30,21 +33,37 @@ class Product extends \Magento\Backend\Block\Widget\Grid\Extended
     protected $_productFactory;
 
     /**
+     * @var Status
+     */
+    private $status;
+
+    /**
+     * @var Visibility
+     */
+    private $visibility;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Backend\Helper\Data $backendHelper
      * @param \Magento\Catalog\Model\ProductFactory $productFactory
      * @param \Magento\Framework\Registry $coreRegistry
      * @param array $data
+     * @param Visibility|null $visibility
+     * @param Status|null $status
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Backend\Helper\Data $backendHelper,
         \Magento\Catalog\Model\ProductFactory $productFactory,
         \Magento\Framework\Registry $coreRegistry,
-        array $data = []
+        array $data = [],
+        Visibility $visibility = null,
+        Status $status = null
     ) {
         $this->_productFactory = $productFactory;
         $this->_coreRegistry = $coreRegistry;
+        $this->visibility = $visibility ?: ObjectManager::getInstance()->get(Visibility::class);
+        $this->status = $status ?: ObjectManager::getInstance()->get(Status::class);
         parent::__construct($context, $backendHelper, $data);
     }
 
@@ -103,6 +122,10 @@ class Product extends \Magento\Backend\Block\Widget\Grid\Extended
         )->addAttributeToSelect(
             'sku'
         )->addAttributeToSelect(
+            'visibility'
+        )->addAttributeToSelect(
+            'status'
+        )->addAttributeToSelect(
             'price'
         )->joinField(
             'position',
@@ -159,6 +182,28 @@ class Product extends \Magento\Backend\Block\Widget\Grid\Extended
         );
         $this->addColumn('name', ['header' => __('Name'), 'index' => 'name']);
         $this->addColumn('sku', ['header' => __('SKU'), 'index' => 'sku']);
+        $this->addColumn(
+            'visibility',
+            [
+                'header' => __('Visibility'),
+                'index' => 'visibility',
+                'type' => 'options',
+                'options' => $this->visibility->getOptionArray(),
+                'header_css_class' => 'col-visibility',
+                'column_css_class' => 'col-visibility'
+            ]
+        );
+
+        $this->addColumn(
+            'status',
+            [
+                'header' => __('Status'),
+                'index' => 'status',
+                'type' => 'options',
+                'options' => $this->status->getOptionArray()
+            ]
+        );
+
         $this->addColumn(
             'price',
             [

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Category/Edit/Section/ProductGrid.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Category/Edit/Section/ProductGrid.php
@@ -29,6 +29,14 @@ class ProductGrid extends Grid
         'name' => [
             'selector' => '#catalog_category_products_filter_name',
         ],
+        'visibility' => [
+            'selector' => '#catalog_category_products_filter_visibility',
+            'input' => 'select',
+        ],
+        'status' => [
+            'selector' => '#catalog_category_products_filter_status',
+            'input' => 'select',
+        ],
     ];
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertCategoryProductsGridFilter.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertCategoryProductsGridFilter.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Test\Constraint;
+
+use Magento\Catalog\Test\Fixture\Category;
+use Magento\Catalog\Test\Page\Adminhtml\CatalogCategoryEdit;
+use Magento\Catalog\Test\Page\Adminhtml\CatalogCategoryIndex;
+use Magento\Mtf\Constraint\AbstractConstraint;
+
+/**
+ * Assert that category products grid filter works correctly.
+ */
+class AssertCategoryProductsGridFilter extends AbstractConstraint
+{
+    /**
+     * Grid columns for tests
+     *
+     * @var array
+     */
+    private $testFilterColumns = [
+        'visibility',
+    ];
+    
+    /**
+     * Assert that category products grid filter works correctly.
+     *
+     * @param CatalogCategoryIndex $catalogCategoryIndex
+     * @param CatalogCategoryEdit $catalogCategoryEdit
+     * @param Category $category
+     * @return void
+     */
+    public function processAssert(
+        CatalogCategoryIndex $catalogCategoryIndex,
+        CatalogCategoryEdit $catalogCategoryEdit,
+        Category $category
+    ) {
+        $catalogCategoryIndex->getTreeCategories()->selectCategory($category, true);
+        $categoryProducts = $category->getDataFieldConfig('category_products')['source']->getProducts();
+        $catalogCategoryEdit->getEditForm()->openSection('category_products');
+        
+        foreach ($this->testFilterColumns as $field) {
+            $this->testGridFilter($categoryProducts, $catalogCategoryEdit, $field);
+        }
+    }
+
+    /**
+     * @param array $categoryProducts
+     * @param CatalogCategoryEdit $catalogCategoryEdit
+     * @param string $filterField
+     */
+    private function testGridFilter(array $categoryProducts, CatalogCategoryEdit $catalogCategoryEdit, $filterField)
+    {
+        $productsByFilter = [];
+        foreach ($categoryProducts as $product) {
+            $filterValue = $product->getData($filterField);
+            if (!isset($productsByFilter[$filterValue])) {
+                $productsByFilter[$filterValue] = [];
+            }
+            $productsByFilter[$filterValue][] = $product;
+        }
+
+        $productsFieldset = $catalogCategoryEdit->getEditForm()->getSection('category_products');
+        foreach ($productsByFilter as $filterValue => $products) {
+            $productsFieldset->getProductGrid()->search([
+                'in_category' => 'Yes',
+                $filterField => $filterValue,
+            ]);
+
+            $expectedRows = [];
+            foreach ($products as $product) {
+                $expectedRows[] = $product->getName();
+            }
+            $gridRows = $productsFieldset->getProductGrid()->getRowsData(['name']);
+            $actualRows = array_column($gridRows, 'name');
+            sort($expectedRows);
+            sort($actualRows);
+
+            \PHPUnit_Framework_Assert::assertEquals(
+                $expectedRows,
+                $actualRows,
+                "Category products grid filter '$filterField' does not work correctly"
+            );
+        }
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'Category products grid filter works correctly';
+    }
+}

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Category/CreateCategoryEntityTest.xml
@@ -175,5 +175,15 @@
             <constraint name="Magento\Catalog\Test\Constraint\AssertCategorySaveMessage" />
             <constraint name="Magento\Catalog\Test\Constraint\AssertCategoryOnCustomWebsite" />
         </variation>
+        <variation name="CreateCategoryEntityTestVariation11_ProductsGridFilter" summary="Apply category products grid filter">
+            <data name="addCategory" xsi:type="string">addSubcategory</data>
+            <data name="category/data/parent_id/dataset" xsi:type="string">default_category</data>
+            <data name="category/data/is_active" xsi:type="string">Yes</data>
+            <data name="category/data/include_in_menu" xsi:type="string">Yes</data>
+            <data name="category/data/name" xsi:type="string">Subcategory%isolation%</data>
+            <data name="category/data/category_products/dataset" xsi:type="string">catalogProductSimple::default, catalogProductSimple::not_visible_individually</data>
+            <constraint name="Magento\Catalog\Test\Constraint\AssertCategorySaveMessage" />
+            <constraint name="Magento\Catalog\Test\Constraint\AssertCategoryProductsGridFilter" />
+        </variation>
     </testCase>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Add visibility and status filter to category product grid to be able to easier filter large amounts of products. Wading through thousands of 'Not visible individually' products is no fun.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Before:
![image](https://user-images.githubusercontent.com/431360/33663563-c9b5edf2-da90-11e7-9899-07d197b9c34b.png)

After:
![image](https://user-images.githubusercontent.com/431360/33663041-a896f816-da8e-11e7-823a-74a27a531e41.png)
& with filter applied;
![image](https://user-images.githubusercontent.com/431360/33663604-ef2100e0-da90-11e7-8f85-722c560e231c.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

This is a backport for 2.3 of https://github.com/magento/magento2/pull/12564, ping @adrian-martinez-interactiv4 