### PR TITLE
magento/magento2#4292: Ability to sitch to default mode

### DIFF
--- a/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
@@ -101,6 +101,9 @@ class SetModeCommand extends Command
                         $modeController->enableProductionMode();
                     }
                     break;
+                case State::MODE_DEFAULT:
+                    $modeController->enableDefaultMode();
+                    break;
                 default:
                     throw new LocalizedException(__('Cannot switch into given mode "%1"', $toMode));
             }

--- a/app/code/Magento/Deploy/Model/Mode.php
+++ b/app/code/Magento/Deploy/Model/Mode.php
@@ -178,6 +178,25 @@ class Mode
     }
 
     /**
+     * Enable Default mode
+     *
+     * @return void
+     */
+    public function enableDefaultMode()
+    {
+        $this->filesystem->cleanupFilesystem(
+            [
+                DirectoryList::CACHE,
+                DirectoryList::GENERATED_CODE,
+                DirectoryList::GENERATED_METADATA,
+                DirectoryList::TMP_MATERIALIZATION_DIR,
+                DirectoryList::STATIC_VIEW,
+            ]
+        );
+        $this->setStoreMode(State::MODE_DEFAULT);
+    }
+
+    /**
      * Get current mode information
      *
      * @return string

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/SetModeCommandTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/SetModeCommandTest.php
@@ -67,6 +67,18 @@ class SetModeCommandTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSetDefaultMode()
+    {
+        $this->modeMock->expects($this->once())->method('enableDefaultMode');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['mode' => 'default']);
+        $this->assertContains(
+            "default mode",
+            $tester->getDisplay()
+        );
+    }
+
     public function testSetProductionSkipCompilation()
     {
         $this->modeMock->expects($this->once())->method('enableProductionModeMinimal');


### PR DESCRIPTION
- mode can be switched back to default w/o throving an error

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4292: Why can't one switch back to default mode ?

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Switch to developer mode php bin/magento deploy:mode:set developer
2. Switch to default mode  php bin/magento deploy:mode:set default

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
