### PR TITLE
magento/magento2#12719: Use full name in welcome message

### DIFF
--- a/app/code/Magento/Theme/view/frontend/templates/html/header.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/header.phtml
@@ -15,7 +15,7 @@ $welcomeMessage = $block->getWelcome();
     case 'welcome': ?>
         <li class="greet welcome" data-bind="scope: 'customer'">
             <!-- ko if: customer().fullname  -->
-            <span data-bind="text: new String('<?= $block->escapeHtml(__('Welcome, %1!', '%1')) ?>').replace('%1', customer().firstname)">
+            <span data-bind="text: new String('<?= $block->escapeHtml(__('Welcome, %1!', '%1')) ?>').replace('%1', customer().fullname)">
             </span>
             <!-- /ko -->
             <!-- ko ifnot: customer().fullname  -->

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertCartPerCustomer.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertCartPerCustomer.php
@@ -53,7 +53,10 @@ class AssertCartPerCustomer extends AbstractConstraint
                     ['customer' => $customer]
                 )->run();
                 \PHPUnit_Framework_Assert::assertEquals(
-                    sprintf(self::WELCOME_MESSAGE, $customer->getFirstname()),
+                    sprintf(
+                        self::WELCOME_MESSAGE,
+                        $customer->getFirstname() . ' ' . $customer->getLastname()
+                    ),
                     $cmsIndex->getLinksBlock()->getWelcomeText(),
                     'Customer welcome message is wrong.'
                 );


### PR DESCRIPTION
### Description
Using full customer name instead of only first name in welcome message

### Fixed Issue
1. magento/magento2#12719: Welcome message is shown with customer's first and last names after confirming account 

### Manual testing scenarios
1. Log in into a customer account in frontend

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
