### PR TITLE
magento/magento2#11953: Product configuration creator does not warn about invalid SKUs

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\ConfigurableProduct\Ui\DataProvider\Product\Form\Modifier;
 
+use Magento\Catalog\Model\Product\Attribute\Backend\Sku;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Ui\Component\Container;
 use Magento\Ui\Component\Form;
@@ -472,8 +473,8 @@ class ConfigurablePanel extends AbstractModifier
                         [
                             'validation' =>
                                 [
-                                    'min_text_length' => '1',
-                                    'max_text_length' => '10',
+                                    'required-entry' => true,
+                                    'max_text_length' => Sku::SKU_MAX_LENGTH,
                                 ]
                         ]
                     ),

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -466,7 +466,17 @@ class ConfigurablePanel extends AbstractModifier
                         [],
                         ['dataScope' => 'product_link']
                     ),
-                    'sku_container' => $this->getColumn('sku', __('SKU')),
+                    'sku_container' => $this->getColumn(
+                        'sku',
+                        __('SKU'),
+                        [
+                            'validation' =>
+                                [
+                                    'min_text_length' => '1',
+                                    'max_text_length' => '10',
+                                ]
+                        ]
+                    ),
                     'price_container' => $this->getColumn(
                         'price',
                         __('Price'),


### PR DESCRIPTION
### Description
- Added validation for SKU field inside "Configurations" tab
- Validation requires this field to be not empty and less than SKU_MAX_LENGTH from Sku model

### Fixed Issues (if relevant)
1. magento/magento2#11953: Product configuration creator does not warn about invalid SKUs

### Manual testing scenarios
#### Preconditions
1. Magento CE 2.2.0 with sample data is installed by Composer.

#### Steps to reproduce
1. In Admin go to Stores -> Attributes -> Product -> Add New Attribute
2. Create an attribute with input type "Text Swatch" and values "Base" and "With Free Storage Kit" (sufficiently long).
3. In Admin go to: Catalog -> Products -> Add Product
4. Set name to "Sony Alpha a7R III Mirrorless Digital Camera (Body only)" e.i. something sufficiently long, near 64 characters, which is the limit for SKU field.
5. Leave the SKU as automatically filled (the same as the name).
6. (If you would append " (With Free Storage Kit)" to the name, the SKU field would appear red/invalid warning about the maximum length of 64 characters.)
7. Save the product. 
8. Open that same product and click on "Create Configurations".
9. Choose the attribute that was just created and "Next".
10. Select both swatch values and "Next".
11. Select whatever images, price, quantity and "Next".
12. Click on "Generate Products".

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
