### PR TITLE
#12808 Add support for 'Skip errors' validation strategy

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
+++ b/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
@@ -178,6 +178,14 @@ class ProcessingErrorAggregator implements ProcessingErrorAggregatorInterface
     }
 
     /**
+     * @return string $validationStrategy
+     */
+    public function getValidationStrategy()
+    {
+        return $this->validationStrategy;
+    }
+
+    /**
      * @return bool
      */
     public function hasToBeTerminated()

--- a/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregatorInterface.php
+++ b/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregatorInterface.php
@@ -80,6 +80,13 @@ interface ProcessingErrorAggregatorInterface
     public function initValidationStrategy($validationStrategy, $allowedErrorCount = 0);
 
     /**
+     * Return the validation strategy
+     *
+     * @return string
+     */
+    public function getValidationStrategy();
+
+    /**
      * Check if the further processing should be stopped
      *
      * @return bool


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
I added in the validation phase of CVS importing some checks about validation strategy. Now, if the validation strategy is chosen to be 'Skip errors', the CVS file will be imported if the invalid rows number is smaller or equal to the number of allowed errors. In the previous versions, even if this option is selected, the data validation will fail if any invalid row is found.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12808: Magento 2.2.2-dev - CSV Import, skip errors not working 

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Download this CSV https://transfer.sh/PGiN8/catalog_product.csv
2. Go to Import section
3. Select 'Products' and 'Add/Update'
4. Select 'Skip Errors' and type '5' as 'Allowed Error Count'
5. Import the downloaded CSV and look how the validation pass even that there are 2 invalid rows

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
