### PR TITLE
Display scroll bar of admin store switcher in OSX computers.

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/actions-bar/_store-switcher.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/actions-bar/_store-switcher.less
@@ -42,6 +42,14 @@
         max-height: 250px;
         overflow-y: auto;
         padding-top: .25em;
+        &::-webkit-scrollbar {
+            -webkit-appearance: none;
+            width: 7px;
+        }
+        &::-webkit-scrollbar-thumb {
+            border-radius: 4px;
+            background-color: rgba(0, 0, 0, .5);
+        }
 
         li {
             border: 0;


### PR DESCRIPTION
As described on https://github.com/magento/magento2/pull/12906 if scrollbar is not displayed, people do not notice that the menu is scrollable and you think there is an issue with the stores that are not displayed

Current Situation:
![current](https://user-images.githubusercontent.com/6410900/34449590-085c7064-ecfa-11e7-8784-59f407728027.png)

PR Solution:
<img width="1440" alt="pr_solution" src="https://user-images.githubusercontent.com/6410900/34449598-1e41fc46-ecfa-11e7-8c3d-bb89963db767.png">


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
