### PR TITLE
Add more parameters to ajax:addToCart

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
@@ -97,7 +97,7 @@ define([
                 success: function (res) {
                     var eventData, parameters;
 
-                    $(document).trigger('ajax:addToCart', form.data().productSku);
+                    $(document).trigger('ajax:addToCart', form.data().productSku, form, res);
 
                     if (self.isLoaderEnabled()) {
                         $('body').trigger(self.options.processStop);


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->
The SKU by itself is not very useful because for most third-party integration you will need at minimum SKU and qty. 

The 'res' is also important because you could write a plugin for Magento\Checkout\Controller\Cart\Add to add more information to the return JSON.



