### PR TITLE
Update CrontabManager.php

### DIFF
--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -138,7 +138,12 @@ class CrontabManager implements CrontabManagerInterface
     private function generateSection($content, $tasks = [])
     {
         if ($tasks) {
-            $content .= PHP_EOL . $this->getTasksBlockStart() . PHP_EOL;
+            // Add EOL symbol to previous line if not exist.
+            if (substr($content, -strlen(PHP_EOL)) !== PHP_EOL) {
+                $content .= PHP_EOL;
+            }
+
+            $content .= $this->getTasksBlockStart() . PHP_EOL;
             foreach ($tasks as $task) {
                 $content .= $task['expression'] . ' ' . PHP_BINARY . ' ' . $task['command'] . PHP_EOL;
             }

--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -138,7 +138,7 @@ class CrontabManager implements CrontabManagerInterface
     private function generateSection($content, $tasks = [])
     {
         if ($tasks) {
-            $content .= $this->getTasksBlockStart() . PHP_EOL;
+            $content .= PHP_EOL . $this->getTasksBlockStart() . PHP_EOL;
             foreach ($tasks as $task) {
                 $content .= $task['expression'] . ' ' . PHP_BINARY . ' ' . $task['command'] . PHP_EOL;
             }

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -338,6 +338,17 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
                     . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
             ],
+            [
+                'tasks' => [
+                    ['command' => '{magentoRoot}run.php % cron:run | grep -v "Ran \'jobs\' by schedule"']
+                ],
+                'content' => '* * * * * /bin/php /var/www/cron.php',
+                'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . md5(BP) . PHP_EOL
+                    . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
+                    . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . md5(BP) . PHP_EOL,
+            ],
         ];
     }
 }


### PR DESCRIPTION
If crontab is already populated, 'php bin/magento cron:install' adds '#~ MAGENTO START' and the rest of code directly to the last row of crontab without any spaces.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
