### PR TITLE
Reorder adding of page layout handles

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/View.php
+++ b/app/code/Magento/Catalog/Helper/Product/View.php
@@ -122,18 +122,18 @@ class View extends \Magento\Framework\App\Helper\AbstractHelper
         // Load default page handles and page configurations
         if ($params && $params->getBeforeHandles()) {
             foreach ($params->getBeforeHandles() as $handle) {
-                $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku], $handle);
                 $resultPage->addPageLayoutHandles(['type' => $product->getTypeId()], $handle, false);
+                $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku], $handle);
             }
         }
-
-        $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku]);
+    
         $resultPage->addPageLayoutHandles(['type' => $product->getTypeId()], null, false);
+        $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku]);
 
         if ($params && $params->getAfterHandles()) {
             foreach ($params->getAfterHandles() as $handle) {
-                $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku], $handle);
                 $resultPage->addPageLayoutHandles(['type' => $product->getTypeId()], $handle, false);
+                $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku], $handle);
             }
         }
 

--- a/app/code/Magento/Review/Controller/Product/ListAction.php
+++ b/app/code/Magento/Review/Controller/Product/ListAction.php
@@ -26,8 +26,8 @@ class ListAction extends ProductController
             $resultPage->getConfig()->setPageLayout($product->getPageLayout());
         }
         $urlSafeSku = rawurlencode($product->getSku());
-        $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku]);
         $resultPage->addPageLayoutHandles(['type' => $product->getTypeId()], null, false);
+        $resultPage->addPageLayoutHandles(['id' => $product->getId(), 'sku' => $urlSafeSku]);
         $resultPage->addUpdate($product->getCustomLayoutUpdate());
         return $resultPage;
     }


### PR DESCRIPTION
Add type-dependent layout handles before more specific ID/SKU layout
handles.

When updating a product page layout for a specific ID with `catalog_product_view_id_<product_ID>.xml` some changes may be overwritten by a less specific `catalog_product_view_type_<product_type>.xml`.

### Description
Change the order of loading the layout handles in `\Magento\Catalog\Helper\Product\View` and `\Magento\Review\Controller\Product\ListAction` to add the type specific layout handles BEFORE more specific ID/SKU specific layout handles.

In `\Magento\Catalog\Controller\Category\View` the updates are already loaded in the above suggested order.
### Fixed Issues (if relevant)
--

### Manual testing scenarios

1. Create a configurable product
2. Create a layout override for this product on by ID base (`catalog_product_view_id_<product_ID>.xml`)
3. In this layout update try to overwrite the `product.info.options.configurable` block with a custom template in referenced block `product.info.options.wrapper`
4. Before applying the PR the custom template is not taken into account, afterwards it is taken into account

### Example override
```
<?xml version="1.0"?>
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <body>
        <referenceBlock name="product.info.options.wrapper">
            <block class="Vendor\Module\Block\Product\View\Type\Configurable"
                name="product.info.options.configurable" as="options_configurable" before="-"
                template="Vendor_Module::product/view/type/options/configurable.phtml"/>
        </referenceBlock>
    </body>
</page>
```
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
