### PR TITLE
[2.1-develop] Set 'quantity_and_stock_status' product attribute value before save

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Stock.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Stock.php
@@ -63,8 +63,8 @@ class Stock extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
             $object->setStockData(array_replace((array)$object->getStockData(), (array)$stockData));
         }
         $object->unsetData($this->getAttribute()->getAttributeCode());
-        if (isset($stockData['is_in_stock'])) {
-            $object->setData($this->getAttribute()->getAttributeCode(), $stockData['is_in_stock']);
+        if ($object->getStockData() !== null) {
+            $object->setData($this->getAttribute()->getAttributeCode(), $object->getStockData()['is_in_stock']);
         }
         parent::beforeSave($object);
     }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Stock.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Stock.php
@@ -63,6 +63,9 @@ class Stock extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
             $object->setStockData(array_replace((array)$object->getStockData(), (array)$stockData));
         }
         $object->unsetData($this->getAttribute()->getAttributeCode());
+        if (isset($stockData['is_in_stock'])) {
+            $object->setData($this->getAttribute()->getAttributeCode(), $stockData['is_in_stock']);
+        }
         parent::beforeSave($object);
     }
 


### PR DESCRIPTION
This pull request is created to set the quantity_and_stock_status product attribute value so this attribute can be used for action filter of target rules.

### Description
Target rules on Commerce Edition possible to be created by action filter of product attribute, including Quantity (attribute code quantity_and_stock_status). But currently, this value is being ignored because the Quantity is managed by Catalog Inventory module with it's own data.

This pull request is created to set the quantity_and_stock_status product attribute value so this attribute can be used for action filter of target rules correctly. But this update, we can make action filter if product in stock or out of stock.

### Fixed Issues (if relevant)
Target rules can be filtered by attribute code quantity_and_stock_status

### Manual testing scenarios
1. Prepare Magento 2.1 installation with sample data loaded
2. from Admin page, go to Stores > Attributes > Product
3. Edit for attribute code quantity_and_stock_status 
4. set  Storefront Properties of Use for Promo Rule Conditions = Yes
5. Create a target rules by go to Marketing > Related Product Rules
6. Add rule by all product to matches
7. Set action filter by Product to display as Product Quantity is Constant Value 'In Stock' for example
8. Disable other rules
#### Before Update Result
1. related products block in PDP is empty
2. Change product attribute of Stock Status, and there is no effect on related products block

#### After Update Result
Change product attribute of Stock Status, and related products block will also be updated accordingly

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

  