### PR TITLE
magento/magento2#12716 : Exclude set default values for visibility attribute

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -147,6 +147,16 @@ abstract class AbstractType
     private $productEntityLinkField;
 
     /**
+     * Skip set default values for list of attributes
+     * if value in import file is empty
+     *
+     * @var array
+     */
+    protected $_skipDefaultValues = [
+        \Magento\CatalogImportExport\Model\Import\Product::COL_VISIBILITY
+    ];
+
+    /**
      * AbstractType constructor
      *
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory $attrSetColFac
@@ -517,7 +527,8 @@ abstract class AbstractType
                 }
             } elseif (array_key_exists($attrCode, $rowData)) {
                 $resultAttrs[$attrCode] = $rowData[$attrCode];
-            } elseif ($withDefaultValue && null !== $attrParams['default_value']) {
+            } elseif ($withDefaultValue && null !== $attrParams['default_value']
+                && !in_array($attrCode, $this->_skipDefaultValues)) {
                 $resultAttrs[$attrCode] = $attrParams['default_value'];
             }
         }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import.csv
@@ -1,4 +1,4 @@
-sku,product_type,store_view_code,name,price,attribute_set_code,categories
-simple1,simple,,"simple 1",25,Default,"Default Category/Category 1"
-simple2,simple,,"simple 2",34,Default,"Default Category/Category 1"
-simple3,simple,,"simple 3",58,Default,"Default Category/Category 1"
+sku,product_type,store_view_code,name,price,attribute_set_code,categories,visibility
+simple1,simple,,"simple 1",25,Default,"Default Category/Category 1","Catalog"
+simple2,simple,,"simple 2",34,Default,"Default Category/Category 1","Catalog"
+simple3,simple,,"simple 3",58,Default,"Default Category/Category 1","Catalog"


### PR DESCRIPTION
Fix was prepeared based on issue 

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

### Fixed Issues (if relevant)
1. magento/magento2#12716: Import doesn't allow to set default value per store view (dropdown fields)

### Manual testing scenarios
1.Log in to Admin
2.Go to Catalog > Products
3.Open product name4
4.Go to Advanced Settings > Auto Settings
5.Check Visibility field - it has value Catalog
6.Switch store view to english or chinese

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
