### PR TITLE
magento/magento2#6113: Validate range-words in Form component (UI Component)

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -85,7 +85,7 @@ define([
         'range-words': [
             function (value, params) {
                 return utils.stripHtml(value).match(/\b\w+\b/g).length >= params[0] &&
-                    value.match(/bw+b/g).length < params[1];
+                    utils.stripHtml(value).match(/\b\w+\b/g).length < params[1];
             },
             $.mage.__('Please enter between {0} and {1} words.')
         ],

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -84,8 +84,10 @@ define([
         ],
         'range-words': [
             function (value, params) {
-                return utils.stripHtml(value).match(/\b\w+\b/g).length >= params[0] &&
-                    utils.stripHtml(value).match(/\b\w+\b/g).length < params[1];
+                var match = utils.stripHtml(value).match(/\b\w+\b/g) || [];
+
+                return match.length >= params[0] &&
+                    match.length <= params[1];
             },
             $.mage.__('Please enter between {0} and {1} words.')
         ],

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/validation/rules.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/validation/rules.test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/* eslint-disable max-nested-callbacks */
+define([
+    'Magento_Ui/js/lib/validation/rules'
+], function (rules) {
+    'use strict';
+
+    describe('Magento_Ui/js/lib/validation/rules', function () {
+        describe('"range-words" method', function () {
+            it('Check on empty value', function () {
+                var value = '',
+                    params = [1,3];
+
+                expect(rules['range-words'].handler(value, params)).toBe(false);
+            });
+
+            it('Check on redundant words', function () {
+                var value = 'a b c d',
+                    params = [1,3];
+
+                expect(rules['range-words'].handler(value, params)).toBe(false);
+            });
+
+            it('Check with three words', function () {
+                var value = 'a b c',
+                    params = [1,3];
+
+                expect(rules['range-words'].handler(value, params)).toBe(true);
+            });
+
+            it('Check with one word', function () {
+                var value = 'a',
+                    params = [1,3];
+
+                expect(rules['range-words'].handler(value, params)).toBe(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Description
- Fixed regexp pattern for range-words validation
- Added tests

### Fixed Issues (if relevant)
1. magento/magento2#6113: Validate range-words in Form component (UI Component)

### Manual testing scenarios

1.  Edit /app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml:
In node with '<field name="name"' replace                      
`<rule name="required-entry" xsi:type="boolean">true</item>`
 to
`<rule name="range-words" xsi:type="array">`
`        <item name="0" xsi:type="number">1</item>`
`        <item name="1" xsi:type="number">3</item>`
`</rule>`
2. Flush cache.
3. In Admin, open any product and click "New Category"
4. Enter any value in "Category Name" field, set any "Parent Category" and press "Create Category"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
