### PR TITLE
magento/magento2#4389 Widget cache error

### DIFF
--- a/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
@@ -167,7 +167,9 @@ class ProductsList extends \Magento\Catalog\Block\Product\AbstractProduct implem
             intval($this->getRequest()->getParam($this->getData('page_var_name'), 1)),
             $this->getProductsPerPage(),
             $conditions,
-            $this->json->serialize($this->getRequest()->getParams())
+            $this->json->serialize($this->getRequest()->getParams()),
+            $this->getTemplate(),
+            $this->getTitle()
         ];
     }
 

--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
@@ -87,8 +87,8 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
     {
         $this->collectionFactory =
             $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Product\CollectionFactory::class)
-            ->setMethods(['create'])
-            ->disableOriginalConstructor()->getMock();
+                ->setMethods(['create'])
+                ->disableOriginalConstructor()->getMock();
         $this->visibility = $this->getMockBuilder(\Magento\Catalog\Model\Product\Visibility::class)
             ->setMethods(['getVisibleInCatalogIds'])
             ->disableOriginalConstructor()
@@ -144,6 +144,8 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
         $this->productsList->setData('conditions', 'some_serialized_conditions');
 
         $this->productsList->setData('page_var_name', 'page_number');
+        $this->productsList->setTemplate('test_template');
+        $this->productsList->setData('title', 'test_title');
         $this->request->expects($this->once())->method('getParam')->with('page_number')->willReturn(1);
 
         $this->request->expects($this->once())->method('getParams')->willReturn('request_params');
@@ -164,7 +166,9 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
             1,
             5,
             'some_serialized_conditions',
-            json_encode('request_params')
+            json_encode('request_params'),
+            'test_template',
+            'test_title'
         ];
         $this->assertEquals($cacheKey, $this->productsList->getCacheKeyInfo());
     }
@@ -249,9 +253,10 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
      * Test public `createCollection` method and protected `getPageSize` method via `createCollection`
      *
      * @param bool $pagerEnable
-     * @param int $productsCount
-     * @param int $productsPerPage
-     * @param int $expectedPageSize
+     * @param int  $productsCount
+     * @param int  $productsPerPage
+     * @param int  $expectedPageSize
+     *
      * @dataProvider createCollectionDataProvider
      */
     public function testCreateCollection($pagerEnable, $productsCount, $productsPerPage, $expectedPageSize)
@@ -380,6 +385,7 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param $collection
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getConditionsForCollection($collection)


### PR DESCRIPTION
-fixed CacheKey assignment

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Add title and template name to CacheKey creation array

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4389 Widget cache error 


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install Magento from develop branch.
2. Add two widgets of type 'Catalog Product List' to the 'CMS homepage' at location content.bottom with different titles, but the same conditions. For example, condition could be product price is greater than 0
3. Refresh cache and visit homepage

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
