### PR TITLE
[Backport 2.3-develop] Handle multiple errors in customer address validation when shown in adminhtml customer edit page

### DIFF
--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -13,6 +13,9 @@ use Magento\Customer\Model\EmailNotificationInterface;
 use Magento\Customer\Model\Metadata\Form;
 use Magento\Framework\Exception\LocalizedException;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class Save extends \Magento\Customer\Controller\Adminhtml\Index
 {
     /**
@@ -264,6 +267,15 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                 $messages = $exception->getMessages();
                 if (empty($messages)) {
                     $messages = $exception->getMessage();
+                }
+                $this->_addSessionErrorMessages($messages);
+                $this->_getSession()->setCustomerFormData($originalRequestData);
+                $returnToEdit = true;
+            } catch (\Magento\Framework\Exception\AbstractAggregateException $exception) {
+                $errors = $exception->getErrors();
+                $messages = [];
+                foreach ($errors as $error) {
+                    $messages[] = $error->getMessage();
                 }
                 $this->_addSessionErrorMessages($messages);
                 $this->_getSession()->setCustomerFormData($originalRequestData);


### PR DESCRIPTION
### Description
When multiple validation errors are found trying to save a customer address, errors are not properly shown in adminhtml customer edit page. Related with PR https://github.com/magento/magento2/pull/12922

### Fixed Issues (if relevant)
None AFAIK

### Manual testing scenarios
1. Simulate several validation errors when trying to save a customer address from admin, for example, adding temporarily this code almost at the end of  `\Magento\Customer\Model\Address\AbstractAddress::validate` method:
```
    /**
     * Validate address attribute values
     *
     * @return bool|array
     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
     * @SuppressWarnings(PHPMD.NPathComplexity)
     */
    public function validate()
    {
        (...)

        $errors = [];
        $errors[] = __('Error 1');
        $errors[] = __('Error 2');

        if (empty($errors) || $this->getShouldIgnoreValidation()) {
            return true;
        }
        return $errors;
    }
```

### Expected result
![captura de pantalla 2017-12-29 a las 14 40 58](https://user-images.githubusercontent.com/17545750/34438574-1a0bb4ca-eca8-11e7-8bd5-60db7deee916.png)

### Actual result
![captura de pantalla 2017-12-29 a las 14 40 10](https://user-images.githubusercontent.com/17545750/34438580-2262b7cc-eca8-11e7-979d-9f9684537ad4.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
