### PR TITLE
FIX: out-of-stock options for configurable product visible on frontend as sellable

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\CatalogInventory\Model\ResourceModel\Stock;
 
-use Magento\CatalogInventory\Model\Stock;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\CatalogInventory\Model\Stock;
 use Magento\Framework\App\ObjectManager;
 
 /**
@@ -46,19 +46,23 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @param \Magento\Store\Model\WebsiteFactory $websiteFactory
      * @param \Magento\Eav\Model\Config $eavConfig
      * @param string $connectionName
+     * @param \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration
      */
     public function __construct(
         \Magento\Framework\Model\ResourceModel\Db\Context $context,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Store\Model\WebsiteFactory $websiteFactory,
         \Magento\Eav\Model\Config $eavConfig,
-        $connectionName = null
+        $connectionName = null,
+        $stockConfiguration = null
     ) {
         parent::__construct($context, $connectionName);
 
         $this->_storeManager = $storeManager;
         $this->_websiteFactory = $websiteFactory;
         $this->eavConfig = $eavConfig;
+        $this->stockConfiguration = $stockConfiguration ?: ObjectManager::getInstance()
+            ->get(StockConfigurationInterface::class);
     }
 
     /**
@@ -204,7 +208,7 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function addStockStatusToSelect(\Magento\Framework\DB\Select $select, \Magento\Store\Model\Website $website)
     {
-        $websiteId = $this->getStockConfiguration()->getDefaultScopeId();
+        $websiteId = $this->getWebsiteId($website->getId());
         $select->joinLeft(
             ['stock_status' => $this->getMainTable()],
             'e.entity_id = stock_status.product_id AND stock_status.website_id=' . $websiteId,
@@ -221,7 +225,7 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function addStockDataToCollection($collection, $isFilterInStock)
     {
-        $websiteId = $this->getStockConfiguration()->getDefaultScopeId();
+        $websiteId = $this->getWebsiteId();
         $joinCondition = $this->getConnection()->quoteInto(
             'e.entity_id = stock_status_index.product_id' . ' AND stock_status_index.website_id = ?',
             $websiteId
@@ -255,7 +259,7 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function addIsInStockFilterToCollection($collection)
     {
-        $websiteId = $this->getStockConfiguration()->getDefaultScopeId();
+        $websiteId = $this->getWebsiteId();
         $joinCondition = $this->getConnection()->quoteInto(
             'e.entity_id = stock_status_index.product_id' . ' AND stock_status_index.website_id = ?',
             $websiteId
@@ -275,6 +279,19 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             Stock\Status::STATUS_IN_STOCK
         );
         return $this;
+    }
+
+    /**
+     * @param \Magento\Store\Model\Website $websiteId
+     * @return int
+     */
+    private function getWebsiteId($websiteId = null)
+    {
+        if (null === $websiteId) {
+            $websiteId = $this->stockConfiguration->getDefaultScopeId();
+        }
+
+        return $websiteId;
     }
 
     /**
@@ -334,19 +351,5 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             }
         }
         return $statuses;
-    }
-
-    /**
-     * @return StockConfigurationInterface
-     *
-     * @deprecated 100.1.0
-     */
-    private function getStockConfiguration()
-    {
-        if ($this->stockConfiguration === null) {
-            $this->stockConfiguration = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\CatalogInventory\Api\StockConfigurationInterface::class);
-        }
-        return $this->stockConfiguration;
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -10,11 +10,11 @@ use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\ConfigurableProduct\Model\Product\Type\Collection\SalableProcessor;
 use Magento\Catalog\Model\Config;
+use Magento\Catalog\Model\Product\Gallery\ReadHandler as GalleryReadHandler;
+use Magento\ConfigurableProduct\Model\Product\Type\Collection\SalableProcessor;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Catalog\Model\Product\Gallery\ReadHandler as GalleryReadHandler;
 
 /**
  * Configurable product type implementation
@@ -267,7 +267,6 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
             $productRepository,
             $serializer
         );
-
     }
 
     /**
@@ -1277,6 +1276,8 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      * Load collection on sub-products for specified configurable product
      *
      * Load collection of sub-products, apply result to specified configurable product and store result to cache
+     * Please note $salableOnly parameter is used for backwards compatibility because of deprecated method
+     * getSalableUsedProducts
      * Number of loaded sub-products depends on $salableOnly parameter
      * $salableOnly = true - result array contains only salable sub-products
      * $salableOnly = false - result array contains all sub-products
@@ -1293,7 +1294,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
         if (!$product->hasData($dataFieldName)) {
             $usedProducts = $this->readUsedProductsCacheData($cacheKey);
             if ($usedProducts === null) {
-                $collection = $this->getConfiguredUsedProductCollection($product);
+                $collection = $this->getConfiguredUsedProductCollection($product, false);
                 if ($salableOnly) {
                     $collection = $this->salableProcessor->process($collection);
                 }
@@ -1387,13 +1388,18 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      * Retrieve related products collection with additional configuration
      *
      * @param \Magento\Catalog\Model\Product $product
+     * @param bool $skipStockFilter
      * @return \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Product\Collection
      */
