### PR TITLE
#12446: Add GetUtilityPageIdentifiers for Manage Custom Pages to be excluded …

### DIFF
--- a/app/code/Magento/Cms/Api/GetUtilityPageIdentifiersInterface.php
+++ b/app/code/Magento/Cms/Api/GetUtilityPageIdentifiersInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Api;
+
+/**
+ * Utility Cms Pages
+ *
+ * @api
+ */
+interface GetUtilityPageIdentifiersInterface
+{
+    /**
+     * Get List Page Identifiers
+     * @return array
+     */
+    public function execute();
+}

--- a/app/code/Magento/Cms/Model/GetUtilityPageIdentifiers.php
+++ b/app/code/Magento/Cms/Model/GetUtilityPageIdentifiers.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Model;
+
+use Magento\Cms\Api\GetUtilityPageIdentifiersInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Utility Cms Pages
+ */
+class GetUtilityPageIdentifiers implements GetUtilityPageIdentifiersInterface
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * UtilityCmsPage constructor.
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Get List Page Identifiers
+     * @return array
+     */
+    public function execute()
+    {
+        $homePageIdentifier = $this->scopeConfig->getValue(
+            'web/default/cms_home_page',
+            ScopeInterface::SCOPE_STORE
+        );
+        $noRouteIdentifier  = $this->scopeConfig->getValue(
+            'web/default/cms_no_route',
+            ScopeInterface::SCOPE_STORE
+        );
+
+        $noCookieIdentifier = $this->scopeConfig->getValue(
+            'web/default/cms_no_cookies',
+            ScopeInterface::SCOPE_STORE
+        );
+
+        return [$homePageIdentifier, $noRouteIdentifier, $noCookieIdentifier];
+    }
+}

--- a/app/code/Magento/Cms/etc/di.xml
+++ b/app/code/Magento/Cms/etc/di.xml
@@ -14,6 +14,7 @@
     <preference for="Magento\Cms\Api\Data\BlockInterface" type="Magento\Cms\Model\Block" />
     <preference for="Magento\Cms\Api\BlockRepositoryInterface" type="Magento\Cms\Model\BlockRepository" />
     <preference for="Magento\Cms\Api\PageRepositoryInterface" type="Magento\Cms\Model\PageRepository" />
+    <preference for="Magento\Cms\Api\GetUtilityPageIdentifiersInterface" type="Magento\Cms\Model\GetUtilityPageIdentifiers" />
     <type name="Magento\Cms\Model\Wysiwyg\Config">
         <arguments>
             <argument name="windowSize" xsi:type="array">

--- a/app/code/Magento/Sitemap/etc/module.xml
+++ b/app/code/Magento/Sitemap/etc/module.xml
@@ -9,6 +9,7 @@
     <module name="Magento_Sitemap" setup_version="2.0.0">
         <sequence>
             <module name="Magento_Robots"/>
+            <module name="Magento_Cms"/>
             <module name="Magento_Catalog"/>
         </sequence>
     </module>


### PR DESCRIPTION
Added Interface and class to get collection of pages identifiers to be excluded from sitemap

### Description
Get default pages from config to be excluded in Sitemap.

### Fixed Issues (if relevant)
1. magento/magento2#12446: Remove /home from the sitemap.xml

### Manual testing scenarios
1. Create Sitemap
2. the pages like  `{domain}/home` `{domain}/no-route` no longer exists for sitemap

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
