### PR TITLE
Feature minimum order amount notice issue

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
+++ b/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
@@ -37,8 +37,8 @@ class ValidationMessage
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\Locale\CurrencyInterface $currency = null,
-        \Magento\Framework\Pricing\Helper\Data $priceHelper
+        \Magento\Framework\Locale\CurrencyInterface $currency,
+        \Magento\Framework\Pricing\Helper\Data $priceHelper = null
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;

--- a/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
+++ b/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
@@ -19,22 +19,32 @@ class ValidationMessage
 
     /**
      * @var \Magento\Framework\Locale\CurrencyInterface
+     * @deprecated since 101.0.0
      */
     private $currency;
+
+    /**
+     * @var \Magento\Framework\Pricing\Helper\Data
+     */
+    private $priceHelper;
 
     /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\Locale\CurrencyInterface $currency
+     * @param \Magento\Framework\Pricing\Helper\Data $priceHelper
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\Locale\CurrencyInterface $currency
+        \Magento\Framework\Locale\CurrencyInterface $currency,
+        \Magento\Framework\Pricing\Helper\Data $priceHelper
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
         $this->currency = $currency;
+        $this->priceHelper = $priceHelper ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Pricing\Helper\Data::class);
     }
 
     /**
@@ -50,13 +60,11 @@ class ValidationMessage
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
         if (!$message) {
-            $currencyCode = $this->storeManager->getStore()->getCurrentCurrencyCode();
-            $minimumAmount = $this->currency->getCurrency($currencyCode)->toCurrency(
-                $this->scopeConfig->getValue(
-                    'sales/minimum_order/amount',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            );
+            $minimumAmount =  $this->priceHelper->currency($this->scopeConfig->getValue(
+                'sales/minimum_order/amount',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            ), true, false);
+
             $message = __('Minimum order amount is %1', $minimumAmount);
         } else {
             //Added in order to address the issue: https://github.com/magento/magento2/issues/8287

--- a/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
+++ b/app/code/Magento/Quote/Model/Quote/Validator/MinimumOrderAmount/ValidationMessage.php
@@ -37,7 +37,7 @@ class ValidationMessage
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\Locale\CurrencyInterface $currency,
+        \Magento\Framework\Locale\CurrencyInterface $currency = null,
         \Magento\Framework\Pricing\Helper\Data $priceHelper
     ) {
         $this->scopeConfig = $scopeConfig;

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
@@ -21,7 +21,6 @@ class ValidationMessageTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
-     * @deprecated since 101.0.0
      */
     private $storeManagerMock;
 
