### PR TITLE
[Backport 2.2] #6460: Add option to keep Files in Rollback

### DIFF
--- a/lib/internal/Magento/Framework/Backup/AbstractBackup.php
+++ b/lib/internal/Magento/Framework/Backup/AbstractBackup.php
@@ -5,12 +5,15 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+
 /**
  * Class to work with archives
  *
  * @api
  */
-abstract class AbstractBackup implements BackupInterface
+abstract class AbstractBackup implements BackupInterface, SourceFileInterface
 {
     /**
      * Backup name
@@ -67,6 +70,13 @@ abstract class AbstractBackup implements BackupInterface
      * @var string
      */
     protected $_lastErrorMessage;
+
+    /**
+     * Keep Source files in Backup
+     *
+     * @var boolean
+     */
+    private $keepSourceFile;
 
     /**
      * Set Backup Extension
@@ -138,14 +148,14 @@ abstract class AbstractBackup implements BackupInterface
      * Set root directory of Magento installation
      *
      * @param string $rootDir
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @return $this
      */
     public function setRootDir($rootDir)
     {
         if (!is_dir($rootDir)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Bad root directory')
+            throw new LocalizedException(
+                new Phrase('Bad root directory')
             );
         }
 
@@ -295,5 +305,27 @@ abstract class AbstractBackup implements BackupInterface
         $name = str_replace(' ', '_', $name);
 
         return $name;
+    }
+
+    /**
+     * Check if keep files of backup
+     *
+     * @return bool
+     */
+    public function keepSourceFile()
+    {
+        return $this->keepSourceFile;
+    }
+
+    /**
+     * Set if keep files of backup
+     *
+     * @param bool $keepSourceFile
+     * @return $this
+     */
+    public function setKeepSourceFile(bool $keepSourceFile)
+    {
+        $this->keepSourceFile = $keepSourceFile;
+        return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Backup/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Backup/Archive/Tar.php
@@ -11,6 +11,10 @@
  */
 namespace Magento\Framework\Backup\Archive;
 
+use Magento\Framework\Backup\Filesystem\Iterator\Filter;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 class Tar extends \Magento\Framework\Archive\Tar
 {
     /**
@@ -35,12 +39,12 @@ class Tar extends \Magento\Framework\Archive\Tar
     {
         $path = $this->_getCurrentFile();
 
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::SELF_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::SELF_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter(
+        $iterator = new Filter(
             $filesystemIterator,
             $this->_skipFiles
         );

--- a/lib/internal/Magento/Framework/Backup/Db.php
+++ b/lib/internal/Magento/Framework/Backup/Db.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Archive;
+use Magento\Framework\Backup\Db\BackupFactory;
+use Magento\Framework\Backup\Filesystem\Iterator\File;
+
 /**
  * Class to work with database backups
  *
@@ -14,14 +18,14 @@ namespace Magento\Framework\Backup;
 class Db extends AbstractBackup
 {
     /**
-     * @var \Magento\Framework\Backup\Db\BackupFactory
+     * @var BackupFactory
      */
     protected $_backupFactory;
 
     /**
-     * @param \Magento\Framework\Backup\Db\BackupFactory $backupFactory
+     * @param BackupFactory $backupFactory
      */
-    public function __construct(\Magento\Framework\Backup\Db\BackupFactory $backupFactory)
+    public function __construct(BackupFactory $backupFactory)
     {
         $this->_backupFactory = $backupFactory;
     }
@@ -38,14 +42,16 @@ class Db extends AbstractBackup
 
         $this->_lastOperationSucceed = false;
 
-        $archiveManager = new \Magento\Framework\Archive();
+        $archiveManager = new Archive();
         $source = $archiveManager->unpack($this->getBackupPath(), $this->getBackupsDir());
 
-        $file = new \Magento\Framework\Backup\Filesystem\Iterator\File($source);
+        $file = new File($source);
         foreach ($file as $statement) {
             $this->getResourceModel()->runCommand($statement);
         }
-        @unlink($source);
+        if ($this->keepSourceFile() === false) {
+            @unlink($source);
+        }
 
         $this->_lastOperationSucceed = true;
 

--- a/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
+++ b/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Framework\Backup\Db;
 
+use Magento\Framework\ObjectManagerInterface;
+
 /**
  * @api
  */
@@ -14,33 +16,33 @@ class BackupFactory
     /**
      * Object manager
      *
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
-    private $_objectManager;
+    private $objectManager;
 
     /**
      * @var string
      */
-    private $_backupInstanceName;
+    private $backupInstanceName;
 
     /**
      * @var string
      */
-    private $_backupDbInstanceName;
+    private $backupDbInstanceName;
 
     /**
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      * @param string $backupInstanceName
      * @param string $backupDbInstanceName
      */
     public function __construct(
-        \Magento\Framework\ObjectManagerInterface $objectManager,
+        ObjectManagerInterface $objectManager,
         $backupInstanceName,
         $backupDbInstanceName
     ) {
-        $this->_objectManager = $objectManager;
-        $this->_backupInstanceName = $backupInstanceName;
-        $this->_backupDbInstanceName = $backupDbInstanceName;
+        $this->objectManager        = $objectManager;
+        $this->backupInstanceName   = $backupInstanceName;
+        $this->backupDbInstanceName = $backupDbInstanceName;
     }
 
     /**
@@ -51,7 +53,7 @@ class BackupFactory
      */
     public function createBackupModel(array $arguments = [])
     {
-        return $this->_objectManager->create($this->_backupInstanceName, $arguments);
+        return $this->objectManager->create($this->backupInstanceName, $arguments);
     }
 
     /**
@@ -62,6 +64,6 @@ class BackupFactory
      */
     public function createBackupDbModel(array $arguments = [])
     {
-        return $this->_objectManager->create($this->_backupDbInstanceName, $arguments);
+        return $this->objectManager->create($this->backupDbInstanceName, $arguments);
     }
 }

--- a/lib/internal/Magento/Framework/Backup/Factory.php
+++ b/lib/internal/Magento/Framework/Backup/Factory.php
@@ -9,6 +9,10 @@
  */
 namespace Magento\Framework\Backup;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Phrase;
+
 /**
  * @api
  */
@@ -17,7 +21,7 @@ class Factory
     /**
      * Object manager
      *
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     private $_objectManager;
 
@@ -54,9 +58,9 @@ class Factory
     protected $_allowedTypes;
 
     /**
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      */
-    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager)
+    public function __construct(ObjectManagerInterface $objectManager)
     {
         $this->_objectManager = $objectManager;
         $this->_allowedTypes = [
@@ -73,13 +77,13 @@ class Factory
      *
      * @param string $type
      * @return BackupInterface
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function create($type)
     {
         if (!in_array($type, $this->_allowedTypes)) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase(
+            throw new LocalizedException(
+                new Phrase(
                     'Current implementation not supported this type (%1) of backup.',
                     [$type]
                 )

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Helper.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Helper.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Framework\Backup\Filesystem;
 
+use Magento\Framework\Backup\Filesystem\Iterator\Filter;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 /**
  * Filesystem helper
  *
@@ -56,12 +60,12 @@ class Helper
      */
     public function rm($path, $skipPaths = [], $removeRoot = false)
     {
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $skipPaths);
+        $iterator = new Filter($filesystemIterator, $skipPaths);
 
         foreach ($iterator as $item) {
             $item->isDir() ? @rmdir($item->__toString()) : @unlink($item->__toString());
@@ -99,12 +103,12 @@ class Helper
             $info['size'] = 0;
         }
 
-        $filesystemIterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path),
-            \RecursiveIteratorIterator::CHILD_FIRST
+        $filesystemIterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path),
+            RecursiveIteratorIterator::CHILD_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $skipFiles);
+        $iterator = new Filter($filesystemIterator, $skipFiles);
 
         foreach ($iterator as $item) {
             if ($item->isLink()) {

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Iterator/Filter.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Iterator/Filter.php
@@ -11,6 +11,8 @@
  */
 namespace Magento\Framework\Backup\Filesystem\Iterator;
 
+use Iterator;
+
 class Filter extends \FilterIterator
 {
     /**
@@ -23,10 +25,10 @@ class Filter extends \FilterIterator
     /**
      * Constructor
      *
-     * @param \Iterator $iterator
+     * @param Iterator $iterator
      * @param array $filters list of files to skip
      */
-    public function __construct(\Iterator $iterator, array $filters)
+    public function __construct(Iterator $iterator, array $filters)
     {
         parent::__construct($iterator);
         $this->_filters = $filters;

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/AbstractRollback.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/AbstractRollback.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\Backup\Filesystem\Rollback;
 
+use Magento\Framework\Backup\Filesystem;
+
 /**
  * Filesystem rollback workers abstract class
  *
@@ -15,16 +17,16 @@ abstract class AbstractRollback
     /**
      * Snapshot object
      *
-     * @var \Magento\Framework\Backup\Filesystem
+     * @var Filesystem
      */
     protected $_snapshot;
 
     /**
      * Default worker constructor
      *
-     * @param \Magento\Framework\Backup\Filesystem $snapshotObject
+     * @param Filesystem $snapshotObject
      */
-    public function __construct(\Magento\Framework\Backup\Filesystem $snapshotObject)
+    public function __construct(Filesystem $snapshotObject)
     {
         $this->_snapshot = $snapshotObject;
     }

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/Fs.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Rollback/Fs.php
@@ -6,6 +6,16 @@
 namespace Magento\Framework\Backup\Filesystem\Rollback;
 
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Archive;
+use Magento\Framework\Archive\Gz;
+use Magento\Framework\Archive\Helper\File;
+use Magento\Framework\Archive\Helper\File\Gz as HelperGz;
+use Magento\Framework\Archive\Tar;
+use Magento\Framework\Backup\Exception\CantLoadSnapshot;
+use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Filesystem\Helper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
 
 /**
  * Rollback worker for rolling back via local filesystem
@@ -15,7 +25,7 @@ use Magento\Framework\App\ObjectManager;
 class Fs extends AbstractRollback
 {
     /**
-     * @var \Magento\Framework\Backup\Filesystem\Helper
+     * @var Helper
      */
     private $fsHelper;
 
@@ -23,7 +33,7 @@ class Fs extends AbstractRollback
      * Files rollback implementation via local filesystem
      *
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      *
      * @see AbstractRollback::run()
      */
@@ -32,8 +42,8 @@ class Fs extends AbstractRollback
         $snapshotPath = $this->_snapshot->getBackupPath();
 
         if (!is_file($snapshotPath) || !is_readable($snapshotPath)) {
-            throw new \Magento\Framework\Backup\Exception\CantLoadSnapshot(
-                new \Magento\Framework\Phrase('Can\'t load snapshot archive')
+            throw new CantLoadSnapshot(
+                new Phrase('Can\'t load snapshot archive')
             );
         }
 
@@ -41,49 +51,55 @@ class Fs extends AbstractRollback
 
         $filesInfo = $fsHelper->getInfo(
             $this->_snapshot->getRootDir(),
-            \Magento\Framework\Backup\Filesystem\Helper::INFO_WRITABLE,
+            Helper::INFO_WRITABLE,
             $this->_snapshot->getIgnorePaths()
         );
 
         if (!$filesInfo['writable']) {
             if (!empty($filesInfo['writableMeta'])) {
-                throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                    new \Magento\Framework\Phrase(
+                throw new NotEnoughPermissions(
+                    new Phrase(
                         'You need write permissions for: %1',
                         [implode(', ', $filesInfo['writableMeta'])]
                     )
                 );
             }
 
-            throw new \Magento\Framework\Backup\Exception\NotEnoughPermissions(
-                new \Magento\Framework\Phrase('Unable to make rollback because not all files are writable')
+            throw new NotEnoughPermissions(
+                new Phrase('Unable to make rollback because not all files are writable')
             );
         }
 
-        $archiver = new \Magento\Framework\Archive();
+        $archiver = new Archive();
 
         /**
          * we need these fake initializations because all magento's files in filesystem will be deleted and autoloader
          * wont be able to load classes that we need for unpacking
          */
-        new \Magento\Framework\Archive\Tar();
-        new \Magento\Framework\Archive\Gz();
-        new \Magento\Framework\Archive\Helper\File('');
-        new \Magento\Framework\Archive\Helper\File\Gz('');
-        new \Magento\Framework\Exception\LocalizedException(new \Magento\Framework\Phrase('dummy'));
+        new Tar();
+        new Gz();
+        new File('');
+        new HelperGz('');
+        new LocalizedException(new Phrase('dummy'));
 
-        $fsHelper->rm($this->_snapshot->getRootDir(), $this->_snapshot->getIgnorePaths());
+        if (!$this->_snapshot->keepSourceFile()) {
+            $fsHelper->rm($this->_snapshot->getRootDir(), $this->_snapshot->getIgnorePaths());
+        }
         $archiver->unpack($snapshotPath, $this->_snapshot->getRootDir());
+
+        if ($this->_snapshot->keepSourceFile() === false) {
+            @unlink($snapshotPath);
+        }
     }
 
     /**
-     * @return \Magento\Framework\Backup\Filesystem\Helper
+     * @return Helper
      * @deprecated 100.2.0
      */
     private function getFsHelper()
     {
         if (!$this->fsHelper) {
-            $this->fsHelper = ObjectManager::getInstance()->get(\Magento\Framework\Backup\Filesystem\Helper::class);
+            $this->fsHelper = ObjectManager::getInstance()->get(Helper::class);
         }
 
         return $this->fsHelper;

--- a/lib/internal/Magento/Framework/Backup/Snapshot.php
+++ b/lib/internal/Magento/Framework/Backup/Snapshot.php
@@ -11,6 +11,7 @@
  */
 namespace Magento\Framework\Backup;
 
+use Exception;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem as AppFilesystem;
 
@@ -48,7 +49,7 @@ class Snapshot extends Filesystem
     /**
      * Implementation Rollback functionality for Snapshot
      *
-     * @throws \Exception
+     * @throws Exception
      * @return bool
      */
     public function rollback()
@@ -59,7 +60,7 @@ class Snapshot extends Filesystem
 
         try {
             $this->_getDbBackupManager()->rollback();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->_removeDbBackup();
             throw $e;
         }
@@ -73,7 +74,7 @@ class Snapshot extends Filesystem
     /**
      * Implementation Create Backup functionality for Snapshot
      *
-     * @throws \Exception
+     * @throws Exception
      * @return bool
      */
     public function create()
@@ -82,7 +83,7 @@ class Snapshot extends Filesystem
 
         try {
             $result = parent::create();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->_removeDbBackup();
             throw $e;
         }

--- a/lib/internal/Magento/Framework/Backup/SourceFileInterface.php
+++ b/lib/internal/Magento/Framework/Backup/SourceFileInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Interface for work with archives
+ *
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+
+namespace Magento\Framework\Backup;
+
+interface SourceFileInterface
+{
+
+    /**
+     * Check if keep files of backup
+     *
+     * @return bool
+     */
+    public function keepSourceFile();
+
+    /**
+     * Set if keep files of backup
+     *
+     * @param bool $keepSourceFile
+     * @return $this
+     */
+    public function setKeepSourceFile(bool $keepSourceFile);
+}

--- a/lib/internal/Magento/Framework/Setup/BackupRollback.php
+++ b/lib/internal/Magento/Framework/Setup/BackupRollback.php
@@ -7,13 +7,12 @@
 namespace Magento\Framework\Setup;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Backup\Factory;
 use Magento\Framework\Backup\Exception\NotEnoughPermissions;
+use Magento\Framework\Backup\Factory;
 use Magento\Framework\Backup\Filesystem;
 use Magento\Framework\Backup\Filesystem\Helper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\Driver\File;
-use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Phrase;
 
@@ -129,7 +128,7 @@ class BackupRollback
         $this->log->log($granularType . ' backup is starting...');
         $fsBackup->create();
         $this->log->log(
-            $granularType. ' backup filename: ' . $fsBackup->getBackupFilename()
+            $granularType . ' backup filename: ' . $fsBackup->getBackupFilename()
             . ' (The archive can be uncompressed with 7-Zip on Windows systems)'
         );
         $this->log->log($granularType . ' backup path: ' . $fsBackup->getBackupPath());
@@ -142,10 +141,11 @@ class BackupRollback
      *
      * @param string $rollbackFile
      * @param string $type
+     * @param boolean $keepSourceFile
      * @return void
      * @throws LocalizedException
      */
-    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM)
+    public function codeRollback($rollbackFile, $type = Factory::TYPE_FILESYSTEM, $keepSourceFile = false)
     {
         if (preg_match('/[0-9]_(filesystem)_(code|media)\.(tgz)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -181,6 +181,7 @@ class BackupRollback
         $fsRollback->setBackupsDir($this->backupsDir);
         $fsRollback->setBackupExtension('tgz');
         $time = explode('_', $rollbackFile);
+        $fsRollback->setKeepSourceFile($keepSourceFile);
         $fsRollback->setTime($time[0]);
         $this->log->log($granularType . ' rollback is starting ...');
         $fsRollback->rollback();
@@ -218,10 +219,11 @@ class BackupRollback
      * Roll back database
      *
      * @param string $rollbackFile
+     * @param boolean $keepSourceFile
      * @return void
      * @throws LocalizedException
      */
-    public function dbRollback($rollbackFile)
+    public function dbRollback($rollbackFile, $keepSourceFile = false)
     {
         if (preg_match('/[0-9]_(db)(.*?).(sql)$/', $rollbackFile) !== 1) {
             throw new LocalizedException(new Phrase('Invalid rollback file.'));
@@ -241,6 +243,7 @@ class BackupRollback
         }
         $dbRollback->setTime($time[0]);
         $this->log->log('DB rollback is starting...');
+        $dbRollback->setKeepSourceFile($keepSourceFile);
         $dbRollback->setResourceModel($this->objectManager->create(\Magento\Backup\Model\ResourceModel\Db::class));
         if ($dbRollback->getBackupFilename() !== $rollbackFile) {
             $correctName = $this->getCorrectFileNameWithoutPrefix($dbRollback, $rollbackFile);

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -134,7 +134,15 @@ class RollbackCommand extends AbstractSetupCommand
                     if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {
                         return \Magento\Framework\Console\Cli::RETURN_FAILURE;
                     }
-                    $this->doRollback($input, $output);
+
+                    $questionKeep = new ConfirmationQuestion(
+                        '<info>Do you want to keep the backups?[y/N]<info>',
+                        false
+                    );
+                    $keepSourceFile = $helper->ask($input, $output, $questionKeep);
+
+                    $this->doRollback($input, $output, $keepSourceFile);
+
                     $output->writeln('<info>Please set file permission of bin/magento to executable</info>');
 
                     return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
@@ -156,24 +164,33 @@ class RollbackCommand extends AbstractSetupCommand
      *
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @param boolean $keepSourceFile
      * @return void
      * @throws \InvalidArgumentException
      */
-    private function doRollback(InputInterface $input, OutputInterface $output)
+    private function doRollback(InputInterface $input, OutputInterface $output, $keepSourceFile)
     {
         $inputOptionProvided = false;
         $rollbackHandler = $this->backupRollbackFactory->create($output);
         if ($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE));
+            $rollbackHandler->codeRollback(
+                $input->getOption(self::INPUT_KEY_CODE_BACKUP_FILE),
+                Factory::TYPE_FILESYSTEM,
+                $keepSourceFile
+            );
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)) {
-            $rollbackHandler->codeRollback($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE), Factory::TYPE_MEDIA);
+            $rollbackHandler->codeRollback(
+                $input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE),
+                Factory::TYPE_MEDIA,
+                $keepSourceFile
+            );
             $inputOptionProvided = true;
         }
         if ($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE)) {
             $this->setAreaCode();
-            $rollbackHandler->dbRollback($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE));
+            $rollbackHandler->dbRollback($input->getOption(self::INPUT_KEY_DB_BACKUP_FILE), $keepSourceFile);
             $inputOptionProvided = true;
         }
         if (!$inputOptionProvided) {

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/RollbackCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/RollbackCommandTest.php
@@ -170,7 +170,7 @@ class RollbackCommandTest extends \PHPUnit\Framework\TestCase
             ->method('isAvailable')
             ->will($this->returnValue(true));
         $this->question
-            ->expects($this->once())
+            ->expects($this->atLeast(2))
             ->method('ask')
             ->will($this->returnValue(false));
         $this->helperSet


### PR DESCRIPTION
Add option to keep files in rollback and improve Readability and PSR of Backup Library
### Description
Ask to user when launch command: `bin/magento setup:rollback` if he wants keep files to future rollbacks. Also I changed variable name protected with underscore to acomplish PSR and I imported all classes to use in class.

### Fixed Issues (if relevant)
1. magento/magento2#6460: [2.1.1 CE] Rollback/Restore deletes database (--db) backup file in ${webroot}/var/backups.

### Manual testing scenarios
1. create backup  e.g: `bin/magento setup:backup --media`
2. rollback backup e.g: `bin/magento setup:rollback -m 1508950479_filesystem_media.tgz`
3. Answer `y` to question: `Do you want to keep the backups?[y/N]`
4. Check that your backup was kept in `var/backups`

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)