### PR TITLE
Throw ValidationException for invalid xml

### DIFF
--- a/app/code/Magento/Config/Model/Config/Structure/Reader.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Reader.php
@@ -124,6 +124,7 @@ class Reader extends \Magento\Framework\Config\Reader\Filesystem
      * Processing nodes of the document before merging
      *
      * @param string $content
+     * @throws \Magento\Framework\Config\Dom\ValidationException
      * @return string
      */
     protected function processingDocument($content)
@@ -131,7 +132,12 @@ class Reader extends \Magento\Framework\Config\Reader\Filesystem
         $object = new DataObject();
         $document = new \DOMDocument();
 
-        $document->loadXML($content);
+        try {
+            $document->loadXML($content);
+        } catch (\Exception $e) {
+            throw new \Magento\Framework\Config\Dom\ValidationException($e->getMessage());
+        }
+
         $this->compiler->compile($document->documentElement, $object, $object);
 
         return $document->saveXML();


### PR DESCRIPTION
This change ensures the offending file path is output in the error
report.

### Description
Currently, when malformed `$content` is fed into `\Magento\Config\Model\Config\Structure\Reader::processingDocument` and unhandled `\Exception` is thrown. The output fails to indicate the location of the offending file, example:  
```
1 exception(s):
Exception #0 (Exception): Warning: DOMDocument::loadXML(): Opening and ending tag mismatch: system line 3 and section in Entity, line: 29 in /path2magento/vendor/magento/module-config/Model/Config/Structure/Reader.php on line 133
```

The proposed change catches the `\Exception` and throws `\Magento\Framework\Config\Dom\ValidationException` instead. This still causes the application to report an error, but logs the offending file in the error report, example:  
```
1 exception(s):
Exception #0 (Magento\Framework\Exception\LocalizedException): Invalid XML in file /path2magento/app/code/Vendor/Module/etc/adminhtml/system.xml:
Warning: DOMDocument::loadXML(): Opening and ending tag mismatch: system line 3 and section in Entity, line: 29 in /path2magento/vendor/magento/module-config/Model/Config/Structure/Reader.php on line 133
```

### Manual testing scenarios
1. Clear config cache
2. Malform any `system.xml` file, such as a duplicate closing tag.
3. Log in to the admin panel and attempt to visit the configuration page.
4. The application will return a 503 response and will include the path to the bad `system.xml` file in the error report.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
