### PR TITLE
[Backport to 2.1-develop] Fix #9243 - Upgrade ZF components. Zend_Service

### DIFF
--- a/lib/internal/Magento/Framework/CurrencyInterface.php
+++ b/lib/internal/Magento/Framework/CurrencyInterface.php
@@ -239,15 +239,19 @@ interface CurrencyInterface
     /**
      * Returns the set service class
      *
-     * @return \Zend_Service
+     * @return \Zend_Currency_CurrencyInterface
+     * @deprecated
+     * @see \Magento\Directory\Model\Currency\Import\ImportInterface
      */
     public function getService();
 
     /**
      * Sets a new exchange service
      *
-     * @param string|\Magento\Framework\Locale\CurrencyInterface $service Service class
-     * @return \Magento\Framework\CurrencyInterface
+     * @param string|\Zend_Currency_CurrencyInterface $service Service class
+     * @return \Zend_Currency_CurrencyInterface
+     * @deprecated
+     * @see \Magento\Directory\Model\Currency\Import\ImportInterface
      */
     public function setService($service);
 }


### PR DESCRIPTION
Resolved issue #9243:
- Removed Magento\Framework\Locale\CurrencyInterface from setService method and changed it to \Zend_Currency_CurrencyInterface which must be provider to this function.
- Changed return type to \Zend_Currency_CurrencyInterface, the given instance of the service is returned by the setService function
- Removed \Zend_Service from getService method and changed it to \Zend_Currency_CurrencyInterface
- Added @deprecated tags to both methods and added @see annotation to the methods. Referenced corresponding interface \Magento\Directory\Model\Currency\Import\ImportInterface

### Backport

Backport of magento/magento2#11291