### PR TITLE
Fix #12900: Braintree "Place Order" button is disabled after failed validation

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
@@ -79,6 +79,7 @@ define(
                      */
                     onError: function (response) {
                         braintree.showError($t('Payment ' + this.getTitle() + ' can\'t be initialized'));
+                        this.isPlaceOrderActionAllowed(true);
                         throw response.message;
                     },
 

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/cc-form.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/cc-form.test.js
@@ -27,7 +27,7 @@ define([
                 ),
                 'Magento_Braintree/js/view/payment/adapter':  jasmine.createSpyObj(
                     'adapter',
-                    ['setup', 'setConfig']
+                    ['setup', 'setConfig', 'showError']
                 )
             },
             braintreeCcForm;
@@ -43,14 +43,17 @@ define([
             };
             injector.mock(mocks);
             injector.require(['Magento_Braintree/js/view/payment/method-renderer/cc-form'], function (Constr) {
-                    braintreeCcForm = new Constr({
-                        provider: 'provName',
-                        name: 'test',
-                        index: 'test'
-                    });
-
-                    done();
+                braintreeCcForm = new Constr({
+                    provider: 'provName',
+                    name: 'test',
+                    index: 'test',
+                    item: {
+                        title: 'Braintree'
+                    }
                 });
+
+                done();
+            });
         });
 
         it('Check if payment code and message container are restored after onActiveChange call.', function () {
@@ -64,6 +67,22 @@ define([
 
             expect(braintreeCcForm.getCode()).toEqual(expectedCode);
             expect(braintreeCcForm.messageContainer).toEqual(expectedMessageContainer);
+        });
+
+        it('Check if form validation fails when "Place Order" button should be active.', function () {
+            var errorMessage = 'Something went wrong.',
+
+                /**
+                 * Anonymous wrapper
+                 */
+                func = function () {
+                    braintreeCcForm.clientConfig.onError({
+                        'message': errorMessage
+                    });
+                };
+
+            expect(func).toThrow(errorMessage);
+            expect(braintreeCcForm.isPlaceOrderActionAllowed()).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
### Description

After failed payment form validation the "Place Order" button is still disabled because `hosted-fields` triggers an error on validation and `isPlaceOrderActionAllowed` is still returns `false`.

 - Added handler to enable "Place Order" button on failed validation
 - Covered changes by js unit test

### Fixed Issues
1. magento/magento2#12900: Braintree "Place Order" button is disabled after failed validation

### Manual testing scenarios

1. Add product to cart and proceed to checkout
2. Fill all customer data and select shipping method. Proceed to payment
3. Select Braintree credit card payment method
4. Input credit card number (dummy)
5. Omit expiry date or CVV
6. Click "Place order" button
7. Error "Payment Credit Card (Braintree) can't be initialized" briefly appears
8. Input expiry date or CVV
9. "Place order" button is disabled/not responsive

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
