### PR TITLE
[Backport to 2.1-develop] Fix configurable attribute options not being sorted

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/AttributeOptionProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Model/AttributeOptionProvider.php
@@ -122,6 +122,12 @@ class AttributeOptionProvider implements AttributeOptionProviderInterface
                 ]
             ),
             []
+        )->joinInner(
+            ['attribute_option' => $this->attributeResource->getTable('eav_attribute_option')],
+            'attribute_option.option_id = entity_value.value',
+            []
+        )->order(
+            'attribute_option.sort_order ASC'
         )->where(
             'super_attribute.product_id = ?',
             $productId

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/AttributeOptionProviderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/AttributeOptionProviderTest.php
@@ -219,18 +219,18 @@ class AttributeOptionProviderTest extends \PHPUnit_Framework_TestCase
         $this->attributeResource->expects($this->exactly(7))
             ->method('getTable')
             ->will(
-            $this->returnValueMap(
-                [
-                    ['catalog_product_super_attribute', 'catalog_product_super_attribute value'],
-                    ['catalog_product_entity', 'catalog_product_entity value'],
-                    ['catalog_product_super_link', 'catalog_product_super_link value'],
-                    ['eav_attribute', 'eav_attribute value'],
-                    ['catalog_product_entity', 'catalog_product_entity value'],
-                    ['catalog_product_super_attribute_label', 'catalog_product_super_attribute_label value'],
-                    ['eav_attribute_option', 'eav_attribute_option value']
-                ]
-            )
-        );
+                $this->returnValueMap(
+                    [
+                        ['catalog_product_super_attribute', 'catalog_product_super_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_link', 'catalog_product_super_link value'],
+                        ['eav_attribute', 'eav_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_attribute_label', 'catalog_product_super_attribute_label value'],
+                        ['eav_attribute_option', 'eav_attribute_option value']
+                    ]
+                )
+            );
 
         $source = $this->getMockBuilder(AbstractSource::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/AttributeOptionProviderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/AttributeOptionProviderTest.php
@@ -97,7 +97,7 @@ class AttributeOptionProviderTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->select = $this->getMockBuilder(Select::class)
-            ->setMethods(['from', 'joinInner', 'joinLeft', 'where', 'columns'])
+            ->setMethods(['from', 'joinInner', 'joinLeft', 'where', 'columns', 'order'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->connectionMock->expects($this->any())
@@ -161,9 +161,27 @@ class AttributeOptionProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->select->expects($this->exactly(1))->method('from')->willReturnSelf();
         $this->select->expects($this->exactly(1))->method('columns')->willReturnSelf();
-        $this->select->expects($this->exactly(5))->method('joinInner')->willReturnSelf();
+        $this->select->expects($this->exactly(6))->method('joinInner')->willReturnSelf();
         $this->select->expects($this->exactly(3))->method('joinLeft')->willReturnSelf();
+        $this->select->expects($this->exactly(1))->method('order')->willReturnSelf();
         $this->select->expects($this->exactly(2))->method('where')->willReturnSelf();
+
+        $this->attributeResource->expects($this->exactly(9))
+            ->method('getTable')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['catalog_product_super_attribute', 'catalog_product_super_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_link', 'catalog_product_super_link value'],
+                        ['eav_attribute', 'eav_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_attribute_label', 'catalog_product_super_attribute_label value'],
+                        ['eav_attribute_option', 'eav_attribute_option value'],
+                        ['eav_attribute_option_value', 'eav_attribute_option_value value']
+                    ]
+                )
+            );
 
         $this->abstractAttribute->expects($this->any())
             ->method('getBackendTable')
@@ -193,9 +211,26 @@ class AttributeOptionProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->select->expects($this->exactly(1))->method('from')->willReturnSelf();
         $this->select->expects($this->exactly(0))->method('columns')->willReturnSelf();
-        $this->select->expects($this->exactly(5))->method('joinInner')->willReturnSelf();
+        $this->select->expects($this->exactly(6))->method('joinInner')->willReturnSelf();
         $this->select->expects($this->exactly(1))->method('joinLeft')->willReturnSelf();
+        $this->select->expects($this->exactly(1))->method('order')->willReturnSelf();
         $this->select->expects($this->exactly(2))->method('where')->willReturnSelf();
+
+        $this->attributeResource->expects($this->exactly(7))
+            ->method('getTable')
+            ->will(
+            $this->returnValueMap(
+                [
+                    ['catalog_product_super_attribute', 'catalog_product_super_attribute value'],
+                    ['catalog_product_entity', 'catalog_product_entity value'],
+                    ['catalog_product_super_link', 'catalog_product_super_link value'],
+                    ['eav_attribute', 'eav_attribute value'],
+                    ['catalog_product_entity', 'catalog_product_entity value'],
+                    ['catalog_product_super_attribute_label', 'catalog_product_super_attribute_label value'],
+                    ['eav_attribute_option', 'eav_attribute_option value']
+                ]
+            )
+        );
 
         $source = $this->getMockBuilder(AbstractSource::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
See github issue #7441, internal ticket MAGETWO-61484 and PR #12420.

### Description
Resolves the issue documented in GitHub ticket #7441. A similar PR was opened before (https://github.com/magento/magento2/pull/12420), which was now ported to Magento 2.1.x and required changes to the related unit tests were made as well.

### Fixed Issues
1. magento/magento2#7441: Configurable attribute options are not sorted

### Manual testing scenarios
(copied over from PR #12420, which is still valid)
**Steps to reproduce**
Create a configurable attribute and add two options at least.
Create a configurable product for these options.
Go to the product page and see the configurable attribute select (options).
Change attribute options sort order and flush all caches.
Go to the product page and see the configurable attribute select (options) looks like before.

**Expected result:**
Configurable options HAVE been reordered.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
