### PR TITLE
Don't try to merge array with null

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer.php
@@ -128,7 +128,7 @@ class Writer
                 $currentData = $this->reader->load($fileKey);
                 $currentComments = $this->commentParser->execute($paths[$fileKey]);
 
-                if ($currentData) {
+                if (is_array($currentData)) {
                     if ($override) {
                         $config = array_merge($currentData, $config);
                     } else {


### PR DESCRIPTION
### Description

When starting the installer the first time, the current config provided to the deployment config writer is not an array, thus `array_replace_recursive` emits a warning. With a stricter error handler this will be converted to an exception which prevents running the installer entirely.

This change fixes the behaviour by checking if the current config is present and resumes operation with the already initialized factory config.
  