### PR TITLE
[Backport to 2.3-develop] Changed constructor typo in Javascript class

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/core/class.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/core/class.js
@@ -27,7 +27,7 @@ define([
      * Creates constructor function which allows
      * initialization without usage of a 'new' operator.
      *
-     * @param {Object} protoProps - Prototypal propeties of a new constructor.
+     * @param {Object} protoProps - Prototypal properties of a new constructor.
      * @param {Function} constructor
      * @returns {Function} Created constructor.
      */


### PR DESCRIPTION
Backport of magento/magento2#11933

Original PR:

Changed variable with typo consturctor to constructor

This was already solved in the 2.3 develop branch, but another commit with a typo was also in the given PR. This was not yet present in de 2.3 develop branch, so backported the original PR to the 2.3 develop branch. 