### PR TITLE
magento/magento2#12699: Multiselect Attribute is not saved

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/AbstractTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/AbstractTest.php
@@ -44,11 +44,13 @@ class AbstractTest extends \PHPUnit\Framework\TestCase
 
         $code = 'test_attr';
         $set = 10;
+        $storeId = 100;
 
         $object = $this->createPartialMock(\Magento\Catalog\Model\Product::class, ['__wakeup']);
 
         $object->setData('test_attr', 'test_attr');
         $object->setData('attribute_set_id', $set);
+        $object->setData('store_id', $storeId);
 
         $entityType = new \Magento\Framework\DataObject();
         $entityType->setEntityTypeCode('test');

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -68,7 +68,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
      *
      * @var array
      */
-    protected $attributesByScope = [];
+    private $attributesByScope = [];
 
     /**
      * Two-dimensional array by table name and attribute name

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -13,6 +13,7 @@ use Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend;
 use Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend;
 use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
 use Magento\Framework\App\Config\Element;
+use Magento\Framework\DataObject;
 use Magento\Framework\DB\Adapter\DuplicateException;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\LocalizedException;
@@ -61,6 +62,13 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
      * @var array
      */
     protected $_attributesByCode = [];
+
+    /**
+     * Attributes stored by scope (store id and attribute set id).
+     *
+     * @var array
+     */
+    protected $attributesByScope = [];
 
     /**
      * Two-dimensional array by table name and attribute name
@@ -455,14 +463,20 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
      * Adding attribute to entity
      *
      * @param AbstractAttribute $attribute
+     * @param DataObject|null $object
      * @return $this
      */
-    public function addAttribute(AbstractAttribute $attribute)
+    public function addAttribute(AbstractAttribute $attribute, $object = null)
     {
         $attribute->setEntity($this);
         $attributeCode = $attribute->getAttributeCode();
 
         $this->_attributesByCode[$attributeCode] = $attribute;
+
+        if ($object !== null) {
+            $suffix = $this->getAttributesCacheSuffix($object);
+            $this->attributesByScope[$suffix][$attributeCode] = $attribute;
+        }
 
         if ($attribute->isStatic()) {
             $this->_staticAttributes[$attributeCode] = $attribute;
@@ -472,6 +486,31 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
 
         return $this;
     }
+
+    /**
+     * Get attributes by scope
+     *
+     * @return array
+     */
+    private function getAttributesByScope($suffix)
+    {
+        return (isset($this->attributesByScope[$suffix]) && !empty($this->attributesByScope[$suffix]))
+            ? $this->attributesByScope[$suffix]
+            : $this->getAttributesByCode();
+    }
+
+    /**
+     * Get attributes cache suffix.
+     *
+     * @param DataObject $object
+     * @return string
+     */
+    private function getAttributesCacheSuffix(DataObject $object)
+    {
+        $attributeSetId = $object->getAttributeSetId() ?: 0;
+        $storeId = $object->getStoreId() ?: 0;
+        return $storeId . '-' . $attributeSetId;
+     }
 
     /**
      * Retrieve partial load flag
@@ -506,7 +545,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Retrieve configuration for all attributes
      *
-     * @param null|\Magento\Framework\DataObject $object
+     * @param null|DataObject $object
      * @return $this
      */
     public function loadAllAttributes($object = null)
@@ -566,7 +605,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Check whether the attribute is Applicable to the object
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   AbstractAttribute $attribute
      * @return  bool
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -611,7 +650,8 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
                 break;
         }
         $results = [];
