### PR TITLE
Fix Back to Sign in url on confirmation form

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/Confirmation.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirmation.php
@@ -6,8 +6,10 @@
  */
 namespace Magento\Customer\Controller\Account;
 
+use Magento\Customer\Model\Url;
 use Magento\Framework\App\Action\Context;
 use Magento\Customer\Model\Session;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Customer\Api\AccountManagementInterface;
@@ -36,23 +38,31 @@ class Confirmation extends \Magento\Customer\Controller\AbstractAccount
     protected $resultPageFactory;
 
     /**
+     * @var Url
+     */
+    private $customerUrl;
+
+    /**
      * @param Context $context
      * @param Session $customerSession
      * @param PageFactory $resultPageFactory
      * @param StoreManagerInterface $storeManager
      * @param AccountManagementInterface $customerAccountManagement
+     * @param Url $customerUrl
      */
     public function __construct(
         Context $context,
         Session $customerSession,
         PageFactory $resultPageFactory,
         StoreManagerInterface $storeManager,
-        AccountManagementInterface $customerAccountManagement
+        AccountManagementInterface $customerAccountManagement,
+        Url $customerUrl = null
     ) {
         $this->session = $customerSession;
         $this->resultPageFactory = $resultPageFactory;
         $this->storeManager = $storeManager;
         $this->customerAccountManagement = $customerAccountManagement;
+        $this->customerUrl = $customerUrl ?: ObjectManager::getInstance()->get(Url::class);
         parent::__construct($context);
     }
 
@@ -98,6 +108,8 @@ class Confirmation extends \Magento\Customer\Controller\AbstractAccount
         $resultPage = $this->resultPageFactory->create();
         $resultPage->getLayout()->getBlock('accountConfirmation')->setEmail(
             $this->getRequest()->getParam('email', $email)
+        )->setLoginUrl(
+            $this->customerUrl->getLoginUrl()
         );
         return $resultPage;
     }

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmationTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmationTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: skozar
+ * Date: 15.12.17
+ * Time: 15:19
+ */
+
+namespace Magento\Customer\Test\Unit\Controller\Account;
+
+use Magento\Customer\Controller\Account\Confirmation;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+class ConfirmationTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Confirmation
+     */
+    private $model;
+    
+    /**
+     * @var \Magento\Customer\Model\Session|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $customerSessionMock;
+
+    /**
+     * @var \Magento\Framework\App\Action\Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var \Magento\Framework\View\Result\PageFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resultPageFactoryMock;
+
+    /**
+     * @var \Magento\Customer\Model\Url|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $customerUrlMock;
+
+    /**
+     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $requestMock;
+
+    public function setUp()
+    {
+        $this->customerSessionMock = $this->getMockBuilder(\Magento\Customer\Model\Session::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isLoggedIn'])
+            ->getMock();
+        $this->contextMock = $this->getMockBuilder(\Magento\Framework\App\Action\Context::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getRequest'])
+            ->getMock();
+        $this->requestMock = $this->getMockBuilder(Http::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPost', 'getParam'])
+            ->getMock();
+        $this->contextMock->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($this->requestMock);
+        
+        $this->resultPageFactoryMock = $this->getMockBuilder(\Magento\Framework\View\Result\PageFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->customerUrlMock = $this->getMockBuilder(\Magento\Customer\Model\Url::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLoginUrl'])
+            ->getMock();
+        $this->model = (new ObjectManagerHelper($this))->getObject(
+            Confirmation::class,
+            [
+                'context' => $this->contextMock,
+                'customerSession' => $this->customerSessionMock,
+                'resultPageFactory' => $this->resultPageFactoryMock,
+                'customerUrl' => $this->customerUrlMock,
+            ]
+        );
+    }
+
+    public function testGetLoginUrl()
+    {
+        $this->customerSessionMock->expects($this->once())
+            ->method('isLoggedIn')
+            ->willReturn(false);
+        
+        $this->requestMock->expects($this->once())->method('getPost')->with('email')->willReturn(null);
+
+        $resultPageMock = $this->getMockBuilder(\Magento\Framework\View\Result\Page::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLayout'])
+            ->getMock();
+
+        $this->resultPageFactoryMock->expects($this->once())->method('create')->willReturn($resultPageMock);
+
+        $layoutMock = $this->getMockBuilder(\Magento\Framework\View\Layout::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBlock'])
+            ->getMock();
+
+        $resultPageMock->expects($this->once())->method('getLayout')->willReturn($layoutMock);
+
+        $blockMock = $this->getMockBuilder(\Magento\Framework\View\Element\Template::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setEmail', 'setLoginUrl'])
+            ->getMock();
+
+        $layoutMock->expects($this->once())->method('getBlock')->with('accountConfirmation')->willReturn($blockMock);
+
+        $blockMock->expects($this->once())->method('setEmail')->willReturnSelf();
+        $blockMock->expects($this->once())->method('setLoginUrl')->willReturnSelf();
+
+        $this->model->execute();
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmationTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmationTest.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: skozar
- * Date: 15.12.17
- * Time: 15:19
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
  */
 
 namespace Magento\Customer\Test\Unit\Controller\Account;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fix Back to Sign in url on confirmation form
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Added login url to Back to Sign in link
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12715: Issue title Storefront Back to Sign in button does not work as expected

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Preconditions

Magento is installed from 2.2-develop branch
Set Require Emails Confirmation = Yes at Stores > Configuration > Customers > Customer Configuration
Steps to reproduce

Go to Storefront as a guest
Start creating new customer
Fill in all the required fields
Click Create an Account
Click click here from message `Please check your email for the confirmation link or click here for a new link
Click Back to Sign In button
Expected result

Customer is redirected to Sign In form

Actual result

Page is just reloaded

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
