### PR TITLE
fixed issue prices aren't readable when using custom price symbol

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_ConfigurableProduct/web/css/source/module/components/_currency-addon.less
+++ b/app/design/adminhtml/Magento/backend/Magento_ConfigurableProduct/web/css/source/module/components/_currency-addon.less
@@ -19,10 +19,30 @@
 
 .currency-addon {
     position: relative;
+    border: 1px solid #adadad;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    display: inline-flex;
+    flex-flow: row nowrap;
+    width: 100%;
+    position: relative;
 
     .admin__control-text {
-        border-width: 1px 1px 1px 0;
-        padding-left: @currency-addon-symbol__width + .2;
+        appearence: none;
+        -webkit-flex-grow: 1;
+        flex-grow: 1;
+        -ms-flex-order: 1;
+        -webkit-order: 1;
+        order: 1;
+        -webkit-flex-shrink: 1;
+        flex-shrink: 1;
+        background-color: transparent;
+        border-color: transparent;
+        box-shadow: none;
+        vertical-align: top;
 
         &:focus {
             + .currency-symbol {
@@ -31,18 +51,29 @@
         }
     }
 
+    label.error {
+        position: absolute;
+        left: 0;
+        top: 33px;
+    }
+
     .currency-symbol {
         border: solid @currency-addon-symbol__border-color;
-        border-width: 0 0 0 1px;
+        border-width: 0;
         box-sizing: border-box;
         color: @currency-addon-symbol__color;
         height: @currency-addon-symbol__height;
-        left: 0;
         padding: 7px 0 0 @indent__xs;
-        position: absolute;
-        top: 0;
+        position: static;
         transition: @smooth__border-color;
-        width: @currency-addon-symbol__width;
+        -webkit-flex-basis: auto;
+        flex-basis: auto;
+        -webkit-flex-grow: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        flex-shrink: 0;
+        z-index: 1;
+        order: 0;
     }
 
     ._error & {


### PR DESCRIPTION
Frontend Works

### Description
Updated currency addon css for bulk price html in configurable product

### Fixed Issues (if relevant)
1. magento/magento2#12430: While assigning prices to configurable products, prices aren's readable when using custom price symbol.

### Manual testing scenarios
1. Fresh Install
2. Tested in all Modes
3. Checked Static Content compile

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
