### PR TITLE
Fix issue #12866: Can't Disable Advanced Reporting

### DIFF
--- a/app/code/Magento/Analytics/Model/Config/Backend/Vertical.php
+++ b/app/code/Magento/Analytics/Model/Config/Backend/Vertical.php
@@ -24,7 +24,7 @@ class Vertical extends \Magento\Framework\App\Config\Value
     public function beforeSave()
     {
         if (empty($this->getValue())) {
-            throw new LocalizedException(__('Please select a vertical.'));
+            throw new LocalizedException(__('Please select an industry.'));
         }
 
         return $this;

--- a/app/code/Magento/Analytics/Setup/InstallData.php
+++ b/app/code/Magento/Analytics/Setup/InstallData.php
@@ -30,7 +30,7 @@ class InstallData implements InstallDataInterface
                     'scope' => 'default',
                     'scope_id' => 0,
                     'path' => 'analytics/subscription/enabled',
-                    'value' => 1
+                    'value' => 0
                 ],
                 [
                     'scope' => 'default',


### PR DESCRIPTION
### Description

Disable Magento_Analytics (aka Advanced Reporting) by default and provide clearer message if an industry is not provided.

### Fixed Issues (if relevant)

1. [magento/magento2#12866](https://github.com/magento/magento2/issues/12866): Can't Disable Advanced Reporting


### Manual testing scenarios

1. Install new Magento 2.2 instance and `Stores > Configuration > General > Advanced Reporting > Advanced Reporting Service` should be set to Disable after install
2. Go to `Stores > Configuration > General > Advanced Reporting` and change **Advanced Reporting Service** to Enable/Disable and press **Save Config**. If an **Industry** is not provided, then the `Please select an industry.` error message is shown rather than `Please select a vertical.` 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
