### PR TITLE
Grid filtration doesn't work for mysql special characters

### DIFF
--- a/app/code/Magento/Ui/Component/Filters/Type/Input.php
+++ b/app/code/Magento/Ui/Component/Filters/Type/Input.php
@@ -65,7 +65,7 @@ class Input extends AbstractFilter
     protected function applyFilter()
     {
         if (isset($this->filterData[$this->getName()])) {
-            $value = $this->filterData[$this->getName()];
+            $value = str_replace(['%', '_'], ['\%', '\_'], $this->filterData[$this->getName()]);
 
             if (!empty($value)) {
                 $filter = $this->filterBuilder->setConditionType('like')


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create several products
2. Open product grid
3. Open filters block
4. Enter % or _ to name field
5. Do filter

###Expected result

Grid shows only products with the symbol

###Actual result

Grid shows all products
 
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
