### PR TITLE
Fix JS error on cart from postcode validation when 'US' is deselected as an allowed country

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
@@ -79,6 +79,7 @@ define(
                      */
                     onError: function (response) {
                         braintree.showError($t('Payment ' + this.getTitle() + ' can\'t be initialized'));
+                        this.isPlaceOrderActionAllowed(true);
                         throw response.message;
                     },
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -57,7 +57,7 @@ $stores = $block->getStoresSortedBySortOrder();
         <input type="hidden" id="option-count-check" value="" />
     </div>
     <script id="row-template" type="text/x-magento-template">
-         <tr>
+        <tr <% if (data.rowClasses) { %>class="<%- data.rowClasses %>"<% } %>>
             <td class="col-draggable">
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()): ?>
                     <div data-role="draggable-handle" class="draggable-handle"

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/options.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/options.js
@@ -24,6 +24,7 @@ define([
                 totalItems: 0,
                 rendered: 0,
                 template: mageTemplate('#row-template'),
+                newOptionClass: 'new-option',
                 isReadOnly: config.isReadOnly,
                 add: function (data, render) {
                     var isNewOption = false,
@@ -32,7 +33,8 @@ define([
                     if (typeof data.id == 'undefined') {
                         data = {
                             'id': 'option_' + this.itemCount,
-                            'sort_order': this.itemCount + 1
+                            'sort_order': this.itemCount + 1,
+                            'rowClasses': this.newOptionClass
                         };
                         isNewOption = true;
                     }
@@ -81,11 +83,12 @@ define([
                         element.addClassName('no-display');
                         element.addClassName('template');
                         element.hide();
-                        jQuery(element).find('input').each(function(index, el) {
-                            el.disabled = 'disabled';
-                        });
                         this.totalItems--;
                         this.updateItemsCountField();
+                    }
+
+                    if (element.hasClassName(this.newOptionClass)) {
+                        element.remove();
                     }
                 },
                 updateItemsCountField: function () {

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/options.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/options.js
@@ -81,6 +81,9 @@ define([
                         element.addClassName('no-display');
                         element.addClassName('template');
                         element.hide();
+                        jQuery(element).find('input').each(function(index, el) {
+                            el.disabled = 'disabled';
+                        });
                         this.totalItems--;
                         this.updateItemsCountField();
                     }

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
@@ -357,12 +357,12 @@ define([
             var element;
 
             _.each(this.disabledAttributes, function (attribute) {
-                registry.get('index = ' + attribute).disabled(false);
+                registry.get('code = ' + attribute, 'index = ' + attribute).disabled(false);
             });
             this.disabledAttributes = [];
 
             _.each(attributes, function (attribute) {
-                element = registry.get('index = ' + attribute.code);
+                element = registry.get('code = ' + attribute.code, 'index = ' + attribute.code);
 
                 if (!_.isUndefined(element)) {
                     element.disabled(true);

--- a/app/code/Magento/Ui/view/base/web/js/form/element/region.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/region.js
@@ -35,6 +35,11 @@ define([
                 return;
             }
             option = options[value];
+
+            if (typeof option === 'undefined') {
+                return;
+            }
+
             defaultPostCodeResolver.setUseDefaultPostCode(!option['is_zipcode_optional']);
 
             if (this.skipValidation) {

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/cc-form.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/cc-form.test.js
@@ -27,7 +27,7 @@ define([
                 ),
                 'Magento_Braintree/js/view/payment/adapter':  jasmine.createSpyObj(
                     'adapter',
-                    ['setup', 'setConfig']
+                    ['setup', 'setConfig', 'showError']
                 )
             },
             braintreeCcForm;
@@ -43,14 +43,17 @@ define([
             };
             injector.mock(mocks);
             injector.require(['Magento_Braintree/js/view/payment/method-renderer/cc-form'], function (Constr) {
-                    braintreeCcForm = new Constr({
-                        provider: 'provName',
-                        name: 'test',
-                        index: 'test'
-                    });
-
-                    done();
+                braintreeCcForm = new Constr({
+                    provider: 'provName',
+                    name: 'test',
+                    index: 'test',
+                    item: {
+                        title: 'Braintree'
+                    }
                 });
+
+                done();
+            });
         });
 
         it('Check if payment code and message container are restored after onActiveChange call.', function () {
@@ -64,6 +67,22 @@ define([
 
             expect(braintreeCcForm.getCode()).toEqual(expectedCode);
             expect(braintreeCcForm.messageContainer).toEqual(expectedMessageContainer);
+        });
+
+        it('Check if form validation fails when "Place Order" button should be active.', function () {
+            var errorMessage = 'Something went wrong.',
+
+                /**
+                 * Anonymous wrapper
+                 */
+                func = function () {
+                    braintreeCcForm.clientConfig.onError({
+                        'message': errorMessage
+                    });
+                };
+
+            expect(func).toThrow(errorMessage);
+            expect(braintreeCcForm.isPlaceOrderActionAllowed()).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
### Description
On the cart page the postcode validation can cause a JS error `Uncaught TypeError: Cannot read property 'is_zipcode_optional' of undefined`.

![screen shot 2018-01-08 at 10 23 47](https://user-images.githubusercontent.com/221714/34666851-3a8a27be-f45e-11e7-9c67-3ca52907a046.png)

To get this error the Magento store has to have deselected 'United States' in the 'Allowed Countries' admin option. Select any country except 'United States' as the default country:- Admin -> Stores -> configuration -> General -> Default Country

If this is the case then Magento will actually cycle through the update() method in `app/code/Magento/Ui/view/base/web/js/form/element/region.js` twice. Once with the two letter code for the country selected as the 'Default Country' and once with the 'US' country code regardless ofwhether the 'United States' is selected as the default country. If the 'United States' is deselected in the 'Allowed Countries' when the update() method in region.js runs using a value of 'US' the 'option' variable in the update() method is undefined. This code checks for this scenario and returns early.

### Manual testing scenarios
1. Create a Store using Magento 2.2.2
2. Select any country except 'United States' as the default country:- Admin -> Stores -> configuration -> General -> Default Country
3. Deselect 'United States' in the 'Allowed Countries' option:- Admin -> Stores -> configuration -> General -> Allow Countries
![screen shot 2018-01-08 at 10 26 05](https://user-images.githubusercontent.com/221714/34667000-f8dc5b9c-f45e-11e7-8980-10e55ff18ed5.png)
3. Add a product to cart and visit the cart page
4. Open up your browsers inspect tool to see the JS error
