### PR TITLE
Update progress.phtml

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -14,12 +14,12 @@ error_reporting(E_ALL);
 if (!defined('PHP_VERSION_ID') || !(PHP_VERSION_ID === 70002 || PHP_VERSION_ID === 70004 || PHP_VERSION_ID >= 70006)) {
     if (PHP_SAPI == 'cli') {
         echo 'Magento supports 7.0.2, 7.0.4, and 7.0.6 or later. ' .
-            'Please read http://devdocs.magento.com/guides/v1.0/install-gde/system-requirements.html';
+            'Please read http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html';
     } else {
         echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">
     <p>Magento supports PHP 7.0.2, 7.0.4, and 7.0.6 or later. Please read
-    <a target="_blank" href="http://devdocs.magento.com/guides/v1.0/install-gde/system-requirements.html">
+    <a target="_blank" href="http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html">
     Magento System Requirements</a>.
 </div>
 HTML;

--- a/setup/view/magento/setup/readiness-check/progress.phtml
+++ b/setup/view/magento/setup/readiness-check/progress.phtml
@@ -336,7 +336,7 @@
                 </div>
 
                 <p ng-show="componentDependency.expanded">For additional assistance, see
-                    <a href="http://devdocs.magento.com/guides/v2.0/install-gde/trouble/php/tshoot_php-set.html"
+                    <a href="http://devdocs.magento.com/guides/v2.2/install-gde/trouble/php/tshoot_php-set.html"
                        target="_blank">PHP settings check help
                     </a>.
                 </p>
@@ -392,7 +392,7 @@
 
                 <div class="readiness-check-side">
                     <p class="side-title">Need Help?</p>
-                    <a href="http://devdocs.magento.com/guides/v2.0/install-gde/system-requirements.html" target="_blank">PHP Extension Help</a>
+                    <a href="http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html" target="_blank">PHP Extension Help</a>
                 </div>
 
                 <span class="readiness-check-icon icon-failed-round"></span>
@@ -413,7 +413,7 @@
                         <p>
                             The best way to resolve this is to install the correct missing extensions. The exact fix depends on our server, your host, and other system variables.
                             <br>
-                            Our <a href="http://devdocs.magento.com/guides/v2.0/install-gde/system-requirements.html" target="_blank">PHP extension help</a> can get you started.
+                            Our <a href="http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html" target="_blank">PHP extension help</a> can get you started.
                         </p>
                         <p>
                             For additional assistance, contact your hosting provider.
@@ -477,7 +477,7 @@
 
             <div class="readiness-check-side">
                 <p class="side-title">Need Help?</p>
-                <a href="http://devdocs.magento.com/guides/v2.0/install-gde/install/file-system-perms.html" target="_blank">File Permission Help</a>
+                <a href="http://devdocs.magento.com/guides/v2.2/install-gde/prereq/file-system-perms.html" target="_blank">File Permission Help</a>
             </div>
 
             <span class="readiness-check-icon icon-failed-round"></span>
@@ -500,7 +500,7 @@
                         The best way to resolve this is to allow write permissions for files in the following Magento directories and subdirectories. The exact fix depends on your server, your host,
                         and other system variables.
                         <br>
-                        For help, see our <a href="http://devdocs.magento.com/guides/v2.0/install-gde/install/file-system-perms.html" target="_blank">File Permission Help</a> or call your hosting provider.
+                        For help, see our <a href="http://devdocs.magento.com/guides/v2.2/install-gde/prereq/file-system-perms.html" target="_blank">File Permission Help</a> or call your hosting provider.
                     </p>
                     <ul class="list" ng-show="permissions.expanded" ng-init="showDetails=false">
                         <li


### PR DESCRIPTION
links to magento dev docs are outdated.  See https://community.magento.com/t5/Technical-Issues/Can-t-install-Magento-2-on-PHP-5-6-30/m-p/82895/highlight/false#M3749 for example

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Some of the links to magento devdocs are outdated. This PR fixes this within progress.phtml.

### Fixed Issues (if relevant)


### Manual testing scenarios
 - install magento via website
 - Test  Error-Paths

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
