### PR TITLE
#6916 Fix notice during Update Bundle Product without changes

### DIFF
--- a/app/code/Magento/Bundle/Controller/Adminhtml/Product/Initialization/Helper/Plugin/Bundle.php
+++ b/app/code/Magento/Bundle/Controller/Adminhtml/Product/Initialization/Helper/Plugin/Bundle.php
@@ -127,7 +127,7 @@ class Bundle
         }
         $options = [];
         foreach ($bundleOptionsData as $key => $optionData) {
-            if ((bool)$optionData['delete']) {
+            if (!empty($optionData['delete'])) {
                 continue;
             }
 


### PR DESCRIPTION
### Description
If we need to update (not new) bundle product and edit any Bundle Items then the saving process works fine.
If we assign a new category and image to the product then the saving process doesn't work. 

### Fixed Issues
1. magento/magento2#6916: Update Bundle Product without changes in bundle items

### Manual testing scenarios
1. Edit sample product "Sprite Yoga Companion Kit"
2. by default this product has 4 options in bundle items. You need to add more so in total you have at least 21 options. And now we got Bundle Items pager.
3. Save product with all options and reload page.
4. Click save without any changes. you should see error.
5. If you move to the second page of bundle items and click save everything works correct.
Looks like system think we trying to remove invisible items.
