### PR TITLE
#9453 - ported down c2e5d77a9516c8305585e819c2f0a0629648cc14

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Session/SidResolverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Session/SidResolverTest.php
@@ -112,6 +112,7 @@ class SidResolverTest extends \PHPUnit\Framework\TestCase
             $this->request->getQuery()->set($this->model->getSessionIdQueryParam($this->session), $testSid);
         }
         $this->assertEquals($sid, $this->model->getSid($this->session));
+        $this->assertEquals($useFrontedSid, $this->model->getUseSessionInUrl());
     }
 
     /**
@@ -150,10 +151,42 @@ class SidResolverTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->model->getUseSessionVar());
     }
 
-    public function testSetGetUseSessionInUrl()
+    /**
+     * Variations of Use SID on frontend value.
+     *
+     * @return array
+     */
+    public function dataProviderSessionInUrl()
     {
-        $this->assertTrue($this->model->getUseSessionInUrl());
-        $this->model->setUseSessionInUrl(false);
-        $this->assertFalse($this->model->getUseSessionInUrl());
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * Testing "Use SID in URLs" flag.
+     * Checking that the method returns config value if not explicitly
+     * overridden.
+     *
+     * @param bool $configValue Use SID on frontend config value.
+     * @dataProvider dataProviderSessionInUrl
+     */
+    public function testSetGetUseSessionInUrl($configValue)
+    {
+        $this->scopeConfig->expects(
+            $this->any()
+        )->method(
+            'getValue'
+        )->with(
+            \Magento\Framework\Session\SidResolver::XML_PATH_USE_FRONTEND_SID,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        )->will(
+            $this->returnValue($configValue)
+        );
+
+        $this->assertEquals($configValue, $this->model->getUseSessionInUrl());
+        $this->model->setUseSessionInUrl(!$configValue);
+        $this->assertEquals(!$configValue, $this->model->getUseSessionInUrl());
     }
 }

--- a/lib/internal/Magento/Framework/Session/SidResolver.php
+++ b/lib/internal/Magento/Framework/Session/SidResolver.php
@@ -44,10 +44,10 @@ class SidResolver implements SidResolverInterface
     /**
      * Use session in URL flag
      *
-     * @var bool
+     * @var bool|null
      * @see \Magento\Framework\UrlInterface
      */
-    protected $_useSessionInUrl = true;
+    protected $_useSessionInUrl;
 
     /**
      * @var string
@@ -82,10 +82,7 @@ class SidResolver implements SidResolverInterface
     public function getSid(SessionManagerInterface $session)
     {
         $sidKey = null;
-        $useSidOnFrontend = $this->scopeConfig->getValue(
-            self::XML_PATH_USE_FRONTEND_SID,
-            $this->_scopeType
-        );
+        $useSidOnFrontend = $this->getUseSessionInUrl();
         if ($useSidOnFrontend && $this->request->getQuery(
             $this->getSessionIdQueryParam($session),
             false
@@ -147,13 +144,22 @@ class SidResolver implements SidResolverInterface
     }
 
     /**
-     * Retrieve use session in URL flag
+     * Retrieve use session in URL flag.
      *
      * @return bool
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
      */
     public function getUseSessionInUrl()
     {
+        if ($this->_useSessionInUrl === null) {
+            //Using config value by default, can be overridden by using the
+            //setter.
+            $this->_useSessionInUrl = (bool)$this->scopeConfig->getValue(
+                self::XML_PATH_USE_FRONTEND_SID,
+                $this->_scopeType
+            );
+        }
+
         return $this->_useSessionInUrl;
     }
 }


### PR DESCRIPTION
 - MAGETWO-70322: [2.1.x][GitHub] SID in URL even if disabled #9453

1. magento/magento2#9453: '?SID' in URL even if disabled

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
