### PR TITLE
FIX: remove not used count() from templates

### DIFF
--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/creditmemo/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/creditmemo/items/renderer.phtml
@@ -12,7 +12,6 @@
 
 <?php $items = $block->getChildren($parentItem) ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
-<?php $_count = count($items) ?>
 <?php $_index = 0 ?>
 
 <?php $_prevOptionId = '' ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/invoice/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/invoice/items/renderer.phtml
@@ -12,7 +12,6 @@
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
 
 <?php $items = $block->getChildren($parentItem) ?>
-<?php $_count = count($items) ?>
 <?php $_index = 0 ?>
 
 <?php $_prevOptionId = '' ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/items/renderer.phtml
@@ -10,7 +10,6 @@
 ?>
 <?php $parentItem = $block->getItem() ?>
 <?php $items = array_merge([$parentItem], $parentItem->getChildrenItems()); ?>
-<?php $_count = count($items) ?>
 <?php $_index = 0 ?>
 
 <?php $_prevOptionId = '' ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/shipment/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/shipment/items/renderer.phtml
@@ -12,7 +12,6 @@
 <?php $parentItem = $block->getItem() ?>
 <?php $items = array_merge([$parentItem->getOrderItem()], $parentItem->getOrderItem()->getChildrenItems()) ?>
 <?php $shipItems = $block->getChildren($parentItem) ?>
-<?php $_count = count($items) ?>
 <?php $_index = 0 ?>
 
 <?php $_prevOptionId = '' ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items.phtml
@@ -40,7 +40,6 @@
             </tr>
         </thead>
         <?php $_items = $_creditmemo->getAllItems(); ?>
-        <?php $_count = count($_items) ?>
         <?php foreach ($_items as $_item): ?>
         <?php if ($_item->getOrderItem()->getParentItem()) {
     continue;

--- a/app/code/Magento/Sales/view/frontend/templates/order/invoice/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/invoice/items.phtml
@@ -37,7 +37,6 @@
             </tr>
         </thead>
         <?php $_items = $_invoice->getAllItems(); ?>
-        <?php $_count = count($_items) ?>
         <?php foreach ($_items as $_item): ?>
         <?php if ($_item->getOrderItem()->getParentItem()) {
     continue;

--- a/app/code/Magento/Sales/view/frontend/templates/order/print/creditmemo.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/print/creditmemo.phtml
@@ -34,11 +34,10 @@
                 </tr>
             </thead>
             <?php $_items = $_creditmemo->getAllItems(); ?>
-            <?php $_count = count($_items); ?>
             <?php foreach ($_items as $_item): ?>
-            <?php if ($_item->getOrderItem()->getParentItem()) {
-    continue;
-} ?>
+            <?php if ($_item->getOrderItem()->getParentItem()): ?>
+                continue;
+            <?php endif; ?>
             <tbody>
                 <?= $block->getItemHtml($_item) ?>
             </tbody>

--- a/app/code/Magento/Sales/view/frontend/templates/order/print/invoice.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/print/invoice.phtml
@@ -32,11 +32,10 @@
             </tr>
             </thead>
             <?php $_items = $_invoice->getItemsCollection(); ?>
-            <?php $_count = $_items->count(); ?>
             <?php foreach ($_items as $_item): ?>
-            <?php if ($_item->getOrderItem()->getParentItem()) {
-    continue;
-} ?>
+                <?php if ($_item->getOrderItem()->getParentItem()): ?>
+                    continue;
+                <?php endif; ?>
             <tbody>
                 <?= $block->getItemHtml($_item) ?>
             </tbody>

--- a/app/code/Magento/Shipping/view/frontend/templates/items.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/items.phtml
@@ -66,7 +66,6 @@
             </tr>
         </thead>
         <?php $_items = $_shipment->getAllItems(); ?>
-        <?php $_count = count($_items) ?>
         <?php foreach ($_items as $_item): ?>
         <?php if ($_item->getOrderItem()->getParentItem()) {
     continue;


### PR DESCRIPTION
Dear Magento2,
The main goal of this PR is to remove not used `count($_items)` in templates. Please, check Description section for details.

Thank you,
Alex

### Description
Found that in some templates Magento2 counts items for table rendering and other stuff but files, add to this PR, do not use `$_count` variable and `<?php $_count = count($_items) ?>` can be excluded from them.

### Fixed Issues (if relevant)
Not related issue found.

### Manual testing scenarios
No need to be tested because just removing a not used variable from templates.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
