### PR TITLE
Make customer name link to customer dashboard

### DIFF
--- a/app/code/Magento/Sales/Model/Order/CustomerManagement.php
+++ b/app/code/Magento/Sales/Model/Order/CustomerManagement.php
@@ -116,6 +116,7 @@ class CustomerManagement implements \Magento\Sales\Api\OrderCustomerManagementIn
         $customer = $this->customerFactory->create(['data' => $customerData]);
         $account = $this->accountManagement->createAccount($customer);
         $order->setCustomerId($account->getId());
+        $order->setCustomerIsGuest(0);
         $this->orderRepository->save($order);
         return $account;
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
When checking out as a guest customer and click "create an account" on success page to create a customer account, you will not be able to click on the customer name to jump to the customer record. 

![image](https://user-images.githubusercontent.com/1415141/34580044-6c3a887e-f159-11e7-9f74-568d99098331.png)
