### PR TITLE
solution for 12825 issue

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
@@ -103,6 +103,12 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
         )->where(
             'attribute.attribute_id = ?',
             $superAttribute->getAttributeId()
+        )->joinInner(
+            ['attribute_opt' => $this->attributeResource->getTable('eav_attribute_option')],
+            'attribute_opt.option_id = entity_value.value',
+            []
+        )->order(
+            'attribute_opt.sort_order ASC'
         );
 
         if (!$superAttribute->getSourceModel()) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Swatch Attribute sorting is not working after updating the position of the attribute options (using drag)

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12825: Configurable options(Text swatch) type does not order on the basis of the sort order provided


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Store -> Attributes -> Product -> Edit Swatch Attribute -> Change option sort order  (using Drag)
2. Go to Product page does not display attribute options, sort order wise
3. Please follow issue number #12825 .

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
