### PR TITLE
Update functional.suite.dist.yml to handle a custom backend name

### DIFF
--- a/dev/tests/acceptance/tests/functional.suite.dist.yml
+++ b/dev/tests/acceptance/tests/functional.suite.dist.yml
@@ -25,7 +25,7 @@ modules:
     config:
         \Magento\FunctionalTestingFramework\Module\MagentoWebDriver:
             url: "%MAGENTO_BASE_URL%"
-            backend_name: admin
+            backend_name: "%MAGENTO_BACKEND_NAME%"
             browser: 'chrome'
             window_size: maximize
             username: "%MAGENTO_ADMIN_USERNAME%"


### PR DESCRIPTION
### Description
In the file `functional.suite.dist.yml`, the value for the `backend_name` configuration is hardcoded. We should be able to customize the value by using the variable `MAGENTO_BACKEND_NAME` defined in the `.env` file.
https://github.com/magento/magento2/blob/b0babda9bc53bb089b2bbfb1ae9d6e7aa222ae8a/dev/tests/acceptance/.env.example#L34

### Manual testing scenarios
1. Setup Magento with a backend name different from `admin`
2. Setup acceptance tests with `MAGENTO_BACKEND_NAME=<your_custom_backend_name>` in your `.env` file
3. Run acceptance tests

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
