### PR TITLE
Add original_inventory_qty to the data that is sent and posted when e…

### DIFF
--- a/app/code/Magento/CatalogInventory/Api/Data/StockItemInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockItemInterface.php
@@ -20,6 +20,7 @@ interface StockItemInterface extends ExtensibleDataInterface
     const PRODUCT_ID = 'product_id';
     const STOCK_ID = 'stock_id';
     const QTY = 'qty';
+    const ORIGINAL_INVENTORY_QTY = 'original_inventory_qty';
     const IS_QTY_DECIMAL = 'is_qty_decimal';
     const SHOW_DEFAULT_NOTIFICATION_MESSAGE = 'show_default_notification_message';
 

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Item.php
@@ -100,7 +100,7 @@ class Item extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         $data = parent::_prepareDataForTable($object, $table);
         $ifNullSql = $this->getConnection()->getIfNullSql('qty');
-        if (!$object->isObjectNew() && $object->getQtyCorrection()) {
+        if (!$object->isObjectNew() && null !== $object->getQtyCorrection()) {
             if ($object->getQty() === null) {
                 $data['qty'] = null;
             } elseif ($object->getQtyCorrection() < 0) {

--- a/app/code/Magento/CatalogInventory/Test/Unit/Ui/DataProvider/Product/Form/Modifier/AdvancedInventoryTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Ui/DataProvider/Product/Form/Modifier/AdvancedInventoryTest.php
@@ -130,7 +130,7 @@ class AdvancedInventoryTest extends AbstractModifierTest
 
         $this->stockItemMock->expects($this->once())->method('getData')->willReturn(['someData']);
         $this->stockItemMock->expects($this->once())->method('getManageStock')->willReturn($someData);
-        $this->stockItemMock->expects($this->once())->method('getQty')->willReturn($someData);
+        $this->stockItemMock->expects($this->exactly(2))->method('getQty')->willReturn($someData);
         $this->stockItemMock->expects($this->once())->method('getMinQty')->willReturn($someData);
         $this->stockItemMock->expects($this->once())->method('getMinSaleQty')->willReturn($someData);
         $this->stockItemMock->expects($this->once())->method('getMaxSaleQty')->willReturn($someData);

--- a/app/code/Magento/CatalogInventory/Ui/DataProvider/Product/Form/Modifier/AdvancedInventory.php
+++ b/app/code/Magento/CatalogInventory/Ui/DataProvider/Product/Form/Modifier/AdvancedInventory.php
@@ -148,6 +148,7 @@ class AdvancedInventory extends AbstractModifier
 
         $result[StockItemInterface::MANAGE_STOCK] = (int)$stockItem->getManageStock();
         $result[StockItemInterface::QTY] = (float)$stockItem->getQty();
+        $result[StockItemInterface::ORIGINAL_INVENTORY_QTY] = (float)$stockItem->getQty();
         $result[StockItemInterface::MIN_QTY] = (float)$stockItem->getMinQty();
         $result[StockItemInterface::MIN_SALE_QTY] = (float)$stockItem->getMinSaleQty();
         $result[StockItemInterface::MAX_SALE_QTY] = (float)$stockItem->getMaxSaleQty();


### PR DESCRIPTION
### Description
This is the 2.3 version of the changes in PR #13000 
Currently, `catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml` puts an input element, `original_inventory_qty` in its output so that when you have the edit product page open in the admin, and sales are processed either in the admin or on the frontend, if you go to save the product you are editing, and the qty has changed elsewhere, you won't obliterate those changes, instead it will determine the difference between `qty` and `original_inventory_qty` and apply that as a `qty_correction` on the `cataloginventory_stock_item` record.

This pull request puts the `original_inventory_qty` field on the form that the UiComponent system renders in the admin, and adds it to the posted data so that the server-side code that exists properly applies the `qty_correction` to the product's `cataloginventory_stock_item` record.

### Fixed Issues (if relevant)
1. magento/magento2#9345: Admin product save overwrites inventory qty even when it is unchanged

### Manual testing scenarios
1. In Admin, open the Edit Product Screen.
2. Make a note of the QTY field on the Edit Product Screen.
3. On the frontend of the site, place and complete an order for the product you opened in step 1.
4. Make a note of how many of the item you purchased.
5. Back in the admin, where you still have the edit Product screen open, Click Save.
6. When the page refreshes, the QTY shown on the screen should be the Original QTY - Purchased QTY

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

  