### PR TITLE
Fix Magento_Checkout address formatting

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/details.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/details.html
@@ -7,7 +7,7 @@
 <div class="billing-address-details" data-bind="if: isAddressDetailsVisible() && currentBillingAddress()">
     <!-- ko text: currentBillingAddress().prefix --><!-- /ko --> <!-- ko text: currentBillingAddress().firstname --><!-- /ko --> <!-- ko text: currentBillingAddress().middlename --><!-- /ko -->
     <!-- ko text: currentBillingAddress().lastname --><!-- /ko --> <!-- ko text: currentBillingAddress().suffix --><!-- /ko --><br/>
-    <!-- ko text: currentBillingAddress().street --><!-- /ko --><br/>
+    <!-- ko text: _.values(currentBillingAddress().street).join(", ") --><!-- /ko --><br/>
     <!-- ko text: currentBillingAddress().city --><!-- /ko -->, <span data-bind="html: currentBillingAddress().region"></span> <!-- ko text: currentBillingAddress().postcode --><!-- /ko --><br/>
     <!-- ko text: getCountryName(currentBillingAddress().countryId) --><!-- /ko --><br/>
     <!-- ko if: (currentBillingAddress().telephone) -->

--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-information/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-information/address-renderer/default.html
@@ -7,7 +7,7 @@
 <!-- ko if: (visible()) -->
     <!-- ko text: address().prefix --><!-- /ko --> <!-- ko text: address().firstname --><!-- /ko --> <!-- ko text: address().middlename --><!-- /ko -->
     <!-- ko text: address().lastname --><!-- /ko --> <!-- ko text: address().suffix --><!-- /ko --><br/>
-    <!-- ko text: address().street --><!-- /ko --><br/>
+    <!-- ko text: _.values(address().street).join(", ") --><!-- /ko --><br/>
     <!-- ko text: address().city --><!-- /ko -->, <span data-bind="html: address().region"></span> <!-- ko text: address().postcode --><!-- /ko --><br/>
     <!-- ko text: getCountryName(address().countryId) --><!-- /ko --><br/>
     <!-- ko if: (address().telephone) -->


### PR DESCRIPTION
### Description

This pull request fixes street format spacing when multiple streets are present to be consistent across **Shipping** and **Review & Payments** checkout steps.

![screen shot 2018-01-10 at 12 03 03 am](https://user-images.githubusercontent.com/14304240/34757870-0da20506-f5a2-11e7-835b-cf11aa682ae7.png)

![screen shot 2018-01-10 at 12 03 19 am](https://user-images.githubusercontent.com/14304240/34757878-14f64948-f5a2-11e7-9004-44c47a079eb6.png)

### Manual testing scenarios

1. On the frontend, create a customer account and enter a default address (leaving the **street_2** form field blank).
2. Add products to the cart and **Proceed to Checkout**
3. Review the shipping address formats on both **Shipping** and **Review & Payments** checkout steps
4. Update customer account address to include the **street_2** form field
5. Repeat steps **2 and 3** ensuring the spacing is consistent

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
