### PR TITLE
magento/magento2#5035 Cannot subscribe to events with a number in name

### DIFF
--- a/lib/internal/Magento/Framework/Event/Test/Unit/Config/_files/valid_events.xml
+++ b/lib/internal/Magento/Framework/Event/Test/Unit/Config/_files/valid_events.xml
@@ -12,4 +12,7 @@
     <event name="authorization_roles_save_before">
         <observer name="second_name" instance="Some_Test_Value_Two" />
     </event>
+    <event name="authorization_roles_save_before123">
+        <observer name="second_name" instance="Some_Test_Value_Two" />
+    </event>
 </config>

--- a/lib/internal/Magento/Framework/Event/etc/events.xsd
+++ b/lib/internal/Magento/Framework/Event/etc/events.xsd
@@ -60,11 +60,11 @@
     <xs:simpleType name="eventName">
         <xs:annotation>
             <xs:documentation>
-                Event name can contain only [a-zA-Z_].
+                Event name can contain only [a-zA-Z0-9_].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Allow to use digits at names of events

### Description
Fixed inconsistence in names in events and sections in system.xml

### Fixed Issues (if relevant)

1. magento/magento2#5035 I can not to subscribe on change of all sections in Stores ->Configuration using event admin_system_config_changed_section

### Manual testing scenarios

M 2.0.7

1. Create extension, create etc/adminhtml/system.xml there
2. add section tab with id, that contains number, in my case "b2b" https://drive.google.com/a/interiorwebdesign.com/file/d/0BzTvZltZJMLlemNCOGVwdUM5S00/view?usp=drivesdk
3. create etc/adminhtml/events.xml and add event listener to listen to changing of this section https://drive.google.com/a/interiorwebdesign.com/file/d/0BzTvZltZJMLlRFpqOEIyc2RKRW8/view?usp=drivesdk


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
