### PR TITLE
#12717 - Catalog Products List widget is not displayed on Storefront

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
@@ -235,6 +235,17 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute implements
      *
      * @return bool
      */
+    public function isEnabledInFlat()
+    {
+        return $this->_isEnabledInFlat();
+    }
+
+
+    /**
+     * Is attribute enabled for flat indexing
+     *
+     * @return bool
+     */
     protected function _isEnabledInFlat()
     {
         return $this->getData('backend_type') == 'static'

--- a/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
@@ -240,7 +240,6 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute implements
         return $this->_isEnabledInFlat();
     }
 
-
     /**
      * Is attribute enabled for flat indexing
      *

--- a/app/code/Magento/CatalogWidget/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/CatalogWidget/Model/Rule/Condition/Product.php
@@ -125,7 +125,11 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
             } else {
                 $alias = 'at_' . $attribute->getAttributeCode();
                 if (!in_array($alias, array_keys($collection->getSelect()->getPart('from')))) {
-                    $collection->joinAttribute($attribute->getAttributeCode(), 'catalog_product/'.$attribute->getAttributeCode(), 'entity_id');
+                    $collection->joinAttribute(
+                        $attribute->getAttributeCode(),
+                        'catalog_product/'.$attribute->getAttributeCode(),
+                        'entity_id'
+                    );
                 }
 
                 $this->joinedAttributes[$attribute->getAttributeCode()] = $alias . '.value';

--- a/app/code/Magento/CatalogWidget/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/CatalogWidget/Model/Rule/Condition/Product.php
@@ -119,8 +119,17 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
         $attribute = $this->getAttributeObject();
 
         if ($collection->isEnabledFlat()) {
-            $alias = array_keys($collection->getSelect()->getPart('from'))[0];
-            $this->joinedAttributes[$attribute->getAttributeCode()] = $alias . '.' . $attribute->getAttributeCode();
+            if ($attribute->isEnabledInFlat()) {
+                $alias = array_keys($collection->getSelect()->getPart('from'))[0];
+                $this->joinedAttributes[$attribute->getAttributeCode()] = $alias . '.' . $attribute->getAttributeCode();
+            } else {
+                $alias = 'at_' . $attribute->getAttributeCode();
+                if (!in_array($alias, array_keys($collection->getSelect()->getPart('from')))) {
+                    $collection->joinAttribute($attribute->getAttributeCode(), 'catalog_product/'.$attribute->getAttributeCode(), 'entity_id');
+                }
+
+                $this->joinedAttributes[$attribute->getAttributeCode()] = $alias . '.value';
+            }
             return $this;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Problem is that when flats are enabled, logic does not check if an attribute is actually present in flat table. Added a check that the attribute is in flat and if not, we join this attribute. 

### Fixed Issues (if relevant)
1. magento/magento2#12717: Catalog Products List widget is not displayed on Storefront

### Manual testing scenarios
Go to Stores > Attributes > Product and open "Color" attribute
Create 2 options red and black
Add this attribute to attribute set
Create 2 simple products with red and black attributes
Go to Stores> Configuration > CATALOG > Catalog > Storefront
Set "Use Flat Catalog Category" = Yes and "Use Flat Catalog Product" = "Yes"
Go to Content > Widgets and create new widget with:
Storefront Properties
Widget Title = Test widget
Assign to Store Views = All Store Views
Layout Updates:
-- Display on = All Pages
-- Container = Main Content Area
Widget Options

Title = test
Number of Products to Display = 10
Conditions: Color is red
run
rm -rf var/* pub/static/* generated/*
php bin/magento indexer:reindex
php bin/magento setup:static-content:deploy
Go to Storefront
Expected result

Widget is visible on Storefront

Actual result

Widget is not visible on Storefront, following error persists in support_report.log:
report.CRITICAL: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'at_color.value' in 'where clause', query was: SELECT COUNT(DISTINCT e.entity_id) FROM catalog_product_flat_1 AS e
INNER JOIN catalog_category_product_index AS cat_index ON cat_index.product_id=e.entity_id AND cat_index.store_id='1' AND cat_index.visibility IN(2, 4) AND cat_index.category_id='2'
INNER JOIN catalog_product_index_price AS price_index ON price_index.entity_id = e.entity_id AND price_index.website_id = '1' AND price_index.customer_group_id = 0 WHERE (((IFNULL(at_color.value, 0) = '13') ))

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
