### PR TITLE
Remove title “Billing Agreements”

### DIFF
--- a/app/code/Magento/Paypal/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/customer_account.xml
@@ -6,9 +6,6 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <head>
-        <title>Billing Agreements</title>
-    </head>
     <body>
         <referenceBlock name="customer_account_navigation">
             <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-billing-agreements-link">


### PR DESCRIPTION
Remove title “Billing Agreements” from customer_account.xml. After logging in the dashboard title will be 'Billing Agreements' because of inheritance.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/7816

### Manual testing scenarios
1. Login
2. Go to dashboard
3. View page title - title tag

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
