### PR TITLE
Add fallback for Product_links position attribute if not set in request

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -66,8 +66,8 @@ class SaveHandler
         $link = $entity->getData($this->metadataPool->getMetadata($entityType)->getLinkField());
         if ($this->linkResource->hasProductLinks($link)) {
             /** @var \Magento\Catalog\Api\Data\ProductInterface $entity */
-            foreach ($this->productLinkRepository->getList($entity) as $link) {
-                $this->productLinkRepository->delete($link);
+            foreach ($this->productLinkRepo->getList($entity) as $link) {
+                $this->productLinkRepo->delete($link);
             }
         }
         $productLinks = $entity->getProductLinks();
@@ -97,7 +97,7 @@ class SaveHandler
 
         if (count($productLinks) > 0) {
             foreach ($entity->getProductLinks() as $link) {
-                $this->productLinkRepository->save($link);
+                $this->productLinkRepo->save($link);
             }
         }
         return $entity;

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -119,7 +119,7 @@ class SaveHandler
             }
         }
 
-        // Check if at least on link without position exists per Link type
+        // Check if at least one link without position exists per Link type
         foreach ($linksByType as $type => $links) {
             foreach ($links as $link) {
                 if (!array_key_exists('position', $link->getData())) {

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -31,18 +31,28 @@ class SaveHandler
     private $linkResource;
 
     /**
+     * @var linkTypeProvider
+     */
+    private $linkTypeProvider;
+
+    /**
+     * SaveHandler constructor.
      * @param MetadataPool $metadataPool
      * @param Link $linkResource
      * @param ProductLinkRepositoryInterface $productLinkRepository
+     * @param \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
      */
     public function __construct(
         MetadataPool $metadataPool,
         Link $linkResource,
-        ProductLinkRepositoryInterface $productLinkRepository
-    ) {
+        ProductLinkRepositoryInterface $productLinkRepository,
+        \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
+    )
+    {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
         $this->productLinkRepository = $productLinkRepository;
+        $this->linkTypeProvider = $linkTypeProvider;
     }
 
     /**
@@ -55,17 +65,74 @@ class SaveHandler
     {
         $link = $entity->getData($this->metadataPool->getMetadata($entityType)->getLinkField());
         if ($this->linkResource->hasProductLinks($link)) {
-            /** @var \Magento\Catalog\Api\Data\ProductInterface $entity*/
+            /** @var \Magento\Catalog\Api\Data\ProductInterface $entity */
             foreach ($this->productLinkRepository->getList($entity) as $link) {
                 $this->productLinkRepository->delete($link);
             }
         }
         $productLinks = $entity->getProductLinks();
+
+        // Build links per type
+        $linksByType = [];
+        foreach ($productLinks as $link) {
+            $linksByType[$link->getLinkType()][] = $link;
+        }
+
+        // Do check
+        $hasPositionLinkType = $this->isPositionsSet($linksByType);
+
+
+        // Bug fix for API if the Position was not set to force set Position attribute in "catalog_product_link_attribute_int"
+        // set Positions attribute values
+        foreach ($hasPositionLinkType as $linkType => $hasPosition) {
+            if (!$hasPosition) {
+                array_walk($linksByType[$linkType], function ($productLink, $position) {
+                    $productLink->setPosition(++$position);
+                });
+            }
+        }
+
+        // Flatten multi-dimensional linksByType in ProductLinks
+        $productLinks = array_reduce($linksByType, 'array_merge', []);
+
         if (count($productLinks) > 0) {
             foreach ($entity->getProductLinks() as $link) {
                 $this->productLinkRepository->save($link);
             }
         }
         return $entity;
+    }
+
+    /**
+     * Check if the position is set for all product links per link type.
+     * array with boolean per type
+     *
+     * @param $linksByType
+     * @return array
+     */
+    private function isPositionsSet($linksByType)
+    {
+        $linkTypes = $this->linkTypeProvider->getLinkTypes();
+
+        // Initialize isPositionSet for existent link types
+        $isPositionSet = [];
+        foreach (array_keys($linkTypes) as $typeName) {
+            if (array_key_exists($typeName, $linksByType)) {
+                $isPositionSet[$typeName] = count($linksByType[$typeName]) > 0;
+            }
+        }
+
+
+        // Check if at least on link without position exists per Link type
+        foreach ($linksByType as $type => $links) {
+            foreach ($links as $link) {
+                if (!array_key_exists('position', $link->getData())) {
+                    $isPositionSet[$type] = false;
+                    break;
+                }
+            }
+        }
+
+        return $isPositionSet;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -77,12 +77,9 @@ class SaveHandler
             $linksByType[$link->getLinkType()][] = $link;
         }
 
-        // Do check
-        $hasPositionLinkType = $this->isPositionSet($linksByType);
-
         // Set array position as a fallback position if necessary
-        foreach ($hasPositionLinkType as $linkType => $hasPosition) {
-            if (!$hasPosition) {
+        foreach ($linksByType as $linkType => $links) {
+            if (!$this->hasPosition($links)) {
                 array_walk($linksByType[$linkType], function ($productLink, $position) {
                     $productLink->setPosition(++$position);
                 });
@@ -101,34 +98,17 @@ class SaveHandler
     }
 
     /**
-     * Check if the position is set for all product links per link type.
-     * array with boolean per type
-     *
-     * @param $linksByType
-     * @return array
+     * Check if at least one link without position
+     * @param $links
+     * @return bool
      */
-    private function isPositionSet($linksByType)
+    public function hasPosition($links)
     {
-        $linkTypes = $this->linkTypeProvider->getLinkTypes();
-
-        // Initialize isPositionSet for existent link types
-        $isPositionSet = [];
-        foreach (array_keys($linkTypes) as $typeName) {
-            if (array_key_exists($typeName, $linksByType)) {
-                $isPositionSet[$typeName] = count($linksByType[$typeName]) > 0;
+        foreach ($links as $link) {
+            if (!array_key_exists('position', $link->getData())) {
+                return false;
             }
         }
-
-        // Check if at least one link without position exists per Link type
-        foreach ($linksByType as $type => $links) {
-            foreach ($links as $link) {
-                if (!array_key_exists('position', $link->getData())) {
-                    $isPositionSet[$type] = false;
-                    break;
-                }
-            }
-        }
-
-        return $isPositionSet;
+        return true;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -18,7 +18,7 @@ class SaveHandler
     /**
      * @var ProductLinkRepositoryInterface
      */
-    protected $productLinkRepo;
+    protected $productLinkRepository;
 
     /**
      * @var MetadataPool
@@ -39,18 +39,18 @@ class SaveHandler
      * SaveHandler constructor.
      * @param MetadataPool $metadataPool
      * @param Link $linkResource
-     * @param ProductLinkRepositoryInterface $productLinkRepo
+     * @param ProductLinkRepositoryInterface $productLinkRepository
      * @param \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
      */
     public function __construct(
         MetadataPool $metadataPool,
         Link $linkResource,
-        ProductLinkRepositoryInterface $productLinkRepo,
+        ProductLinkRepositoryInterface $productLinkRepository,
         \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
     ) {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
-        $this->productLinkRepo = $productLinkRepo;
+        $this->productLinkRepository = $productLinkRepository;
         $this->linkTypeProvider = $linkTypeProvider;
     }
 
@@ -65,8 +65,8 @@ class SaveHandler
         $link = $entity->getData($this->metadataPool->getMetadata($entityType)->getLinkField());
         if ($this->linkResource->hasProductLinks($link)) {
             /** @var \Magento\Catalog\Api\Data\ProductInterface $entity */
-            foreach ($this->productLinkRepo->getList($entity) as $link) {
-                $this->productLinkRepo->delete($link);
+            foreach ($this->productLinkRepository->getList($entity) as $link) {
+                $this->productLinkRepository->delete($link);
             }
         }
         $productLinks = $entity->getProductLinks();
@@ -94,7 +94,7 @@ class SaveHandler
 
         if (count($productLinks) > 0) {
             foreach ($entity->getProductLinks() as $link) {
-                $this->productLinkRepo->save($link);
+                $this->productLinkRepository->save($link);
             }
         }
         return $entity;

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -47,8 +47,7 @@ class SaveHandler
         Link $linkResource,
         ProductLinkRepositoryInterface $productLinkRepo,
         \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
-    )
-    {
+    ) {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
         $this->productLinkRepo = $productLinkRepo;
@@ -81,8 +80,7 @@ class SaveHandler
         // Do check
         $hasPositionLinkType = $this->isPositionsSet($linksByType);
 
-        // Bug fix for API if the Position was not set to force set Position attribute in "catalog_product_link_attribute_int"
-        // set Positions attribute values
+        // Set array position as a fallback position if necessary
         foreach ($hasPositionLinkType as $linkType => $hasPosition) {
             if (!$hasPosition) {
                 array_walk($linksByType[$linkType], function ($productLink, $position) {

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -47,8 +47,7 @@ class SaveHandler
         Link $linkResource,
         ProductLinkRepositoryInterface $productLinkRepo,
         \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
-    )
-    {
+    ) {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
         $this->productLinkRepo = $productLinkRepo;

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -18,7 +18,7 @@ class SaveHandler
     /**
      * @var ProductLinkRepositoryInterface
      */
-    protected $productLinkRepository;
+    protected $productLinkRepo;
 
     /**
      * @var MetadataPool
@@ -39,19 +39,19 @@ class SaveHandler
      * SaveHandler constructor.
      * @param MetadataPool $metadataPool
      * @param Link $linkResource
-     * @param ProductLinkRepositoryInterface $productLinkRepository
+     * @param ProductLinkRepositoryInterface $productLinkRepo
      * @param \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
      */
     public function __construct(
         MetadataPool $metadataPool,
         Link $linkResource,
-        ProductLinkRepositoryInterface $productLinkRepository,
+        ProductLinkRepositoryInterface $productLinkRepo,
         \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
     )
     {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
-        $this->productLinkRepository = $productLinkRepository;
+        $this->productLinkRepo = $productLinkRepo;
         $this->linkTypeProvider = $linkTypeProvider;
     }
 

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -81,7 +81,6 @@ class SaveHandler
         // Do check
         $hasPositionLinkType = $this->isPositionsSet($linksByType);
 
-
         // Bug fix for API if the Position was not set to force set Position attribute in "catalog_product_link_attribute_int"
         // set Positions attribute values
         foreach ($hasPositionLinkType as $linkType => $hasPosition) {
@@ -121,7 +120,6 @@ class SaveHandler
                 $isPositionSet[$typeName] = count($linksByType[$typeName]) > 0;
             }
         }
-
 
         // Check if at least on link without position exists per Link type
         foreach ($linksByType as $type => $links) {

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -78,7 +78,7 @@ class SaveHandler
         }
 
         // Do check
-        $hasPositionLinkType = $this->isPositionsSet($linksByType);
+        $hasPositionLinkType = $this->isPositionSet($linksByType);
 
         // Set array position as a fallback position if necessary
         foreach ($hasPositionLinkType as $linkType => $hasPosition) {
@@ -107,7 +107,7 @@ class SaveHandler
      * @param $linksByType
      * @return array
      */
-    private function isPositionsSet($linksByType)
+    private function isPositionSet($linksByType)
     {
         $linkTypes = $this->linkTypeProvider->getLinkTypes();
 

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -69,11 +69,10 @@ class SaveHandler
                 $this->productLinkRepository->delete($link);
             }
         }
-        $productLinks = $entity->getProductLinks();
 
         // Build links per type
         $linksByType = [];
-        foreach ($productLinks as $link) {
+        foreach ($entity->getProductLinks() as $link) {
             $linksByType[$link->getLinkType()][] = $link;
         }
 
@@ -99,10 +98,10 @@ class SaveHandler
 
     /**
      * Check if at least one link without position
-     * @param $links
+     * @param array $links
      * @return bool
      */
-    public function hasPosition($links)
+    private function hasPosition($links)
     {
         foreach ($links as $link) {
             if (!array_key_exists('position', $link->getData())) {

--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -101,7 +101,7 @@ class SaveHandler
      * @param array $links
      * @return bool
      */
-    private function hasPosition($links)
+    private function hasPosition(array $links)
     {
         foreach ($links as $link) {
             if (!array_key_exists('position', $link->getData())) {


### PR DESCRIPTION
By setting product_links index on a product via API call, only the first two of each link type are shown in the backend or a in the response of a GET request, although they are correctly added to the database.
The problem was that if the position wasn't set there's no default value or a fallback set in the table "catalog_product_link_attribute_int" for the position attribute.

### Description
in SaveHandler class from Magento\Catalog\Model\Product\Link 
A check goes in all Products link by type to check if the position were set for all products of this type, else if any wasn't set then do a fallback by array position. 

### Manual testing scenarios
Before applying PR:
1. POST/PUT request to following API endpoint with more than 2 linked products (product_links) per link_type without a position: http://dev.domian.com/rest/V1/products/{sku}  
2. Perform a GET request to http://dev.domian.com/rest/V1/products/{sku}  - you should only see the first two linked products per link type

After applying PR:
1. POST/PUT request to following API endpoint with more than 2 linked products (product_links) per link_type without a position: http://dev.domian.com/rest/V1/products/{sku}  
2. Perform a GET request to http://dev.domian.com/rest/V1/products/{sku}  - you should see all linked products per link type with a position set.

If the position is set manually in the POST/PUT request for all products of a specific link type, this positions should be taken into account.
