### PR TITLE
#12625: Add Current Date to update_time Field for Block and Pages

### DIFF
--- a/app/code/Magento/Cms/Model/Block.php
+++ b/app/code/Magento/Cms/Model/Block.php
@@ -6,7 +6,6 @@
 namespace Magento\Cms\Model;
 
 use Magento\Cms\Api\Data\BlockInterface;
-use Magento\Cms\Model\ResourceModel\Block as ResourceCmsBlock;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Model\AbstractModel;
 
@@ -58,6 +57,11 @@ class Block extends AbstractModel implements BlockInterface, IdentityInterface
     public function beforeSave()
     {
         $needle = 'block_id="' . $this->getId() . '"';
+
+        if ($this->hasDataChanges()) {
+            $this->setUpdateTime(null);
+        }
+
         if (false == strstr($this->getContent(), $needle)) {
             return parent::beforeSave();
         }

--- a/app/code/Magento/Cms/Model/Page.php
+++ b/app/code/Magento/Cms/Model/Page.php
@@ -6,12 +6,11 @@
 namespace Magento\Cms\Model;
 
 use Magento\Cms\Api\Data\PageInterface;
-use Magento\Cms\Model\ResourceModel\Page as ResourceCmsPage;
+use Magento\Cms\Helper\Page as PageHelper;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Cms\Helper\Page as PageHelper;
 
 /**
  * Cms Page Model
@@ -546,6 +545,10 @@ class Page extends AbstractModel implements PageInterface, IdentityInterface
     {
         $originalIdentifier = $this->getOrigData('identifier');
         $currentIdentifier = $this->getIdentifier();
+
+        if ($this->hasDataChanges()) {
+            $this->setUpdateTime(null);
+        }
 
         if (!$this->getId() || $originalIdentifier === $currentIdentifier) {
             return parent::beforeSave();

--- a/app/code/Magento/Cms/Model/ResourceModel/Block.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block.php
@@ -7,10 +7,10 @@ namespace Magento\Cms\Model\ResourceModel;
 
 use Magento\Cms\Api\Data\BlockInterface;
 use Magento\Framework\DB\Select;
+use Magento\Framework\EntityManager\EntityManager;
+use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Framework\EntityManager\EntityManager;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Store\Model\Store;

--- a/app/code/Magento/Cms/Model/ResourceModel/Page.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page.php
@@ -6,18 +6,18 @@
 
 namespace Magento\Cms\Model\ResourceModel;
 
+use Magento\Cms\Api\Data\PageInterface;
 use Magento\Cms\Model\Page as CmsPage;
 use Magento\Framework\DB\Select;
+use Magento\Framework\EntityManager\EntityManager;
+use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Framework\EntityManager\EntityManager;
-use Magento\Cms\Api\Data\PageInterface;
 
 /**
  * Cms page mysql resource

--- a/dev/tests/integration/testsuite/Magento/Cms/Model/BlockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/BlockTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Model;
+
+use Magento\Cms\Api\BlockRepositoryInterface;
+use Magento\Cms\Model\BlockFactory;
+use Magento\Cms\Model\ResourceModel\Block;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppArea adminhtml
+ */
+class BlockTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var Block
+     */
+    private $blockResource;
+
+    /**
+     * @var BlockFactory
+     */
+    private $blockFactory;
+
+    /**
+     * @var BlockRepositoryInterface
+     */
+    private $blockRepository;
+
+    protected function setUp()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+
+        /** @var BlockFactory $blockFactory */
+        /** @var Block $blockResource */
+        $this->blockResource   = $this->objectManager->create(Block::class);
+        $this->blockFactory    = $this->objectManager->create(BlockFactory::class);
+        $this->blockRepository = $this->objectManager->create(BlockRepositoryInterface::class);
+    }
+
+    /**
+     * Test UpdateTime
+     * @param array $blockData
+     * @throws \Exception
+     * @magentoDbIsolation enabled
+     * @dataProvider testUpdateTimeDataProvider
+     */
+    public function testUpdateTime(array $blockData)
+    {
+        # Prepare and save the temporary block
+        $tempBlock = $this->blockFactory->create();
+        $tempBlock->setData($blockData);
+        $this->blockResource->save($tempBlock);
+
+        # Load previously created block and compare update_time field
+        $block = $this->blockRepository->getById($tempBlock->getId());
+        $date  = $this->objectManager->get(DateTime::class)->date();
+        $this->assertEquals($date, $block->getUpdateTime());
+    }
+
+    /**
+     * Data provider "testUpdateTime" method
+     * @return array
+     */
+    public function testUpdateTimeDataProvider()
+    {
+        return [
+            [
+                'data' => [
+                    'title'      => 'Test title',
+                    'stores'     => [0],
+                    'identifier' => 'test-identifier',
+                    'content'    => 'Test content',
+                    'is_active'  => 1
+                ]
+            ]
+        ];
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Cms/Model/PageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/PageTest.php
@@ -6,17 +6,13 @@
 namespace Magento\Cms\Model;
 
 use Magento\Cms\Api\PageRepositoryInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
 
 /**
  * @magentoAppArea adminhtml
  */
 class PageTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var \Magento\Cms\Model\Page
-     */
-    protected $model;
-
     protected function setUp()
     {
         $user = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
@@ -51,15 +47,14 @@ class PageTest extends \PHPUnit\Framework\TestCase
      */
     public function testUpdateTime()
     {
-        $updateTime = '2016-09-01 00:00:00';
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\Cms\Model\Page $page */
         $page = $objectManager->create(\Magento\Cms\Model\Page::class);
         $page->setData(['title' => 'Test', 'stores' => [1]]);
-        $page->setUpdateTime($updateTime);
         $page->save();
         $page = $objectManager->get(PageRepositoryInterface::class)->getById($page->getId());
-        $this->assertEquals($updateTime, $page->getUpdateTime());
+        $date = $objectManager->get(DateTime::class)->date();
+        $this->assertEquals($date, $page->getUpdateTime());
     }
 
     public function generateIdentifierFromTitleDataProvider()


### PR DESCRIPTION
Set Current Date Time to update_time field

### Description
add current date time to 'update_time' in `_beforeSave` method  for Page and Block

### Fixed Issues (if relevant)
1. magento/magento2#12625: when saving a page in magento 2.2.1, 'Modified' date field is not getting updated

### Manual testing scenarios
1. Login to magento admin
2. Go to Content > Pages
3. In Action column, click select > edit
4. Make changes to that page and click 'Save Page'

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
