### PR TITLE
Customer account navigation block container doesn't have  a name 

### DIFF
--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -12,6 +12,7 @@
             <block class="Magento\Framework\View\Element\Template" name="sidebar.main.account_nav" template="Magento_Theme::html/collapsible.phtml" before="-">
                 <arguments>
                     <argument name="block_css" xsi:type="string">account-nav</argument>
+                    <argument name="block_title" xsi:type="string">Account Sidebar</argument>
                 </arguments>
                 <block class="Magento\Customer\Block\Account\Navigation" name="customer_account_navigation" before="-">
                     <arguments>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -12,7 +12,7 @@
             <block class="Magento\Framework\View\Element\Template" name="sidebar.main.account_nav" template="Magento_Theme::html/collapsible.phtml" before="-">
                 <arguments>
                     <argument name="block_css" xsi:type="string">account-nav</argument>
-                    <argument name="block_title" xsi:type="string">Account Sidebar</argument>
+                    <argument name="block_title" xsi:type="string" translate="true">Account Sidebar</argument>
                 </arguments>
                 <block class="Magento\Customer\Block\Account\Navigation" name="customer_account_navigation" before="-">
                     <arguments>

--- a/app/code/Magento/Theme/view/frontend/templates/html/collapsible.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/collapsible.phtml
@@ -8,11 +8,14 @@
 
 ?>
 
-<div class="block <?= /* @escapeNotVerified */ $block->getBlockCss() ?>">
-    <div class="title <?= /* @escapeNotVerified */ $block->getBlockCss() ?>-title" data-mage-init='{"toggleAdvanced": {"toggleContainers": "#<?= /* @escapeNotVerified */ $block->getBlockCss() ?>", "selectorsToggleClass": "active"}}'>
-        <strong><?= /* @escapeNotVerified */ $block->getBlockTitle() ?></strong>
+<?php if ($block->getChildHtml()): ?>
+    <div class="block <?= /* @escapeNotVerified */ $block->getBlockCss() ?>">
+        <div class="title <?= /* @escapeNotVerified */ $block->getBlockCss() ?>-title" data-mage-init='{"toggleAdvanced": {"toggleContainers": "#<?= /* @escapeNotVerified */ $block->getBlockCss() ?>", "selectorsToggleClass": "active"}}'>
+            <strong><?= /* @escapeNotVerified */ $block->getBlockTitle() ?></strong>
+        </div>
+        <div class="content <?= /* @escapeNotVerified */ $block->getBlockCss() ?>-content" id="<?= /* @escapeNotVerified */ $block->getBlockCss() ?>">
+            <?= $block->getChildHtml() ?>
+        </div>
     </div>
-    <div class="content <?= /* @escapeNotVerified */ $block->getBlockCss() ?>-content" id="<?= /* @escapeNotVerified */ $block->getBlockCss() ?>">
-        <?= $block->getChildHtml() ?>
-    </div>
-</div>
+<?php endif ;?>
+


### PR DESCRIPTION
- a name or as attribute
Add the suggestion  but it is only showing Label
-seems not good.So,add a condition to phtml.
It makes title only visible when it has childhtml

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12892: Issue title


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1.Please open the Customer account link e.g. http://domain.com/customer/account
2.loggin as Customer  and then go to the Dashboard page
3.Now, you don't see any Section like **<strong></strong>** at the left section of customer account pages.
4.For case,I have added a **conditions to prevent to show the Only title/label* * whenever child does not have any html output By  adding **if ($block->getChildHtml()):**.It  is helpful for UI respective view.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
