### PR TITLE
magento/magento2#12213 Topmenu links stop working after resizing the browser window

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -430,6 +430,7 @@ define([
         _toggleMobileMode: function () {
             var subMenus;
 
+            $('.level-top').addClass('mobile');
             $(this.element).off('mouseenter mouseleave');
             this._on({
                 /**
@@ -442,6 +443,10 @@ define([
                     target = $(event.target).closest('.ui-menu-item');
 
                     if (!target.hasClass('level-top') || !target.has('.ui-menu').length) {
+                        window.location.href = target.find('> a').attr('href');
+                    }
+
+                    if (target.hasClass('level-top') && !target.hasClass('mobile')) {
                         window.location.href = target.find('> a').attr('href');
                     }
                 },
@@ -480,6 +485,8 @@ define([
          */
         _toggleDesktopMode: function () {
             var categoryParent, html;
+
+            $('.level-top').removeClass('mobile');
 
             this._on({
                 /**


### PR DESCRIPTION
The topmenu links that have subcategories stop working as expected when the browser window is reduced to small and enlarged to original size again.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12213

### Preconditions
1. Magento Commerce 2.2.1 OR Magento Commerce 2.1.9.
2. Browser: Google Chrome Version 62.0.3202.89 (Official Build) (64-bit)

### Steps to reproduce
1. Enable production mode
2. Open the homepage on a screen resolution of 1920x1080 or beyond.
3. Resize the browser window to as small as possible in the horizontal direction.
4. Resize the browser window again to the original resolution.

### Expected result
1. The topmenu items that have subcategories can be clicked with the mouse pointer causing a redirection to a new page.

### Actual result
1. The topmenu items that have subcategories do not respond to a mouse click. No redirection. No javascript errors in the console.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
