### PR TITLE
Eliminate the need for inheritance for action controllers.

### DIFF
--- a/app/code/Magento/Customer/Model/App/Action/ContextPlugin.php
+++ b/app/code/Magento/Customer/Model/App/Action/ContextPlugin.php
@@ -8,8 +8,7 @@ namespace Magento\Customer\Model\App\Action;
 
 use Magento\Customer\Model\Context;
 use Magento\Customer\Model\GroupManagement;
-use Magento\Framework\App\Action\AbstractAction;
-use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ActionInterface;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Http\Context as HttpContext;
 
@@ -41,12 +40,11 @@ class ContextPlugin
     /**
      * Set customer group and customer session id to HTTP context
      *
-     * @param AbstractAction $subject
-     * @param RequestInterface $request
+     * @param ActionInterface $subject
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeDispatch(AbstractAction $subject, RequestInterface $request)
+    public function beforeExecute(ActionInterface $subject)
     {
         $this->httpContext->setValue(
             Context::CONTEXT_GROUP,

--- a/app/code/Magento/Customer/Model/Plugin/CustomerNotification.php
+++ b/app/code/Magento/Customer/Model/Plugin/CustomerNotification.php
@@ -72,7 +72,7 @@ class CustomerNotification
         $this->state = $state;
         $this->customerRepository = $customerRepository;
         $this->logger = $logger;
-        $this->request = $request ?? ObjectManager::getInstance()->get(RequestInterface::class);
+        $this->request = $request;
     }
 
     /**
@@ -101,13 +101,30 @@ class CustomerNotification
     }
 
     /**
+     * Return the shared request.
+     * If the request wasn't injected because of the backward compatible optional constructor dependency,
+     * create a new request instance.
+     *
+     * @return RequestInterface
+     */
+    private function getRequest(): RequestInterface
+    {
+        if (null === $this->request) {
+            $this->request = ObjectManager::getInstance()->get(RequestInterface::class);
+        }
+        return $this->request;
+    }
+
+    /**
      * Because RequestInterface has no isPost method the check is requied before calling it.
      *
      * @return bool
      */
     private function isPostRequest(): bool
     {
-        return method_exists($this->request, 'isPost') && $this->request->isPost();
+        $request = $this->getRequest();
+
+        return method_exists($request, 'isPost') && $request->isPost();
     }
 
     /**

--- a/app/code/Magento/Customer/Model/Plugin/CustomerNotification.php
+++ b/app/code/Magento/Customer/Model/Plugin/CustomerNotification.php
@@ -77,7 +77,7 @@ class CustomerNotification
 
     /**
      * Refresh the customer session on frontend post requests if an update session notification is registered.
-     * 
+     *
      * @param ActionInterface $subject
      * @return void
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -87,8 +87,7 @@ class CustomerNotification
     {
         $customerId = $this->session->getCustomerId();
 
-        if ($this->isFrontendRequest() && $this->isPostRequest() && $this->isSessionUpdateRegisteredFor($customerId))
-        {
+        if ($this->isFrontendRequest() && $this->isPostRequest() && $this->isSessionUpdateRegisteredFor($customerId)) {
             try {
                 $customer = $this->customerRepository->getById($customerId);
                 $this->session->setCustomerData($customer);
@@ -103,7 +102,7 @@ class CustomerNotification
 
     /**
      * Because RequestInterface has no isPost method the check is requied before calling it.
-     * 
+     *
      * @return bool
      */
     private function isPostRequest(): bool
@@ -113,7 +112,7 @@ class CustomerNotification
 
     /**
      * Check if the current application area is frontend.
-     * 
+     *
      * @return bool
      * @throws \Magento\Framework\Exception\LocalizedException
      */
@@ -124,7 +123,7 @@ class CustomerNotification
 
     /**
      * True if the session for the given customer ID needs to be refreshed.
-     * 
+     *
      * @param int $customerId
      * @return bool
      */

--- a/app/code/Magento/Customer/Model/Plugin/CustomerNotification.php
+++ b/app/code/Magento/Customer/Model/Plugin/CustomerNotification.php
@@ -3,13 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Customer\Model\Plugin;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\Customer\NotificationStorage;
 use Magento\Customer\Model\Session;
-use Magento\Framework\App\Action\AbstractAction;
+use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -43,6 +45,11 @@ class CustomerNotification
     private $logger;
 
     /**
+     * @var RequestInterface|\Magento\Framework\App\Request\Http
+     */
+    private $request;
+
+    /**
      * Initialize dependencies.
      *
      * @param Session $session
@@ -50,37 +57,38 @@ class CustomerNotification
      * @param State $state
      * @param CustomerRepositoryInterface $customerRepository
      * @param LoggerInterface $logger
+     * @param RequestInterface|null $request
      */
     public function __construct(
         Session $session,
         NotificationStorage $notificationStorage,
         State $state,
         CustomerRepositoryInterface $customerRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        RequestInterface $request = null
     ) {
         $this->session = $session;
         $this->notificationStorage = $notificationStorage;
         $this->state = $state;
         $this->customerRepository = $customerRepository;
         $this->logger = $logger;
+        $this->request = $request ?? ObjectManager::getInstance()->get(RequestInterface::class);
     }
 
     /**
-     * @param AbstractAction $subject
-     * @param RequestInterface $request
+     * Refresh the customer session on frontend post requests if an update session notification is registered.
+     * 
+     * @param ActionInterface $subject
      * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeDispatch(AbstractAction $subject, RequestInterface $request)
+    public function beforeExecute(ActionInterface $subject)
     {
         $customerId = $this->session->getCustomerId();
 
-        if ($this->state->getAreaCode() == Area::AREA_FRONTEND && $request->isPost()
-            && $this->notificationStorage->isExists(
-                NotificationStorage::UPDATE_CUSTOMER_SESSION,
-                $customerId
-            )
-        ) {
+        if ($this->isFrontendRequest() && $this->isPostRequest() && $this->isSessionUpdateRegisteredFor($customerId))
+        {
             try {
                 $customer = $this->customerRepository->getById($customerId);
                 $this->session->setCustomerData($customer);
@@ -91,5 +99,37 @@ class CustomerNotification
                 $this->logger->error($e);
             }
         }
+    }
+
+    /**
+     * Because RequestInterface has no isPost method the check is requied before calling it.
+     * 
+     * @return bool
+     */
+    private function isPostRequest(): bool
+    {
+        return method_exists($this->request, 'isPost') && $this->request->isPost();
+    }
+
+    /**
+     * Check if the current application area is frontend.
+     * 
+     * @return bool
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function isFrontendRequest(): bool
+    {
+        return $this->state->getAreaCode() == Area::AREA_FRONTEND;
+    }
+
+    /**
+     * True if the session for the given customer ID needs to be refreshed.
+     * 
+     * @param int $customerId
+     * @return bool
+     */
+    private function isSessionUpdateRegisteredFor($customerId): bool
+    {
+        return $this->notificationStorage->isExists(NotificationStorage::UPDATE_CUSTOMER_SESSION, $customerId);
     }
 }

--- a/app/code/Magento/Customer/Model/Visitor.php
+++ b/app/code/Magento/Customer/Model/Visitor.php
@@ -167,7 +167,7 @@ class Visitor extends \Magento\Framework\Model\AbstractModel
         $this->setLastVisitAt((new \DateTime())->format(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT));
 
         // prevent saving Visitor for safe methods, e.g. GET request
