### PR TITLE
magento/magento2#12705: Integrity constraint violation error after re…

### DIFF
--- a/app/code/Magento/ConfigurableProductSales/Model/Order/Reorder/OrderedProductAvailabilityChecker.php
+++ b/app/code/Magento/ConfigurableProductSales/Model/Order/Reorder/OrderedProductAvailabilityChecker.php
@@ -45,7 +45,7 @@ class OrderedProductAvailabilityChecker implements OrderedProductAvailabilityChe
     public function isAvailable(Item $item)
     {
         $buyRequest = $item->getBuyRequest();
-        $superAttribute = $buyRequest->getData()['super_attribute'];
+        $superAttribute = isset($buyRequest->getData()['super_attribute']) ? $buyRequest->getData()['super_attribute'] : [];
         $connection = $this->getConnection();
         $select = $connection->select();
         $orderItemParentId = $item->getParentItem()->getProductId();

--- a/app/code/Magento/ConfigurableProductSales/Model/Order/Reorder/OrderedProductAvailabilityChecker.php
+++ b/app/code/Magento/ConfigurableProductSales/Model/Order/Reorder/OrderedProductAvailabilityChecker.php
@@ -45,7 +45,7 @@ class OrderedProductAvailabilityChecker implements OrderedProductAvailabilityChe
     public function isAvailable(Item $item)
     {
         $buyRequest = $item->getBuyRequest();
-        $superAttribute = isset($buyRequest->getData()['super_attribute']) ? $buyRequest->getData()['super_attribute'] : [];
+        $superAttribute = $buyRequest->getData()['super_attribute'] ?? [];
         $connection = $this->getConnection();
         $select = $connection->select();
         $orderItemParentId = $item->getParentItem()->getProductId();

--- a/app/code/Magento/Quote/Model/Quote/Item.php
+++ b/app/code/Magento/Quote/Model/Quote/Item.php
@@ -745,6 +745,9 @@ class Item extends \Magento\Quote\Model\Quote\Item\AbstractItem implements \Mage
                 unset($this->_options[$index]);
                 unset($this->_optionsByCode[$option->getCode()]);
             } else {
+                if (!$option->getItem() || !$option->getItem()->getId()) {
+                    $option->setItem($this);
+                }
                 $option->save();
             }
         }


### PR DESCRIPTION
…ordering product with custom options

- Fixed issue by updating options if parent item is same for more than one product
- Fixed issue for reordering in admin while checking the availability of product, which is not available in case of associated product.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Generated Pull Request for fixing the issue regarding custom options in a configurable product with the same configuration but different custom option values in the case of reordering. Also fixed an issue along with for checking product availability while reordering from admin. 

### Fixed Issues (if relevant)
1. magento/magento2# #[12705](https://github.com/magento/magento2/issues/12705): Integrity constraint violation error after reordering product with custom options

### Manual testing scenarios
1. Create a configurable product from admin with set of configurable options and add a custom option specific to radio option and values
2. Add 2 product to cart with same configurable options, but different custom options value.
3. Place an order with the same.
4. Then reorder the same order either from Customer My Account or From Admin, the product should get reordered with all the configurable options and it's custom options.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
