### PR TITLE
Fix error loading theme configuration on PHP 7.2

### DIFF
--- a/lib/internal/Magento/Framework/View/Design/Theme/ThemeList.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/ThemeList.php
@@ -234,7 +234,7 @@ class ThemeList extends \Magento\Framework\Data\Collection implements ListInterf
         $media = $themeConfig->getMedia();
 
         $parentPathPieces = $themeConfig->getParentTheme();
-        if (count($parentPathPieces) == 1) {
+        if (is_array($parentPathPieces) && count($parentPathPieces) == 1) {
             $pathPieces = $pathData['theme_path_pieces'];
             array_pop($pathPieces);
             $parentPathPieces = array_merge($pathPieces, $parentPathPieces);


### PR DESCRIPTION
This fixes an issue loading theme configuration on PHP 7.2 by checking that `$parentPathPieces` is an array before counting it, avoiding an error when the value is `NULL`. PHP [no longer allows](http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types) running `count()` on non-countable types.

An easy way to trigger this bug in the current 2.2 branch is to run the `setup:upgrade` command:
```
$ php bin/magento setup:upgrade
...
Running data recurring...
Warning: count(): Parameter must be an array or an object that implements Countable in vendor/magento/framework/View/Design/Theme/ThemeList.php on line 237
```

This might be better to merge into 2.3, but I'm not sure what the planned version support/release scheduled for 2.2 vs 2.3 is.