### PR TITLE
[Backport to 2.1-develop] Attribute with "Catalog Input Type for Store Owner" equal "Fixed Product Tax" for Multi-store

### DIFF
--- a/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Manager/Website.php
+++ b/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Manager/Website.php
@@ -67,7 +67,6 @@ class Website
             return $this->websites = $websites;
         }
 
-
         if ($storeId = $this->locator->getStore()->getId()) {
             /** @var WebsiteInterface $website */
             $website = $this->storeManager->getStore($storeId)->getWebsite();

--- a/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Manager/Website.php
+++ b/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Manager/Website.php
@@ -71,7 +71,7 @@ class Website
         if ($storeId = $this->locator->getStore()->getId()) {
             /** @var WebsiteInterface $website */
             $website = $this->storeManager->getStore($storeId)->getWebsite();
-            $websites[$website->getId()] = [
+            $websites[] = [
                 'value' => $website->getId(),
                 'label' => $this->formatLabel(
                     $website->getName(),
@@ -84,7 +84,7 @@ class Website
                 if (!in_array($website->getId(), $product->getWebsiteIds())) {
                     continue;
                 }
-                $websites[$website->getId()] = [
+                $websites[] = [
                     'value' => $website->getId(),
                     'label' => $this->formatLabel(
                         $website->getName(),


### PR DESCRIPTION
### Backport 

This PR is a backport of the following PR: magento/magento2#12397

### Description
Attribute with "Catalog Input Type for Store Owner" equal "Fixed Product Tax" did not work correctly for multi-stores.

### Fixed Issues

1. magento/magento2#12393: Attribute with "Catalog Input Type for Store Owner" equal "Fixed Product Tax" for Multi-store

### Manual testing scenarios

1. Create two websites website1 (website_id = 1), website2 (website_id =2)
2. Create new product SKU=product1 and check for "Product in Websites" only website2.
3. Create new product attribute "attribute1" with "Catalog Input Type for Store Owner" equal "Fixed Product Tax".
4. Assign attribute1 to default attribute set.
5. Open product "product1" and find attribute1 and click the button "add" near "attribute1".
  