### PR TITLE
Check if the path given is already an absolute path

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -846,7 +846,7 @@ class File implements DriverInterface
         // check if the path given is already an absolute path containing the
         // basepath. so if the basepath starts at position 0 in the path, we
         // must not concatinate them again because path is already absolute.
-        if (0 === strpos($path, $basePath)) {
+        if (0 === strpos($path, $basePath) || @file_exists($this->getScheme($scheme) . $path)) {
             return $this->getScheme($scheme) . $path;
         }
 


### PR DESCRIPTION
### Description
The Magento\Framework\Filesystem\Driver\File::isFile function returns false, because it concatenates the symlink path with the absolute path in getAbsolutePath.

### Fixed Issues
1. magento/magento2#8368: Invalid template files for every vendor templates

### Manual testing scenarios
1. Put your vendor folder in an other directory (e.g., in /srv/magento/vendor).
2. Create a symbolic link for vendor to its new path (e.g. ln -s /srv/magento/vendor /var/www/vendor).
3. Try to load any website page (e.g. http://example.com/).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)