### PR TITLE
Newsletter\Model\Subscriber::loadByEmail() does not use MySQL index

### DIFF
--- a/app/code/Magento/Newsletter/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Newsletter/Setup/UpgradeSchema.php
@@ -12,7 +12,7 @@ use Magento\Framework\Setup\UpgradeSchemaInterface;
 /**
  * Upgrade the Newsletter module DB scheme
  */
-class UpgradeSchema implements  UpgradeSchemaInterface
+class UpgradeSchema implements UpgradeSchemaInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Newsletter/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Newsletter/Setup/UpgradeSchema.php
@@ -1,22 +1,21 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 namespace Magento\Newsletter\Setup;
-
 
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
+
 /**
  * Upgrade the Newsletter module DB scheme
  */
 class UpgradeSchema implements  UpgradeSchemaInterface
 {
-
     /**
-     * Upgrades DB schema for a module
-     *
-     * @param SchemaSetupInterface $setup
-     * @param ModuleContextInterface $context
-     * @return void
+     * {@inheritdoc}
      */
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {

--- a/app/code/Magento/Newsletter/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Newsletter/Setup/UpgradeSchema.php
@@ -1,0 +1,37 @@
+<?php
+namespace Magento\Newsletter\Setup;
+
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+/**
+ * Upgrade the Newsletter module DB scheme
+ */
+class UpgradeSchema implements  UpgradeSchemaInterface
+{
+
+    /**
+     * Upgrades DB schema for a module
+     *
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
+     * @return void
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        if (version_compare($context->getVersion(), '2.0.1', '<')) {
+            $connection = $setup->getConnection();
+
+            $connection->addIndex(
+                $setup->getTable('newsletter_subscriber'),
+                $setup->getIdxName('newsletter_subscriber', ['subscriber_email']),
+                ['subscriber_email']
+            );
+        }
+
+        $setup->endSetup();
+    }
+}

--- a/app/code/Magento/Newsletter/etc/module.xml
+++ b/app/code/Magento/Newsletter/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Newsletter" setup_version="2.0.0">
+    <module name="Magento_Newsletter" setup_version="2.0.1">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Customer"/>


### PR DESCRIPTION
- Use MYSQL index
- Add an Mysql Index key via upgrade Schema
- files  add  at app/code/Magento/Newsletter/Setup/UpgradeScheme.php
- Modified at app/code/Magento/Newsletter/etc/module.xml

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12787: newsletter-subscriber-loadbyemail-mysql-index-issue


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

Require to run Setup command for upgrade Newsletter Scheme
Run below query at database to check index key exists for field **subscriber_email**

> EXPLAIN SELECT * FROM newsletter_subscriber WHERE subscriber_email='{EmailId}'


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
