### PR TITLE
Config parsing fails - Braintree - Issue #12298

### DIFF
--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -14,6 +14,7 @@ use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Braintree\Gateway\Config\Config;
 
 /**
  * Class CountryCreditCard
@@ -65,17 +66,19 @@ class CountryCreditCard extends Value
      */
     public function beforeSave()
     {
-        $value = $this->getValue();
+        $value = $this->serializer->unserialize($this->getValue());
         $result = [];
-        foreach ($value as $data) {
-            if (empty($data['country_id']) || empty($data['cc_types'])) {
-                continue;
-            }
-            $country = $data['country_id'];
-            if (array_key_exists($country, $result)) {
-                $result[$country] = $this->appendUniqueCountries($result[$country], $data['cc_types']);
-            } else {
-                $result[$country] = $data['cc_types'];
+        if (is_array($value)) {
+            foreach ($value as $data) {
+                if (empty($data['country_id']) || empty($data['cc_types'])) {
+                    continue;
+                }
+                $country = $data['country_id'];
+                if (array_key_exists($country, $result)) {
+                    $result[$country] = $this->appendUniqueCountries($result[$country], $data['cc_types']);
+                } else {
+                    $result[$country] = $data['cc_types'];
+                }
             }
         }
         $this->setValue($this->serializer->serialize($result));

--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Braintree\Model\Adminhtml\System\Config;
 
 use Magento\Framework\App\Cache\TypeListInterface;
@@ -15,8 +14,6 @@ use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
 use Magento\Framework\Serialize\Serializer\Json;
-use Magento\Braintree\Gateway\Config\Config;
-use Psr\Log\LoggerInterface;
 
 /**
  * Class CountryCreditCard
@@ -34,13 +31,6 @@ class CountryCreditCard extends Value
     private $serializer;
 
     /**
-     * Logger.
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
@@ -49,7 +39,6 @@ class CountryCreditCard extends Value
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param \Magento\Framework\Serialize\Serializer\Json $serializer
-     * @param LoggerInterface $logger
      * @param array $data
      */
     public function __construct(
@@ -61,13 +50,11 @@ class CountryCreditCard extends Value
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
         Json $serializer = null,
-        LoggerInterface $logger = null,
         array $data = []
     ) {
         $this->mathRandom = $mathRandom;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(Json::class);
-        $this->logger = $logger;
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
     }
 
@@ -78,13 +65,7 @@ class CountryCreditCard extends Value
      */
     public function beforeSave()
     {
-        $value = null;
-        try {
-            $value = $this->serializer->unserialize($this->getValue(Config::KEY_COUNTRY_CREDIT_CARD));
-        } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-        }
-
+        $value = $this->getValue();
         $result = [];
         if (is_array($value)) {
             foreach ($value as $data) {

--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -16,6 +16,7 @@ use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Braintree\Gateway\Config\Config;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class CountryCreditCard
@@ -33,6 +34,13 @@ class CountryCreditCard extends Value
     private $serializer;
 
     /**
+     * Logger.
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
@@ -40,8 +48,9 @@ class CountryCreditCard extends Value
      * @param \Magento\Framework\Math\Random $mathRandom
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
-     * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json $serializer
+     * @param LoggerInterface $logger
+     * @param array $data
      */
     public function __construct(
         Context $context,
@@ -51,12 +60,14 @@ class CountryCreditCard extends Value
         Random $mathRandom,
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
-        array $data = [],
-        Json $serializer = null
+        Json $serializer = null,
+        LoggerInterface $logger = null,
+        array $data = []
     ) {
         $this->mathRandom = $mathRandom;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(Json::class);
+        $this->logger = $logger;
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
     }
 
@@ -71,7 +82,7 @@ class CountryCreditCard extends Value
         try {
             $value = $this->serializer->unserialize($this->getValue(Config::KEY_COUNTRY_CREDIT_CARD));
         } catch (\Exception $e) {
-            unset($e);
+            $this->logger->error($e->getMessage());
         }
 
         $result = [];

--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -67,10 +67,12 @@ class CountryCreditCard extends Value
      */
     public function beforeSave()
     {
-        $value = json_decode(
-            $this->getValue(Config::KEY_COUNTRY_CREDIT_CARD),
-            true
-        );
+        $value = null;
+        try {
+            $value = $this->serializer->unserialize($this->getValue(Config::KEY_COUNTRY_CREDIT_CARD));
+        } catch (\Exception $e) {
+            unset($e);
+        }
 
         $result = [];
         if (is_array($value)) {

--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Braintree\Model\Adminhtml\System\Config;
 
 use Magento\Framework\App\Cache\TypeListInterface;
@@ -66,7 +67,11 @@ class CountryCreditCard extends Value
      */
     public function beforeSave()
     {
-        $value = $this->serializer->unserialize($this->getValue());
+        $value = json_decode(
+            $this->getValue(Config::KEY_COUNTRY_CREDIT_CARD),
+            true
+        );
+
         $result = [];
         if (is_array($value)) {
             foreach ($value as $data) {

--- a/app/code/Magento/Braintree/Test/Unit/Model/Adminhtml/System/Config/CountryCreditCardTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Adminhtml/System/Config/CountryCreditCardTest.php
@@ -63,11 +63,11 @@ class CountryCreditCardTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider beforeSaveDataProvider
-     * @param array $value
+     * @param array|string $value
      * @param array $expectedValue
      * @param string $encodedValue
      */
-    public function testBeforeSave(array $value, array $expectedValue, $encodedValue)
+    public function testBeforeSave($value, array $expectedValue, $encodedValue)
     {
         $this->model->setValue($value);
 
@@ -87,6 +87,11 @@ class CountryCreditCardTest extends \PHPUnit\Framework\TestCase
     public function beforeSaveDataProvider()
     {
         return [
+            'string' => [
+                'value' => '[]',
+                'expected' => [],
+                'encoded' => '[]'
+            ],
             'empty_value' => [
                 'value' => [],
                 'expected' => [],


### PR DESCRIPTION
After setup:upgrade, during the config import, an exception interrupt the upgrade for a non-parsed config value.

### Description
This pull request fix this problem during config import:
`Import failed: Warning: Invalid argument supplied for foreach() in /var/www/html/vendor/magento/module-braintree/Model/Adminhtml/System/Config/CountryCreditCard.php on line 70`

### Fixed Issue
1. magento/magento2#12298

### Manual testing scenarios
1. Configure Braintree payment system
2. magento app:config:dump
3. magento setup:upgrade

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
