### PR TITLE
[Backport] Cron starts when it's already running

### DIFF
--- a/app/code/Magento/Cron/Model/Schedule.php
+++ b/app/code/Magento/Cron/Model/Schedule.php
@@ -221,16 +221,17 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
-     * Sets a job to STATUS_RUNNING only if it is currently in STATUS_PENDING.
-     * Returns true if status was changed and false otherwise.
+     * Lock the cron job so no other scheduled instances run simultaneously.
      *
-     * This is used to implement locking for cron jobs.
+     * Sets a job to STATUS_RUNNING only if it is currently in STATUS_PENDING
+     * and no other jobs of the same code are currently in STATUS_RUNNING.
+     * Returns true if status was changed and false otherwise.
      *
      * @return boolean
      */
     public function tryLockJob()
     {
-        if ($this->_getResource()->trySetJobStatusAtomic(
+        if ($this->_getResource()->trySetJobUniqueStatusAtomic(
             $this->getId(),
             self::STATUS_RUNNING,
             self::STATUS_PENDING

--- a/app/code/Magento/Cron/Test/Unit/Model/ScheduleTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/ScheduleTest.php
@@ -23,7 +23,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
 
         $this->resourceJobMock = $this->getMockBuilder('Magento\Cron\Model\ResourceModel\Schedule')
             ->disableOriginalConstructor()
-            ->setMethods(['trySetJobStatusAtomic', '__wakeup', 'getIdFieldName'])
+            ->setMethods(['trySetJobUniqueStatusAtomic', '__wakeup', 'getIdFieldName'])
             ->getMockForAbstractClass();
 
         $this->resourceJobMock->expects($this->any())
@@ -336,7 +336,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
         $scheduleId = 1;
 
         $this->resourceJobMock->expects($this->once())
-            ->method('trySetJobStatusAtomic')
+            ->method('trySetJobUniqueStatusAtomic')
             ->with($scheduleId, Schedule::STATUS_RUNNING, Schedule::STATUS_PENDING)
             ->will($this->returnValue(true));
 
@@ -360,7 +360,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
         $scheduleId = 1;
 
         $this->resourceJobMock->expects($this->once())
-            ->method('trySetJobStatusAtomic')
+            ->method('trySetJobUniqueStatusAtomic')
             ->with($scheduleId, Schedule::STATUS_RUNNING, Schedule::STATUS_PENDING)
             ->will($this->returnValue(false));
 

--- a/dev/tests/integration/testsuite/Magento/Cron/Model/ScheduleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cron/Model/ScheduleTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cron\Model;
+
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use \Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Test \Magento\Cron\Model\Schedule
+ *
+ * @magentoDbIsolation enabled
+ */
+class ScheduleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ScheduleFactory
+     */
+    private $scheduleFactory;
+
+    /**
+     * @var DateTime
+     */
+    protected $dateTime;
+
+    public function setUp()
+    {
+        $this->dateTime = Bootstrap::getObjectManager()->create(DateTime::class);
+        $this->scheduleFactory = Bootstrap::getObjectManager()->create(ScheduleFactory::class);
+    }
+
+    /**
+     * If there are no currently locked jobs, locking one of them should succeed
+     */
+    public function testTryLockJobNoLockedJobsSucceeds()
+    {
+        for ($i = 1; $i < 6; $i++) {
+            $this->createSchedule("test_job", Schedule::STATUS_PENDING, 60 * $i);
+        }
+        $schedule = $this->createSchedule("test_job", Schedule::STATUS_PENDING);
+
+        $this->assertTrue($schedule->tryLockJob());
+    }
+
+    /**
+     * If the job is already locked, attempting to lock it again should fail
+     */
+    public function testTryLockJobAlreadyLockedFails()
+    {
+        $schedule = $this->createSchedule("test_job", Schedule::STATUS_RUNNING);
+
+        $this->assertFalse($schedule->tryLockJob());
+    }
+
+    /**
+     * If there's a job already locked, should not be able to lock another job
+     */
+    public function testTryLockJobOtherLockedFails()
+    {
+        $this->createSchedule("test_job", Schedule::STATUS_RUNNING);
+        $schedule = $this->createSchedule("test_job", Schedule::STATUS_PENDING, 60);
+
+        $this->assertFalse($schedule->tryLockJob());
+    }
+
+    /**
+     * Should be able to lock a job if a job with a different code is locked
+     */
+    public function testTryLockJobDifferentJobLocked()
+    {
+        $this->createSchedule("test_job_other", Schedule::STATUS_RUNNING);
+        $schedule = $this->createSchedule("test_job", Schedule::STATUS_PENDING);
+
+        $this->assertTrue($schedule->tryLockJob());
+    }
+
+    /**
+     * Creates a schedule with the given job code, status, and schedule time offset
+     *
+     * @param string $jobCode
+     * @param string $status
+     * @param int $timeOffset
+     * @return Schedule
+     */
+    private function createSchedule($jobCode, $status, $timeOffset = 0)
+    {
+        $schedule = $this->scheduleFactory->create()
+            ->setCronExpr("* * * * *")
+            ->setJobCode($jobCode)
+            ->setStatus($status)
+            ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()))
+            ->setScheduledAt(strftime('%Y-%m-%d %H:%M', $this->dateTime->gmtTimestamp() + $timeOffset));
+        $schedule->save();
+
+        return $schedule;
+    }
+}


### PR DESCRIPTION
### Description
This is a backport to 2.1-develop for the fix from https://github.com/magento/magento2/commit/2992ee2cb9ca752ca8ac9666704d6f56c08d2474

### Fixed Issues (if relevant)
1. magento/magento2#10650: Cron starts when it's already running

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a cron that takes a while (for example, sleep 15 minutes)
2. Schedule it to run every 5 minutes
3. The other jobs should wait for the first job to complete, even though they are scheduled to run every 5 minutes.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
