### PR TITLE
Fix Newsletter Subscribe Workflow

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -614,8 +614,9 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
                         $this->sendConfirmationSuccessEmail();
                         break;
                     case self::STATUS_NOT_ACTIVE:
-                        if ($isConfirmNeed)
+                        if ($isConfirmNeed) {
                             $this->sendConfirmationRequestEmail();
+                        }
                         break;
                 }
             } catch (MailException $e) {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -604,14 +604,19 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
 
         $this->save();
         $sendSubscription = $sendInformationEmail;
-        if ($sendSubscription === null xor $sendSubscription) {
+        if ($sendSubscription === null xor $sendSubscription && $this->isStatusChanged()) {
             try {
-                if ($isConfirmNeed) {
-                    $this->sendConfirmationRequestEmail();
-                } elseif ($this->isStatusChanged() && $status == self::STATUS_UNSUBSCRIBED) {
-                    $this->sendUnsubscriptionEmail();
-                } elseif ($this->isStatusChanged() && $status == self::STATUS_SUBSCRIBED) {
-                    $this->sendConfirmationSuccessEmail();
+                switch ($status) {
+                    case self::STATUS_UNSUBSCRIBED:
+                        $this->sendUnsubscriptionEmail();
+                        break;
+                    case self::STATUS_SUBSCRIBED:
+                        $this->sendConfirmationSuccessEmail();
+                        break;
+                    case self::STATUS_NOT_ACTIVE:
+                        if ($isConfirmNeed)
+                            $this->sendConfirmationRequestEmail();
+                        break;
                 }
             } catch (MailException $e) {
                 // If we are not able to send a new account email, this should be ignored


### PR DESCRIPTION
### Description
This pull request fixes that the newsletter confirmation email will be sent multiple times and that the Confirmation Succes and Unsubscription Email will be sent at the correct states.

### Fixed Issues (if relevant)
1. magento/magento2#12876: Multiple newsletter confirmation emails sent

### Manual testing scenarios
1. Change configuration under `Stores > Configuration > Customers > Newsletter > Subscription Options > Need to Confirm` to Yes
2. Sign up for Newsletter on frontend as a guest
3. Follow confirmation link in email
4. Create an account and check Sign Up for Newsletter within the form and use the same email as in Step 2

1. Go to your customer account edit
2. Save your customer account without changing anything

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
