### PR TITLE
magento/magento2#5998: Translation - $block->escapeHtml($_option->getTitle()) does not get translated

### DIFF
--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/checkbox.phtml
@@ -14,7 +14,7 @@
 
 <div class="field admin__field options<?php if ($_option->getRequired()) echo ' required _required' ?>">
     <label class="label admin__field-label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
 
     <div class="control admin__field-control">

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/multi.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/multi.phtml
@@ -12,7 +12,7 @@
 <?php $_selections = $_option->getSelections(); ?>
 <?php $_skipSaleableCheck = $this->helper('Magento\Catalog\Helper\Product')->getSkipSaleableCheck(); ?>
 <div class="field admin__field <?php if ($_option->getRequired()) echo ' required' ?><?php if ($_option->getDecoratedIsLast()):?> last<?php endif; ?>">
-    <label class="label admin__field-label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label admin__field-label"><span><?= $block->escapeHtml(__($_option->getTitle())) ?></span></label>
     <div class="control admin__field-control">
         <?php if (count($_selections) == 1 && $_option->getRequired()): ?>
             <?= /* @escapeNotVerified */ $block->getSelectionQtyTitlePrice($_selections[0]) ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
@@ -15,7 +15,7 @@
 <?php list($_defaultQty, $_canChangeQty) = $block->getDefaultValues(); ?>
 
 <div class="field admin__field options<?php if ($_option->getRequired()) echo ' required' ?>">
-    <label class="label admin__field-label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label admin__field-label"><span><?= $block->escapeHtml(__($_option->getTitle())) ?></span></label>
     <div class="control admin__field-control">
         <div class="nested<?php if ($_option->getDecoratedIsLast()):?> last<?php endif; ?>">
         <?php if ($block->showSingle()): ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/select.phtml
@@ -15,7 +15,7 @@
 <?php list($_defaultQty, $_canChangeQty) = $block->getDefaultValues(); ?>
 
 <div class="field admin__field option<?php if ($_option->getDecoratedIsLast()):?> last<?php endif; ?><?php if ($_option->getRequired()) echo ' required _required' ?>">
-    <label class="label admin__field-label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label admin__field-label"><span><?= $block->escapeHtml(__($_option->getTitle())) ?></span></label>
     <div class="control admin__field-control">
         <?php if ($block->showSingle()): ?>
             <?= /* @escapeNotVerified */ $block->getSelectionTitlePrice($_selections[0]) ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -13,7 +13,7 @@
 <?php $_selections = $_option->getSelections() ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
     <label class="label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
     <div class="control">
         <div class="nested options-list">

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
@@ -12,7 +12,7 @@
 <?php $_selections = $_option->getSelections() ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
     <label class="label" for="bundle-option-<?= /* @escapeNotVerified */ $_option->getId() ?>">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
     <div class="control">
         <?php if ($block->showSingle()): ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
@@ -15,7 +15,7 @@
 
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
     <label class="label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
     <div class="control">
         <div class="nested options-list">

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/select.phtml
@@ -15,7 +15,7 @@
 <?php list($_defaultQty, $_canChangeQty) = $block->getDefaultValues(); ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
     <label class="label" for="bundle-option-<?= /* @escapeNotVerified */ $_option->getId() ?>">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
     <div class="control">
         <?php if ($block->showSingle()): ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
@@ -12,7 +12,7 @@
 <?php $_optionId = $_option->getId(); ?>
 <div class="admin__field field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
   <label class="label admin__field-label">
-      <?= $block->escapeHtml($_option->getTitle()) ?>
+      <?= $block->escapeHtml(__($_option->getTitle())) ?>
       <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
   </label>
   <div class="admin__field-control control">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
@@ -63,7 +63,7 @@ require(['prototype'], function(){
 
 <div class="admin__field <?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="admin__field-label label">
-        <?= $block->escapeHtml($_option->getTitle()) ?>
+        <?= $block->escapeHtml(__($_option->getTitle())) ?>
         <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
     </label>
     <div class="admin__field-control control">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/select.phtml
@@ -11,7 +11,7 @@
 <?php $_option = $block->getOption(); ?>
 <div class="admin__field field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="label admin__field-label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
     <div class="control admin__field-control">
         <?= $block->getValuesHtml() ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
@@ -11,7 +11,7 @@
 <?php $_option = $block->getOption(); ?>
 <div class="field admin__field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="admin__field-label label">
-        <?= $block->escapeHtml($_option->getTitle()) ?>
+        <?= $block->escapeHtml(__($_option->getTitle())) ?>
         <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
     </label>
     <div class="control admin__field-control">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
@@ -14,7 +14,7 @@
     data-mage-init='{"priceOptionDate":{"fromSelector":"#product_addtocart_form"}}'>
     <fieldset class="fieldset fieldset-product-options-inner<?= /* @escapeNotVerified */ $class ?>">
         <legend class="legend">
-            <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+            <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
             <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
         </legend>
         <div class="control">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/default.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/default.phtml
@@ -9,5 +9,5 @@
 ?>
 <?php $_option = $block->getOption() ?>
 <div class="field">
-    <label class="label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label"><span><?= $block->escapeHtml(__($_option->getTitle())) ?></span></label>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
@@ -18,7 +18,7 @@
 
 <div class="field file<?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="<?= /* @noEscape */ $_fileName ?>" id="<?= /* @noEscape */ $_fileName ?>-label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
         <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
     </label>
     <?php if ($_fileExists): ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/select.phtml
@@ -15,7 +15,7 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
 ?>
 <div class="field<?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="select_<?= /* @escapeNotVerified */ $_option->getId() ?>">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
     </label>
     <div class="control">
         <?= $block->getValuesHtml() ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
@@ -16,7 +16,7 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
     echo ' textarea';
 } ?><?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="options_<?= /* @escapeNotVerified */ $_option->getId() ?>_text">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $block->escapeHtml(__($_option->getTitle())) ?></span>
         <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
     </label>
 


### PR DESCRIPTION
### Description
 - Replaced $_option->getTitle() to __($_option->getTitle()) in templates

### Fixed Issues (if relevant)
1. magento/magento2#5998: Translation - $block->escapeHtml($_option->getTitle()) does not get translated

### Manual testing scenarios
1. Go to product view  page.
2. Product options must be trnslated

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
