### PR TITLE
Respect "Learn More Link" in Recently Viewed Products widget options

### DIFF
--- a/app/code/Magento/Catalog/view/base/web/template/product/link.html
+++ b/app/code/Magento/Catalog/view/base/web/template/product/link.html
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<a class="product-item-link"
+<a if="isAllowed()"
+   class="product-item-link"
    attr="href: $row().url"
    text="label"/>


### PR DESCRIPTION
### Description
`Learn More Link` widget option in a Recently Viewed Products widget isn't respecting its setting.

### Fixed Issues (if relevant)
1. None

### Manual testing scenarios
1. Create Recently Viewed Products widget.
2. In Widget Options > Product attributes to show, enable `Name`, `Image` and `Price`.
3. On frontend the widget will also display the `Learn More Link`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
