### PR TITLE
[Backport to 2.1-develop] Fix #10682: Meta description and keywords transform to html entities

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -226,7 +226,7 @@ class Config
     public function setMetadata($name, $content)
     {
         $this->build();
-        $this->metadata[$name] = htmlentities($content);
+        $this->metadata[$name] = htmlspecialchars($content);
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © 2013-2018 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 


### PR DESCRIPTION
### Description
Changed the htmlentities function to the htmlspecialchars function. It's not necessary to do HTML encoding on all characters as described in #10682. Since the content is used within HTML tags, we still need to encode special HTML chars in order to make sure that chars like "'& etc, will not break the page.

### Backport

1. Backport for PR: magento/magento2#11829

### Fixed Issues
1. magento/magento2#10682
