### PR TITLE
[Fix] store switcher not showing all stores if the height is bigger than 250px

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/actions-bar/_store-switcher.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/actions-bar/_store-switcher.less
@@ -39,7 +39,6 @@
     .dropdown-menu {
         left: 0;
         margin-top: .5em;
-        max-height: 250px;
         overflow-y: auto;
         padding-top: .25em;
 


### PR DESCRIPTION
### Description

Store view switcher in Admin does not display all stores if the height of them is bigger than 250px. Admin cannot select those stores to edit their configuration

Current Bug:
![current_bug](https://user-images.githubusercontent.com/6410900/34409754-2cb18e92-ebcc-11e7-8368-96b5307b434a.png)

PR fix:
![fixed](https://user-images.githubusercontent.com/6410900/34409755-2cc947e4-ebcc-11e7-9f7e-e8881601f3a7.png)


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create 3 Websites with 3 stores views each
2. Save
3. Click over the "Store View" Admin switcher. 

**Expected**: All stores are displayed
**Actual result**: Not all are displayed. Only the first ones up to 250px height

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
