### PR TITLE
resolved default country selection issue while creating new customer …

### DIFF
--- a/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
@@ -68,6 +68,10 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      * @since 100.1.0
      */
     protected $countriesWithNotRequiredStates;
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManager;
 
     /**
      * Initialize dependencies.
@@ -82,6 +86,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      * @param \Magento\Framework\Stdlib\ArrayUtils $arrayUtils
      * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
      * @param \Magento\Framework\App\Helper\AbstractHelper $helperData
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param array $countriesWithNotRequiredStates
      * @param mixed $connection
      * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource
@@ -98,6 +103,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         \Magento\Framework\Stdlib\ArrayUtils $arrayUtils,
         \Magento\Framework\Locale\ResolverInterface $localeResolver,
         \Magento\Framework\App\Helper\AbstractHelper $helperData,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
         array $countriesWithNotRequiredStates = [],
         \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
         \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
@@ -109,6 +115,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $this->_countryFactory = $countryFactory;
         $this->_arrayUtils = $arrayUtils;
         $this->helperData = $helperData;
+        $this->storeManager = $storeManager;
         $this->countriesWithNotRequiredStates = $countriesWithNotRequiredStates;
     }
 
@@ -275,6 +282,15 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             $sort = [$name => $foregroundCountry] + $sort;
         }
         $isRegionVisible = (bool)$this->helperData->isShowNonRequiredState();
+        $defaultCountry = [];
+        foreach ($this->storeManager->getWebsites() as $website) {
+            $defaultCountryConfig = $this->_scopeConfig->getValue(
+                \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_COUNTRY,
+                ScopeInterface::SCOPE_WEBSITES,
+                $website
+            );
+            $defaultCountry[$defaultCountryConfig][] = $website->getId();
+        }
         $options = [];
         foreach ($sort as $label => $value) {
             $options = $this->addForegroundCountriesToOptionArray($emptyLabel, $options);
@@ -286,6 +302,9 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             }
             if ($this->helperData->isZipCodeOptional($value)) {
                 $option['is_zipcode_optional'] = true;
+            }
+            if (isset($defaultCountry[$value])) {
+                $option['is_default'] = $defaultCountry[$value];
             }
             $options[] = $option;
         }

--- a/app/code/Magento/Directory/Test/Unit/Model/ResourceModel/Country/CollectionTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/ResourceModel/Country/CollectionTest.php
@@ -8,6 +8,8 @@
 
 namespace Magento\Directory\Test\Unit\Model\ResourceModel\Country;
 
+use Magento\Store\Api\Data\WebsiteInterface;
+
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -22,6 +24,11 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfigMock;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManagerMock;
 
     protected function setUp()
     {
@@ -53,6 +60,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
         $countryFactory = $this->createMock(\Magento\Directory\Model\ResourceModel\CountryFactory::class);
         $helperDataMock = $this->createMock(\Magento\Directory\Helper\Data::class);
+        $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $arguments = [
             'logger' => $logger,
@@ -63,7 +71,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             'scopeConfig' => $this->scopeConfigMock,
             'countryFactory' => $countryFactory,
             'resource' => $resource,
-            'helperData' => $helperDataMock
+            'helperData' => $helperDataMock,
+            'storeManager' => $this->storeManagerMock
         ];
         $this->_model = $objectManager
             ->getObject(\Magento\Directory\Model\ResourceModel\Country\Collection::class, $arguments);
@@ -78,6 +87,14 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testToOptionArray($optionsArray, $emptyLabel, $foregroundCountries, $expectedResults)
     {
+        $website1 = $this->createMock(WebsiteInterface::class);
+        $website1->expects($this->atLeastOnce())
+            ->method('getId')
+            ->willReturn(1);
+        $this->storeManagerMock->expects($this->once())
+            ->method('getWebsites')
+            ->willReturn([$website1]);
+
         foreach ($optionsArray as $itemData) {
             $this->_model->addItem(new \Magento\Framework\DataObject($itemData));
         }

--- a/app/code/Magento/Ui/view/base/web/js/form/element/country.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/country.js
@@ -28,7 +28,7 @@ define([
          * @param {String} field
          */
         filter: function (value, field) {
-            var result;
+            var result, defaultCountry;
 
             if (!field) { //validate field, if we are on update
                 field = this.filterBy.field;
@@ -46,6 +46,19 @@ define([
 
             this.setOptions(result);
             this.reset();
+
+			if(!this.value()){
+                _.each(result, function (item) {
+                    var defaultValue = item['is_default'];
+                    if (defaultValue) {
+                        if(defaultValue.includes(value)){
+                            defaultCountry = item.value;
+                            return;
+                        }
+			        }
+			    });
+                this.value(defaultCountry);
+            }
         }
     });
 });

--- a/app/code/Magento/Ui/view/base/web/js/form/element/country.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/country.js
@@ -28,7 +28,7 @@ define([
          * @param {String} field
          */
         filter: function (value, field) {
-            var result, defaultCountry;
+            var result, defaultCountry, defaultValue;
 
             if (!field) { //validate field, if we are on update
                 field = this.filterBy.field;
@@ -47,17 +47,15 @@ define([
             this.setOptions(result);
             this.reset();
 
-			if(!this.value()){
-                _.each(result, function (item) {
-                    var defaultValue = item['is_default'];
-                    if (defaultValue) {
-                        if(defaultValue.includes(value)){
-                            defaultCountry = item.value;
-                            return;
-                        }
-			        }
-			    });
-                this.value(defaultCountry);
+            if (!this.value()) {
+                defaultCountry = _.filter(result, function (item) {
+                    return item['is_default'] && item['is_default'].includes(value);
+                });
+
+                if (defaultCountry.length) {
+                    defaultValue = defaultCountry.shift();
+                    this.value(defaultValue.value);
+                }
             }
         }
     });


### PR DESCRIPTION
Backend Works

### Description
Insert the "is_default" field country options based on website scope into country option array.
Used the "is_default" value in customer edit address form to pre selected the country. 

### Fixed Issues (if relevant)
1. magento/magento2#3483: Default country selection issue while creating new customer from backend

### Manual testing scenarios
1. Fresh Install
2. Tested in all Modes
3. Ran Successfull Test Cases

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
