### PR TITLE
fix create product with sku=0

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
@@ -127,8 +127,11 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product
             $resource->getAttribute('special_from_date')->setMaxValue($product->getSpecialToDate());
             $resource->getAttribute('news_from_date')->setMaxValue($product->getNewsToDate());
             $resource->getAttribute('custom_design_from')->setMaxValue($product->getCustomDesignTo());
-
-            $this->productValidator->validate($product, $this->getRequest(), $response);
+            $validationResult = $this->productValidator->validate($product, $this->getRequest(), $response);
+            if (true !== $validationResult) {
+                $response->setError(true);
+                $response->setMessages($validationResult);
+            }
         } catch (\Magento\Eav\Model\Entity\Attribute\Exception $e) {
             $response->setError(true);
             $response->setAttribute($e->getAttributeCode());

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product.php
@@ -556,6 +556,9 @@ class Product extends AbstractResource
         if ($attributeSet->getEntityTypeId() != $entityType->getId()) {
             return ['attribute_set' => 'Invalid attribute set entity type'];
         }
+        if ($object->getSku() === "0") {
+            return ['sku' => 'Invalid sku'];
+        }
 
         return parent::validate($object);
     }

--- a/app/code/Magento/Catalog/Ui/DataProvider/CatalogEavValidationRules.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/CatalogEavValidationRules.php
@@ -32,6 +32,9 @@ class CatalogEavValidationRules
         if ($attribute->getFrontendInput() === 'price') {
             $rules['validate-zero-or-greater'] = true;
         }
+        if ($data['code'] == 'sku') {
+            $rules['pattern'] = '^(?!0$).*';
+        }
 
         $validationClasses = explode(' ', $attribute->getFrontendClass());
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Product with zero sku save and create on frontend and grid, but error on product page in admin panel.

### Manual testing scenarios
1. Go Catalog->Product->Add New Product
2. Create product with SKU=0
3. Save product.

Result: 
Product save and show on frontend and product grid in admin panel, but error on product page in admin panel.

True result: 
Product not created.
