### PR TITLE
[2.3.x] Fix undeclared dependency magento/zendframework1 by magento/framework

### DIFF
--- a/lib/internal/Magento/Framework/composer.json
+++ b/lib/internal/Magento/Framework/composer.json
@@ -25,6 +25,7 @@
         "lib-libxml": "*",
         "colinmollenhour/php-redis-session-abstract": "~1.2.2",
         "composer/composer": "1.4.1",
+        "magento/zendframework1": "~1.13.0",
         "monolog/monolog": "^1.17",
         "oyejorge/less.php": "~1.7.0",
         "symfony/console": "~2.3, !=2.7.0",


### PR DESCRIPTION
### Description
Add dependency magento/framework to zendframework1

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/12967: Undeclared dependency magento/zendframework1 by magento/framework

### Manual testing scenarios
1. ...
2. ...

### Related PRs
1. #12990
2. #12991
3. #12992

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)