### PR TITLE
Updated cron documentation URL to 2.2

### DIFF
--- a/app/code/Magento/Indexer/Model/Message/Invalid.php
+++ b/app/code/Magento/Indexer/Model/Message/Invalid.php
@@ -71,7 +71,7 @@ class Invalid implements \Magento\Framework\Notification\MessageInterface
         return __(
             'One or more <a href="%1">indexers are invalid</a>. Make sure your <a href="%2" target="_blank">Magento cron job</a> is running.',
             $url,
-            'http://devdocs.magento.com/guides/v2.0/config-guide/cli/config-cli-subcommands-cron.html#config-cli-cron-bkg'
+            'http://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-cron.html#create-or-remove-the-magento-crontab'
         );
         //@codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
### Description
The documentation for setting up the cron jobs has updated significantly since 2.0/2.1, as Magento now automates the creation of the crontab. It is now worth pointing users to the new version of the documentation, as the installation instructions on the old documentation are now redundant.

### Fixed Issues (if relevant)
None

### Manual testing scenarios
1. Ensure that the URL specified points to the relevant section of the cron 2.2 documentation.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
