### PR TITLE
#3727 - Magento2 REST API with XML data is not working during invento…

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/Rest/Request/Deserializer/Xml.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Request/Deserializer/Xml.php
@@ -75,8 +75,7 @@ class Xml implements \Magento\Framework\Webapi\Rest\Request\DeserializerInterfac
             throw new \Magento\Framework\Webapi\Exception($exceptionMessage);
         }
         $data = $this->_xmlParser->xmlToArray();
-        /** Data will always have exactly one element so it is safe to call reset here. */
-        return reset($data);
+        return $data;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/Deserializer/XmlTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/Deserializer/XmlTest.php
@@ -54,7 +54,7 @@ class XmlTest extends \PHPUnit\Framework\TestCase
         $validInputXml = '<?xml version="1.0"?><xml><key1>test1</key1><key2>test2</key2></xml>';
         $returnArray = ['xml' => ['key1' => 'test1', 'key2' => 'test2']];
         $this->_xmlParserMock->expects($this->once())->method('xmlToArray')->will($this->returnValue($returnArray));
-        $expectedArray = ['key1' => 'test1', 'key2' => 'test2'];
+        $expectedArray = ['xml' => ['key1' => 'test1', 'key2' => 'test2']];
         /** Initialize SUT. */
         $this->assertEquals(
             $expectedArray,


### PR DESCRIPTION
Magento2 REST API with XML data is not working during inventory upload

### Description
When we pass xml data with multi level child element then it will work with REST API 

### Fixed Issues (if relevant)
1. magento/magento2#3727: Magento2 REST API with XML data is not working during inventory upload

### Manual testing scenarios
1. Fresh install
2. Make following REST request:
`POST /rest/default/V1/products/:productSku/stockItems/:itemId`
with following Body:
```xml
<stockItem>
    <itemId>2</itemId>
    <productId>2</productId>
    <qty>10</qty>
    <isInStock>true</isInStock>
    <isQtyDecimal>true</isQtyDecimal>
    <showDefaultNotificationMessage>true</showDefaultNotificationMessage>
    <useConfigMinQty>true</useConfigMinQty>
    <minQty>0</minQty>
    <useConfigMinSaleQty>0</useConfigMinSaleQty>
    <minSaleQty>0</minSaleQty>
    <useConfigMaxSaleQty>true</useConfigMaxSaleQty>
    <maxSaleQty>0</maxSaleQty>
    <useConfigBackorders>true</useConfigBackorders>
    <backorders>0</backorders>
    <useConfigNotifyStockQty>true</useConfigNotifyStockQty>
    <notifyStockQty>0</notifyStockQty>
    <useConfigQtyIncrements>true</useConfigQtyIncrements>
    <qtyIncrements>0</qtyIncrements>
    <useConfigEnableQtyInc>true</useConfigEnableQtyInc>
    <enableQtyIncrements>true</enableQtyIncrements>
    <useConfigManageStock>true</useConfigManageStock>
    <manageStock>true</manageStock>
    <lowStockDate></lowStockDate>
    <isDecimalDivided>true</isDecimalDivided>
    <stockStatusChangedAuto>0</stockStatusChangedAuto>
</stockItem>
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

  