### PR TITLE
Issue/10838 Customer Grid Indexer not working

### DIFF
--- a/lib/internal/Magento/Framework/Indexer/Handler/AttributeHandler.php
+++ b/lib/internal/Magento/Framework/Indexer/Handler/AttributeHandler.php
@@ -35,7 +35,7 @@ class AttributeHandler implements HandlerInterface
                 'left'
             );
         } else {
-            $source->addAttributeToSelect($fieldInfo['origin'], 'left');
+            $source->addFieldToSelect($fieldInfo['origin'], 'left');
         }
     }
 }


### PR DESCRIPTION
### Description
Fix Customer Grid reindex process

### Fixed Issues
1. magento/magento2#10838: Magento 2.2.0rc23: Customer Grid Indexer not working

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a customer attribute with is_used_in_grid => true
2. Run bin/magento indexer:reindex customer_grid command

