### PR TITLE
Split X-Magento-Tags HTTP header into multiple headers

### DIFF
--- a/app/code/Magento/PageCache/Model/HTTP/Header/XMagentoTags.php
+++ b/app/code/Magento/PageCache/Model/HTTP/Header/XMagentoTags.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Magento\PageCache\Model\HTTP\Header;
+
+use Zend\Http\Header\MultipleHeaderInterface;
+use Zend\Http\Header\GenericHeader;
+use Zend\Http\Header\HeaderValue;
+use Zend\Http\Header\Exception;
+
+class XMagentoTags implements MultipleHeaderInterface
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * XMagentoTags constructor.
+     *
+     * @param string|null $value
+     */
+    public function __construct($value = null)
+    {
+        if ($value) {
+            HeaderValue::assertValid($value);
+            $this->value = $value;
+        }
+    }
+
+    /**
+     * Create X-Magento-Tags header from a given header line
+     *
+     * @param string $headerLine The header line to parse.
+     *
+     * @return self
+     * @throws Exception\InvalidArgumentException If the name field in the given header line does not match.
+     */
+    public static function fromString($headerLine)
+    {
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+
+        // check to ensure proper header type for this factory
+        if (strtolower($name) !== 'x-magento-tags') {
+            throw new Exception\InvalidArgumentException(
+                sprintf(
+                    'Invalid header line for X-Magento-Tags string: "%s"',
+                    $name
+                )
+            );
+        }
+
+        // @todo implementation details
+        $header = new static($value);
+
+        return $header;
+    }
+
+    /**
+     * Cast multiple header objects to a single string header
+     *
+     * @param  array $headers
+     * @throws Exception\InvalidArgumentException
+     * @return string
+     */
+    public function toStringMultipleHeaders(array $headers)
+    {
+        $name = $this->getFieldName();
+        $values = array($this->getFieldValue());
+        foreach ($headers as $header) {
+            if (!$header instanceof static) {
+                throw new Exception\InvalidArgumentException(
+                    'This method toStringMultipleHeaders was expecting an array of headers of the same type'
+                );
+            }
+            $values[] = $header->getFieldValue();
+        }
+
+        return $name . ': ' . implode(',', $values) . "\r\n";
+    }
+
+    /**
+     * Get the header name
+     *
+     * @return string
+     */
+    public function getFieldName()
+    {
+        return 'X-Magento-Tags';
+    }
+
+    /**
+     * Get the header value
+     *
+     * @return string
+     */
+    public function getFieldValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Return the header as a string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'X-Magento-Tags: ' . $this->getFieldValue();
+    }
+}

--- a/app/code/Magento/PageCache/Model/HTTP/PhpEnvironment/ResponsePlugin.php
+++ b/app/code/Magento/PageCache/Model/HTTP/PhpEnvironment/ResponsePlugin.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Magento\PageCache\Model\HTTP\PhpEnvironment;
+
+use Magento\Framework\HTTP\PhpEnvironment\Response as Subject;
+use Magento\PageCache\Model\Config;
+use Zend\Http\HeaderLoader;
+use Magento\PageCache\Model\HTTP\Header\XMagentoTags;
+
+class ResponsePlugin
+{
+    /**
+     * Approximately 8kb in length
+     *
+     * @var int
+     */
+    private $requestSize = 8000;
+
+    /**
+     * PageCache configuration
+     *
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * ResponsePlugin constructor.
+     *
+     * @param Config $config
+     */
+    public function __construct(
+        Config $config
+    ) {
+        $this->config = $config;
+    }
+
+    /**
+     * Special case for handling X-Magento-Tags header
+     * splits very long header into multiple headers
+     *
+     * @param Subject  $subject
+     * @param \Closure $proceed
+     * @param string   $name
+     * @param string   $value
+     * @param bool     $replace
+     *
+     * @return Subject|mixed
+     */
+    public function aroundSetHeader(Subject $subject, \Closure $proceed, $name, $value, $replace = false)
+    {
+        //if varnish isn't enabled, don't do anything
+        if (!$this->config->isEnabled() || $this->config->getType() != Config::VARNISH) {
+            return $proceed($name, $value, $replace);
+        }
+
+        $this->addHeaderToStaticMap();
+
+        if ($name == 'X-Magento-Tags') {
+            $headerLength = 0;
+            $value = (string)$value;
+            $tags = explode(',', $value);
+
+            $newTags = [];
+            foreach ($tags as $tag) {
+                if ($headerLength + strlen($tag) > $this->requestSize - count($tags) - 1) {
+                    $tagString = implode(',', $tags);
+                    $subject->getHeaders()->addHeaderLine($name, $tagString);
+                    $newTags = [];
+                    $headerLength = 0;
+                }
+                $headerLength += strlen($tag);
+                $newTags[] = $tag;
+            }
+
+            return $subject;
+        }
+
+        return $proceed($name, $value, $replace);
+    }
+
+    /**
+     * Add X-Magento-Tags header to HeaderLoader static map
+     */
+    private function addHeaderToStaticMap()
+    {
+        HeaderLoader::addStaticMap(
+            [
+                'xmagentotags' => XMagentoTags::class,
+            ]
+        );
+    }
+
+}

