### PR TITLE
Add customer login url from Customer Url model to checkout config so …

### DIFF
--- a/app/code/Magento/Customer/Model/Checkout/ConfigProvider.php
+++ b/app/code/Magento/Customer/Model/Checkout/ConfigProvider.php
@@ -23,7 +23,7 @@ class ConfigProvider implements ConfigProviderInterface
     /**
      * @var UrlInterface
      */
-    protected $urlBuilder;
+    protected $customerUrl;
 
     /**
      * @var ScopeConfigInterface
@@ -31,16 +31,16 @@ class ConfigProvider implements ConfigProviderInterface
     protected $scopeConfig;
 
     /**
-     * @param UrlInterface $urlBuilder
+     * @param Url $customerUrl
      * @param StoreManagerInterface $storeManager
      * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        UrlInterface $urlBuilder,
+        Url $customerUrl,
         StoreManagerInterface $storeManager,
         ScopeConfigInterface $scopeConfig
     ) {
-        $this->urlBuilder = $urlBuilder;
+        $this->customerUrl = $customerUrl;
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
     }
@@ -78,7 +78,7 @@ class ConfigProvider implements ConfigProviderInterface
      */
     protected function getLoginUrl()
     {
-        return $this->urlBuilder->getUrl(Url::ROUTE_ACCOUNT_LOGIN);
+        return $this->customerUrl->getLoginUrl();
     }
 
     /**


### PR DESCRIPTION
…it contains the referer url if necessary

### Description
Use the url created in the customer model instead of creating a new one with the url builder. The current way isn't adding a referrer parameter when required

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12627: Referer is not added to login url in checkout config

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Enable `Redirect Customer to Account Dashboard after Logging in` in the Magento backend.
2. Retrieve the login url from the `window.checkout` object (key is customerLoginUrl)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
