### PR TITLE
Resolved Checkout-Payment-Wrong promo code cancelled issue

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
@@ -24,7 +24,7 @@
                 <div class="field">
                     <label for="coupon_code" class="label"><span><?= /* @escapeNotVerified */ __('Enter discount code') ?></span></label>
                     <div class="control">
-                        <input type="text" class="input-text" id="coupon_code" name="coupon_code" value="<?= $block->escapeHtml($block->getCouponCode()) ?>" placeholder="<?= $block->escapeHtml(__('Enter discount code')) ?>" />
+                        <input type="text" class="input-text" id="coupon_code" name="coupon_code" value="<?= $block->escapeHtml($block->getCouponCode()) ?>" placeholder="<?= $block->escapeHtml(__('Enter discount code')) ?>" <?php if (strlen($block->getCouponCode())): ?> disabled="disabled" <?php endif; ?> />
                     </div>
                 </div>
                 <div class="actions-toolbar">

--- a/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
@@ -24,7 +24,7 @@
                     <div class="control">
                         <input class="input-text"
                                type="text"
-                               id="discount-code-applied"
+                               id="discount-code"
                                name="discount_code"
                                data-validate="{'required-entry':true}"
                                data-bind="value: couponCode, attr:{disabled:isApplied() , placeholder: $t('Enter discount code')} " />

--- a/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
@@ -22,23 +22,14 @@
                         <span data-bind="i18n: 'Enter discount code'"></span>
                     </label>
                     <div class="control">
-                        <!-- ko ifnot: isApplied() -->
                         <input class="input-text"
-                               type="text"
-                               id="discount-code"
-                               name="discount_code"
-                               data-validate="{'required-entry':true}"
-                               data-bind="value: couponCode, attr:{placeholder: $t('Enter discount code')} " />
-                        <!-- /ko -->
-                        <!-- ko if: isApplied() -->
-                        <input class="input-text"
+                               data-bind="attr:{disabled:isApplied()}"
                                type="text"
                                id="discount-code-applied"
                                disabled="disabled"
                                name="discount_code"
                                data-validate="{'required-entry':true}"
                                data-bind="value: couponCode, attr:{placeholder: $t('Enter discount code')} " />
-                        <!-- /ko -->
                     </div>
                 </div>
             </div>

--- a/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
@@ -22,12 +22,23 @@
                         <span data-bind="i18n: 'Enter discount code'"></span>
                     </label>
                     <div class="control">
+                        <!-- ko ifnot: isApplied() -->
                         <input class="input-text"
                                type="text"
                                id="discount-code"
                                name="discount_code"
                                data-validate="{'required-entry':true}"
                                data-bind="value: couponCode, attr:{placeholder: $t('Enter discount code')} " />
+                        <!-- /ko -->
+                        <!-- ko if: isApplied() -->
+                        <input class="input-text"
+                               type="text"
+                               id="discount-code-applied"
+                               disabled="disabled"
+                               name="discount_code"
+                               data-validate="{'required-entry':true}"
+                               data-bind="value: couponCode, attr:{placeholder: $t('Enter discount code')} " />
+                        <!-- /ko -->
                     </div>
                 </div>
             </div>

--- a/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/payment/discount.html
@@ -23,13 +23,11 @@
                     </label>
                     <div class="control">
                         <input class="input-text"
-                               data-bind="attr:{disabled:isApplied()}"
                                type="text"
                                id="discount-code-applied"
-                               disabled="disabled"
                                name="discount_code"
                                data-validate="{'required-entry':true}"
-                               data-bind="value: couponCode, attr:{placeholder: $t('Enter discount code')} " />
+                               data-bind="value: couponCode, attr:{disabled:isApplied() , placeholder: $t('Enter discount code')} " />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Wrong promo code cancelled issue on Checkout > Payment and Cart page.

### Description
Disabled the input box for promo code when promo code is already applied to the site.

### Manual testing scenarios

1. Create one cart price rule from admin side Marketing > Cart Price Rules and use Specific Coupon for Coupon field or use any existing promo code to use in front side.
2. Add any product in cart
3. Apply promo code from cart page
4. Once promo code is applied then input box for add promo code will be disabled, we need to cancel the existing applied promo code then we apply new one.
5. Same with checkout page, apply any promo code on checkout page.

### Expected result
Promo code input box will be disabled once we apply any promo code.

### Actual result
Promo code removed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
