### PR TITLE
[Backport #12666 into 2.3-develop] Fix incorrect DHL Product codes

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -606,7 +606,7 @@ class Carrier extends \Magento\Dhl\Model\AbstractDhl implements \Magento\Shippin
             'L' => __('Express 10:30'),
             'G' => __('Domestic economy select'),
             'W' => __('Economy select'),
-            'I' => __('Break bulk economy'),
+            'I' => __('Domestic express 9:00'),
             'N' => __('Domestic express'),
             'O' => __('Others'),
             'R' => __('Globalmail business'),
@@ -616,7 +616,7 @@ class Carrier extends \Magento\Dhl\Model\AbstractDhl implements \Magento\Shippin
         ];
 
         $nonDocType = [
-            '1' => __('Customer services'),
+            '1' => __('Domestic express 12:00'),
             '3' => __('Easy shop'),
             '4' => __('Jetline'),
             '8' => __('Express easy'),

--- a/app/code/Magento/Dhl/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Dhl/Test/Unit/Model/CarrierTest.php
@@ -447,4 +447,67 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
             ]
         ];
     }
+    
+    /**
+     * @dataProvider dhlProductsDataProvider
+     *
+     * @param string $docType
+     * @param array $products
+     */
+    public function testGetDhlProducts(string $docType, array $products)
+    {
+        $this->assertEquals($products, $this->model->getDhlProducts($docType));
+    }
+
+    /**
+     * @return array
+     */
+    public function dhlProductsDataProvider() : array
+    {
+        return [
+            'doc' => [
+                'docType' => \Magento\Dhl\Model\Carrier::DHL_CONTENT_TYPE_DOC,
+                'products' => [
+                    '2' => 'Easy shop',
+                    '5' => 'Sprintline',
+                    '6' => 'Secureline',
+                    '7' => 'Express easy',
+                    '9' => 'Europack',
+                    'B' => 'Break bulk express',
+                    'C' => 'Medical express',
+                    'D' => 'Express worldwide',
+                    'U' => 'Express worldwide',
+                    'K' => 'Express 9:00',
+                    'L' => 'Express 10:30',
+                    'G' => 'Domestic economy select',
+                    'W' => 'Economy select',
+                    'I' => 'Domestic express 9:00',
+                    'N' => 'Domestic express',
+                    'O' => 'Others',
+                    'R' => 'Globalmail business',
+                    'S' => 'Same day',
+                    'T' => 'Express 12:00',
+                    'X' => 'Express envelope',
+                ]
+            ],
+            'non-doc' => [
+                'docType' => \Magento\Dhl\Model\Carrier::DHL_CONTENT_TYPE_NON_DOC,
+                'products' => [
+                    '1' => 'Domestic express 12:00',
+                    '3' => 'Easy shop',
+                    '4' => 'Jetline',
+                    '8' => 'Express easy',
+                    'P' => 'Express worldwide',
+                    'Q' => 'Medical express',
+                    'E' => 'Express 9:00',
+                    'F' => 'Freight worldwide',
+                    'H' => 'Economy select',
+                    'J' => 'Jumbo box',
+                    'M' => 'Express 10:30',
+                    'V' => 'Europack',
+                    'Y' => 'Express 12:00',
+                ]
+            ]
+        ];
+    }
 }

--- a/app/code/Magento/Dhl/i18n/en_US.csv
+++ b/app/code/Magento/Dhl/i18n/en_US.csv
@@ -23,14 +23,12 @@ Europack,Europack
 "Express 10:30","Express 10:30"
 "Domestic economy select","Domestic economy select"
 "Economy select","Economy select"
-"Break bulk economy","Break bulk economy"
 "Domestic express","Domestic express"
 Others,Others
 "Globalmail business","Globalmail business"
 "Same day","Same day"
 "Express 12:00","Express 12:00"
 "Express envelope","Express envelope"
-"Customer services","Customer services"
 Jetline,Jetline
 "Freight worldwide","Freight worldwide"
 "Jumbo box","Jumbo box"
@@ -81,3 +79,5 @@ Size,Size
 "Show Method if Not Applicable","Show Method if Not Applicable"
 "Sort Order","Sort Order"
 Debug,Debug
+"Domestic express 9:00","Domestic express 9:00"
+"Domestic express 12:00","Domestic express 12:00"


### PR DESCRIPTION
Backport of #12666 into 2.3-develop

### Description
There are two DHL product codes in the DHL Shipping module that are incorrect.

Product Code "1" changed from "Customer Services" to "Domestic express 12:00"
Product Code "I" changed from "Break bulk economy" to "Domestic express 9:00"

DHL product codes are now inline with those published in latest DHL products and services guide.

See [DHLIS1 - Products and Services](http://www.dhl.co.uk/content/dam/downloads/uk/Express/PDFs/developer_centre/dhlis1_products_and_services.pdf)

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
