### PR TITLE
Fix JS error on cart from postcode validation when 'US' is deselected as an allowed country

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/region.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/region.js
@@ -35,6 +35,11 @@ define([
                 return;
             }
             option = options[value];
+
+            if (typeof option === 'undefined') {
+                return;
+            }
+
             defaultPostCodeResolver.setUseDefaultPostCode(!option['is_zipcode_optional']);
 
             if (this.skipValidation) {


### PR DESCRIPTION
### Description
On the cart page the postcode validation can cause a JS error Uncaught TypeError: Cannot read property 'is_zipcode_optional' of undefined.
![screen shot 2018-01-08 at 10 23 47](https://user-images.githubusercontent.com/221714/34667828-9da86c44-f462-11e7-85dc-307298c72e42.png)

To get this error the Magento store has to have deselected 'United States' in the 'Allowed Countries' admin option. Select any country except 'United States' as the default country:- Admin -> Stores -> configuration -> General -> Default Country

If this is the case then Magento will actually cycle through the update() method in app/code/Magento/Ui/view/base/web/js/form/element/region.js twice. Once with the two letter code for the country selected as the 'Default Country' and once with the 'US' country code regardless ofwhether the 'United States' is selected as the default country. If the 'United States' is deselected in the 'Allowed Countries' when the update() method in region.js runs using a value of 'US' the 'option' variable in the update() method is undefined. This code checks for this scenario and returns early.

### Manual testing scenarios
1. Create a Store using Magento 2.2.2
2. Select any country except 'United States' as the default country:- Admin -> Stores -> configuration -> General -> Default Country
3. Deselect 'United States' in the 'Allowed Countries' option:- Admin -> Stores -> configuration -> General -> Allow Countries.
![screen shot 2018-01-08 at 10 26 05](https://user-images.githubusercontent.com/221714/34667813-8b5bb488-f462-11e7-9eae-c1e92ec94e13.png)
4. Add a product to cart and visit the cart page
5. Open up your browsers inspect tool to see the JS error

