### PR TITLE
Throw exception if invalid method is called instead of silently retur…

### DIFF
--- a/app/code/Magento/Indexer/Model/Indexer/Collection.php
+++ b/app/code/Magento/Indexer/Model/Indexer/Collection.php
@@ -104,106 +104,139 @@ class Collection extends \Magento\Framework\Data\Collection
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     public function getColumnValues($colName)
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     public function getItemsByColumnValue($column, $value)
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     public function getItemByColumnValue($column, $value)
     {
-        return null;
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     public function setDataToAll($key, $value = null)
     {
-        return $this;
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     public function setItemObjectClass($className)
     {
-        return $this;
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
+     * @throws \BadMethodCallException
      */
     public function toXml()
     {
-        return '';
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     public function toArray($arrRequiredFields = [])
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
+     * @throws \BadMethodCallException
      */
     public function toOptionArray()
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
+     * @throws \BadMethodCallException
      */
     public function toOptionHash()
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0 Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     protected function _toOptionArray($valueField = 'id', $labelField = 'name', $additional = [])
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 
     /**
      * {@inheritdoc} Prevents handle collection items as DataObject class instances.
      * @deprecated 100.2.0  Should not be used in the current implementation.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \BadMethodCallException
      */
     protected function _toOptionHash($valueField = 'id', $labelField = 'name')
     {
-        return [];
+        throw new \BadMethodCallException(
+            __METHOD__ . ' should not be used in the current implementation'
+        );
     }
 }

--- a/app/code/Magento/Indexer/Test/Unit/Model/Indexer/CollectionTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/Indexer/CollectionTest.php
@@ -200,11 +200,15 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      * @param array $arguments
      * @dataProvider stubMethodsDataProvider
      */
-    public function testStubMethods(string $methodName, array $arguments)
+    public function testInvalidMethods(string $methodName, array $arguments)
     {
         $this->statesFactoryMock
             ->expects($this->never())
             ->method('create');
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(
+            Collection::class . "::$methodName should not be used in the current implementation"
+        );
         $collection = $this->objectManagerHelper->getObject(
             Collection::class,
             [
@@ -251,37 +255,6 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
                 'toOptionHash',
                 []
             ],
-        ];
-    }
-
-    /**
-     * @param string $methodName
-     * @param array $arguments
-     * @dataProvider stubMethodsWithReturnSelfDataProvider
-     */
-    public function testStubMethodsWithReturnSelf(string $methodName, array $arguments)
-    {
-        $this->statesFactoryMock
-            ->expects($this->never())
-            ->method('create');
-        $collection = $this->objectManagerHelper->getObject(
-            Collection::class,
-            [
-                'entityFactory' => $this->entityFactoryMock,
-                'config' => $this->configMock,
-                'statesFactory' => $this->statesFactoryMock,
-                '_items' => [$this->getIndexerMock()],
-            ]
-        );
-        $this->assertInstanceOf(Collection::class, $collection->{$methodName}(...$arguments));
-    }
-
-    /**
-     * @return array
-     */
-    public function stubMethodsWithReturnSelfDataProvider()
-    {
-        return [
             [
                 'setDataToAll',
                 ['colName', 'value']


### PR DESCRIPTION
…ning wrong values

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
In Magento 2.2, a bunch of inherited methods  have been deprecated in \Magento\Indexer\Model\Indexer\Collection. Unfortunately they also are overridden to return empty values, which silently breaks integrations which rely on them.

This leads to unnessecarily hard to find bugs and is worse than actually failing. Now they throw `BadMethodCall` exceptions so that any developer who uses the methods immediately knows why they don't work.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Run the following code, e.g. in an integration test:
```
        $indexerCollection = $this->objectManager->create(IndexerCollection::class);
        $indexerIds = $indexerCollection->getColumnValues('indexer_id');
```
2. Previously, `$indexerIds` was an empty array. After the change, we get an exception.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
