### PR TITLE
Ranged selects always miss the last range

### DIFF
--- a/lib/internal/Magento/Framework/DB/Query/BatchRangeIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchRangeIterator.php
@@ -113,7 +113,7 @@ class BatchRangeIterator implements BatchIteratorInterface
     public function current()
     {
         if (null === $this->currentSelect) {
-            $this->isValid = ($this->currentOffset + $this->batchSize) <= $this->totalItemCount;
+            $this->isValid = $this->currentOffset < $this->totalItemCount;
             $this->currentSelect = $this->initSelectObject();
         }
         return $this->currentSelect;
@@ -144,7 +144,7 @@ class BatchRangeIterator implements BatchIteratorInterface
         if (null === $this->currentSelect) {
             $this->current();
         }
-        $this->isValid = ($this->batchSize + $this->currentOffset) <= $this->totalItemCount;
+        $this->isValid = $this->currentOffset < $this->totalItemCount;
         $select = $this->initSelectObject();
         if ($this->isValid) {
             $this->iteration++;

--- a/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchRangeIteratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchRangeIteratorTest.php
@@ -116,6 +116,6 @@ class BatchRangeIteratorTest extends \PHPUnit\Framework\TestCase
             $iterations++;
         }
 
-        $this->assertEquals(10, $iterations);
+        $this->assertEquals(11, $iterations);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
I found this bug because some of my categories were empty. catalog_category_product_index did not contain all category product relations that are in catalog_category_product. Per category type (anchor, non-anchor) the highest category id's were missing from the index.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Ranged selects always miss the last range:
```php
// 2.1-develop:
        $this->isValid = ($this->batchSize + $this->currentOffset) < $this->totalItemCount;

// 2.2-develop:
        $this->isValid = ($this->batchSize + $this->currentOffset) <= $this->totalItemCount;
```
Suppose you have a total item count of 530 items:
Batch size: 500
Offset: 0
(batch size + offset) = 500
500 <= 530 is TRUE, so generate a query with offset 0 and limit 500
Returns item 1 - 500

Batch size: 500
Offset: 500
(batch size + offset) = 1000
1000 <= 530 is FALSE, so DO NOT generate a query with offset 500 and limit 500
Query is not created
Does not return items 501 - 530

The actual check should be: 
```php
        $this->isValid = $this->currentOffset < $this->totalItemCount;
```

Suppose you have a total item count of 530 items:
Batch size: 500
Offset: 0
0 <= 530 is TRUE, so generate a query with offset 0 and limit 500
Returns item 1 - 500

Batch size: 500
Offset: 500
500 <= 530 is TRUE, so generate a query with offset 500 and limit 500
Returns item 500 - 530

Batch size: 500
Offset: 1000
1000 <= 530 is FALSE, so DO NOT generate a query with offset 1000 and limit 500
Query is not created

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. catalog_category_product_index should contain all category product relations that are also in catalog_category_product.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
