### PR TITLE
Removing option_id from a duplicated option

### DIFF
--- a/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
+++ b/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
@@ -26,8 +26,16 @@ class Bundle implements \Magento\Catalog\Model\Product\CopyConstructorInterface
 
         $bundleOptions = $product->getExtensionAttributes()->getBundleProductOptions() ?: [];
         $duplicatedBundleOptions = [];
+        
+        /**
+         * @var string $key
+         * @var \Magento\Bundle\Model\Option $bundleOption
+         */
         foreach ($bundleOptions as $key => $bundleOption) {
-            $duplicatedBundleOptions[$key] = clone $bundleOption;
+            $duplicatedBundleOption = clone $bundleOption;
+            $duplicatedBundleOption->unsetData('option_id');
+
+            $duplicatedBundleOptions[$key] = $duplicatedBundleOption;
         }
         $duplicate->getExtensionAttributes()->setBundleProductOptions($duplicatedBundleOptions);
     }


### PR DESCRIPTION
### Description
When duplicating bundled product, the option_id was not unset. The new option row is inserted, but the option id is not changed. As such, any deletions to the deleted product's options resulted in those same deletions happening on the original product.

### Manual testing scenarios
1. Create a bundle product and assign some products.
2. Save that bundle product.
3. Note the `option_id` in the `catalog_product_bundle_option` table.
4. Save and Duplicate the bundle product.
5. After the bugfix, the `option_id` value should be different than the `option_id` for the original product.

### Contribution checklist
  - [X] All commits are accompanied by meaningful commit messages
 - [X] Pull request has a meaningful description of its purpose
- [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
