### PR TITLE
Solution for 12825 issue.

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
@@ -97,6 +97,12 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
         )->where(
             'attribute.attribute_id = ?',
             $superAttribute->getAttributeId()
+        )->joinInner(
+            ['attribute_opt' => $this->attributeResource->getTable('eav_attribute_option')],
+            'attribute_opt.option_id = entity_value.value',
+            []
+        )->order(
+            'attribute_opt.sort_order ASC'
         );
 
         if (!$superAttribute->getSourceModel()) {

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Attribute/OptionSelectBuilderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Attribute/OptionSelectBuilderTest.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\ConfigurableProduct\Test\Unit\Model\ResourceModel\Attribute;
 
+use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionProvider;
 use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionSelectBuilder;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute;
-use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionProvider;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Framework\App\ScopeInterface;
-use Magento\Framework\DB\Select;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 
 /**
@@ -58,7 +58,7 @@ class OptionSelectBuilderTest extends \PHPUnit\Framework\TestCase
      * @var ScopeInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $scope;
-    
+
     protected function setUp()
     {
         $this->connectionMock = $this->getMockBuilder(AdapterInterface::class)
@@ -112,7 +112,7 @@ class OptionSelectBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->select->expects($this->exactly(1))->method('from')->willReturnSelf();
         $this->select->expects($this->exactly(1))->method('columns')->willReturnSelf();
-        $this->select->expects($this->exactly(5))->method('joinInner')->willReturnSelf();
+        $this->select->expects($this->exactly(6))->method('joinInner')->willReturnSelf();
         $this->select->expects($this->exactly(3))->method('joinLeft')->willReturnSelf();
         $this->select->expects($this->exactly(2))->method('where')->willReturnSelf();
 

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Attribute/OptionSelectBuilderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Attribute/OptionSelectBuilderTest.php
@@ -138,7 +138,7 @@ class OptionSelectBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->select->expects($this->exactly(1))->method('from')->willReturnSelf();
         $this->select->expects($this->exactly(0))->method('columns')->willReturnSelf();
-        $this->select->expects($this->exactly(5))->method('joinInner')->willReturnSelf();
+        $this->select->expects($this->exactly(6))->method('joinInner')->willReturnSelf();
         $this->select->expects($this->exactly(1))->method('joinLeft')->willReturnSelf();
         $this->select->expects($this->exactly(2))->method('where')->willReturnSelf();
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Swatch Attribute sorting is not working after updating the position of the attribute options (using drag)
### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12825: Configurable options(Text swatch) type does not order on the basis of the sort order provided

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Store -> Attributes -> Product -> Edit Swatch Attribute -> Change option sort order (using Drag)
2. Go to Product page does not display attribute options, sort order wise.
3. Please follow issue number #12825

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
