### PR TITLE
Out of Stock message issue when add child product of Configurable / Bundle product

### DIFF
--- a/app/code/Magento/CatalogInventory/Helper/Stock.php
+++ b/app/code/Magento/CatalogInventory/Helper/Stock.php
@@ -147,7 +147,7 @@ class Stock
      */
     public function addIsInStockFilterToCollection($collection)
     {
-        $stockFlag = 'has_stock_status_filter'; 
+        $stockFlag = 'has_stock_status_filter';
         $childFlag = 'product_children';
         if (!$collection->hasFlag($stockFlag) && !$collection->hasFlag($childFlag)) {
             $isShowOutOfStock = $this->scopeConfig->getValue(

--- a/app/code/Magento/CatalogInventory/Helper/Stock.php
+++ b/app/code/Magento/CatalogInventory/Helper/Stock.php
@@ -147,8 +147,9 @@ class Stock
      */
     public function addIsInStockFilterToCollection($collection)
     {
-        $stockFlag = 'has_stock_status_filter';
-        if (!$collection->hasFlag($stockFlag)) {
+        $stockFlag = 'has_stock_status_filter'; 
+        $childFlag = 'product_children';
+        if (!$collection->hasFlag($stockFlag) && !$collection->hasFlag($childFlag)) {
             $isShowOutOfStock = $this->scopeConfig->getValue(
                 \Magento\CatalogInventory\Model\Configuration::XML_PATH_SHOW_OUT_OF_STOCK,
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE


### PR DESCRIPTION
I was looking one of Magento issues i.e. https://github.com/magento/magento2/issues/12317 related to out of stock swatch option should be hidden based on selection, but when I tried to reproduce this issue, I get to know there is one more issue with the configurable drop-down attributes. When we assign **out of stock** simple product variation to the configurable product, it gives the wrong message when we select that combination option and press add to cart button. It should say out of stock product but it says you have not selected an option. The same way, there is an issue with bundle product as well. 

**## Steps to reproduce**

1. Create a configurable product with at least two configurable attributes like "Size" and "Color" with Input Type **dropdown**. 
2. Set one of the child products like "Large Red" to quantity zero and "out of stock."
3. Clear the cache, run the reindex. 
4. Go to Configurable Product detail page and select size "Large" and color "Red" and press "Add to Cart". You'll get the error message, "You need to choose options for your item.", but instead, it should "This product is out of stock."
5. Same way, create bundle product with at least two simple products assigned with an option. 
6. One of two simple product assigned to bundle product must be out of stock. 
7. Clear the cache, run the reindex. 
8. Go to Bundle Product detail page and select out of stock simple product from bundle product and press "Add to Cart". You'll get the error message, "The options you selected are not available.", but instead, it should say "This product is out of stock."

**## Expected result**
When we add the configurable product to cart with out of stock variation, you'll get the error message, "The options you selected are not available.". Same way, when we add bundle product to cart with out of stock child product, you'll get the error message, "The options you selected are not available.".

**## Actual result**
In both cases, add configurable / bundle product to cart with out of stock variation, the error message should be "This product is out of stock."

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 