### PR TITLE
Fix vault_payment_token install script type where column defaults were not set

### DIFF
--- a/app/code/Magento/Vault/Setup/InstallSchema.php
+++ b/app/code/Magento/Vault/Setup/InstallSchema.php
@@ -90,13 +90,13 @@ class InstallSchema implements InstallSchemaInterface
                 'is_active',
                 Table::TYPE_BOOLEAN,
                 null,
-                ['nullable' => false, 'dafault' => true],
+                ['nullable' => false, 'default' => true],
                 'Is active flag'
             )->addColumn(
                 'is_visible',
                 Table::TYPE_BOOLEAN,
                 null,
-                ['nullable' => false, 'dafault' => true],
+                ['nullable' => false, 'default' => true],
                 'Is visible flag'
             )->addIndex(
                 $setup->getIdxName(


### PR DESCRIPTION
Fixed typo in the vault_payment_token install script.

### Description
The is_active and is_visible columns were defaulting to false, however should default to true.