### PR TITLE
Magento 2.2 Develop fix for #12221 Google Analytics Pageview Triggered twice

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -1,4 +1,4 @@
-Copyright © 2013-2017 Magento, Inc.
+Copyright © 2013-2018 Magento, Inc.
 
 Each Magento source file included in this distribution is licensed under OSL 3.0 or the Magento Enterprise Edition (MEE) license
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2018 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 define(function () {

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/payload-extender.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © 2013-2018 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 define(function () {

--- a/app/code/Magento/Customer/view/frontend/web/js/invalidation-processor.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/invalidation-processor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2018 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 define([

--- a/app/code/Magento/Customer/view/frontend/web/js/invalidation-processor.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/invalidation-processor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © 2013-2018 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 define([

--- a/app/code/Magento/Customer/view/frontend/web/js/invalidation-rules/website-rule.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/invalidation-rules/website-rule.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2018 Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 define([

--- a/app/code/Magento/Customer/view/frontend/web/js/invalidation-rules/website-rule.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/invalidation-rules/website-rule.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © 2013-2018 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 define([

--- a/app/code/Magento/GoogleAnalytics/view/frontend/web/js/google-analytics.js
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/web/js/google-analytics.js
@@ -54,7 +54,7 @@ define([
             ga('send', 'pageview' + config.pageTrackingData.optPageUrl);
 
             // Process orders data
-            if (config.ordersTrackingData) {
+            if (config.ordersTrackingData.length) {
                 ga('require', 'ec', 'ec.js');
 
                 //Set currency code

--- a/app/code/Magento/Theme/etc/config.xml
+++ b/app/code/Magento/Theme/etc/config.xml
@@ -45,7 +45,7 @@ Disallow: /*SID=
                 <welcome>Default welcome msg!</welcome>
             </header>
             <footer translate="copyright">
-                <copyright>Copyright &#169; 2013-2017 Magento, Inc. All rights reserved.</copyright>
+                <copyright>Copyright &#169; 2013-2018 Magento, Inc. All rights reserved.</copyright>
             </footer>
         </design>
         <theme>

--- a/app/code/Magento/Theme/i18n/en_US.csv
+++ b/app/code/Magento/Theme/i18n/en_US.csv
@@ -142,7 +142,7 @@ Empty,Empty
 "1 column","1 column"
 Configuration,Configuration
 "Default welcome msg!","Default welcome msg!"
-"Copyright © 2013-2017 Magento, Inc. All rights reserved.","Copyright © 2013-2017 Magento, Inc. All rights reserved."
+"Copyright © 2013-2018 Magento, Inc. All rights reserved.","Copyright © 2013-2018 Magento, Inc. All rights reserved."
 "Design Config Grid","Design Config Grid"
 "Rebuild design config grid index","Rebuild design config grid index"
 "Admin empty","Admin empty"

--- a/dev/tests/integration/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/Config/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/Config/SaveTest.php
@@ -67,7 +67,7 @@ class SaveTest extends AbstractBackendController
             'header_logo_height' => '',
             'header_logo_alt' => '',
             'header_welcome' => 'Default welcome msg!',
-            'footer_copyright' => 'Copyright © 2013-2017 Magento, Inc. All rights reserved.',
+            'footer_copyright' => 'Copyright © 2013-2018 Magento, Inc. All rights reserved.',
             'footer_absolute_footer' => '',
             'default_robots' => 'INDEX,FOLLOW',
             'custom_instructions' => '',


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Fixing analytics issue for PageViews getting triggered twice.
#MM18IN

### Fixed Issues (if relevant)
1. #12221 : Google analytics pageview being triggered twice.


### Manual testing scenarios
1. Created a test Analytics account
2. Triggered analytics data and checked via Google Tags tool (Tag Assistant by Google) in chrome.
 

