### PR TITLE
[Backport to 2.1-develop] Fix #10812: htaccess Options override

### DIFF
--- a/pub/media/.htaccess
+++ b/pub/media/.htaccess
@@ -1,4 +1,4 @@
-Options All -Indexes
+Options -Indexes
 
 <IfModule mod_php5.c>
 php_flag engine 0

--- a/pub/media/theme_customization/.htaccess
+++ b/pub/media/theme_customization/.htaccess
@@ -1,4 +1,4 @@
-Options All -Indexes
+Options -Indexes
 <Files ~ "\.xml$">
     Order allow,deny
     Deny from all


### PR DESCRIPTION
Fix for isse Fix #10812. 

The Apache documentation for the Options Directive mentions the following:

_**Warning**
Mixing Options with a + or - with those without is not valid syntax and is likely to cause unexpected results._
http://httpd.apache.org/docs/2.2/mod/core.html#options 

So occording to the documentation "Options All -Indexes" is not valid syntax. Removed the option "All" from the .htaccess file. This is the default option. We only want to make sure that the Indexes option is not present, so that Apache will not return a list of files in the directory. The ExecCGI option will be disabled by the .htaccess as well. The FollowSymLinks option will be set automatically when the mod_rewrite module is found. As far is I can see there is no need to set or unset the other options in the Options Directive, so it's safe to remove the option All from the .htaccess files. 

### Backport

This PR is a backport of: magento/magento2#11327