### PR TITLE
Change _getHtml to append class rather than overwrite for children

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -235,12 +235,12 @@ class Topmenu extends Template implements IdentityInterface
 
             if ($childLevel == 0 && $outermostClass) {
                 $outermostClassCode = ' class="' . $outermostClass . '" ';
-                $current_class = $child->getClass();
+                $currentClass = $child->getClass();
 
-                if (empty($current_class)) {
+                if (empty($currentClass)) {
                     $child->setClass($outermostClass);
                 } else {
-                    $child->setClass($current_class . ' ' . $outermostClass);
+                    $child->setClass($currentClass . ' ' . $outermostClass);
                 }
             }
 

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -235,7 +235,13 @@ class Topmenu extends Template implements IdentityInterface
 
             if ($childLevel == 0 && $outermostClass) {
                 $outermostClassCode = ' class="' . $outermostClass . '" ';
-                $child->setClass($outermostClass);
+                $current_class = $child->getClass();
+
+                if (empty($current_class)) {
+                    $child->setClass($outermostClass);
+                } else {
+                    $child->setClass($current_class . ' ' . $outermostClass);
+                }
             }
 
             if (count($colBrakes) && $colBrakes[$counter]['colbrake']) {


### PR DESCRIPTION
Change _getHtml to append class rather than overwrite for children

### Description
When creating a dependency injection for the Magento\Theme\Block\Html\Topmenu class, we are unable to change class names on children in a beforeGetHtml method because the protected method _getHtml declares setClass() on all children items. What this contribution changes is checking each child for an existing class and appends the $outermostClass if true.

### Manual testing scenarios
1. Create a di.xml in a custom module that creates a plugin for the Magento\Theme\Block\Html\Topmenu class.
2. In a beforeGetHtml injection, add a loop over the (Magento\Theme\Block\Html\Topmenu) $subject->getMenu()->getChildren() and ->setClass() on each one.
3. With this contribution, each child gets the class specified. Without, it gets overwritten.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
