### PR TITLE
magento/magento2#12439 Newsletter subscription success email not sent…

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -633,6 +633,8 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             $this->setStatus(self::STATUS_SUBSCRIBED)
                 ->setStatusChanged(true)
                 ->save();
+
+            $this->sendConfirmationSuccessEmail();
             return true;
         }
 

--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
@@ -341,6 +341,21 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $code = 111;
         $this->subscriber->setCode($code);
         $this->resource->expects($this->once())->method('save')->willReturnSelf();
+        $storeModel = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId'])
+            ->getMock();
+        $transport = $this->createMock(\Magento\Framework\Mail\TransportInterface::class);
+        $this->scopeConfig->expects($this->any())->method('getValue')->willReturn(true);
+        $this->transportBuilder->expects($this->once())->method('setTemplateIdentifier')->willReturnSelf();
+        $this->transportBuilder->expects($this->once())->method('setTemplateOptions')->willReturnSelf();
+        $this->transportBuilder->expects($this->once())->method('setTemplateVars')->willReturnSelf();
+        $this->transportBuilder->expects($this->once())->method('setFrom')->willReturnSelf();
+        $this->transportBuilder->expects($this->once())->method('addTo')->willReturnSelf();
+        $this->storeManager->expects($this->any())->method('getStore')->willReturn($storeModel);
+        $storeModel->expects($this->any())->method('getId')->willReturn(1);
+        $this->transportBuilder->expects($this->once())->method('getTransport')->willReturn($transport);
+        $transport->expects($this->once())->method('sendMessage')->willReturnSelf();
 
         $this->assertTrue($this->subscriber->confirm($code));
     }


### PR DESCRIPTION
… after confirmation

    added sendSuccessMessage

### Description

Added $this->sendConfirmationSuccessEmail(); to confirm method of \Magento\Newsletter\Model\Subscriber.

### Fixed Issues (if relevant)

magento/magento2#12439 Newsletter subscription success email not sent after confirmation

### Manual testing scenarios

1. Change configuration under Stores > Configuration > Customers > Newsletter > Subscription Options > Need to Confirm to Yes
2. Sign up for Newsletter on frontend
3. Follow confirmation link in email
4. Confirmation email should arrive


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
