### PR TITLE
Fix import from external jpeg images

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -162,9 +162,9 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
             }
 
             //only use filename (for URI with query parameters)
-            $parsedUrl = parse_url($url);
-            if ($parsedUrl['path']) {
-                $urlPathValues = explode('/', $parsedUrl['path']);
+            $parsedUrlPath = parse_url($url, PHP_URL_PATH);
+            if ($parsedUrlPath) {
+                $urlPathValues = explode('/', $parsedUrlPath);
                 if (!empty($urlPathValues)) {
                     $fileName = end($urlPathValues);
                 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -161,6 +161,15 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
                 $read = $this->_readFactory->create($url, DriverPool::HTTPS);
             }
 
+            //only use filename (for URI with query parameters)
+            $parsedUrl = parse_url($url);
+            if ($parsedUrl['path']) {
+                $urlPathValues = explode('/', $parsedUrl['path']);
+                if (!empty($urlPathValues)) {
+                    $fileName = end($urlPathValues);
+                }
+            }
+
             $fileName = preg_replace('/[^a-z0-9\._-]+/i', '', $fileName);
             $this->_directory->writeFile(
                 $this->_directory->getRelativePath($this->getTmpDir() . '/' . $fileName),

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/UploaderTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/UploaderTest.php
@@ -217,12 +217,32 @@ class UploaderTest extends \PHPUnit\Framework\TestCase
             [
                 '$fileUrl' => 'http://test_uploader_file',
                 '$expectedHost' => 'test_uploader_file',
-                '$expectedFileName' => 'httptest_uploader_file',
+                '$expectedFileName' => 'test_uploader_file',
             ],
             [
                 '$fileUrl' => 'https://!:^&`;file',
                 '$expectedHost' => '!:^&`;file',
-                '$expectedFileName' => 'httpsfile',
+                '$expectedFileName' => 'file',
+            ],
+            [
+                '$fileUrl' => 'https://www.google.com/image.jpg',
+                '$expectedHost' => 'www.google.com/image.jpg',
+                '$expectedFileName' => 'image.jpg',
+            ],
+            [
+                '$fileUrl' => 'https://www.google.com/image.jpg?param=1',
+                '$expectedHost' => 'www.google.com/image.jpg?param=1',
+                '$expectedFileName' => 'image.jpg',
+            ],
+            [
+                '$fileUrl' => 'https://www.google.com/image.jpg?param=1&param=2',
+                '$expectedHost' => 'www.google.com/image.jpg?param=1&param=2',
+                '$expectedFileName' => 'image.jpg',
+            ],
+            [
+                '$fileUrl' => 'http://www.google.com/image.jpg?param=1&param=2',
+                '$expectedHost' => 'www.google.com/image.jpg?param=1&param=2',
+                '$expectedFileName' => 'image.jpg',
             ],
         ];
     }


### PR DESCRIPTION
Unable to import products with external jpeg images hosted on a CDN with dynamic URLs not ending with ".jpg" or ".jpeg", e.g.

If accepted I'll create backport to 2.2 & 2.1.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/12533
2. https://github.com/magento/magento2/issues/12455
3. https://github.com/magento-engcom/import-export-improvements/issues/57
4. https://github.com/magento/magento2/issues/5306
5. https://github.com/firegento/FireGento_FastSimpleImport2/issues/50

### Manual testing scenarios
Check all issues. My CSV in attachment.
[products.csv.zip](https://github.com/magento/magento2/files/1584810/products.csv.zip)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