-        if ($this->requestSafety->isSafeMethod()) {
+        if ($this->getRequest()->isSafeMethod()) {
             return $this;
         }
         if (!$this->getId()) {
@@ -190,7 +190,7 @@ class Visitor extends \Magento\Framework\Model\AbstractModel
     public function saveByRequest($observer)
     {
         // prevent saving Visitor for safe methods, e.g. GET request
-        if ($this->skipRequestLogging || $this->requestSafety->isSafeMethod() || $this->isModuleIgnored($observer)) {
+        if ($this->skipRequestLogging || $this->getRequest()->isSafeMethod() || $this->isModuleIgnored($observer)) {
             return $this;
         }
 
@@ -334,15 +334,15 @@ class Visitor extends \Magento\Framework\Model\AbstractModel
      * If the request wasn't injected because of the backward compatible optional constructor dependency,
      * create a new request instance.
      *
-     * @return \Magento\Framework\App\RequestInterface|\Magento\Framework\App\Request\Http
+     * @return \Magento\Framework\App\RequestSafetyInterface|\Magento\Framework\App\Request\Http
      */
     private function getRequest()
     {
-        if (null === $this->request) {
+        if (null === $this->requestSafety) {
             $this->request = \Magento\Framework\App\ObjectManager::getInstance()->create(
                 \Magento\Framework\App\RequestInterface::class
             );
         }
-        return $this->request;
+        return $this->requestSafety;
     }
 }

--- a/app/code/Magento/Customer/Model/Visitor.php
+++ b/app/code/Magento/Customer/Model/Visitor.php
@@ -330,6 +330,10 @@ class Visitor extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
+     * Return the shared request.
+     * If the request wasn't injected because of the backward compatible optional constructor dependency,
+     * create a new request instance.
+     *
      * @return \Magento\Framework\App\RequestInterface|\Magento\Framework\App\Request\Http
      */
     private function getRequest()

--- a/app/code/Magento/Customer/Model/Visitor.php
+++ b/app/code/Magento/Customer/Model/Visitor.php
@@ -213,7 +213,7 @@ class Visitor extends \Magento\Framework\Model\AbstractModel
     public function isModuleIgnored($observer)
     {
         if (is_array($this->ignores) && $observer) {
-            $curModule = $observer->getEvent()->getControllerAction()->getRequest()->getRouteName();
+            $curModule = $this->getRequest()->getRouteName();
             if (isset($this->ignores[$curModule])) {
                 return true;
             }
@@ -327,5 +327,18 @@ class Visitor extends \Magento\Framework\Model\AbstractModel
             )
         );
         return $configValue ?: static::DEFAULT_ONLINE_MINUTES_INTERVAL;
+    }
+
+    /**
+     * @return \Magento\Framework\App\RequestInterface|\Magento\Framework\App\Request\Http
+     */
+    private function getRequest()
+    {
+        if (null === $this->request) {
+            $this->request = \Magento\Framework\App\ObjectManager::getInstance()->create(
+                \Magento\Framework\App\RequestInterface::class
+            );
+        }
+        return $this->request;
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/App/Action/ContextPluginTest.php
@@ -53,10 +53,7 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * Test aroundDispatch
-     */
-    public function testBeforeDispatch()
+    public function testBeforeExecute()
     {
         $this->customerSessionMock->expects($this->once())
             ->method('getCustomerGroupId')
@@ -74,6 +71,6 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
                     ]
                 )
             );
-        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+        $this->plugin->beforeExecute($this->subjectMock, $this->requestMock);
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/App/Action/ContextPluginTest.php
@@ -24,19 +24,14 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
     protected $customerSessionMock;
 
     /**
-     * @var \Magento\Framework\App\Http\Context $httpContext|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Http\Context|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $httpContextMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Action\Action|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $subjectMock;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $requestMock;
 
     /**
      * Set up
@@ -46,7 +41,6 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         $this->customerSessionMock = $this->createMock(\Magento\Customer\Model\Session::class);
         $this->httpContextMock = $this->createMock(\Magento\Framework\App\Http\Context::class);
         $this->subjectMock = $this->createMock(\Magento\Framework\App\Action\Action::class);
-        $this->requestMock = $this->createMock(\Magento\Framework\App\RequestInterface::class);
         $this->plugin = new \Magento\Customer\Model\App\Action\ContextPlugin(
             $this->customerSessionMock,
             $this->httpContextMock
@@ -71,6 +65,6 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
                     ]
                 )
             );
-        $this->plugin->beforeExecute($this->subjectMock, $this->requestMock);
+        $this->plugin->beforeExecute($this->subjectMock);
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/VisitorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/VisitorTest.php
@@ -109,7 +109,7 @@ class VisitorTest extends \PHPUnit\Framework\TestCase
                 'session' => $this->session,
                 'resource' => $this->resource,
                 'ignores' => ['test_route_name' => true],
-                'request' => $this->request,
+                'requestSafety' => $this->request,
             ]
         );
         $this->request->method('getRouteName')->willReturn('test_route_name');

--- a/app/code/Magento/Customer/Test/Unit/Model/VisitorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/VisitorTest.php
@@ -39,6 +39,11 @@ class VisitorTest extends \PHPUnit\Framework\TestCase
      */
     protected $session;
 
+    /**
+     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $request;
+
     protected function setUp()
     {
         $this->registry = $this->createMock(\Magento\Framework\Registry::class);
@@ -46,6 +51,7 @@ class VisitorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getSessionId', 'getVisitorData', 'setVisitorData'])
             ->getMock();
+        $this->request = $this->createMock(\Magento\Framework\App\Request\Http::class);
 
         $this->objectManagerHelper = new ObjectManagerHelper($this);
 
@@ -68,7 +74,8 @@ class VisitorTest extends \PHPUnit\Framework\TestCase
             [
                 'registry' => $this->registry,
                 'session' => $this->session,
-                'resource' => $this->resource
+                'resource' => $this->resource,
+                'request' => $this->request,
             ]
         );
 
@@ -101,13 +108,12 @@ class VisitorTest extends \PHPUnit\Framework\TestCase
                 'registry' => $this->registry,
                 'session' => $this->session,
                 'resource' => $this->resource,
-                'ignores' => ['test_route_name' => true]
+                'ignores' => ['test_route_name' => true],
+                'request' => $this->request,
             ]
         );
-        $request = new \Magento\Framework\DataObject(['route_name' => 'test_route_name']);
-        $action =  new \Magento\Framework\DataObject(['request' => $request]);
-        $event =  new \Magento\Framework\DataObject(['controller_action' => $action]);
-        $observer = new \Magento\Framework\DataObject(['event' => $event]);
+        $this->request->method('getRouteName')->willReturn('test_route_name');
+        $observer = new \Magento\Framework\DataObject();
         $this->assertTrue($this->visitor->isModuleIgnored($observer));
     }
 

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -320,7 +320,7 @@
     <type name="Magento\Directory\Model\AllowedCountries">
         <plugin name="customerAllowedCountries" type="Magento\Customer\Model\Plugin\AllowedCountries"/>
     </type>
-    <type name="Magento\Framework\App\Action\AbstractAction">
+    <type name="Magento\Framework\App\ActionInterface">
         <plugin name="customerNotification" type="Magento\Customer\Model\Plugin\CustomerNotification"/>
     </type>
     <type name="Magento\PageCache\Observer\FlushFormKey">

--- a/app/code/Magento/Customer/etc/frontend/di.xml
+++ b/app/code/Magento/Customer/etc/frontend/di.xml
@@ -20,8 +20,8 @@
         <plugin name="customer-session-depersonalize"
                 type="Magento\Customer\Model\Layout\DepersonalizePlugin" sortOrder="10"/>
     </type>
-    <type name="Magento\Framework\App\Action\AbstractAction">
-        <plugin name="customer-app-action-dispatchController-context-plugin"
+    <type name="Magento\Framework\App\ActionInterface">
+        <plugin name="customer-app-action-executeController-context-plugin"
                 type="Magento\Customer\Model\App\Action\ContextPlugin" sortOrder="10"/>
     </type>
     <preference for="Magento\Customer\CustomerData\SectionPoolInterface"

--- a/app/code/Magento/Store/App/Action/Plugin/StoreCheck.php
+++ b/app/code/Magento/Store/App/Action/Plugin/StoreCheck.php
@@ -4,7 +4,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Store\App\Action\Plugin;
+
+use Magento\Framework\App\ActionInterface;
 
 class StoreCheck
 {
@@ -23,17 +26,14 @@ class StoreCheck
     }
 
     /**
-     * @param \Magento\Framework\App\Action\AbstractAction $subject
-     * @param \Magento\Framework\App\RequestInterface $request
+     * @param ActionInterface $subject
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @throws \Magento\Framework\Exception\State\InitException
      */
-    public function beforeDispatch(
-        \Magento\Framework\App\Action\AbstractAction $subject,
-        \Magento\Framework\App\RequestInterface $request
-    ) {
-        if (!$this->_storeManager->getStore()->isActive()) {
+    public function beforeExecute(ActionInterface $subject)
+    {
+        if (! $this->_storeManager->getStore()->isActive()) {
             throw new \Magento\Framework\Exception\State\InitException(
                 __('Current store is not active.')
             );

--- a/app/code/Magento/Store/Test/Unit/App/Action/Plugin/StoreCheckTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Action/Plugin/StoreCheckTest.php
@@ -13,12 +13,12 @@ class StoreCheckTest extends \PHPUnit\Framework\TestCase
     protected $_plugin;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $_storeManagerMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\Store|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $_storeMock;
 
@@ -26,12 +26,7 @@ class StoreCheckTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Framework\App\Action\AbstractAction|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $subjectMock;
-
-    /**
-     * @var \Magento\Framework\App\RequestInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $requestMock;
-
+    
     protected function setUp()
     {
         $this->_storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
@@ -43,7 +38,6 @@ class StoreCheckTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($this->_storeMock)
         );
-        $this->requestMock = $this->createMock(\Magento\Framework\App\RequestInterface::class);
         $this->subjectMock = $this->getMockBuilder(\Magento\Framework\App\Action\AbstractAction::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -58,13 +52,13 @@ class StoreCheckTest extends \PHPUnit\Framework\TestCase
     public function testBeforeExecuteWhenStoreNotActive()
     {
         $this->_storeMock->expects($this->any())->method('isActive')->will($this->returnValue(false));
-        $this->_plugin->beforeExecute($this->subjectMock, $this->requestMock);
+        $this->_plugin->beforeExecute($this->subjectMock);
     }
 
     public function testBeforeExecuteWhenStoreIsActive()
     {
         $this->_storeMock->expects($this->any())->method('isActive')->will($this->returnValue(true));
-        $result = $this->_plugin->beforeExecute($this->subjectMock, $this->requestMock);
+        $result = $this->_plugin->beforeExecute($this->subjectMock);
         $this->assertNull($result);
     }
 }

--- a/app/code/Magento/Store/Test/Unit/App/Action/Plugin/StoreCheckTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Action/Plugin/StoreCheckTest.php
@@ -55,16 +55,16 @@ class StoreCheckTest extends \PHPUnit\Framework\TestCase
      * @expectedException \Magento\Framework\Exception\State\InitException
      * @expectedExceptionMessage Current store is not active.
      */
-    public function testBeforeDispatchWhenStoreNotActive()
+    public function testBeforeExecuteWhenStoreNotActive()
     {
         $this->_storeMock->expects($this->any())->method('isActive')->will($this->returnValue(false));
-        $this->_plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+        $this->_plugin->beforeExecute($this->subjectMock, $this->requestMock);
     }
 
-    public function testBeforeDispatchWhenStoreIsActive()
+    public function testBeforeExecuteWhenStoreIsActive()
     {
         $this->_storeMock->expects($this->any())->method('isActive')->will($this->returnValue(true));
-        $result = $this->_plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+        $result = $this->_plugin->beforeExecute($this->subjectMock, $this->requestMock);
         $this->assertNull($result);
     }
 }

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -56,11 +56,9 @@
     </type>
     <preference for="Magento\Framework\App\ScopeResolverInterface" type="Magento\Store\Model\Resolver\Store" />
     <preference for="Magento\Framework\App\Router\PathConfigInterface" type="Magento\Store\Model\PathConfig" />
-    <type name="Magento\Framework\App\Action\AbstractAction">
-        <plugin name="storeCheck" type="Magento\Store\App\Action\Plugin\StoreCheck" sortOrder="10"/>
-        <plugin name="designLoader" type="Magento\Framework\App\Action\Plugin\Design" sortOrder="30"/>
-    </type>
     <type name="Magento\Framework\App\ActionInterface">
+        <plugin name="storeCheck" type="Magento\Store\App\Action\Plugin\StoreCheck"/>
+        <plugin name="designLoader" type="Magento\Framework\App\Action\Plugin\Design"/>
         <plugin name="eventDispatch"  type="Magento\Framework\App\Action\Plugin\EventDispatchPlugin"/>
         <plugin name="actionFlagNoDispatch"  type="Magento\Framework\App\Action\Plugin\ActionFlagNoDispatchPlugin"/>
     </type>

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -62,6 +62,7 @@
     </type>
     <type name="Magento\Framework\App\ActionInterface">
         <plugin name="eventDispatch"  type="Magento\Framework\App\Action\Plugin\EventDispatchPlugin"/>
+        <plugin name="actionFlagNoDispatch"  type="Magento\Framework\App\Action\Plugin\ActionFlagNoDispatchPlugin"/>
     </type>
     <type name="Magento\Framework\Url\SecurityInfo">
         <plugin name="storeUrlSecurityInfo" type="Magento\Store\Url\Plugin\SecurityInfo"/>

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -60,6 +60,9 @@
         <plugin name="storeCheck" type="Magento\Store\App\Action\Plugin\StoreCheck" sortOrder="10"/>
         <plugin name="designLoader" type="Magento\Framework\App\Action\Plugin\Design" sortOrder="30"/>
     </type>
+    <type name="Magento\Framework\App\ActionInterface">
+        <plugin name="eventDispatch"  type="Magento\Framework\App\Action\Plugin\EventDispatchPlugin"/>
+    </type>
     <type name="Magento\Framework\Url\SecurityInfo">
         <plugin name="storeUrlSecurityInfo" type="Magento\Store\Url\Plugin\SecurityInfo"/>
     </type>

--- a/app/code/Magento/Tax/Model/App/Action/ContextPlugin.php
+++ b/app/code/Magento/Tax/Model/App/Action/ContextPlugin.php
@@ -75,9 +75,8 @@ class ContextPlugin
      * @return mixed
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeDispatch(
-        \Magento\Framework\App\ActionInterface $subject,
-        \Magento\Framework\App\RequestInterface $request
+    public function beforeExecute(
+        \Magento\Framework\App\ActionInterface $subject
     ) {
         if (!$this->customerSession->isLoggedIn() ||
             !$this->moduleManager->isEnabled('Magento_PageCache') ||

--- a/app/code/Magento/Tax/Test/Unit/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Tax/Test/Unit/App/Action/ContextPluginTest.php
@@ -111,9 +111,9 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
      * @param bool $cache
      * @param bool $taxEnabled
      * @param bool $loggedIn
-     * @dataProvider beforeDispatchDataProvider
+     * @dataProvider beforeExecuteDataProvider
      */
-    public function testBeforeDispatch($cache, $taxEnabled, $loggedIn)
+    public function testBeforeExecute($cache, $taxEnabled, $loggedIn)
     {
         $this->customerSessionMock->expects($this->any())
             ->method('isLoggedIn')
@@ -159,8 +159,7 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
             }
 
             $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
-            $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
-            $result = $this->contextPlugin->beforeDispatch($action, $request);
+            $result = $this->contextPlugin->beforeExecute($action);
             $this->assertNull($result);
         } else {
             $this->assertFalse($loggedIn);
@@ -170,7 +169,7 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function beforeDispatchDataProvider()
+    public function beforeExecuteDataProvider()
     {
         return [
             [false, false, false],

--- a/app/code/Magento/Tax/etc/frontend/di.xml
+++ b/app/code/Magento/Tax/etc/frontend/di.xml
@@ -35,7 +35,7 @@
         <plugin name="tax-session-depersonalize"
                 type="Magento\Tax\Model\Layout\DepersonalizePlugin" sortOrder="20"/>
     </type>
-    <type name="Magento\Framework\App\Action\AbstractAction">
+    <type name="Magento\Framework\App\ActionInterface">
         <plugin name="tax-app-action-dispatchController-context-plugin"
                 type="Magento\Tax\Model\App\Action\ContextPlugin"/>
     </type>

--- a/app/code/Magento/Theme/Model/Theme/Plugin/Registration.php
+++ b/app/code/Magento/Theme/Model/Theme/Plugin/Registration.php
@@ -5,8 +5,7 @@
  */
 namespace Magento\Theme\Model\Theme\Plugin;
 
-use Magento\Backend\App\AbstractAction;
-use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ActionInterface;
 use Magento\Theme\Model\Theme\Registration as ThemeRegistration;
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
@@ -69,15 +68,13 @@ class Registration
     /**
      * Add new theme from filesystem and update existing
      *
-     * @param AbstractAction $subject
-     * @param RequestInterface $request
+     * @param ActionInterface $subject
      *
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeDispatch(
-        AbstractAction $subject,
-        RequestInterface $request
+    public function beforeExecute(
+        ActionInterface $subject
     ) {
         try {
             if ($this->appState->getMode() != AppState::MODE_PRODUCTION) {

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Plugin/RegistrationTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Plugin/RegistrationTest.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Theme\Test\Unit\Model\Theme\Plugin;
 
+use Magento\Framework\App\ActionInterface;
 use Magento\Theme\Model\Theme\Plugin\Registration;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
@@ -17,8 +18,8 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
     /** @var \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $logger;
 
-    /** @var \Magento\Backend\App\AbstractAction|\PHPUnit_Framework_MockObject_MockObject */
-    protected $abstractAction;
+    /** @var ActionInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $action;
 
     /** @var \Magento\Framework\App\RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $request;
@@ -39,12 +40,7 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
     {
         $this->themeRegistration = $this->createMock(\Magento\Theme\Model\Theme\Registration::class);
         $this->logger = $this->getMockForAbstractClass(\Psr\Log\LoggerInterface::class, [], '', false);
-        $this->abstractAction = $this->getMockForAbstractClass(
-            \Magento\Backend\App\AbstractAction::class,
-            [],
-            '',
-            false
-        );
+        $this->action = $this->createMock(ActionInterface::class);
         $this->request = $this->getMockForAbstractClass(\Magento\Framework\App\RequestInterface::class, [], '', false);
         $this->appState = $this->createMock(\Magento\Framework\App\State::class);
         $this->themeCollection = $this->createMock(\Magento\Theme\Model\Theme\Collection::class);
@@ -60,10 +56,10 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param bool $hasParentTheme
-     * @dataProvider dataProviderBeforeDispatch
+     * @dataProvider dataProviderBeforeExecute
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function testBeforeDispatch(
+    public function testBeforeExecute(
         $hasParentTheme
     ) {
         $themeId = 1;
@@ -147,13 +143,13 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
             ->method('save')
             ->willReturnSelf();
 
-        $this->plugin->beforeDispatch($this->abstractAction, $this->request);
+        $this->plugin->beforeExecute($this->action);
     }
 
     /**
      * @return array
      */
-    public function dataProviderBeforeDispatch()
+    public function dataProviderBeforeExecute()
     {
         return [
             [true],
@@ -164,7 +160,7 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
     public function testBeforeDispatchWithProductionMode()
     {
         $this->appState->expects($this->once())->method('getMode')->willReturn('production');
-        $this->plugin->beforeDispatch($this->abstractAction, $this->request);
+        $this->plugin->beforeExecute($this->action, $this->request);
     }
 
     public function testBeforeDispatchWithException()
@@ -173,6 +169,6 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
         $this->themeRegistration->expects($this->once())->method('register')->willThrowException($exception);
         $this->logger->expects($this->once())->method('critical');
 
-        $this->plugin->beforeDispatch($this->abstractAction, $this->request);
+        $this->plugin->beforeExecute($this->action, $this->request);
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Plugin/RegistrationTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Plugin/RegistrationTest.php
@@ -21,9 +21,6 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
     /** @var ActionInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $action;
 
-    /** @var \Magento\Framework\App\RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
-    protected $request;
-
     /** @var \Magento\Framework\App\State|\PHPUnit_Framework_MockObject_MockObject */
     protected $appState;
 
@@ -41,7 +38,6 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
         $this->themeRegistration = $this->createMock(\Magento\Theme\Model\Theme\Registration::class);
         $this->logger = $this->getMockForAbstractClass(\Psr\Log\LoggerInterface::class, [], '', false);
         $this->action = $this->createMock(ActionInterface::class);
-        $this->request = $this->getMockForAbstractClass(\Magento\Framework\App\RequestInterface::class, [], '', false);
         $this->appState = $this->createMock(\Magento\Framework\App\State::class);
         $this->themeCollection = $this->createMock(\Magento\Theme\Model\Theme\Collection::class);
         $this->themeLoader = $this->createMock(\Magento\Theme\Model\ResourceModel\Theme\Collection::class);
@@ -160,7 +156,7 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
     public function testBeforeDispatchWithProductionMode()
     {
         $this->appState->expects($this->once())->method('getMode')->willReturn('production');
-        $this->plugin->beforeExecute($this->action, $this->request);
+        $this->plugin->beforeExecute($this->action);
     }
 
     public function testBeforeDispatchWithException()
@@ -169,6 +165,6 @@ class RegistrationTest extends \PHPUnit\Framework\TestCase
         $this->themeRegistration->expects($this->once())->method('register')->willThrowException($exception);
         $this->logger->expects($this->once())->method('critical');
 
-        $this->plugin->beforeExecute($this->action, $this->request);
+        $this->plugin->beforeExecute($this->action);
     }
 }

--- a/app/code/Magento/Weee/Model/App/Action/ContextPlugin.php
+++ b/app/code/Magento/Weee/Model/App/Action/ContextPlugin.php
@@ -92,17 +92,14 @@ class ContextPlugin
 
     /**
      * @param \Magento\Framework\App\ActionInterface $subject
-     * @param \Magento\Framework\App\RequestInterface $request
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function beforeDispatch(
-        \Magento\Framework\App\ActionInterface $subject,
-        \Magento\Framework\App\RequestInterface $request
-    ) {
+    public function beforeExecute(\Magento\Framework\App\ActionInterface $subject)
+    {
         if (!$this->weeeHelper->isEnabled() ||
             !$this->customerSession->isLoggedIn() ||
             !$this->moduleManager->isEnabled('Magento_PageCache') ||

--- a/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
@@ -123,7 +123,7 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testBeforeDispatchBasedOnDefault()
+    public function testBeforeExecuteBasedOnDefault()
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -188,10 +188,10 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
         $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeDispatch($action, $request);
+        $this->contextPlugin->beforeExecute($action, $request);
     }
 
-    public function testBeforeDispatchBasedOnOrigin()
+    public function testBeforeExecuteBasedOnOrigin()
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -217,10 +217,10 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
         $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeDispatch($action, $request);
+        $this->contextPlugin->beforeExecute($action, $request);
     }
 
-    public function testBeforeDispatchBasedOnBilling()
+    public function testBeforeExecuteBasedOnBilling()
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -289,10 +289,10 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
         $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeDispatch($action, $request);
+        $this->contextPlugin->beforeExecute($action, $request);
     }
 
-    public function testBeforeDispatchBasedOnShipping()
+    public function testBeforeExecuterBasedOnShipping()
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -361,6 +361,6 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
         $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeDispatch($action, $request);
+        $this->contextPlugin->beforeExecute($action, $request);
     }
 }

--- a/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
@@ -14,49 +14,59 @@ namespace Magento\Weee\Test\Unit\App\Action;
 class ContextPluginTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Tax\Helper\Data
+     * @var \Magento\Tax\Helper\Data|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $taxHelperMock;
 
     /**
-     * @var \Magento\Weee\Helper\Data
+     * @var \Magento\Weee\Helper\Data|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $weeeHelperMock;
 
     /**
-     * @var \Magento\Weee\Model\Tax
+     * @var \Magento\Weee\Model\Tax|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $weeeTaxMock;
 
     /**
-     * @var \Magento\Framework\App\Http\Context
+     * @var \Magento\Framework\App\Http\Context|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $httpContextMock;
 
     /**
-     * @var \Magento\Tax\Model\Calculation\Proxy
+     * @var \Magento\Tax\Model\Calculation\Proxy|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $taxCalculationMock;
 
     /**
-     * @var \Magento\Framework\Module\Manager
+     * @var \Magento\Framework\Module\Manager|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $moduleManagerMock;
 
     /**
-     * @var \Magento\PageCache\Model\Config
+     * @var \Magento\PageCache\Model\Config|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $cacheConfigMock;
 
     /**
-     * @var \Magento\Store\Model\StoreManager
+     * @var \Magento\Store\Model\StoreManager|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $storeManageMock;
+    protected $storeManagerMock;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfig
+     * @var \Magento\Framework\App\Config|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $scopeConfigMock;
+
+    /**
+     * @var \Magento\Customer\Model\Session|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $customerSessionMock;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $objectManager;
 
     /**
      * @var \Magento\Tax\Model\App\Action\ContextPlugin
@@ -98,7 +108,7 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
         $this->cacheConfigMock = $this->getMockBuilder(\Magento\PageCache\Model\Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-
+               
         $this->storeManagerMock = $this->getMockBuilder(\Magento\Store\Model\StoreManager::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -185,10 +195,10 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
             ->method('setValue')
             ->with('weee_tax_region', ['countryId' => 'US', 'regionId' => 0], 0);
 
+        /** @var \Magento\Framework\App\Test\Unit\Action\Stub\ActionStub $action */
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
-        $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeExecute($action, $request);
+        $this->contextPlugin->beforeExecute($action);
     }
 
     public function testBeforeExecuteBasedOnOrigin()
@@ -214,10 +224,10 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
             ->method('getTaxBasedOn')
             ->willReturn('origin');
 
+        /** @var \Magento\Framework\App\Test\Unit\Action\Stub\ActionStub $action */
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
-        $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeExecute($action, $request);
+        $this->contextPlugin->beforeExecute($action);
     }
 
     public function testBeforeExecuteBasedOnBilling()
@@ -286,10 +296,10 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
             ->method('setValue')
             ->with('weee_tax_region', ['countryId' => 'US', 'regionId' => 1], 0);
 
+        /** @var \Magento\Framework\App\Test\Unit\Action\Stub\ActionStub $action */
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
-        $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeExecute($action, $request);
+        $this->contextPlugin->beforeExecute($action);
     }
 
     public function testBeforeExecuterBasedOnShipping()
@@ -358,9 +368,9 @@ class ContextPluginTest extends \PHPUnit\Framework\TestCase
             ->method('setValue')
             ->with('weee_tax_region', ['countryId' => 'US', 'regionId' => 1], 0);
 
+        /** @var \Magento\Framework\App\Test\Unit\Action\Stub\ActionStub $action */
         $action = $this->objectManager->getObject(\Magento\Framework\App\Test\Unit\Action\Stub\ActionStub::class);
-        $request = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getActionName']);
 
-        $this->contextPlugin->beforeExecute($action, $request);
+        $this->contextPlugin->beforeExecute($action);
     }
 }

--- a/app/code/Magento/Weee/etc/frontend/di.xml
+++ b/app/code/Magento/Weee/etc/frontend/di.xml
@@ -13,7 +13,7 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Framework\App\Action\AbstractAction">
+    <type name="Magento\Framework\App\ActionInterface">
         <plugin name="weee-app-action-dispatchController-context-plugin"
                 type="Magento\Weee\Model\App\Action\ContextPlugin"/>
     </type>

--- a/dev/tests/integration/testsuite/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/PlaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/PlaceTest.php
@@ -14,7 +14,7 @@ class PlaceTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
 {
     /**
      * Test requestToAuthorizenetData returning
-     * 
+     *
      * @magentoAppArea adminhtml
      */
     public function testExecuteAuthorizenetDataReturning()

--- a/dev/tests/integration/testsuite/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/PlaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/PlaceTest.php
@@ -14,6 +14,8 @@ class PlaceTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
 {
     /**
      * Test requestToAuthorizenetData returning
+     * 
+     * @magentoAppArea adminhtml
      */
     public function testExecuteAuthorizenetDataReturning()
     {

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFilesTest.php
@@ -10,6 +10,8 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Test for \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\DeleteFiles class.
+ *
+ * @magentoAppArea adminhtml
  */
 class DeleteFilesTest extends \PHPUnit\Framework\TestCase
 {

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFolderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFolderTest.php
@@ -10,6 +10,8 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Test for \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\DeleteFolder class.
+ *
+ * @magentoAppArea adminhtml
  */
 class DeleteFolderTest extends \PHPUnit\Framework\TestCase
 {

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/NewFolderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/NewFolderTest.php
@@ -10,6 +10,8 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Test for \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\NewFolder class.
+ *
+ * @magentoAppArea adminhtml
  */
 class NewFolderTest extends \PHPUnit\Framework\TestCase
 {

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/UploadTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/UploadTest.php
@@ -10,6 +10,8 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Test for \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images\Upload class.
+ *
+ * @magentoAppArea adminhtml
  */
 class UploadTest extends \PHPUnit\Framework\TestCase
 {

--- a/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
@@ -1,0 +1,174 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App;
+
+use Magento\Backend\Model\Auth as BackendAuth;
+use Magento\Backend\Model\UrlInterface as BackendUrl;
+use Magento\Framework\App\TestStubs\InheritanceBasedBackendAction;
+use Magento\Framework\App\TestStubs\InheritanceBasedFrontendAction;
+use Magento\Framework\App\TestStubs\InterfaceOnlyBackendAction;
+use Magento\Framework\App\TestStubs\InterfaceOnlyFrontendAction;
+use Magento\Framework\Event;
+use Magento\Security\Model\Plugin\Auth as SecurityAuth;
+use Magento\TestFramework\Bootstrap as TestFramework;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+class ControllerActionTest extends TestCase
+{
+    public function setupEventManagerSpy(): void
+    {
+        /** @var ObjectManager $objectManager */
+        $objectManager = ObjectManager::getInstance();
+
+        $originalEventManager = $objectManager->create(Event\ManagerInterface::class);
+        $eventManagerSpy = new class($originalEventManager) implements Event\ManagerInterface
+        {
+            /**
+             * @var Event\ManagerInterface
+             */
+            private $delegate;
+
+            /**
+             * @var array[];
+             */
+            private $dispatchedEvents = [];
+
+            public function __construct(Event\ManagerInterface $delegate)
+            {
+                $this->delegate = $delegate;
+            }
+
+            public function dispatch($eventName, array $data = [])
+            {
+                $this->dispatchedEvents[$eventName][] = [$eventName, $data];
+                $this->delegate->dispatch($eventName, $data);
+            }
+
+            public function spyOnDispatchedEvent(string $eventName): array
+            {
+                return $this->dispatchedEvents[$eventName] ?? [];
+            }
+        };
+
+        $objectManager->addSharedInstance($eventManagerSpy, Event\Manager\Proxy::class);
+    }
+
+    private function assertEventDispatchCount($eventName, $expectedCount): void
+    {
+        $message = sprintf('Event %s was expected to be dispatched %d time(s).', $eventName, $expectedCount);
+        $this->assertCount($expectedCount, $this->getEventManager()->spyOnDispatchedEvent($eventName), $message);
+    }
+
+    /**
+     * @return \Magento\Framework\App\Request\Http
+     */
+    private function getRequest(): RequestInterface
+    {
+        return ObjectManager::getInstance()->get(\Magento\Framework\App\Request\Http::class);
+    }
+
+    private function fakeBackendAuthentication()
+    {
+        $objectManager = ObjectManager::getInstance();
+        $objectManager->get(BackendUrl::class)->turnOffSecretKey();
+
+        $auth = $objectManager->get(BackendAuth::class);
+        $auth->login(TestFramework::ADMIN_NAME, TestFramework::ADMIN_PASSWORD);
+    }
+
+    private function configureRequestForAction(string $route, string $actionPath, string $actionName)
+    {
+        $request = $this->getRequest();
+        
+        $request->setRouteName($route);
+        $request->setControllerName($actionPath);
+        $request->setActionName($actionName);
+        $request->setDispatched();
+    }
+
+    private function getEventManager(): Event\ManagerInterface
+    {
+        return ObjectManager::getInstance()->get(Event\ManagerInterface::class);
+    }
+
+    private function assertPreAndPostDispatchEventsAreDispatched()
+    {
+        $this->assertEventDispatchCount('controller_action_predispatch', 1);
+        $this->assertEventDispatchCount('controller_action_predispatch_testroute', 1);
+        $this->assertEventDispatchCount('controller_action_predispatch_testroute_actionpath_actionname', 1);
+        $this->assertEventDispatchCount('controller_action_postdispatch_testroute_actionpath_actionname', 1);
+        $this->assertEventDispatchCount('controller_action_postdispatch_testroute', 1);
+        $this->assertEventDispatchCount('controller_action_postdispatch', 1);
+    }
+
+    /**
+     * @magentoAppArea frontend
+     * @magentoAppIsolation enabled
+     */
+    public function testInheritanceBasedFrontendActionDispatchesEvents()
+    {
+        $this->setupEventManagerSpy();
+        
+        /** @var InheritanceBasedFrontendAction $action */
+        $action = ObjectManager::getInstance()->create(InheritanceBasedFrontendAction::class);
+        $this->configureRequestForAction('testroute', 'actionpath', 'actionname');
+        
+        $action->dispatch($this->getRequest());
+
+        $this->assertPreAndPostDispatchEventsAreDispatched();
+    }
+
+    /**
+     * @magentoAppArea frontend
+     * @magentoAppIsolation enabled
+     */
+    public function testInterfaceOnlyFrontendActionDispatchesEvents()
+    {
+        $this->setupEventManagerSpy();
+        
+        /** @var InterfaceOnlyFrontendAction $action */
+        $action = ObjectManager::getInstance()->create(InterfaceOnlyFrontendAction::class);
+        $this->configureRequestForAction('testroute', 'actionpath', 'actionname');
+
+        $action->execute();
+
+        $this->assertPreAndPostDispatchEventsAreDispatched();
+    }
+
+    /**
+     * @magentoAppArea adminhtml
+     * @magentoAppIsolation enabled
+     */
+    public function testInheritanceBasedAdminhtmlActionDispatchesEvents()
+    {
+        $this->fakeBackendAuthentication();
+        
+        $this->setupEventManagerSpy();
+
+        /** @var InheritanceBasedBackendAction $action */
+        $action = ObjectManager::getInstance()->create(InheritanceBasedBackendAction::class);
+        $this->configureRequestForAction('testroute', 'actionpath', 'actionname');
+
+        $action->dispatch($this->getRequest());
+
+        $this->assertPreAndPostDispatchEventsAreDispatched();
+    }
+
+    /**
+     * @magentoAppArea adminhtml
+     * @magentoAppIsolation enabled
+     */
+    public function testInterfaceOnlyAdminhtmlActionDispatchesEvents()
+    {
+        $this->setupEventManagerSpy();
+
+        /** @var InterfaceOnlyBackendAction $action */
+        $action = ObjectManager::getInstance()->create(InterfaceOnlyBackendAction::class);
+        $this->configureRequestForAction('testroute', 'actionpath', 'actionname');
+
+        $action->execute();
+
+        $this->assertPreAndPostDispatchEventsAreDispatched();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
@@ -9,12 +9,13 @@ use Magento\Framework\App\TestStubs\InheritanceBasedFrontendAction;
 use Magento\Framework\App\TestStubs\InterfaceOnlyBackendAction;
 use Magento\Framework\App\TestStubs\InterfaceOnlyFrontendAction;
 use Magento\Framework\Event;
-use Magento\Security\Model\Plugin\Auth as SecurityAuth;
 use Magento\TestFramework\Bootstrap as TestFramework;
 use Magento\TestFramework\ObjectManager;
+use Magento\TestFramework\Request as TestHttpRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @magentoAppIsolation enabled
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.UnusedLocalVariable)
  */
@@ -65,11 +66,11 @@ class ControllerActionTest extends TestCase
     }
 
     /**
-     * @return \Magento\Framework\App\Request\Http
+     * @return TestHttpRequest
      */
     private function getRequest(): RequestInterface
     {
-        return ObjectManager::getInstance()->get(\Magento\TestFramework\Request::class);
+        return ObjectManager::getInstance()->get(TestHttpRequest::class);
     }
 
     private function fakeAuthenticatedBackendRequest()
@@ -108,7 +109,6 @@ class ControllerActionTest extends TestCase
 
     /**
      * @magentoAppArea frontend
-     * @magentoAppIsolation enabled
      */
     public function testInheritanceBasedFrontendActionDispatchesEvents()
     {
@@ -125,7 +125,6 @@ class ControllerActionTest extends TestCase
 
     /**
      * @magentoAppArea frontend
-     * @magentoAppIsolation enabled
      */
     public function testInterfaceOnlyFrontendActionDispatchesEvents()
     {
@@ -142,7 +141,6 @@ class ControllerActionTest extends TestCase
 
     /**
      * @magentoAppArea adminhtml
-     * @magentoAppIsolation enabled
      */
     public function testInheritanceBasedAdminhtmlActionDispatchesEvents()
     {
@@ -161,7 +159,6 @@ class ControllerActionTest extends TestCase
 
     /**
      * @magentoAppArea adminhtml
-     * @magentoAppIsolation enabled
      */
     public function testInterfaceOnlyAdminhtmlActionDispatchesEvents()
     {
@@ -178,7 +175,6 @@ class ControllerActionTest extends TestCase
 
     /**
      * @magentoAppArea frontend
-     * @magentoAppIsolation enabled
      */
     public function testSettingTheNoDispatchActionFlagProhibitsExecuteAndPostdispatchEvents()
     {

--- a/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
  * @magentoAppIsolation enabled
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
 class ControllerActionTest extends TestCase
 {

--- a/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
@@ -14,6 +14,9 @@ use Magento\TestFramework\Bootstrap as TestFramework;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ControllerActionTest extends TestCase
 {
     public function setupEventManagerSpy(): void

--- a/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/ControllerActionTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ControllerActionTest extends TestCase
 {
-    public function setupEventManagerSpy(): void
+    public function setupEventManagerSpy()
     {
         /** @var ObjectManager $objectManager */
         $objectManager = ObjectManager::getInstance();
@@ -57,7 +57,7 @@ class ControllerActionTest extends TestCase
         $objectManager->addSharedInstance($eventManagerSpy, Event\Manager\Proxy::class);
     }
 
-    private function assertEventDispatchCount($eventName, $expectedCount): void
+    private function assertEventDispatchCount($eventName, $expectedCount)
     {
         $message = sprintf('Event %s was expected to be dispatched %d time(s).', $eventName, $expectedCount);
         $this->assertCount($expectedCount, $this->getEventManager()->spyOnDispatchedEvent($eventName), $message);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedBackendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedBackendAction.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App\TestStubs;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\View\Result\PageFactory;
+
+class InheritanceBasedBackendAction extends Action
+{
+    /**
+     * @var PageFactory
+     */
+    private $pageFactory;
+
+    public function __construct(Action\Context $context, PageFactory $pageFactory)
+    {
+        parent::__construct($context);
+        $this->pageFactory = $pageFactory;
+    }
+
+    public function execute()
+    {
+        return $this->pageFactory->create();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedBackendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedBackendAction.php
@@ -5,6 +5,9 @@ namespace Magento\Framework\App\TestStubs;
 use Magento\Backend\App\Action;
 use Magento\Framework\View\Result\PageFactory;
 
+/**
+ * Stub inheritance based backend action controller for testing purposes.
+ */
 class InheritanceBasedBackendAction extends Action
 {
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedFrontendAction.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App\TestStubs;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+
+class InheritanceBasedFrontendAction extends Action
+{
+    /**
+     * @var PageFactory
+     */
+    private $pageFactory;
+
+    public function __construct(Context $context, PageFactory $pageFactory)
+    {
+        parent::__construct($context);
+        $this->pageFactory = $pageFactory;
+    }
+
+    public function execute()
+    {
+        return $this->pageFactory->create();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedFrontendAction.php
@@ -6,6 +6,9 @@ use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\View\Result\PageFactory;
 
+/**
+ * Stub inheritance based frontend action controller for testing purposes.
+ */
 class InheritanceBasedFrontendAction extends Action
 {
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InheritanceBasedFrontendAction.php
@@ -13,6 +13,11 @@ class InheritanceBasedFrontendAction extends Action
      */
     private $pageFactory;
 
+    /**
+     * @var bool
+     */
+    private $executeWasCalled = false;
+
     public function __construct(Context $context, PageFactory $pageFactory)
     {
         parent::__construct($context);
@@ -21,6 +26,12 @@ class InheritanceBasedFrontendAction extends Action
 
     public function execute()
     {
+        $this->executeWasCalled = true;
         return $this->pageFactory->create();
+    }
+
+    public function isExecuted(): bool
+    {
+        return $this->executeWasCalled;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyBackendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyBackendAction.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App\TestStubs;
+
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\View\Result\PageFactory;
+
+class InterfaceOnlyBackendAction implements ActionInterface
+{
+    /**
+     * @var PageFactory
+     */
+    private $pageFactory;
+
+    public function __construct(PageFactory $pageFactory)
+    {
+        $this->pageFactory = $pageFactory;
+    }
+
+    public function execute()
+    {
+        return $this->pageFactory->create();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyBackendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyBackendAction.php
@@ -5,6 +5,9 @@ namespace Magento\Framework\App\TestStubs;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\View\Result\PageFactory;
 
+/**
+ * Stub interface action controller implementation for testing purposes. 
+ */
 class InterfaceOnlyBackendAction implements ActionInterface
 {
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyBackendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyBackendAction.php
@@ -6,7 +6,7 @@ use Magento\Framework\App\ActionInterface;
 use Magento\Framework\View\Result\PageFactory;
 
 /**
- * Stub interface action controller implementation for testing purposes. 
+ * Stub interface action controller implementation for testing purposes.
  */
 class InterfaceOnlyBackendAction implements ActionInterface
 {

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
@@ -3,7 +3,6 @@
 namespace Magento\Framework\App\TestStubs;
 
 use Magento\Framework\App\ActionInterface;
-use Magento\Framework\App\RequestInterface;
 use Magento\Framework\View\Result\PageFactory;
 
 class InterfaceOnlyFrontendAction implements ActionInterface
@@ -13,30 +12,13 @@ class InterfaceOnlyFrontendAction implements ActionInterface
      */
     private $pageFactory;
 
-    /**
-     * @var RequestInterface
-     */
-    private $request;
-
-    public function __construct(PageFactory $pageFactory, RequestInterface $request)
+    public function __construct(PageFactory $pageFactory)
     {
         $this->pageFactory = $pageFactory;
-        $this->request = $request;
     }
 
     public function execute()
     {
         return $this->pageFactory->create();
-    }
-
-    /**
-     * This method is a workaround for the interface violation where core code expects
-     * actions to extend the AbstractAction :(((((
-     * 
-     * @return RequestInterface
-     */
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App\TestStubs;
+
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\View\Result\PageFactory;
+
+class InterfaceOnlyFrontendAction implements ActionInterface
+{
+    /**
+     * @var PageFactory
+     */
+    private $pageFactory;
+
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    public function __construct(PageFactory $pageFactory, RequestInterface $request)
+    {
+        $this->pageFactory = $pageFactory;
+        $this->request = $request;
+    }
+
+    public function execute()
+    {
+        return $this->pageFactory->create();
+    }
+
+    /**
+     * This method is a workaround for the interface violation where core code expects
+     * actions to extend the AbstractAction :(((((
+     * 
+     * @return RequestInterface
+     */
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
@@ -5,6 +5,9 @@ namespace Magento\Framework\App\TestStubs;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\View\Result\PageFactory;
 
+/**
+ * Stub interface only based frontend action controller for testing purposes.
+ */
 class InterfaceOnlyFrontendAction implements ActionInterface
 {
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/TestStubs/InterfaceOnlyFrontendAction.php
@@ -12,6 +12,11 @@ class InterfaceOnlyFrontendAction implements ActionInterface
      */
     private $pageFactory;
 
+    /**
+     * @var bool
+     */
+    private $executeWasCalled = false;
+
     public function __construct(PageFactory $pageFactory)
     {
         $this->pageFactory = $pageFactory;
@@ -19,6 +24,12 @@ class InterfaceOnlyFrontendAction implements ActionInterface
 
     public function execute()
     {
+        $this->executeWasCalled = true;
         return $this->pageFactory->create();
+    }
+
+    public function isExecuted(): bool
+    {
+        return $this->executeWasCalled;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/Billing/AgreementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/Billing/AgreementTest.php
@@ -19,6 +19,7 @@ class AgreementTest extends \Magento\TestFramework\TestCase\AbstractController
      *
      * @magentoDataFixture Magento/Customer/_files/customer.php
      * @magentoDbIsolation enabled
+     * @magentoAppArea frontend
      */
     public function testReturnWizardAction()
     {

--- a/lib/internal/Magento/Framework/App/Action/Action.php
+++ b/lib/internal/Magento/Framework/App/Action/Action.php
@@ -92,32 +92,12 @@ abstract class Action extends AbstractAction
     {
         $this->_request = $request;
         $profilerKey = 'CONTROLLER_ACTION:' . $request->getFullActionName();
-        $eventParameters = ['controller_action' => $this, 'request' => $request];
-        $this->_eventManager->dispatch('controller_action_predispatch', $eventParameters);
-        $this->_eventManager->dispatch('controller_action_predispatch_' . $request->getRouteName(), $eventParameters);
-        $this->_eventManager->dispatch(
-            'controller_action_predispatch_' . $request->getFullActionName(),
-            $eventParameters
-        );
         \Magento\Framework\Profiler::start($profilerKey);
 
         $result = null;
         if ($request->isDispatched() && !$this->_actionFlag->get('', self::FLAG_NO_DISPATCH)) {
             \Magento\Framework\Profiler::start('action_body');
             $result = $this->execute();
-            \Magento\Framework\Profiler::start('postdispatch');
-            if (!$this->_actionFlag->get('', self::FLAG_NO_POST_DISPATCH)) {
-                $this->_eventManager->dispatch(
-                    'controller_action_postdispatch_' . $request->getFullActionName(),
-                    $eventParameters
-                );
-                $this->_eventManager->dispatch(
-                    'controller_action_postdispatch_' . $request->getRouteName(),
-                    $eventParameters
-                );
-                $this->_eventManager->dispatch('controller_action_postdispatch', $eventParameters);
-            }
-            \Magento\Framework\Profiler::stop('postdispatch');
             \Magento\Framework\Profiler::stop('action_body');
         }
         \Magento\Framework\Profiler::stop($profilerKey);

--- a/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
@@ -6,6 +6,9 @@ use Magento\Framework\App\ActionFlag;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\ResponseInterface;
 
+/**
+ * 
+ */
 class ActionFlagNoDispatchPlugin
 {
     /**
@@ -28,7 +31,7 @@ class ActionFlagNoDispatchPlugin
      * @param ActionInterface $subject
      * @param callable $proceed
      * @return ResponseInterface
-     *
+     * 
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(ActionInterface $subject, callable $proceed)

--- a/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
@@ -28,7 +28,7 @@ class ActionFlagNoDispatchPlugin
      * @param ActionInterface $subject
      * @param callable $proceed
      * @return ResponseInterface
-     * 
+     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(ActionInterface $subject, callable $proceed)

--- a/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
@@ -7,7 +7,7 @@ use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\ResponseInterface;
 
 /**
- * 
+ *
  */
 class ActionFlagNoDispatchPlugin
 {
@@ -31,7 +31,7 @@ class ActionFlagNoDispatchPlugin
      * @param ActionInterface $subject
      * @param callable $proceed
      * @return ResponseInterface
-     * 
+     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(ActionInterface $subject, callable $proceed)

--- a/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App\Action\Plugin;
+
+use Magento\Framework\App\ActionFlag;
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\ResponseInterface;
+
+class ActionFlagNoDispatchPlugin
+{
+    /**
+     * @var ActionFlag
+     */
+    private $actionFlag;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    public function __construct(ActionFlag $actionFlag, ResponseInterface $response)
+    {
+        $this->actionFlag = $actionFlag;
+        $this->response = $response;
+    }
+
+    public function aroundExecute(ActionInterface $subject, callable $proceed)
+    {
+        return $this->actionFlag->get('', ActionInterface::FLAG_NO_DISPATCH) ? $this->response : $proceed();
+    }
+}

--- a/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
@@ -24,6 +24,13 @@ class ActionFlagNoDispatchPlugin
         $this->response = $response;
     }
 
+    /**
+     * @param ActionInterface $subject
+     * @param callable $proceed
+     * @return ResponseInterface
+     * 
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
     public function aroundExecute(ActionInterface $subject, callable $proceed)
     {
         return $this->actionFlag->get('', ActionInterface::FLAG_NO_DISPATCH) ? $this->response : $proceed();

--- a/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/ActionFlagNoDispatchPlugin.php
@@ -7,7 +7,7 @@ use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\ResponseInterface;
 
 /**
- *
+ * Do not call Action::execute() if the action flag FLAG_NO_DISPATCH is set.
  */
 class ActionFlagNoDispatchPlugin
 {
@@ -28,6 +28,8 @@ class ActionFlagNoDispatchPlugin
     }
 
     /**
+     * Do not call proceed if the no dispatch action flag is set.
+     *
      * @param ActionInterface $subject
      * @param callable $proceed
      * @return ResponseInterface

--- a/lib/internal/Magento/Framework/App/Action/Plugin/Design.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/Design.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\App\Action\Plugin;
 
 use Magento\Framework\Message\MessageInterface;
@@ -35,15 +36,12 @@ class Design
      * Initialize design
      *
      * @param \Magento\Framework\App\ActionInterface $subject
-     * @param \Magento\Framework\App\RequestInterface $request
      *
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeDispatch(
-        \Magento\Framework\App\ActionInterface $subject,
-        \Magento\Framework\App\RequestInterface $request
-    ) {
+    public function beforeExecute(\Magento\Framework\App\ActionInterface $subject)
+    {
         try {
             $this->_designLoader->load();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -38,6 +38,8 @@ class EventDispatchPlugin
     public function beforeExecute(ActionInterface $subject)
     {
         $this->dispatchPreDispatchEvents($subject);
+        
+        return [];
     }
 
     /**
@@ -56,7 +58,7 @@ class EventDispatchPlugin
      */
     public function afterExecute(ActionInterface $subject, $result)
     {
-        if (! $this->isSetActionNoPostDispatchFlag($subject)) {
+        if (! $this->isSetActionNoPostDispatchFlag()) {
             $this->dispatchPostDispatchEvents($subject);
         }
         
@@ -66,8 +68,9 @@ class EventDispatchPlugin
     /**
      * @param ActionInterface $subject
      * @return bool
+     * 
      */
-    private function isSetActionNoPostDispatchFlag(ActionInterface $subject): bool
+    private function isSetActionNoPostDispatchFlag(): bool
     {
         return $this->actionFlag->get('', Action::FLAG_NO_DISPATCH) ||
                $this->actionFlag->get('', Action::FLAG_NO_POST_DISPATCH);

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -68,7 +68,7 @@ class EventDispatchPlugin
     /**
      * @param ActionInterface $subject
      * @return bool
-     * 
+     *
      */
     private function isSetActionNoPostDispatchFlag(): bool
     {

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Magento\Framework\App\Action\Plugin;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\HTTP\PhpEnvironment\Response;
+
+class EventDispatchPlugin
+{
+    /**
+     * @var Http|RequestInterface
+     */
+    private $request;
+
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    public function __construct(RequestInterface $request, ManagerInterface $eventManager)
+    {
+        \assert($request instanceof Http, sprintf('The request has to be an instance of %s.', Http::class));
+        $this->request = $request;
+        $this->eventManager = $eventManager;
+    }
+
+    public function beforeExecute(ActionInterface $subject)
+    {
+        $this->dispatchPreDispatchEvents($subject);
+    }
+
+    /**
+     * @param ActionInterface $subject
+     * @return mixed[]
+     */
+    private function getEventParameters(ActionInterface $subject): array
+    {
+        return ['controller_action' => $subject, 'request' => $this->request];
+    }
+
+    /**
+     * @param ActionInterface $subject
+     * @param ResultInterface|Response|null $result
+     * @return ResultInterface|Response|null
+     */
+    public function afterExecute(ActionInterface $subject, $result)
+    {
+        if (! $this->isSetActionNoPostDispatchFlag($subject)) {
+            $this->dispatchPostDispatchEvents($subject);
+        }
+        
+        return $result;
+    }
+
+    /**
+     * @param ActionInterface $subject
+     * @return bool
+     */
+    private function isSetActionNoPostDispatchFlag(ActionInterface $subject): bool
+    {
+        return $subject instanceof Action && $subject->getActionFlag()->get('', Action::FLAG_NO_POST_DISPATCH);
+    }
+
+    /**
+     * @param ActionInterface $action
+     */
+    private function dispatchPreDispatchEvents(ActionInterface $action)
+    {
+        $this->eventManager->dispatch('controller_action_predispatch', $this->getEventParameters($action));
+        $this->eventManager->dispatch(
+            'controller_action_predispatch_' . $this->request->getRouteName(),
+            $this->getEventParameters($action)
+        );
+        $this->eventManager->dispatch(
+            'controller_action_predispatch_' . $this->request->getFullActionName(),
+            $this->getEventParameters($action)
+        );
+    }
+
+    /**
+     * @param ActionInterface $action
+     */
+    private function dispatchPostDispatchEvents(ActionInterface $action)
+    {
+        $this->eventManager->dispatch(
+            'controller_action_postdispatch_' . $this->request->getFullActionName(),
+            $this->getEventParameters($action)
+        );
+        $this->eventManager->dispatch(
+            'controller_action_postdispatch_' . $this->request->getRouteName(),
+            $this->getEventParameters($action)
+        );
+        $this->eventManager->dispatch('controller_action_postdispatch', $this->getEventParameters($action));
+    }
+}

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -3,6 +3,7 @@
 namespace Magento\Framework\App\Action\Plugin;
 
 use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\ActionFlag;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\RequestInterface;
@@ -22,11 +23,16 @@ class EventDispatchPlugin
      */
     private $eventManager;
 
-    public function __construct(RequestInterface $request, ManagerInterface $eventManager)
+    /**
+     * @var ActionFlag
+     */
+    private $actionFlag;
+
+    public function __construct(RequestInterface $request, ManagerInterface $eventManager, ActionFlag $actionFlag)
     {
-        \assert($request instanceof Http, sprintf('The request has to be an instance of %s.', Http::class));
         $this->request = $request;
         $this->eventManager = $eventManager;
+        $this->actionFlag = $actionFlag;
     }
 
     public function beforeExecute(ActionInterface $subject)
@@ -63,7 +69,7 @@ class EventDispatchPlugin
      */
     private function isSetActionNoPostDispatchFlag(ActionInterface $subject): bool
     {
-        return $subject instanceof Action && $subject->getActionFlag()->get('', Action::FLAG_NO_POST_DISPATCH);
+        return $this->actionFlag->get('', Action::FLAG_NO_POST_DISPATCH);
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -12,7 +12,7 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\HTTP\PhpEnvironment\Response;
 
 /**
- *
+ * Dispatch the controller_action_predispatch and controller_action_post_dispatch events.
  */
 class EventDispatchPlugin
 {
@@ -38,12 +38,19 @@ class EventDispatchPlugin
         $this->actionFlag = $actionFlag;
     }
 
+    /**
+     * Trigger the controller_action_predispatch events
+     *
+     * @param ActionInterface $subject
+     */
     public function beforeExecute(ActionInterface $subject)
     {
         $this->dispatchPreDispatchEvents($subject);
     }
 
     /**
+     * Build the event parameter array
+     *
      * @param ActionInterface $subject
      * @return mixed[]
      */
@@ -53,6 +60,8 @@ class EventDispatchPlugin
     }
 
     /**
+     * Trigger the controller_action_postdispatch events if the suppressing action flag is not set
+     *
      * @param ActionInterface $subject
      * @param ResultInterface|Response|null $result
      * @return ResultInterface|Response|null
@@ -67,6 +76,8 @@ class EventDispatchPlugin
     }
 
     /**
+     * Check if action flags are set that would suppress the post dispatch events.
+     *
      * @param ActionInterface $subject
      * @return bool
      *
@@ -78,6 +89,8 @@ class EventDispatchPlugin
     }
 
     /**
+     * Dispatch the controller_action_predispatch events.
+     *
      * @param ActionInterface $action
      */
     private function dispatchPreDispatchEvents(ActionInterface $action)
@@ -94,6 +107,8 @@ class EventDispatchPlugin
     }
 
     /**
+     * Dispatch the controller_action_postdispatch events.
+     *
      * @param ActionInterface $action
      */
     private function dispatchPostDispatchEvents(ActionInterface $action)

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -69,7 +69,8 @@ class EventDispatchPlugin
      */
     private function isSetActionNoPostDispatchFlag(ActionInterface $subject): bool
     {
-        return $this->actionFlag->get('', Action::FLAG_NO_POST_DISPATCH);
+        return $this->actionFlag->get('', Action::FLAG_NO_DISPATCH) ||
+               $this->actionFlag->get('', Action::FLAG_NO_POST_DISPATCH);
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -11,6 +11,9 @@ use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\HTTP\PhpEnvironment\Response;
 
+/**
+ * 
+ */
 class EventDispatchPlugin
 {
     /**
@@ -38,8 +41,6 @@ class EventDispatchPlugin
     public function beforeExecute(ActionInterface $subject)
     {
         $this->dispatchPreDispatchEvents($subject);
-        
-        return [];
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
+++ b/lib/internal/Magento/Framework/App/Action/Plugin/EventDispatchPlugin.php
@@ -12,7 +12,7 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\HTTP\PhpEnvironment\Response;
 
 /**
- * 
+ *
  */
 class EventDispatchPlugin
 {

--- a/lib/internal/Magento/Framework/App/ActionInterface.php
+++ b/lib/internal/Magento/Framework/App/ActionInterface.php
@@ -25,8 +25,6 @@ interface ActionInterface
     /**
      * Execute action based on request and return result
      *
-     * Note: Request will be added as operation argument in future
-     *
      * @return \Magento\Framework\Controller\ResultInterface|ResponseInterface
      * @throws \Magento\Framework\Exception\NotFoundException
      */

--- a/lib/internal/Magento/Framework/App/Test/Unit/Action/Plugin/DesignTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Action/Plugin/DesignTest.php
@@ -7,14 +7,13 @@ namespace Magento\Framework\App\Test\Unit\Action\Plugin;
 
 class DesignTest extends \PHPUnit\Framework\TestCase
 {
-    public function testAroundDispatch()
+    public function testBeforeExecute()
     {
         $subjectMock = $this->createMock(\Magento\Framework\App\Action\Action::class);
         $designLoaderMock = $this->createMock(\Magento\Framework\View\DesignLoader::class);
         $messageManagerMock = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
-        $requestMock = $this->createMock(\Magento\Framework\App\RequestInterface::class);
         $plugin = new \Magento\Framework\App\Action\Plugin\Design($designLoaderMock, $messageManagerMock);
         $designLoaderMock->expects($this->once())->method('load');
-        $plugin->beforeDispatch($subjectMock, $requestMock);
+        $plugin->beforeExecute($subjectMock);
     }
 }


### PR DESCRIPTION
### Description
Kindly see issue https://github.com/magento/community-features/issues/9 for detailed information.

### Fixed Issues (if relevant)
All the CE unit and integration tests pass. The big question is how the EE will do.
When this PR is merged, frontend action controllers don't have to extend AbstractAction, they only have to implement the ActionInterface.

This PR mainly moves the dispatching of the controller_predispatch events into a plugin.  
It also changes the plugins for `Action::dispatch()` method to `ActionInterface::execute()`.  
Finally, it preserves the behavior in regards to the `NO_DISPATCH` and `NO_POST_DISPATCH` action flags.

Backend action controllers still have to extend the backend module abstract Action for authentication - moving that to a plugin will be a separate PR.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

  