-        foreach ($this->getAttributesByCode() as $attrCode => $attribute) {
+        $suffix = $this->getAttributesCacheSuffix($args[0]);
+        foreach ($this->getAttributesByScope($suffix) as $attrCode => $attribute) {
             if (isset($args[0]) && is_object($args[0]) && !$this->_isApplicableAttribute($args[0], $attribute)) {
                 continue;
             }
@@ -830,7 +870,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Validate all object's attributes against configuration
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @throws \Magento\Eav\Model\Entity\Attribute\Exception
      * @return true|array
      */
@@ -856,10 +896,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Set new increment id to object
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return $this
      */
-    public function setNewIncrementId(\Magento\Framework\DataObject $object)
+    public function setNewIncrementId(DataObject $object)
     {
         if ($object->getIncrementId()) {
             return $this;
@@ -878,7 +918,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
      * Check attribute unique value
      *
      * @param AbstractAttribute $attribute
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return bool
      */
     public function checkAttributeUniqueValue(AbstractAttribute $attribute, $object)
@@ -1051,7 +1091,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Retrieve select object for loading base entity row
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   string|int $rowId
      * @return  \Magento\Framework\DB\Select
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -1071,7 +1111,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Retrieve select object for loading entity attributes values
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   string $table
      * @return  \Magento\Framework\DB\Select
      */
@@ -1091,7 +1131,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Initialize attribute value for object
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   array $valueRow
      * @return $this
      */
@@ -1181,8 +1221,8 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Retrieve Object instance with original data
      *
-     * @param \Magento\Framework\DataObject $object
-     * @return \Magento\Framework\DataObject
+     * @param DataObject $object
+     * @return DataObject
      */
     protected function _getOrigObject($object)
     {
@@ -1422,7 +1462,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
         /**
          * Process base row
          */
-        $entityObject = new \Magento\Framework\DataObject($entityRow);
+        $entityObject = new DataObject($entityRow);
         $entityRow = $this->_prepareDataForTable($entityObject, $entityTable);
         if ($insertEntity) {
             if (!empty($entityId)) {
@@ -1477,7 +1517,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Insert entity attribute value
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   AbstractAttribute $attribute
      * @param   mixed $value
      * @return $this
@@ -1490,7 +1530,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Update entity attribute value
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   AbstractAttribute $attribute
      * @param   mixed $valueId
      * @param   mixed $value
@@ -1585,10 +1625,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Delete entity attribute values
      *
-     * @param   \Magento\Framework\DataObject $object
+     * @param   DataObject $object
      * @param   string $table
      * @param   array $info
-     * @return  \Magento\Framework\DataObject
+     * @return  DataObject
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function _deleteAttributes($object, $table, $info)
@@ -1614,13 +1654,13 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Save attribute
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @param string $attributeCode
      * @return $this
      * @throws \Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function saveAttribute(\Magento\Framework\DataObject $object, $attributeCode)
+    public function saveAttribute(DataObject $object, $attributeCode)
     {
         $attribute = $this->getAttribute($attributeCode);
         $backend = $attribute->getBackend();
@@ -1666,8 +1706,8 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Return attribute row to prepare where statement
      *
-     * @param \Magento\Framework\DataObject $entity
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $entity
+     * @param DataObject $object
      * @param \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
      * @return array
      */
@@ -1688,7 +1728,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Delete entity using current object's data
      *
-     * @param \Magento\Framework\DataObject|int|string $object
+     * @param DataObject|int|string $object
      * @return $this
      * @throws \Exception
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
@@ -1730,7 +1770,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Evaluate Delete operations
      *
-     * @param \Magento\Framework\DataObject|int|string $object
+     * @param DataObject|int|string $object
      * @param string|int $id
      * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
      * @return void
@@ -1764,10 +1804,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * After Load Entity process
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return $this
      */
-    protected function _afterLoad(\Magento\Framework\DataObject $object)
+    protected function _afterLoad(DataObject $object)
     {
         \Magento\Framework\Profiler::start('after_load');
         $this->walkAttributes('backend/afterLoad', [$object]);
@@ -1778,10 +1818,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Before delete Entity process
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return $this
      */
-    protected function _beforeSave(\Magento\Framework\DataObject $object)
+    protected function _beforeSave(DataObject $object)
     {
         $this->walkAttributes('backend/beforeSave', [$object]);
         return $this;
@@ -1790,10 +1830,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * After Save Entity process
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return $this
      */
-    protected function _afterSave(\Magento\Framework\DataObject $object)
+    protected function _afterSave(DataObject $object)
     {
         $this->walkAttributes('backend/afterSave', [$object]);
         return $this;
@@ -1802,10 +1842,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Before Delete Entity process
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return $this
      */
-    protected function _beforeDelete(\Magento\Framework\DataObject $object)
+    protected function _beforeDelete(DataObject $object)
     {
         $this->walkAttributes('backend/beforeDelete', [$object]);
         return $this;
@@ -1814,10 +1854,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * After delete entity process
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @return $this
      */
-    protected function _afterDelete(\Magento\Framework\DataObject $object)
+    protected function _afterDelete(DataObject $object)
     {
         $this->walkAttributes('backend/afterDelete', [$object]);
         return $this;
@@ -1887,10 +1927,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Perform actions after entity load
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @since 100.1.0
      */
-    public function afterLoad(\Magento\Framework\DataObject $object)
+    public function afterLoad(DataObject $object)
     {
         $this->_afterLoad($object);
     }
@@ -1898,10 +1938,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Perform actions before entity save
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @since 100.1.0
      */
-    public function beforeSave(\Magento\Framework\DataObject $object)
+    public function beforeSave(DataObject $object)
     {
         $this->_beforeSave($object);
     }
@@ -1909,10 +1949,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Perform actions after entity save
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @since 100.1.0
      */
-    public function afterSave(\Magento\Framework\DataObject $object)
+    public function afterSave(DataObject $object)
     {
         $this->_afterSave($object);
     }
@@ -1920,10 +1960,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Perform actions before entity delete
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @since 100.1.0
      */
-    public function beforeDelete(\Magento\Framework\DataObject $object)
+    public function beforeDelete(DataObject $object)
     {
         $this->_beforeDelete($object);
     }
@@ -1931,10 +1971,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Perform actions after entity delete
      *
-     * @param \Magento\Framework\DataObject $object
+     * @param DataObject $object
      * @since 100.1.0
      */
-    public function afterDelete(\Magento\Framework\DataObject $object)
+    public function afterDelete(DataObject $object)
     {
         $this->_afterDelete($object);
     }

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -463,20 +463,14 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
      * Adding attribute to entity
      *
      * @param AbstractAttribute $attribute
-     * @param DataObject|null $object
      * @return $this
      */
-    public function addAttribute(AbstractAttribute $attribute, $object = null)
+    public function addAttribute(AbstractAttribute $attribute)
     {
         $attribute->setEntity($this);
         $attributeCode = $attribute->getAttributeCode();
 
         $this->_attributesByCode[$attributeCode] = $attribute;
-
-        if ($object !== null) {
-            $suffix = $this->getAttributesCacheSuffix($object);
-            $this->attributesByScope[$suffix][$attributeCode] = $attribute;
-        }
 
         if ($attribute->isStatic()) {
             $this->_staticAttributes[$attributeCode] = $attribute;
@@ -488,13 +482,28 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     }
 
     /**
+     * Adding attribute to entity by scope.
+     *
+     * @param AbstractAttribute $attribute
+     * @param DataObject|null $entity
+     * @return $this
+     */
+    public function addAttributeByScope(AbstractAttribute $attribute, $entity = null)
+    {
+        $suffix = $entity !== null ? $this->getAttributesCacheSuffix($entity) : '0-0';
+        $attributeCode = $attribute->getAttributeCode();
+        $this->attributesByScope[$suffix][$attributeCode] = $attribute;
+        return $this->addAttribute($attribute);
+    }
+
+    /**
      * Get attributes by scope
      *
      * @return array
      */
     private function getAttributesByScope($suffix)
     {
-        return (isset($this->attributesByScope[$suffix]) && !empty($this->attributesByScope[$suffix]))
+        return !empty($this->attributesByScope[$suffix])
             ? $this->attributesByScope[$suffix]
             : $this->getAttributesByCode();
     }

--- a/app/code/Magento/Eav/Model/Entity/AttributeLoader.php
+++ b/app/code/Magento/Eav/Model/Entity/AttributeLoader.php
@@ -67,10 +67,10 @@ class AttributeLoader implements AttributeLoaderInterface
         $resource->unsetAttributes();
 
         foreach ($defaultAttributesCodes as $attributeCode) {
-            $resource->addAttribute($this->_getDefaultAttribute($resource, $attributeCode));
+            $resource->addAttribute($this->_getDefaultAttribute($resource, $attributeCode), $object);
         }
         foreach ($attributes as $attributeCode => $attribute) {
-            $resource->addAttribute($attribute);
+            $resource->addAttribute($attribute, $object);
         }
         return $resource;
     }

--- a/app/code/Magento/Eav/Model/Entity/AttributeLoader.php
+++ b/app/code/Magento/Eav/Model/Entity/AttributeLoader.php
@@ -51,13 +51,13 @@ class AttributeLoader implements AttributeLoaderInterface
      * Retrieve configuration for all attributes
      *
      * @param AbstractEntity $resource
-     * @param DataObject|null $object
+     * @param DataObject|null $entity
      * @return AbstractEntity
      * @throws LocalizedException
      */
-    public function loadAllAttributes(AbstractEntity $resource, DataObject $object = null)
+    public function loadAllAttributes(AbstractEntity $resource, DataObject $entity = null)
     {
-        $attributes = $this->config->getEntityAttributes($resource->getEntityType(), $object);
+        $attributes = $this->config->getEntityAttributes($resource->getEntityType(), $entity);
         $attributeCodes = array_keys($attributes);
         /**
          * Check and init default attributes
@@ -67,10 +67,10 @@ class AttributeLoader implements AttributeLoaderInterface
         $resource->unsetAttributes();
 
         foreach ($defaultAttributesCodes as $attributeCode) {
-            $resource->addAttribute($this->_getDefaultAttribute($resource, $attributeCode), $object);
+            $resource->addAttributeByScope($this->_getDefaultAttribute($resource, $attributeCode), $entity);
         }
         foreach ($attributes as $attributeCode => $attribute) {
-            $resource->addAttribute($attribute, $object);
+            $resource->addAttributeByScope($attribute, $entity);
         }
         return $resource;
     }

--- a/app/code/Magento/Eav/Model/Entity/AttributeLoaderInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/AttributeLoaderInterface.php
@@ -17,8 +17,8 @@ interface AttributeLoaderInterface
      * Retrieve configuration for all attributes
      *
      * @param AbstractEntity $resource
-     * @param DataObject|null $object
+     * @param DataObject|null $entity
      * @return AbstractEntity
      */
-    public function loadAllAttributes(AbstractEntity $resource, DataObject $object = null);
+    public function loadAllAttributes(AbstractEntity $resource, DataObject $entity = null);
 }

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/AbstractEntityTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/AbstractEntityTest.php
@@ -320,19 +320,29 @@ class AbstractEntityTest extends \PHPUnit\Framework\TestCase
             [
                 'test_attr',
                 $attributeSetId,
-                ['test_attr' => 'test_attr', 'attribute_set_id' => $attributeSetId, 'entity_id' => null],
+                [
+                    'test_attr' => 'test_attr',
+                    'attribute_set_id' => $attributeSetId,
+                    'entity_id' => null,
+                    'store_id' => 1
+                ],
                 null,
             ],
             [
                 'test_attr',
                 $attributeSetId,
-                ['test_attr' => 'test_attr', 'attribute_set_id' => $attributeSetId, 'entity_id' => 12345],
+                [
+                    'test_attr' => 'test_attr',
+                    'attribute_set_id' => $attributeSetId,
+                    'entity_id' => 12345,
+                    'store_id' => 1
+                ],
                 ['test_attr' => 'test_attr']
             ],
             [
                 'test_attr',
                 $attributeSetId,
-                ['test_attr' => '99.99', 'attribute_set_id' => $attributeSetId, 'entity_id' => 12345],
+                ['test_attr' => '99.99', 'attribute_set_id' => $attributeSetId, 'entity_id' => 12345, 'store_id' => 1],
                 ['test_attr' => '99.9900']
             ]
         ];

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/AttributeLoaderTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/AttributeLoaderTest.php
@@ -78,7 +78,7 @@ class AttributeLoaderTest extends \PHPUnit\Framework\TestCase
         $attributeMock->expects($this->once())->method('setIsGlobal')->with(1)->willReturnSelf();
         $attributeMock->expects($this->once())->method('setEntityType')->with($this->entityTypeMock)->willReturnSelf();
         $attributeMock->expects($this->once())->method('setEntityTypeId')->with($entityTypeId)->willReturnSelf();
-        $this->entityMock->expects($this->once())->method('addAttribute')->with($attributeMock)->willReturnSelf();
+        $this->entityMock->expects($this->once())->method('addAttributeByScope')->willReturnSelf();
         $this->attributeLoader->loadAllAttributes($this->entityMock, $dataObject);
     }
 
@@ -102,8 +102,7 @@ class AttributeLoaderTest extends \PHPUnit\Framework\TestCase
             ->method('getEntityAttributes')->willReturn($attributeCodes);
         $this->entityMock->expects($this->once())->method('getDefaultAttributes')->willReturn($defaultAttributes);
         $this->entityMock->expects($this->once())->method('unsetAttributes')->willReturnSelf();
-        $this->entityMock->expects($this->atLeastOnce())
-            ->method('addAttribute')->with($attributeMock)->willReturnSelf();
+        $this->entityMock->expects($this->atLeastOnce())->method('addAttributeByScope')->willReturnSelf();
         $this->objectManagerMock->expects($this->never())->method('create');
         $this->attributeLoader->loadAllAttributes($this->entityMock, $dataObject);
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fixed attribute loading for different entities in AbstractEntity
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Fixed attribute loading for different entities in AbstractEntity
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12767: Multiselect Attribute is not saved for a product in the admin panel when it has a related product using another attribute set

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Steps to reproduce

Create 2 attribute sets from the Default one.
Create a multi-select attribute and assign it to set #1.
Create a product 1 with attribute set #2.
Create a product 2 with attribute set #1 and set a product 1 as it's related product.
Save product 2 without populating the multi-select.
Edit the product 2, populate multi-select and click save.
Notice the selected option is not saved
Expected result

Multiselect Attribute should be saved for a product in the admin panel when it has a related product using another attribute set.

Actual result

Multiselect Attribute is not saved for a product in the admin panel when it has a related product using another attribute set

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
