### PR TITLE
[2.2-develop] Fixes #12660 invalid parameter configuration provided for  argument

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/UiComponentFactory.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponentFactory.php
@@ -147,6 +147,14 @@ class UiComponentFactory extends DataObject
         }
         $components = array_filter($components);
         $componentArguments['components'] = $components;
+
+       /**
+        * Prevent passing ACL restricted blocks to htmlContent constructor
+        */
+        if (isset($componentArguments['block']) && !$componentArguments['block']) {
+            return null;
+        }
+
         if (!isset($componentArguments['context'])) {
             $componentArguments['context'] = $renderContext;
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
In clean Magento 2.2.0, 2.2.1, 2.2.2 ```Invalid parameter configuration provided for $block argument of Magento\\Ui\\Component\\HtmlContent``` exception is thrown for admin role restricted to customer management with no ACL permissions to newsletter or sales tab

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12660: Invalid parameter configuration provided for $block argument upon no ACL permissions to the block
2. magento/magento2#12452:  ACL permissions issue

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Create new admin user role with customer tab permissions only
2. Assign new admin user to the role
3. Login as the user
4. Try to create new customer

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
