### PR TITLE
Add missing preference for ObjectManager\ConfigInterface in integrati…

### DIFF
--- a/dev/tests/integration/etc/di/preferences/ce.php
+++ b/dev/tests/integration/etc/di/preferences/ce.php
@@ -16,6 +16,8 @@ return [
     \Magento\Framework\App\Response\Http::class => \Magento\TestFramework\Response::class,
     \Magento\Framework\Interception\PluginListInterface::class =>
         \Magento\TestFramework\Interception\PluginList::class,
+    \Magento\Framework\Interception\ObjectManager\ConfigInterface::class =>
+        \Magento\TestFramework\ObjectManager\Config::class,
     \Magento\Framework\Interception\ObjectManager\Config\Developer::class =>
         \Magento\TestFramework\ObjectManager\Config::class,
     \Magento\Framework\View\LayoutInterface::class => \Magento\TestFramework\View\Layout::class,


### PR DESCRIPTION
…on tests

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
A missing preference caused failures in integration tests as soon as the object manager config interface occured in the dependency graph of an instantiated class.

### Fixed Issues (if relevant)
1. magento/magento2#12844: "Cannot instantiate interface Magento\Framework\Interception\ObjectManager\ConfigInterface" error in integration tests

### Manual testing scenarios

See Issue

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
