### PR TITLE
Stop the profiler when returning early in \Magento\Eav\Model\Config::getAttribute

### DIFF
--- a/app/code/Magento/Eav/Model/Config.php
+++ b/app/code/Magento/Eav/Model/Config.php
@@ -503,6 +503,7 @@ class Config
         }
 
         if (isset($this->attributes[$entityTypeCode][$code])) {
+            \Magento\Framework\Profiler::stop('EAV: ' . __METHOD__);
             return $this->attributes[$entityTypeCode][$code];
         }
 


### PR DESCRIPTION
Magento\Eav\Model\Config::getAttribute doesn't stop the Profiler when returning early, and thus incorrectly reports run time in these cases. 
This pull fixes it by stopping the profiler before returning

### Manual testing scenarios
1. In an unmodified Magento 2.2 codebase, enable profiling (I used mirasvit/profiler for convenience) 
2. Make a request for a page and observe that a large number of EAV getAttribute calls have run times
similar to the entire response time of the page.
3. Repeat with this pull request and see that the run times are reported more accurately
