### PR TITLE
Add error message if not logged in for adding products to wishlist

### DIFF
--- a/app/code/Magento/Wishlist/Controller/Index/Plugin.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Plugin.php
@@ -30,26 +30,29 @@ class Plugin
     protected $config;
 
     /**
-     * @var \Magento\Framework\App\Response\RedirectInterface
+     * @var \Magento\Framework\Message\ManagerInterface $messageManager
      */
-    protected $redirector;
+    protected $messageManager;
 
     /**
      * @param CustomerSession $customerSession
      * @param \Magento\Wishlist\Model\AuthenticationStateInterface $authenticationState
      * @param ScopeConfigInterface $config
      * @param RedirectInterface $redirector
+     * @param \Magento\Framework\Message\ManagerInterface $messageManager
      */
     public function __construct(
         CustomerSession $customerSession,
         \Magento\Wishlist\Model\AuthenticationStateInterface $authenticationState,
         ScopeConfigInterface $config,
-        RedirectInterface $redirector
+        RedirectInterface $redirector,
+        \Magento\Framework\Message\ManagerInterface $messageManager
     ) {
         $this->customerSession = $customerSession;
         $this->authenticationState = $authenticationState;
         $this->config = $config;
         $this->redirector = $redirector;
+        $this->messageManager = $messageManager;
     }
 
     /**
@@ -72,6 +75,10 @@ class Plugin
             $this->customerSession->setBeforeModuleName('wishlist');
             $this->customerSession->setBeforeControllerName('index');
             $this->customerSession->setBeforeAction('add');
+
+            if ($request->getActionName() == 'add') {
+                $this->messageManager->addErrorMessage(__('You must login or register to add items to your wishlist.'));
+            }
         }
         if (!$this->config->isSetFlag('wishlist/general/active')) {
             throw new NotFoundException(__('Page not found.'));

--- a/app/code/Magento/Wishlist/Controller/Index/Plugin.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Plugin.php
@@ -35,21 +35,29 @@ class Plugin
     protected $redirector;
 
     /**
+     * @var \Magento\Framework\Message\ManagerInterface $messageManager
+     */
+    protected $messageManager;
+
+    /**
      * @param CustomerSession $customerSession
      * @param \Magento\Wishlist\Model\AuthenticationStateInterface $authenticationState
      * @param ScopeConfigInterface $config
      * @param RedirectInterface $redirector
+     * @param \Magento\Framework\Message\ManagerInterface $messageManager
      */
     public function __construct(
         CustomerSession $customerSession,
         \Magento\Wishlist\Model\AuthenticationStateInterface $authenticationState,
         ScopeConfigInterface $config,
-        RedirectInterface $redirector
+        RedirectInterface $redirector,
+        \Magento\Framework\Message\ManagerInterface $messageManager
     ) {
         $this->customerSession = $customerSession;
         $this->authenticationState = $authenticationState;
         $this->config = $config;
         $this->redirector = $redirector;
+        $this->messageManager = $messageManager;
     }
 
     /**
@@ -72,6 +80,10 @@ class Plugin
             $this->customerSession->setBeforeModuleName('wishlist');
             $this->customerSession->setBeforeControllerName('index');
             $this->customerSession->setBeforeAction('add');
+
+            if ($request->getActionName() == 'add') {
+                $this->messageManager->addErrorMessage(__('You must login or register to add items to your wishlist.'));
+            }
         }
         if (!$this->config->isSetFlag('wishlist/general/active')) {
             throw new NotFoundException(__('Page not found.'));

--- a/app/code/Magento/Wishlist/Controller/Index/Plugin.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Plugin.php
@@ -30,14 +30,14 @@ class Plugin
     protected $config;
 
     /**
-     * @var \Magento\Framework\Message\ManagerInterface $messageManager
+     * @var \Magento\Framework\App\Response\RedirectInterface
      */
     protected $redirector;
 
     /**
-     * @var \Magento\Framework\Message\ManagerInterface $messageManager
+     * @var \Magento\Framework\Message\ManagerInterface
      */
-    protected $messageManager;
+    private $messageManager;
 
     /**
      * @param CustomerSession $customerSession

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/PluginTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/PluginTest.php
@@ -29,6 +29,11 @@ class PluginTest extends \PHPUnit\Framework\TestCase
     protected $redirector;
 
     /**
+     * @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $messageManager;
+
+    /**
      * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $request;
@@ -53,6 +58,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase
         $this->authenticationState = $this->createMock(\Magento\Wishlist\Model\AuthenticationState::class);
         $this->config = $this->createMock(\Magento\Framework\App\Config::class);
         $this->redirector = $this->createMock(\Magento\Store\App\Response\Redirect::class);
+        $this->messageManager = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
         $this->request = $this->createMock(\Magento\Framework\App\Request\Http::class);
     }
 
@@ -63,6 +69,7 @@ class PluginTest extends \PHPUnit\Framework\TestCase
             $this->authenticationState,
             $this->config,
             $this->redirector,
+            $this->messageManager,
             $this->request
         );
     }
@@ -73,7 +80,8 @@ class PluginTest extends \PHPUnit\Framework\TestCase
             $this->customerSession,
             $this->authenticationState,
             $this->config,
-            $this->redirector
+            $this->redirector,
+            $this->messageManager
         );
     }
 

--- a/app/code/Magento/Wishlist/i18n/en_US.csv
+++ b/app/code/Magento/Wishlist/i18n/en_US.csv
@@ -116,3 +116,4 @@ Action,Action
 Configure,Configure
 Delete,Delete
 "Product Details and Comment","Product Details and Comment"
+"You must login or register to add items to your wishlist.","You must login or register to add items to your wishlist."


### PR DESCRIPTION
### Description

When you add a product to the wishlist and you're not logged in you're redirected to the login page without any warning. In this PR I've added short warning why you're redirect to the login page.

### Manual testing scenarios
Add product to wishlist without logging in.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
