### PR TITLE
Fix wishlist item getBuyRequest with no options

### DIFF
--- a/app/code/Magento/Wishlist/Model/Item.php
+++ b/app/code/Magento/Wishlist/Model/Item.php
@@ -472,7 +472,7 @@ class Item extends AbstractModel implements ItemInterface
     public function getBuyRequest()
     {
         $option = $this->getOptionByCode('info_buyRequest');
-        $initialData = $option ? unserialize($option->getValue()) : null;
+        $initialData = $option ? unserialize($option->getValue()) : [];
 
         if ($initialData instanceof \Magento\Framework\DataObject) {
             $initialData = $initialData->getData();

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemTest.php
@@ -323,4 +323,15 @@ class ItemTest extends \PHPUnit_Framework_TestCase
             ->willReturn($productMock);
         $this->assertEquals($productMock, $this->model->getProduct());
     }
+
+    public function testGetBuyRequestWithNoOption()
+    {
+        $buyRequest = $this->model->getBuyRequest();
+
+        $this->assertInstanceOf(\Magento\Framework\DataObject::class, $buyRequest);
+        $this->assertEquals([
+            'qty' => 0,
+            'original_qty' => null
+        ], $buyRequest->getData());
+    }
 }


### PR DESCRIPTION
### Description
Fixes an issue where the default value for a wishlist item's buyRequest data was `null`, when it must always be an `array`.

### Fixed Issues (if relevant)
None that I know of.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
