### PR TITLE
[Backport to 2.2-develop] The quote address fields length expanded in the database

### DIFF
--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Quote\Setup;
 
+use Magento\Framework\DB\Ddl\Table;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
@@ -40,7 +41,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'street',
                 'street',
                 [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'type' => Table::TYPE_TEXT,
                     'length' => 255,
                     'comment' => 'Street'
                 ]
@@ -61,7 +62,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 $setup->getTable('quote_address', self::$connectionName),
                 'shipping_method',
                 [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'type' => Table::TYPE_TEXT,
                     'length' => 120
                 ]
             );
@@ -72,31 +73,51 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 $setup->getTable('quote_address', self::$connectionName),
                 'firstname',
                 [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'type' => Table::TYPE_TEXT,
                     'length' => 255,
                 ]
             )->modifyColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'middlename',
                 [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'type' => Table::TYPE_TEXT,
                     'length' => 40,
                 ]
             )->modifyColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'lastname',
                 [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'type' => Table::TYPE_TEXT,
                     'length' => 255,
                 ]
             )->modifyColumn(
                 $setup->getTable('quote', self::$connectionName),
                 'updated_at',
                 [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                    'type' => Table::TYPE_TIMESTAMP,
                     'nullable' => false,
-                    'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT_UPDATE,
+                    'default' => Table::TIMESTAMP_INIT_UPDATE,
                 ]
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.7', '<')) {
+            $connection = $setup->getConnection(self::$connectionName);
+            $connection->modifyColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'telephone',
+                ['type' => Table::TYPE_TEXT, 'length' => 255]
+            )->modifyColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'fax',
+                ['type' => Table::TYPE_TEXT, 'length' => 255]
+            )->modifyColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'region',
+                ['type' => Table::TYPE_TEXT, 'length' => 255]
+            )->modifyColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'city',
+                ['type' => Table::TYPE_TEXT, 'length' => 255]
             );
         }
         $setup->endSetup();

--- a/app/code/Magento/Quote/etc/module.xml
+++ b/app/code/Magento/Quote/etc/module.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Quote" setup_version="2.0.6">
+    <module name="Magento_Quote" setup_version="2.0.7">
     </module>
 </config>


### PR DESCRIPTION
### Backport

This PR is a backport of magento/magento2#11286
  
### Description
The following fields length has been expanded in the quote_address database table:

- telephone
- fax
- region
- city

### Fixed Issues
magento/magento2#10869: field lengths differ across many tables
magento/magento2#10868: field lengths differ across many tables