### PR TITLE
[2.2.x] Fix undeclared dependency magento/zendframework1 by magento/framework

### DIFF
--- a/lib/internal/Magento/Framework/composer.json
+++ b/lib/internal/Magento/Framework/composer.json
@@ -33,7 +33,8 @@
         "zendframework/zend-uri": "^2.5.1",
         "zendframework/zend-validator": "^2.6.0",
         "zendframework/zend-stdlib": "^2.7.7",
-        "zendframework/zend-http": "^2.6.0"
+        "zendframework/zend-http": "^2.6.0",
+        "magento/zendframework1": "~1.13.0"
     },
     "suggest": {
         "ext-imagick": "Use Image Magick >=3.0.0 as an optional alternative image processing library"


### PR DESCRIPTION
### Description
Add dependency magento/framework to zendframework1

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/12967: Undeclared dependency magento/zendframework1 by magento/framework

### Manual testing scenarios
1. ...
2. ...

### Related PRs
1. #12990
2. #12991
3. #12992

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)