### PR TITLE
Add product ID and SKU to wishlist customer data

### DIFF
--- a/app/code/Magento/Wishlist/CustomerData/Wishlist.php
+++ b/app/code/Magento/Wishlist/CustomerData/Wishlist.php
@@ -123,6 +123,8 @@ class Wishlist implements SectionSourceInterface
         $product = $wishlistItem->getProduct();
         return [
             'image' => $this->getImageData($product),
+            'product_sku' => $product->getSku(),
+            'product_id' => $product->getId(),
             'product_url' => $this->wishlistHelper->getProductUrl($wishlistItem),
             'product_name' => $product->getName(),
             'product_price' => $this->block->getProductPriceHtml(

--- a/app/code/Magento/Wishlist/Test/Unit/CustomerData/WishlistTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/CustomerData/WishlistTest.php
@@ -77,6 +77,8 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
         $imageLabel = 'image_label';
         $imageWidth = 'image_width';
         $imageHeight = 'image_height';
+        $productSku = 'product_sku';
+        $productId = 'product_id';
         $productUrl = 'product_url';
         $productName = 'product_name';
         $productPrice = 'product_price';
@@ -97,6 +99,8 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
                         'width' => $imageWidth,
                         'height' => $imageHeight,
                     ],
+                    'product_sku' => $productSku,
+                    'product_id' => $productId,
                     'product_url' => $productUrl,
                     'product_name' => $productName,
                     'product_price' => $productPrice,
@@ -187,6 +191,12 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productUrl);
 
         $productMock->expects($this->once())
+            ->method('getSku')
+            ->willReturn($productSku);
+        $productMock->expects($this->once())
+            ->method('getId')
+            ->willReturn($productId);
+        $productMock->expects($this->once())
             ->method('getName')
             ->willReturn($productName);
 
@@ -246,6 +256,8 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
         $imageLabel = 'image_label';
         $imageWidth = 'image_width';
         $imageHeight = 'image_height';
+        $productSku = 'product_sku';
+        $productId = 'product_id';
         $productUrl = 'product_url';
         $productName = 'product_name';
         $productPrice = 'product_price';
@@ -272,6 +284,8 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
                         'width' => $imageWidth,
                         'height' => $imageHeight,
                     ],
+                    'product_sku' => $productSku,
+                    'product_id' => $productId,
                     'product_url' => $productUrl,
                     'product_name' => $productName,
                     'product_price' => $productPrice,
@@ -288,6 +302,8 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
                         'width' => $imageWidth,
                         'height' => $imageHeight,
                     ],
+                    'product_sku' => $productSku,
+                    'product_id' => $productId,
                     'product_url' => $productUrl,
                     'product_name' => $productName,
                     'product_price' => $productPrice,
@@ -374,6 +390,14 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
         $productMock->expects($this->exactly(2))
             ->method('getName')
             ->willReturn($productName);
+
+        $productMock->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn($productId);
+
+        $productMock->expects($this->exactly(2))
+            ->method('getSku')
+            ->willReturn($productSku);
 
         $this->sidebarMock->expects($this->exactly(2))
             ->method('getProductPriceHtml')


### PR DESCRIPTION
### Description
This adds a product's ID and SKU to the wishlist customer data stored in local storage. 

### Fixed Issues (if relevant)
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
