### PR TITLE
Fixes #12584

### DIFF
--- a/app/code/Magento/Bundle/Model/LinkManagement.php
+++ b/app/code/Magento/Bundle/Model/LinkManagement.php
@@ -203,6 +203,9 @@ class LinkManagement implements \Magento\Bundle\Api\ProductLinkManagementInterfa
         if ($productLink->getIsDefault() !== null) {
             $selectionModel->setIsDefault($productLink->getIsDefault());
         }
+        if ($productLink->getWebsiteId() !== null) {
+            $selectionModel->setWebsiteId($productLink->getWebsiteId());
+        }
 
         return $selectionModel;
     }

--- a/app/code/Magento/Bundle/Model/OptionRepository.php
+++ b/app/code/Magento/Bundle/Model/OptionRepository.php
@@ -248,6 +248,7 @@ class OptionRepository implements \Magento\Bundle\Api\ProductOptionRepositoryInt
         if (is_array($option->getProductLinks())) {
             $productLinks = $option->getProductLinks();
             foreach ($productLinks as $productLink) {
+                $productLink->setWebsiteId($this->storeManager->getStore($product->getStoreId())->getWebsiteId());
                 if (!$productLink->getId() && !$productLink->getSelectionId()) {
                     $linksToAdd[] = $productLink;
                 } else {

--- a/app/code/Magento/Bundle/Model/Selection.php
+++ b/app/code/Magento/Bundle/Model/Selection.php
@@ -20,6 +20,8 @@ namespace Magento\Bundle\Model;
  * @method \Magento\Bundle\Model\Selection setPosition(int $value)
  * @method int getIsDefault()
  * @method \Magento\Bundle\Model\Selection setIsDefault(int $value)
+ * @method int getWebsiteId()
+ * @method \Magento\Bundle\Model\Selection setWebsiteId(int $value)
  * @method int getSelectionPriceType()
  * @method \Magento\Bundle\Model\Selection setSelectionPriceType(int $value)
  * @method float getSelectionPriceValue()

--- a/app/code/Magento/Bundle/Test/Unit/Model/LinkManagementTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/LinkManagementTest.php
@@ -462,13 +462,15 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
      */
     public function testAddChildCouldNotSave()
     {
+        $websiteId = 100;
         $productLink = $this->getMockBuilder(\Magento\Bundle\Api\Data\LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getWebsiteId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->expects($this->any())->method('getSku')->will($this->returnValue('linked_product_sku'));
         $productLink->expects($this->any())->method('getOptionId')->will($this->returnValue(1));
         $productLink->expects($this->any())->method('getSelectionId')->will($this->returnValue(1));
+        $productLink->expects($this->any())->method('getWebsiteId')->will($this->returnValue($websiteId));
 
         $this->metadataMock->expects($this->once())->method('getLinkField')->willReturn($this->linkField);
         $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
@@ -535,13 +537,16 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
 
     public function testAddChild()
     {
+        $websiteId = 100;
+
         $productLink = $this->getMockBuilder(\Magento\Bundle\Api\Data\LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getWebsiteId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->expects($this->any())->method('getSku')->will($this->returnValue('linked_product_sku'));
         $productLink->expects($this->any())->method('getOptionId')->will($this->returnValue(1));
         $productLink->expects($this->any())->method('getSelectionId')->will($this->returnValue(1));
+        $productLink->expects($this->any())->method('getWebsiteId')->will($this->returnValue($websiteId));
 
         $this->metadataMock->expects($this->once())->method('getLinkField')->willReturn($this->linkField);
         $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
@@ -614,9 +619,10 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
         $linkProductId = 45;
         $parentProductId = 32;
         $bundleProductSku = 'bundleProductSku';
+        $websiteId = 100;
 
         $productLink = $this->getMockBuilder(\Magento\Bundle\Api\Data\LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getWebsiteId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->expects($this->any())->method('getSku')->will($this->returnValue('linked_product_sku'));
@@ -629,6 +635,7 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
         $productLink->expects($this->any())->method('getCanChangeQuantity')->will($this->returnValue($canChangeQuantity));
         $productLink->expects($this->any())->method('getIsDefault')->will($this->returnValue($isDefault));
         $productLink->expects($this->any())->method('getSelectionId')->will($this->returnValue($optionId));
+        $productLink->expects($this->any())->method('getWebsiteId')->will($this->returnValue($websiteId));
 
         $this->metadataMock->expects($this->once())->method('getLinkField')->willReturn($this->linkField);
         $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
@@ -670,7 +677,8 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
                 'setSelectionPriceType',
                 'setSelectionPriceValue',
                 'setSelectionCanChangeQty',
-                'setIsDefault'
+                'setIsDefault',
+                'setWebsiteId'
             ]);
         $selection->expects($this->once())->method('save');
         $selection->expects($this->once())->method('load')->with($id)->will($this->returnSelf());
@@ -684,6 +692,7 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
         $selection->expects($this->once())->method('setSelectionPriceValue')->with($price);
         $selection->expects($this->once())->method('setSelectionCanChangeQty')->with($canChangeQuantity);
         $selection->expects($this->once())->method('setIsDefault')->with($isDefault);
+        $selection->expects($this->once())->method('setWebsiteId')->with($websiteId);
 
         $this->bundleSelectionMock->expects($this->once())->method('create')->will($this->returnValue($selection));
         $this->assertTrue($this->model->saveChild($bundleProductSku, $productLink));
@@ -697,14 +706,16 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
         $id = 12;
         $linkProductId = 45;
         $parentProductId = 32;
+        $websiteId = 200;
 
         $productLink = $this->getMockBuilder(\Magento\Bundle\Api\Data\LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getWebsiteId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->expects($this->any())->method('getSku')->will($this->returnValue('linked_product_sku'));
         $productLink->expects($this->any())->method('getId')->will($this->returnValue($id));
         $productLink->expects($this->any())->method('getSelectionId')->will($this->returnValue(1));
+        $productLink->expects($this->any())->method('getWebsiteId')->will($this->returnValue($websiteId));
         $bundleProductSku = 'bundleProductSku';
 
         $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
@@ -744,13 +755,15 @@ class LinkManagementTest extends \PHPUnit\Framework\TestCase
                 'setSelectionPriceType',
                 'setSelectionPriceValue',
                 'setSelectionCanChangeQty',
-                'setIsDefault'
+                'setIsDefault',
+                'setWebsiteId'
             ]);
         $mockException = $this->createMock(\Exception::class);
         $selection->expects($this->once())->method('save')->will($this->throwException($mockException));
         $selection->expects($this->once())->method('load')->with($id)->will($this->returnSelf());
         $selection->expects($this->any())->method('getId')->will($this->returnValue($id));
         $selection->expects($this->once())->method('setProductId')->with($linkProductId);
+        $selection->expects($this->once())->method('setWebsiteId')->with($websiteId);
 
         $this->bundleSelectionMock->expects($this->once())->method('create')->will($this->returnValue($selection));
         $this->model->saveChild($bundleProductSku, $productLink);


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Bundle Item prices are missing their website id which is checked for in `\Magento\Bundle\Model\Selection::afterSave`. This check always failed.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12584: Bundle Item price cannot differ per website

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. see the scenario in magento/magento2#12584

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
