### PR TITLE
Update checkout controller json usage

### DIFF
--- a/app/code/Magento/Checkout/Controller/Account/Create.php
+++ b/app/code/Magento/Checkout/Controller/Account/Create.php
@@ -84,7 +84,7 @@ class Create extends \Magento\Framework\App\Action\Action
                 ]
             );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, $e->getMessage());
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
             throw $e;
         }
     }

--- a/app/code/Magento/Checkout/Controller/Account/Create.php
+++ b/app/code/Magento/Checkout/Controller/Account/Create.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Checkout\Controller\Account;
 
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -55,7 +56,7 @@ class Create extends \Magento\Framework\App\Action\Action
     public function execute()
     {
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
-        $resultJson = $this->_objectManager->get(\Magento\Framework\Controller\Result\JsonFactory::class)->create();
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
         if ($this->customerSession->isLoggedIn()) {
             return $resultJson->setData(

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Account/CreateTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Account/CreateTest.php
@@ -38,12 +38,14 @@ class CreateTest extends \PHPUnit\Framework\TestCase
     protected $orderCustomerService;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Controller\ResultFactory|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $objectManagerMock;
+    private $resultFactory;
 
-    protected $resultFactory;
-    protected $resultPage;
+    /**
+     * @var \Magento\Framework\Controller\ResultInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resultPage;
 
     protected function setUp()
     {
@@ -53,12 +55,10 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $this->orderCustomerService = $this->createMock(\Magento\Sales\Api\OrderCustomerManagementInterface::class);
         $this->messageManager = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
 
-        $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
         $contextMock = $this->createPartialMock(
             \Magento\Framework\App\Action\Context::class,
             ['getObjectManager', 'getResultFactory']
         );
-        $contextMock->expects($this->once())->method('getObjectManager')->willReturn($this->objectManagerMock);
         $this->resultFactory = $this->getMockBuilder(\Magento\Framework\Controller\ResultFactory::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Account/CreateTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Account/CreateTest.php
@@ -112,7 +112,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             ->with(100)
             ->will($this->returnValue($customer));
 
-        $resultJson = '{"errors": "false", "message": "A letter with further instructions will be sent to your email."}';
+        $resultJson = '{"errors":"false", "message":"A letter with further instructions will be sent to your email."}';
         $this->resultFactory->expects($this->once())
             ->method('create')
             ->with(ResultFactory::TYPE_JSON)

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Account/CreateTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Account/CreateTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Checkout\Test\Unit\Controller\Account;
 
+use Magento\Framework\Controller\ResultFactory;
+
 /**
  * Shopping cart edit tests
  */
@@ -40,6 +42,9 @@ class CreateTest extends \PHPUnit\Framework\TestCase
      */
     protected $objectManagerMock;
 
+    protected $resultFactory;
+    protected $resultPage;
+
     protected function setUp()
     {
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -49,8 +54,20 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         $this->messageManager = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
 
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
-        $contextMock = $this->createPartialMock(\Magento\Framework\App\Action\Context::class, ['getObjectManager']);
+        $contextMock = $this->createPartialMock(
+            \Magento\Framework\App\Action\Context::class,
+            ['getObjectManager', 'getResultFactory']
+        );
         $contextMock->expects($this->once())->method('getObjectManager')->willReturn($this->objectManagerMock);
+        $this->resultFactory = $this->getMockBuilder(\Magento\Framework\Controller\ResultFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $contextMock->expects($this->once())
+            ->method('getResultFactory')
+            ->willReturn($this->resultFactory);
+        $this->resultPage = $this->getMockBuilder(\Magento\Framework\Controller\ResultInterface::class)
+            ->setMethods(['setData'])
+            ->getMockForAbstractClass();
 
         $this->action = $objectManagerHelper->getObject(
             \Magento\Checkout\Controller\Account\Create::class,
@@ -66,53 +83,48 @@ class CreateTest extends \PHPUnit\Framework\TestCase
 
     public function testExecuteAddsSessionMessageIfCustomerIsLoggedIn()
     {
-        $jsonFactoryMock = $this->createMock(\Magento\Framework\Controller\Result\JsonFactory::class);
-        $this->objectManagerMock->expects($this->once())
-            ->method('get')
-            ->with(\Magento\Framework\Controller\Result\JsonFactory::class)
-            ->willReturn($jsonFactoryMock);
-        $jsonMock = $this->createMock(\Magento\Framework\Controller\Result\Json::class);
-        $jsonFactoryMock->expects($this->once())->method('create')->willReturn($jsonMock);
-
-        $this->customerSession->expects($this->once())->method('isLoggedIn')->will($this->returnValue(true));
-
-        $jsonMock->expects($this->once())
+        $resultJson = '{"errors": "true", "message": "Customer is already registered"}';
+        $this->customerSession->expects($this->once())
+            ->method('isLoggedIn')
+            ->will($this->returnValue(true));
+        $this->resultFactory->expects($this->once())
+            ->method('create')
+            ->with(ResultFactory::TYPE_JSON)
+            ->willReturn($this->resultPage);
+        $this->resultPage->expects($this->once())
             ->method('setData')
             ->with(
                 [
                     'errors' => true,
                     'message' => __('Customer is already registered')
                 ]
-            )->willReturnSelf();
-        $this->action->execute();
+            )->willReturn($resultJson);
+        $this->assertEquals($resultJson, $this->action->execute());
     }
 
     public function testExecute()
     {
-        $jsonFactoryMock = $this->createMock(\Magento\Framework\Controller\Result\JsonFactory::class);
-        $this->objectManagerMock->expects($this->once())
-            ->method('get')
-            ->with(\Magento\Framework\Controller\Result\JsonFactory::class)
-            ->willReturn($jsonFactoryMock);
-        $jsonMock = $this->createMock(\Magento\Framework\Controller\Result\Json::class);
-        $jsonFactoryMock->expects($this->once())->method('create')->willReturn($jsonMock);
-
         $this->customerSession->expects($this->once())->method('isLoggedIn')->will($this->returnValue(false));
         $this->checkoutSession->expects($this->once())->method('getLastOrderId')->will($this->returnValue(100));
         $customer = $this->createMock(\Magento\Customer\Api\Data\CustomerInterface::class);
-        $this->orderCustomerService->expects($this->once())->method('create')->with(100)->will(
-            $this->returnValue($customer)
-        );
+        $this->orderCustomerService->expects($this->once())
+            ->method('create')
+            ->with(100)
+            ->will($this->returnValue($customer));
 
-        $jsonMock->expects($this->once())
+        $resultJson = '{"errors": "false", "message": "A letter with further instructions will be sent to your email."}';
+        $this->resultFactory->expects($this->once())
+            ->method('create')
+            ->with(ResultFactory::TYPE_JSON)
+            ->willReturn($this->resultPage);
+        $this->resultPage->expects($this->once())
             ->method('setData')
             ->with(
                 [
                     'errors' => false,
                     'message' => __('A letter with further instructions will be sent to your email.')
                 ]
-            )->willReturnSelf();
-
-        $this->action->execute();
+            )->willReturn($resultJson);
+        $this->assertEquals($resultJson, $this->action->execute());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The controller `app/code/Magento/Checkout/Controller/Account/Create.php` uses the object manager directly when building it's json response. I have replaced the usage of object manager with the usage of `$this->resultFactory->create(ResultFactory::TYPE_JSON);`

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Creating an account via checkout using this branch and the clean mainline branch should result in the exact same behavior.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
