### PR TITLE
Fix jumping content on page reload in admin area

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/_structure.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/_structure.less
@@ -36,6 +36,7 @@ body {
 //  ToDo UI: should be moved to messages
 .notices-wrapper {
     margin: 0 3rem;
+    min-height: 5rem;
     .messages {
         margin-bottom: 0;
     }


### PR DESCRIPTION
For thousands of years in the ancient history of Magento 2, Magento admin and developers, working in the admin area have been annoyed by jumping page content when they load or reload a page and a system message is available.
This PR is intended to take this burden from anyone working in the Magento 2 admin area and to live happily ever after.

### Description
This PR sets a min-height on the notices-wrapper, causing the page not to jump any more. See also this video i've created (before/after): [https://www.youtube.com/watch?v=btPogRyFP98](https://www.youtube.com/watch?v=btPogRyFP98).
Fyi: The `min-height: 5rem` was duplicated from the child element `.message-system-short`.

### Fixed Issues (if relevant)
No issues known or found.

### Manual testing scenarios
Given that there is any system notice that Magento 2 is showing (indexer or cache needs to be renewed, tax settings wrong, etc.)
1. Open any page in the magento admin area 
2. Load or reload page
3. See that the content is loaded
4. As soon as the system messages on top of the page are loaded, the content jumps 3rem/5px down

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
