### PR TITLE
Fix issue 12894: Can't remove State is required for all countries

### DIFF
--- a/app/code/Magento/Directory/etc/adminhtml/system.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/system.xml
@@ -109,6 +109,7 @@
                 <field id="state_required" translate="label" type="multiselect" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>State is Required for</label>
                     <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                    <can_be_empty>1</can_be_empty>
                 </field>
                 <field id="display_all" translate="label" type="select" sortOrder="8" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Allow to Choose State if It is Optional for Country</label>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
In this PR was fixed a minor issue in System Configuration page reported in #12894.
It is about **_State options_** -> **_State is required for_** which do not allow you to leave the multiselect empty (have no required states for any countries).

![image](https://user-images.githubusercontent.com/13456702/34431741-377d2d82-ec7a-11e7-8458-fd34d170f3c6.png)

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12894: Can't remove State is required for all countries

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Login to admin page
2. Navigate to **_Stores_** > **_Configuration_** > **_General_**
3. In the fieldset **_State is Required for_** disable all options.
4. Click to save
5. Fieldset **_State is Required for_** has no any selected values
