### PR TITLE
Fix for reverting stock twice for cancelled orders

### DIFF
--- a/app/code/Magento/CatalogInventory/etc/events.xml
+++ b/app/code/Magento/CatalogInventory/etc/events.xml
@@ -27,9 +27,6 @@
     <event name="sales_model_service_quote_submit_failure">
         <observer name="inventory" instance="Magento\CatalogInventory\Observer\RevertQuoteInventoryObserver"/>
     </event>
-    <event name="restore_quote">
-        <observer name="inventory" instance="Magento\CatalogInventory\Observer\RevertQuoteInventoryObserver"/>
-    </event>
     <event name="sales_order_item_cancel">
         <observer name="inventory" instance="Magento\CatalogInventory\Observer\CancelOrderItemObserver"/>
     </event>


### PR DESCRIPTION
### Description
Fix for reverting stock twice for cancelled orders:
- Removed cataloginventory event observer `restore_quote`, that increased the stock when rebuilding a quote. Reverting quote inventory should be responsibility either of `sales_model_service_quote_submit_failure` or `sales_order_item_cancel` events;

### Fixed Issues
1. magento/magento2#9969: Cancel order and restore quote methods increase stocks twice

