### PR TITLE
Add Ability To Separate Frontend / Adminhtml in New Relic

### DIFF
--- a/app/code/Magento/NewRelicReporting/Model/Config.php
+++ b/app/code/Magento/NewRelicReporting/Model/Config.php
@@ -162,6 +162,16 @@ class Config
     }
 
     /**
+     * Returns configured separate apps value
+     *
+     * @return bool
+     */
+    public function isSeparateApps()
+    {
+        return (bool)$this->scopeConfig->getValue('newrelicreporting/general/separate_apps');
+    }
+
+    /**
      * Returns config setting for overall cron to be enabled
      *
      * @return bool

--- a/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
+++ b/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
@@ -42,6 +42,19 @@ class NewRelicWrapper
     }
 
     /**
+     * Wrapper for 'newrelic_set_appname'
+     *
+     * @param string $appName
+     * @return void
+     */
+    public function setAppName($appName)
+    {
+        if (extension_loaded('newrelic')) {
+            newrelic_set_appname($appName);
+        }
+    }
+
+    /**
      * Checks whether newrelic-php5 agent is installed
      *
      * @return bool

--- a/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
+++ b/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
@@ -47,7 +47,7 @@ class NewRelicWrapper
      * @param string $appName
      * @return void
      */
-    public function setAppName($appName)
+    public function setAppName(string $appName)
     {
         if (extension_loaded('newrelic')) {
             newrelic_set_appname($appName);

--- a/app/code/Magento/NewRelicReporting/Plugin/StatePlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatePlugin.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\NewRelicReporting\Plugin;
+
+use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\NewRelicReporting\Model\Config;
+use Magento\NewRelicReporting\Model\NewRelicWrapper;
+
+class StatePlugin
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var NewRelicWrapper
+     */
+    private $newRelicWrapper;
+
+    /**
+     * @param Config $config
+     * @param NewRelicWrapper $newRelicWrapper
+     */
+    public function __construct(
+        Config $config,
+        NewRelicWrapper $newRelicWrapper
+    ) {
+        $this->config = $config;
+        $this->newRelicWrapper = $newRelicWrapper;
+    }
+
+    /**
+     * Set separate appname
+     *
+     * @param State $subject
+     * @param null $result
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterSetAreaCode(State $state, $result)
+    {
+        if (!$this->shouldSetAppName()) {
+            return;
+        }
+
+        try {
+            $this->newRelicWrapper->setAppName($this->appName($state));
+        } catch (LocalizedException $e) {
+            return;
+        }
+    }
+
+    private function appName(State $state)
+    {
+        $code = $state->getAreaCode();
+        $current = $this->config->getNewRelicAppName();
+
+        return $current . ';' . $current . '_' . $code;
+    }
+
+    private function shouldSetAppName()
+    {
+        if (!$this->config->isNewRelicEnabled()) {
+            return false;
+        }
+
+        if (!$this->config->getNewRelicAppName()) {
+            return false;
+        }
+
+        if (!$this->config->isSeparateApps()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/code/Magento/NewRelicReporting/Plugin/StatePlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatePlugin.php
@@ -9,6 +9,7 @@ use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\NewRelicReporting\Model\Config;
 use Magento\NewRelicReporting\Model\NewRelicWrapper;
+use Psr\Log\LoggerInterface;
 
 class StatePlugin
 {
@@ -23,15 +24,22 @@ class StatePlugin
     private $newRelicWrapper;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Config $config
      * @param NewRelicWrapper $newRelicWrapper
      */
     public function __construct(
         Config $config,
-        NewRelicWrapper $newRelicWrapper
+        NewRelicWrapper $newRelicWrapper,
+        LoggerInterface $logger
     ) {
         $this->config = $config;
         $this->newRelicWrapper = $newRelicWrapper;
+        $this->logger = $logger;
     }
 
     /**
@@ -52,6 +60,7 @@ class StatePlugin
         try {
             $this->newRelicWrapper->setAppName($this->appName($state));
         } catch (LocalizedException $e) {
+            $this->logger->critical($e);
             return;
         }
     }

--- a/app/code/Magento/NewRelicReporting/Plugin/StatePlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatePlugin.php
@@ -54,14 +54,14 @@ class StatePlugin
     public function afterSetAreaCode(State $state, $result)
     {
         if (!$this->shouldSetAppName()) {
-            return;
+            return $result;
         }
 
         try {
             $this->newRelicWrapper->setAppName($this->appName($state));
         } catch (LocalizedException $e) {
             $this->logger->critical($e);
-            return;
+            return $result;
         }
     }
 

--- a/app/code/Magento/NewRelicReporting/etc/adminhtml/system.xml
+++ b/app/code/Magento/NewRelicReporting/etc/adminhtml/system.xml
@@ -46,6 +46,11 @@
                     <label>New Relic Application Name</label>
                     <comment>This is located by navigating to Settings from the New Relic APM website</comment>
                 </field>
+                <field id="separate_apps" translate="label comment" type="select" sortOrder="9" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Send Adminhtml and Frontend as Separate Apps</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>In addition to the main app (which includes all PHP execution), separate apps for adminhtml and frontend will be created. Requires New Relic Application Name to be set.</comment>
+                </field>
             </group>
             <group id="cron" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Cron</label>

--- a/app/code/Magento/NewRelicReporting/etc/di.xml
+++ b/app/code/Magento/NewRelicReporting/etc/di.xml
@@ -30,6 +30,9 @@
     <type name="Magento\Framework\App\Http">
         <plugin name="framework-http-newrelic" type="Magento\NewRelicReporting\Plugin\HttpPlugin"/>
     </type>
+    <type name="Magento\Framework\App\State">
+        <plugin name="framework-state-newrelic" type="Magento\NewRelicReporting\Plugin\StatePlugin"/>
+    </type>
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">

--- a/app/code/Magento/NewRelicReporting/i18n/en_US.csv
+++ b/app/code/Magento/NewRelicReporting/i18n/en_US.csv
@@ -21,3 +21,5 @@ General,General
 "This is located by navigating to Settings from the New Relic APM website","This is located by navigating to Settings from the New Relic APM website"
 Cron,Cron
 "Enable Cron","Enable Cron"
+"Send Adminhtml and Frontend as Separate Apps","Send Adminhtml and Frontend as Separate Apps"
+"In addition to the main app (which includes all PHP execution), separate apps for adminhtml and frontend will be created. Requires New Relic Application Name to be set.","In addition to the main app (which includes all PHP execution), separate apps for adminhtml and frontend will be created. Requires New Relic Application Name to be set."

--- a/dev/tests/integration/testsuite/Magento/NewRelicReporting/Plugin/SeparateAppsTest.php
+++ b/dev/tests/integration/testsuite/Magento/NewRelicReporting/Plugin/SeparateAppsTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\NewRelicReporting\Plugin;
+
+use Magento\Framework\App\State;
+use Magento\NewRelicReporting\Model\NewRelicWrapper;
+use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\Helper\Bootstrap;
+
+class SeparateAppsTest extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * @var ObjectManager
+	 */
+	private $objectManager;
+
+	protected function setUp()
+	{
+		$this->objectManager = Bootstrap::getObjectManager();
+	}
+
+	/**
+	 * @magentoConfigFixture default/newrelicreporting/general/enable 1
+	 * @magentoConfigFixture default/newrelicreporting/general/app_name beverly_hills
+	 * @magentoConfigFixture default/newrelicreporting/general/separate_apps 1
+	 */
+	public function testAppNameIsSetWhenConfiguredCorrectly()
+	{
+		$newRelicWrapper = $this->getMockBuilder(NewRelicWrapper::class)
+			->setMethods(['setAppName'])
+			->getMock();
+
+		$this->objectManager->configure([NewRelicWrapper::class => ['shared' => true]]);
+		$this->objectManager->addSharedInstance($newRelicWrapper, NewRelicWrapper::class);
+
+		$newRelicWrapper->expects($this->once())
+			->method('setAppName')
+			->with($this->equalTo('beverly_hills;beverly_hills_90210'));
+
+		$state = $this->objectManager->get(State::class);
+
+		$state->setAreaCode('90210');
+	}
+}

--- a/dev/tests/integration/testsuite/Magento/NewRelicReporting/Plugin/SeparateAppsTest.php
+++ b/dev/tests/integration/testsuite/Magento/NewRelicReporting/Plugin/SeparateAppsTest.php
@@ -12,36 +12,36 @@ use Magento\TestFramework\Helper\Bootstrap;
 
 class SeparateAppsTest extends \PHPUnit\Framework\TestCase
 {
-	/**
-	 * @var ObjectManager
-	 */
-	private $objectManager;
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
 
-	protected function setUp()
-	{
-		$this->objectManager = Bootstrap::getObjectManager();
-	}
+    protected function setUp()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+    }
 
-	/**
-	 * @magentoConfigFixture default/newrelicreporting/general/enable 1
-	 * @magentoConfigFixture default/newrelicreporting/general/app_name beverly_hills
-	 * @magentoConfigFixture default/newrelicreporting/general/separate_apps 1
-	 */
-	public function testAppNameIsSetWhenConfiguredCorrectly()
-	{
-		$newRelicWrapper = $this->getMockBuilder(NewRelicWrapper::class)
-			->setMethods(['setAppName'])
-			->getMock();
+    /**
+     * @magentoConfigFixture default/newrelicreporting/general/enable 1
+     * @magentoConfigFixture default/newrelicreporting/general/app_name beverly_hills
+     * @magentoConfigFixture default/newrelicreporting/general/separate_apps 1
+     */
+    public function testAppNameIsSetWhenConfiguredCorrectly()
+    {
+        $newRelicWrapper = $this->getMockBuilder(NewRelicWrapper::class)
+            ->setMethods(['setAppName'])
+            ->getMock();
 
-		$this->objectManager->configure([NewRelicWrapper::class => ['shared' => true]]);
-		$this->objectManager->addSharedInstance($newRelicWrapper, NewRelicWrapper::class);
+        $this->objectManager->configure([NewRelicWrapper::class => ['shared' => true]]);
+        $this->objectManager->addSharedInstance($newRelicWrapper, NewRelicWrapper::class);
 
-		$newRelicWrapper->expects($this->once())
-			->method('setAppName')
-			->with($this->equalTo('beverly_hills;beverly_hills_90210'));
+        $newRelicWrapper->expects($this->once())
+            ->method('setAppName')
+            ->with($this->equalTo('beverly_hills;beverly_hills_90210'));
 
-		$state = $this->objectManager->get(State::class);
+        $state = $this->objectManager->get(State::class);
 
-		$state->setAreaCode('90210');
-	}
+        $state->setAreaCode('90210');
+    }
 }


### PR DESCRIPTION
### Description

Adds a new setting which, when enabled, reports frontend and adminhtml as separate apps to New Relic.

frontend and adminhtml are **in addition to** the "main" app which includes both (for backwards compatibility). The user needs to set "New Relic Application Name" to use this feature as the area is appended to the appname setting, separated by and underscore.

![image](https://user-images.githubusercontent.com/4132322/34459093-24bbfa36-edb3-11e7-99b0-0249c343ac0a.png)

![image](https://user-images.githubusercontent.com/4132322/34459091-0a68116a-edb3-11e7-8f56-8bf4d9e9baea.png)

Useful as slow transactions in admin activity can cause false positives New Relic alerts / skew average response time metrics. Using this feature allows monitoring and alerting on only frontend traffic by configuring alerts for just the frontend New Relic app.

### Manual testing scenarios

1. Pull in changes to a testing environment with New Relic agent installed
2. Ensure "Enable New Relic Intergration" is set to yes
3. Ensure "New Relic Application Name" is set
4. Turn on "Send Adminhtml and Frontend as Separate Apps Setting"
5. Navigate the frontend and backend of Magento
6. Login to New Relic and observe 3 apps ("main" app, "adminhtml" app, and "frontend" app).

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
