### PR TITLE
Fix close full screen gallery from touch devices

### DIFF
--- a/lib/web/fotorama/fotorama.js
+++ b/lib/web/fotorama/fotorama.js
@@ -1217,14 +1217,6 @@ fotoramaVersion = '4.6.4';
         stopPropagation && e.stopPropagation && e.stopPropagation();
     }
 
-    function stubEvent($el, eventType) {
-        $el.on(eventType, function (e) {
-            stopEvent(e, true);
-
-            return false;
-        });
-    }
-
     function getDirectionSign(forward) {
         return forward ? '>' : '<';
     }
@@ -2158,11 +2150,6 @@ fotoramaVersion = '4.6.4';
             if (o_allowFullScreen) {
                 $fullscreenIcon.prependTo($stage);
                 o_nativeFullScreen = FULLSCREEN && o_allowFullScreen === 'native';
-
-                // Due 300ms click delay on mobile devices
-                // we stub touchend and fallback to click.
-                // MAGETWO-69567
-                stubEvent($fullscreenIcon, 'touchend');
             } else {
                 $fullscreenIcon.detach();
                 o_nativeFullScreen = false;


### PR DESCRIPTION
Fix close full screen gallery from touch devices removing commits  dd9d57f170282900b32513ed4c7142f81cd413e1 and a232e0753026b081a83f1aa6fd47800da125a8c6

### Description
Unable to close the gallery's full screen on touch devices

### Fixed Issues (if relevant)
1. magento/magento2#12726: Can't Close Pop-up Photo in Product View

### Manual testing scenarios
1. Magento 2.2.1 version
2. Upload a product with multiple photos
3. Go to this product on **touch device**, click on main photo to open full gallery, and then try close.
4. Observe how you can't close this gallery.

**Other info:** In the tests performed after the fix
- Original touch devices (like a smartphone): it's works well. 
- Firefox developer tool enabling touch simulation: generates a click behind the close button.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)