### PR TITLE
Removed not-needed scrollbar from checkout sidebar

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -242,6 +242,10 @@
 
         .product-image-wrapper {
             &:extend(.abs-reset-image-wrapper all);
+
+            img {
+                vertical-align: top;
+            }
         }
 
         .product-item-pricing {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -252,6 +252,10 @@
 
         .product-image-wrapper {
             &:extend(.abs-reset-image-wrapper all);
+
+            img {
+                vertical-align: top;
+            }
         }
 
         .product-item-pricing {


### PR DESCRIPTION
### Description
This commit fixes empty gap below the image in checkout sidebar panel that could produce not-needed scrollbar.

Tested on `Chrome Version 63.0.3239.108 (Official Build) (64-bit)`

### Manual testing scenarios
1. Add product to the cart. I've used "Overnight Duffle" from sample data module.
2. Proceed to checkout and see if scrollbar is rendered is cart sidebar aside the product

Before | After
----------|-------
![before](https://user-images.githubusercontent.com/306080/34148667-e7c9fcc4-e4aa-11e7-87b7-c0918ca0d1e3.png) | ![after](https://user-images.githubusercontent.com/306080/34148670-eaf89950-e4aa-11e7-895c-195c872c5f1d.png)


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