-    private function getConfiguredUsedProductCollection(\Magento\Catalog\Model\Product $product)
-    {
+    private function getConfiguredUsedProductCollection(
+        \Magento\Catalog\Model\Product $product,
+        $skipStockFilter = true
+    ) {
         $collection = $this->getUsedProductCollection($product);
+        if ($skipStockFilter) {
+            $collection->setFlag('has_stock_status_filter', true);
+        }
         $collection
-            ->setFlag('has_stock_status_filter', true)
             ->addAttributeToSelect($this->getCatalogConfig()->getProductAttributes())
             ->addFilterByRequiredOptions()
             ->setStoreId($product->getStoreId());

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/ConfigurableTest.php
@@ -8,20 +8,20 @@ namespace Magento\ConfigurableProduct\Test\Unit\Model\Product\Type;
 use Magento\Catalog\Api\Data\ProductExtensionInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Config;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
-use Magento\Framework\EntityManager\EntityMetadata;
-use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Customer\Model\Session;
-use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\CollectionFactory;
-use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection;
 use Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface;
-use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Collection\SalableProcessor;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\AttributeFactory;
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection;
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\CollectionFactory;
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Product\Collection as ProductCollection;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\ConfigurableFactory;
+use Magento\Customer\Model\Session;
 use Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend;
 use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
-use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Product\Collection as ProductCollection;
-use Magento\ConfigurableProduct\Model\Product\Type\Collection\SalableProcessor;
+use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
+use Magento\Framework\EntityManager\EntityMetadata;
+use Magento\Framework\EntityManager\MetadataPool;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)


### PR DESCRIPTION
This PR is for configurable product out-of-stock option fix with several improvements for generally used methods. Please, check **Description** and **Code changes explanation** sections for more detail information.

### Description
If one of the configurable product options will be out-of-stock but has status enabled, it will be visible on the frontend (product page with swatches). 
But, when a customer selects it and tries to add to the cart the next message will be shown: "You need to choose options for your item." And item will not be added to the cart. 
The main problem here that the out-of-stock and not salable option is shown as normal one without any notification before adding to the cart and when a customer tries to add it to the cart this generates useless load on the system.

### Fixed Issues (if relevant)
The most relevant issue is https://github.com/magento/magento2/issues/5948 
Despite the fact that this issue was closed, it still can be reproduced on the Magento2 2.2.2. 

### Manual testing scenarios
1. Select configurable product using swatches
2. Choose one random option (simple product) and change it's qty to 0. You will get status "Out-of-stock"
3. Go to the product page, reload it
4. Select option with out-of-stock status and press "Add to cart button"
5. The page will be reloaded and error message will be shown

Accepted criteria: out-of-stock option should be shown as not-selectable and there is no ability to add it to the cart.

### Code changes explanation
1.  `Magento\ConfigurableProduct\Model\Product\Type\Configurable::loadUsedProducts(\Magento\Catalog\Model\Product $product, $cacheKey, $salableOnly = false)` method had 2 issues:

- the `$salableOnly` variable never used since 100.2.0 because of deprecated method `getSalableUsedProducts` and, as a result, the stock status filter was not added to the collection object
- even if the `$salableOnly` filter will be `true` and `$this->salableProcessor->process($collection)` will be executed, it will not get any effect because items were previously loaded in `$collection = $this->getConfiguredUsedProductCollection($product);`   It means that collection will not be updated with the real stock status data. 
Items (`$this->_items`) were loaded before by `$this->getItems()` method in `$collection->addMediaGalleryData()` and `$collection->addTierPriceData()`. 
This is why I have moved `$collection->addMediaGalleryData()` and `$collection->addTierPriceData()` to another method and execute them after all other collection modifications. 

Also, I removed the `if($salableOnly) {...}` condition because there is no need to skip it. With other provided changes product collection will contain all products with correct stock statuses. There will not be skipped products which is equal to current behaviour.

The `$collection->setFlag('has_stock_status_filter',false);` line was added to add stock status filter.

2. `Magento\ConfigurableProduct\Model\Product\Type\Collection\SalableProcessor::process(Collection $collection, $isFilterInStock = true)` has 3 improvements:

- This method now has second param `$isFilterInStock` with default value equals to `true`. It makes it more flexible because now you can just add stock status to collection or filter it by status equals to 1 (in stock)

- `!$collection->hasFlag($stockFlag) || !$collection->getFlag($stockFlag)` this change allow develoeprs to check what value has collcetion flag. This was added because the `hasFlag()' method checks only if current key exists - `array_key_exists($flag, $this->_flags);`

- `$stockStatusResource->addStockDataToCollection($collection, $isFilterInStock);` now uses `$isFilterInStock` value as parametr

3. `Magento\CatalogInventory\Model\ResourceModel\Stock\Status` has next changes

- `addStockStatusToSelect`, `addStockDataToCollection`, `addIsInStockFilterToCollection` now have `$websiteId` with `null` as default value and `$this->getWebsiteId($websiteId)` method for website condition check

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
