### PR TITLE
Unable to save "State is Required for" multiselect with all options unchecked #12703

### DIFF
--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
@@ -210,6 +210,15 @@ require([
                     Element.extend(element).disabled = false;
                 }
             });
+            $$('select[multiple]').each(function(element) {
+                var $element = Element.extend(element);
+                if (_.isEmpty($element.getValue())) {
+                    var option = document.createElement('option');
+                    option.value = '';
+                    $element.appendChild(option);
+                    $element.setValue(['']);
+                }
+            });
             jQuery(form).trigger('afterValidate');
             form.submit();
         }

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
@@ -213,6 +213,7 @@ require([
             $$('select[multiple]').each(function(element) {
                 var $element = Element.extend(element);
                 if (_.isEmpty($element.getValue())) {
+                    // empty option should be created to set empty value for multiselect
                     var option = document.createElement('option');
                     option.value = '';
                     $element.appendChild(option);

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Cest/AdminUpdateStateOptionsCest.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Cest/AdminUpdateStateOptionsCest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Test/etc/testSchema.xsd">
+    <cest name="AdminUpdateStateOptionsCest">
+        <annotations>
+            <features value="Update State Options"/>
+            <description value="Unable to save state options with all options unchecked"/>
+        </annotations>
+        <test name="UpdateStateOptions">
+            <annotations>
+                <title value="You should be able to save state options with all options unchecked in the admin panel."/>
+                <group value="config"/>
+                <group value="skip" />
+            </annotations>
+            <loginAsAdmin stepKey="loginAsAdmin"/>
+            <amOnPage url="{{AdminConfigPage.url}}" stepKey="navigateToConfigPage"/>
+            <waitForPageLoad time="30" stepKey="waitForPageLoad1"/>
+            <conditionalClick selector="{{AdminConfigGeneralSection.StateOptionsTab}}" dependentSelector="{{AdminConfigGeneralSection.ExpandedStateOptionsTab}}" visible="false" stepKey="clickOnStateOptionsTab"/>
+            <selectOption selector="{{AdminConfigGeneralSection.StateOptions}}" parameterArray="['Afghanistan','Algeria', 'Anguilla']" stepKey="fillStateOptions"/>
+            <click selector="#save" stepKey="clickOnSaveButton"/>
+            <unselectOption parameterArray="['Afghanistan','Algeria', 'Anguilla']" selector="{{AdminConfigGeneralSection.StateOptions}}" stepKey="unselectAllOptions" />
+            <click selector="#save" stepKey="clickOnSaveButtonTwo"/>
+            <grabMultiple selector="{{AdminConfigGeneralSection.StateOptions}}" returnVariable="SelectedOptions" stepKey="grabOptions" />
+            <assertEmpty actual="SelectedOptions" actualType="variable" stepKey="assertOptionsAreEmpty" />
+        </test>
+    </cest>
+</config>

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Page/AdminConfigPage.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Page/AdminConfigPage.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/PageObject.xsd">
+    <page name="AdminConfigPage" url="admin/admin/system_config/" module="Magento_Config">
+        <section name="AdminConfigTabSection"/>
+        <section name="AdminConfigGeneralStateOptionsSection"/>
+    </page>
+</config>

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Section/AdminConfigGeneralSection.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Section/AdminConfigGeneralSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
+    <section name="AdminConfigGeneralSection">
+        <element name="StateOptionsTab" type="button" selector="#general_region-head"/>
+        <element name="ExpandedStateOptionsTab" type="button" selector="//a[@id='general_region-head'][contains(@class, 'open')]"/>
+        <element name="StateOptions" type="multiselect" selector="#general_region_state_required"/>
+    </section>
+</config>

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Section/AdminConfigTabSection.xml
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/Section/AdminConfigTabSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Page/etc/SectionObject.xsd">
+    <section name="AdminConfigTabSection">
+        <element name="GeneralTab" type="button" selector="//div[contains(@class, 'admin__page-nav-title')][contains(., 'General')]"/>
+        <element name="ExpandedGeneralTab" type="button" selector="//div[contains(@class, 'admin__page-nav-title')][@aria-expanded='false'][contains(., 'General')]"/>
+        <element name="GeneralLink" type="button" selector="//ul[contains(@class, 'admin__page-nav-items')][contains(., 'General')]"/>
+    </section>
+</config>


### PR DESCRIPTION
### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Install Magento from 2.2-develop branch

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Go to Store>Configuration>General>State Options
2. In the 'State is Required for' list make sure no options are selected
3. Save configuration

### Expected result
<!--- Tell us what should happen -->
1. Last checked options still selected

### Actual result
<!--- Tell us what happens instead -->
1. No options should be selected

https://github.com/magento/magento2/issues/12703