### PR TITLE
Sort configurable attribute options by sort_order

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
@@ -91,6 +91,12 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
                 ]
             ),
             []
+        )->joinInner(
+            ['attribute_option' => $this->attributeResource->getTable('eav_attribute_option')],
+            'attribute_option.option_id = entity_value.value',
+            []
+        )->order(
+            'attribute_option.sort_order ASC'
         )->where(
             'super_attribute.product_id = ?',
             $productId

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Attribute/OptionSelectBuilderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Attribute/OptionSelectBuilderTest.php
@@ -66,7 +66,7 @@ class OptionSelectBuilderTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->select = $this->getMockBuilder(Select::class)
-            ->setMethods(['from', 'joinInner', 'joinLeft', 'where', 'columns'])
+            ->setMethods(['from', 'joinInner', 'joinLeft', 'where', 'columns', 'order'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->connectionMock->expects($this->atLeastOnce())
@@ -112,9 +112,27 @@ class OptionSelectBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->select->expects($this->exactly(1))->method('from')->willReturnSelf();
         $this->select->expects($this->exactly(1))->method('columns')->willReturnSelf();
-        $this->select->expects($this->exactly(5))->method('joinInner')->willReturnSelf();
+        $this->select->expects($this->exactly(6))->method('joinInner')->willReturnSelf();
         $this->select->expects($this->exactly(3))->method('joinLeft')->willReturnSelf();
+        $this->select->expects($this->exactly(1))->method('order')->willReturnSelf();
         $this->select->expects($this->exactly(2))->method('where')->willReturnSelf();
+
+        $this->attributeResourceMock->expects($this->exactly(9))
+            ->method('getTable')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['catalog_product_super_attribute', 'catalog_product_super_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_link', 'catalog_product_super_link value'],
+                        ['eav_attribute', 'eav_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_attribute_label', 'catalog_product_super_attribute_label value'],
+                        ['eav_attribute_option', 'eav_attribute_option value'],
+                        ['eav_attribute_option_value', 'eav_attribute_option_value value']
+                    ]
+                )
+            );
 
         $this->abstractAttributeMock->expects($this->atLeastOnce())
             ->method('getAttributeId')
@@ -138,9 +156,26 @@ class OptionSelectBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->select->expects($this->exactly(1))->method('from')->willReturnSelf();
         $this->select->expects($this->exactly(0))->method('columns')->willReturnSelf();
-        $this->select->expects($this->exactly(5))->method('joinInner')->willReturnSelf();
+        $this->select->expects($this->exactly(6))->method('joinInner')->willReturnSelf();
         $this->select->expects($this->exactly(1))->method('joinLeft')->willReturnSelf();
+        $this->select->expects($this->exactly(1))->method('order')->willReturnSelf();
         $this->select->expects($this->exactly(2))->method('where')->willReturnSelf();
+
+        $this->attributeResourceMock->expects($this->exactly(7))
+            ->method('getTable')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['catalog_product_super_attribute', 'catalog_product_super_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_link', 'catalog_product_super_link value'],
+                        ['eav_attribute', 'eav_attribute value'],
+                        ['catalog_product_entity', 'catalog_product_entity value'],
+                        ['catalog_product_super_attribute_label', 'catalog_product_super_attribute_label value'],
+                        ['eav_attribute_option', 'eav_attribute_option value']
+                    ]
+                )
+            );
 
         $this->abstractAttributeMock->expects($this->atLeastOnce())
             ->method('getAttributeId')


### PR DESCRIPTION
See github issue #7441, internal ticket MAGETWO-61484 and PR #12420.

### Description
Resolves the issue documented in GitHub ticket #7441. A similar PR was opened before (https://github.com/magento/magento2/pull/12420), which is re-opened by this PR and required changes to the related unit tests were made as well.

### Fixed Issues
1. magento/magento2#7441: Configurable attribute options are not sorted

### Manual testing scenarios
(copied over from PR #12420, which is still valid)
**Steps to reproduce**
Create a configurable attribute and add two options at least.
Create a configurable product for these options.
Go to the product page and see the configurable attribute select (options).
Change attribute options sort order and flush all caches.
Go to the product page and see the configurable attribute select (options) looks like before.

**Expected result:**
Configurable options HAVE been reordered.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests
 - [x] All automated tests passed successfully (was tested with success locally, awaiting results from Travis)