### PR TITLE
Remove @escapeNotVerified from documentation

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/XssPhtmlTemplateTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/XssPhtmlTemplateTest.php
@@ -27,16 +27,14 @@ class XssPhtmlTemplateTest extends \PHPUnit\Framework\TestCase
              * Static test will cover the following cases:
              *
              * 1. /\* @noEscape \*\/ before output. Output doesn't require escaping. Test is green.
-             * 2. /\* @escapeNotVerified \*\/ before output. Output escaping is not checked and
-             *    should be verified. Test is green.
-             * 3. Methods which contains "html" in their names (e.g. echo $object->{suffix}Html{postfix}() ).
+             * 2. Methods which contains "html" in their names (e.g. echo $object->{suffix}Html{postfix}() ).
              *    Data is ready for the HTML output. Test is green.
-             * 4. AbstractBlock methods escapeHtml, escapeUrl, escapeQuote, escapeXssInUrl are allowed. Test is green.
-             * 5. Type casting and php function count() are allowed
+             * 3. AbstractBlock methods escapeHtml, escapeUrl, escapeQuote, escapeXssInUrl are allowed. Test is green.
+             * 4. Type casting and php function count() are allowed
              *    (e.g. echo (int)$var, echo (float)$var, echo (bool)$var, echo count($var)). Test is green.
-             * 6. Output in single quotes (e.g. echo 'some text'). Test is green.
-             * 7. Output in double quotes without variables (e.g. echo "some text"). Test is green.
-             * 8. Other of p.1-7. Output is not escaped. Test is red.
+             * 5. Output in single quotes (e.g. echo 'some text'). Test is green.
+             * 6. Output in double quotes without variables (e.g. echo "some text"). Test is green.
+             * 7. Other of p.1-6. Output is not escaped. Test is red.
              *
              * @param string $file
              */


### PR DESCRIPTION
The inline documentation of the static test for XSS vulnerabilities doesn't reflect that `@escapeNotVerified` is disallowed in >= 2.2.

### Description
Update the comment to reflect the documentation (compare [2.1](http://devdocs.magento.com/guides/v2.1/frontend-dev-guide/templates/template-security.html#Static-Test) and [2.2](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/templates/template-security.html)).

### Fixed Issues (if relevant)
No issue here.

### Manual testing scenarios
1. Compare the documentation in the code with the [documentation in devdocs]((http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/templates/template-security.html)).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