@@ -55,29 +54,17 @@ class ValidationMessageTest extends \PHPUnit\Framework\TestCase
     {
         $minimumAmount = 20;
         $minimumAmountCurrency = '$20';
-        $currencyCode = 'currency_code';
+        $this->scopeConfigMock->expects($this->at(0))->method('getValue')->with('sales/minimum_order/description', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)->willReturn(null);
 
-        $this->scopeConfigMock->expects($this->at(0))
-            ->method('getValue')
-            ->with('sales/minimum_order/description', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn(null);
-
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn($minimumAmount);
+        $this->scopeConfigMock->expects($this->at(1))->method('getValue')->with('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)->willReturn($minimumAmount);
 
         $this->priceHelperMock->expects($this->once())
             ->method('currency')
             ->with($minimumAmount, true, false)
             ->will($this->returnValue($minimumAmountCurrency));
 
-        $this->assertEquals(
-            __('Minimum order amount is %1', $minimumAmountCurrency),
-            $this->model->getMessage()
-        );
+        $this->assertEquals(__('Minimum order amount is %1', $minimumAmountCurrency), $this->model->getMessage());
     }
-
     public function testGetConfigMessage()
     {
         $configMessage = 'config_message';

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
@@ -21,24 +21,33 @@ class ValidationMessageTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
+     * @deprecated since 101.0.0
      */
     private $storeManagerMock;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
+     * @deprecated since 101.0.0
      */
     private $currencyMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $priceHelperMock;
 
     protected function setUp()
     {
         $this->scopeConfigMock = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
         $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->currencyMock = $this->createMock(\Magento\Framework\Locale\CurrencyInterface::class);
+        $this->priceHelperMock = $this->createMock(\Magento\Framework\Pricing\Helper\Data::class);
 
         $this->model = new \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage(
             $this->scopeConfigMock,
             $this->storeManagerMock,
-            $this->currencyMock
+            $this->currencyMock,
+            $this->priceHelperMock
         );
     }
 
@@ -58,20 +67,17 @@ class ValidationMessageTest extends \PHPUnit\Framework\TestCase
             ->with('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
             ->willReturn($minimumAmount);
 
-        $storeMock = $this->createPartialMock(\Magento\Store\Model\Store::class, ['getCurrentCurrencyCode']);
-        $storeMock->expects($this->once())->method('getCurrentCurrencyCode')->willReturn($currencyCode);
-        $this->storeManagerMock->expects($this->once())->method('getStore')->willReturn($storeMock);
-
-        $currencyMock = $this->createMock(\Magento\Framework\Currency::class);
-        $this->currencyMock->expects($this->once())
-            ->method('getCurrency')
-            ->with($currencyCode)
-            ->willReturn($currencyMock);
-
-        $currencyMock->expects($this->once())
-            ->method('toCurrency')
-            ->with($minimumAmount)
-            ->willReturn($minimumAmountCurrency);
+        $this->priceHelperMock->expects(
+            $this->once()
+        )->method(
+            'currency'
+        )->with(
+            $minimumAmount,
+            true,
+            false
+        )->will(
+            $this->returnValue($minimumAmountCurrency)
+        );
 
         $this->assertEquals(
             __('Minimum order amount is %1', $minimumAmountCurrency),

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
@@ -67,17 +67,10 @@ class ValidationMessageTest extends \PHPUnit\Framework\TestCase
             ->with('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
             ->willReturn($minimumAmount);
 
-        $this->priceHelperMock->expects(
-            $this->once()
-        )->method(
-            'currency'
-        )->with(
-            $minimumAmount,
-            true,
-            false
-        )->will(
-            $this->returnValue($minimumAmountCurrency)
-        );
+        $this->priceHelperMock->expects($this->once())
+            ->method('currency')
+            ->with($minimumAmount, true, false)
+            ->will($this->returnValue($minimumAmountCurrency));
 
         $this->assertEquals(
             __('Minimum order amount is %1', $minimumAmountCurrency),

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
@@ -54,9 +54,15 @@ class ValidationMessageTest extends \PHPUnit\Framework\TestCase
     {
         $minimumAmount = 20;
         $minimumAmountCurrency = '$20';
-        $this->scopeConfigMock->expects($this->at(0))->method('getValue')->with('sales/minimum_order/description', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)->willReturn(null);
+        $this->scopeConfigMock->expects($this->at(0))
+            ->method('getValue')
+            ->with('sales/minimum_order/description', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn(null);
 
-        $this->scopeConfigMock->expects($this->at(1))->method('getValue')->with('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)->willReturn($minimumAmount);
+        $this->scopeConfigMock->expects($this->at(1))
+            ->method('getValue')
+            ->with('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn($minimumAmount);
 
         $this->priceHelperMock->expects($this->once())
             ->method('currency')


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
During currency switch notice message shows wrong calculation of minimum order amount.


### Description
<!--- Provide a description of the changes proposed in the pull request -->
This is about notice message of min order amount on cart page.When we have set min order amount and on cart page someone change currency, user see same amount and only currency symbol changed. It should recalculate amount also.
Instead of currency convert, we use price helper then it gives us re calculated price amount in notice message.


### Fixed Issues (if relevant)
<!--- Provide a list of fixed iss
![32069992-def1c89c-ba58-11e7-8e7e-bdece0d6f268](https://user-images.githubusercontent.com/33098216/34648343-588eb54a-f3be-11e7-9ab7-ff06b5b3ef5a.png)
![32069993-df303d34-ba58-11e7-8d97-a021f5f5b31f](https://user-images.githubusercontent.com/33098216/34648344-58dea334-f3be-11e7-90de-21c8896cd735.png)

ues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Preconditions

Any Product must be created and enabled in frontend with the price greater then 0 or less then 1000
Steps to reproduce

Enable Minimum Order Amount
Login to [Magento Admin Panel]/ Stores -> Configuration -> Sales -> Sales -> Minimum Order Amount and do the following
Set Enable "Yes"
Enter Amount for example 1000
Leave Description Message text blank
Leave Error to Show in Shopping Cart blank
Save the Configurations by clicking on "Save Config" button on top right corner
Now setup Multiple currencies for that follow below steps
Go to section Stores -> Configuration->General->Currency Setup

Now select multiple currencies from Allowed Currencies by pressing ctrl key
select Brazilian Real, Indian Rupee, Japanese Yen, Russian Ruble, US Dollar

Import Currency Rates
Go to Stores -> Under Currency Title click on Currency Rates.
Select any of service and click on import rates it will import live currency rates.
Go to Frontend Add any product in shopping cart add any product 1 qty which has price less then 1000.
Go to cart page "View and Edit Cart" link which you can see on Minicart Popup or by browsing url [Magento base url]/heckout/cart/
You can see the default message on "Minimum order amount is $1,000.00"
Now change the currencies from header upper right corner. You can see Minimum order amount is $1,000.00 in any currency you selected

##  Expected Result 
![32069992-def1c89c-ba58-11e7-8e7e-bdece0d6f268](https://user-images.githubusercontent.com/33098216/34648352-6bc27002-f3be-11e7-865a-98f7e90881c6.png)
![32069993-df303d34-ba58-11e7-8d97-a021f5f5b31f](https://user-images.githubusercontent.com/33098216/34648355-700fc4c0-f3be-11e7-9f48-fdc4ea4fa4ec.png)


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