--- a/app/code/Magento/PageCache/etc/frontend/di.xml
+++ b/app/code/Magento/PageCache/etc/frontend/di.xml
@@ -25,4 +25,7 @@
     <type name="Magento\Framework\App\Response\Http">
         <plugin name="response-http-page-cache" type="Magento\PageCache\Model\App\Response\HttpPlugin"/>
     </type>
+    <type name="Magento\Framework\HTTP\PhpEnvironment\Response">
+        <plugin name="response-split-x-magento-tags-headers" type="Magento\PageCache\Model\HTTP\PhpEnvironment\ResponsePlugin" />
+    </type>
 </config>

--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -169,6 +169,10 @@ sub vcl_backend_response {
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
     }
+
+    # collect all x-magento-tags headers
+    std.collect(beresp.http.X-Magento-Tags);
+
     return (deliver);
 }
 

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -170,6 +170,10 @@ sub vcl_backend_response {
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
     }
+
+    # collect all x-magento-tags headers
+    std.collect(beresp.http.X-Magento-Tags);
+
     return (deliver);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
On Magento sites with large catalogs, it's easy to hit HTTP header length limit on Varnish or HTTP server, for categories that have large amount of products and are set as anchor. This is because all of the product tags are sent in initial backend_fetch request. 

This is usually addressed by implementing a workaround from the documentation http://devdocs.magento.com/guides/v2.2/config-guide/varnish/tshoot-varnish-503.html . Thing is, that workaround doesn't solve the issue, as you end up increasing the limit constantly as categories grow larger. 

Furthermore, you might hit another limit on your Apache/nginx HTTP server, as [both](http://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfieldsize) [have](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) 8kB max header value by default.

In M2.2 https://github.com/magento/magento2/commit/2529ec4fc035eec8c524e94c0b73efd8c3efbb28 , cache tags have been refactored to be a bit shorter (e.g. cat_p_xx instead of catalog_product_xx), which is another workaround to address the same issue.

According to RFC2616 https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html:

> Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This pull request proposes splitting the X-Magento-Tags header into multiple X-Magento-Tags headers that would stay roughly under 8kB limit each.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. Fixes magento/magento2#8696
2. Fixes magento/magento2#6401

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set category as "anchor" and assign about 2500 products to it (it's important that X-Magento-Tags header goes over 8kB limit)
2. Set up Magento store to use Varnish, with default Magento-generated VCL and no other parameter configured (ignore workaround/recommendations from this page http://devdocs.magento.com/guides/v2.2/config-guide/varnish/tshoot-varnish-503.html or just assign 2500 more products to the same category)
3. Attempt to open a category on frontend
4. Category returns 503 error from Varnish
5. If you have varnishlog active at the time this occurs, observe the error `FetchError     http read error: overflow` on `bereq 2 fetch` request

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
