### PR TITLE
magento/magento2#12209: Substitution payment method - Incorrect message

### DIFF
--- a/app/code/Magento/Payment/view/adminhtml/templates/info/substitution.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/substitution.phtml
@@ -10,6 +10,8 @@
  */
 ?>
 <div>
-    <?php $block->escapeHtml($block->getMethod()->getTitle());?>
+    <?= $block->getMethod()->getTitle()
+        ? $block->escapeHtml($block->getMethod()->getTitle())
+        : $block->escapeHtml(__('Payment method')); ?>
     <?= $block->escapeHtml(__(' is not available. You still can process offline actions.')) ?>
 </div>


### PR DESCRIPTION
- fixed message showing if payment method is not available

### Description
Also added check if method has title

### Fixed Issues (if relevant)
1. magento/magento2#12209: Substitution payment method - Incorrect message

### Manual testing scenarios
#### Preconditions
1. Magento 2.1.9 (same should be in 2.2-develop and 2.3-develop)
2. DB migrated from M1, payment method wasn't migrated, so it's not available

#### Steps to reproduce
1. Go to Admin panel and look at existing order
2. View "Payment & Shipping Method" section

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
