### PR TITLE
Naming collision in Javascript ui registry (backend)

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
@@ -357,12 +357,12 @@ define([
             var element;
 
             _.each(this.disabledAttributes, function (attribute) {
-                registry.get('index = ' + attribute).disabled(false);
+                registry.get('code = ' + attribute, 'index = ' + attribute).disabled(false);
             });
             this.disabledAttributes = [];
 
             _.each(attributes, function (attribute) {
-                element = registry.get('index = ' + attribute.code);
+                element = registry.get('code = ' + attribute.code, 'index = ' + attribute.code);
 
                 if (!_.isUndefined(element)) {
                     element.disabled(true);


### PR DESCRIPTION
Added more strict elements selection.

### Description
The JS is broken in next case: when new configurable attribute is created with the code name that is equal to "index" property of any uiComponent on the page.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12555: Naming collision in Javascript ui registry (backend)

### Manual testing scenarios
Add a configurable attribute with attribute code set as "content", or any other name which exists as identifier on the product edit page (for example, "gallery", "review" ,"related").

Add it to the default attribute set

Edit a product.
1. Move to magento admin panel.
2. Move to Catalog -> Products page.
3. Press "Add Product" button.
4. Fill the required fields.
5. Press "Create Configurations" button.
6. Press "New Attribute" button that is in slide out panel.
7. Fill the required fields and open the "Advanced Attribute Properties" panel.
8. Set "content" value to "Attribute Code" field. 
9. Save the attribute.
10. Select created attribute in the attributes list and press "next" button.
11. Add some value and press next.
12. Press "Generate Products" button.

Expected result: Products are generated.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
