### PR TITLE
Add failsafe to items.phtml

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -151,7 +151,7 @@ switch ($type = $block->getType()) {
 }
 ?>
 
-<?php if (isset($exist)):?>
+<?php if (isset($exist) && $exist):?>
 
     <?php if ($type == 'related' || $type == 'upsell'): ?>
         <?php if ($type == 'related'): ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -147,11 +147,15 @@ switch ($type = $block->getType()) {
     break;
 
     case 'other':
+        $exist = null;
     break;
+
+    default:
+        $exist = null;
 }
 ?>
 
-<?php if (isset($exist) && $exist):?>
+<?php if ($exist):?>
 
     <?php if ($type == 'related' || $type == 'upsell'): ?>
         <?php if ($type == 'related'): ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -147,15 +147,11 @@ switch ($type = $block->getType()) {
     break;
 
     case 'other':
-        $exist = null;
     break;
-        
-    default:
-        $exist = null;
 }
 ?>
 
-<?php if ($exist):?>
+<?php if (isset($exist)):?>
 
     <?php if ($type == 'related' || $type == 'upsell'): ?>
         <?php if ($type == 'related'): ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -146,10 +146,6 @@ switch ($type = $block->getType()) {
         }
     break;
 
-    case 'other':
-        $exist = null;
-    break;
-
     default:
         $exist = null;
 }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -147,7 +147,11 @@ switch ($type = $block->getType()) {
     break;
 
     case 'other':
+        $exist = null;
     break;
+        
+    default:
+        $exist = null;
 }
 ?>
 


### PR DESCRIPTION
### Description
We received a warning that $exist is undefined - not entirely sure what the exact scenario was but adding this as a failsafe.

I have made sure that $exist is defined (null) in the 'default' and 'other' case.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

  