### PR TITLE
Magento Backend Login since 2.1.10 / 2.2 does not autocomplete passwords

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/login.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/login.phtml
@@ -27,7 +27,7 @@
                        value=""
                        data-validate="{required:true}"
                        placeholder="<?= /* @escapeNotVerified */ __('user name') ?>"
-                       autocomplete="off"
+                       autocomplete="username"
                     />
             </div>
         </div>
@@ -43,7 +43,7 @@
                        data-validate="{required:true}"
                        value=""
                        placeholder="<?= /* @escapeNotVerified */ __('password') ?>"
-                       autocomplete="new-password"
+                       autocomplete="current-password"
                     />
             </div>
         </div>


### PR DESCRIPTION
### Description
Since upgrading to 2.1.10 (even 2.2) the Backend login for Magento 2 no longer autocompletes passwords, a useful browser feature for easing login to websites by allowing significantly more complex and secure passwords to be protected under a single user password that is then protected by corporate policies that enforce complexity and rotation. It also eases the risk during the window between leavers being removed from corporate login and being removed from Magento.

It seems previously Magento tried to use autocomplete "off" to disable this feature. However, many browser vendors consider this to be "abusive" as it disables key browser features, so choose to ignore autocomplete "off" on any password fields.

> There is a general consensus within Chrome that there are no security benefits to autocomplete="off".
>
> (Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c17)

This PR restores the previously functionality that allowed autocompletion of password in Magento backend login but improves it to use the new autocomplete HTML5 values `username` and `current-password`.

### Manual testing scenarios
1. Load Magento backend login, and login, no prompt is given to save password

or

1. If you previously had saved password for Magento login before upgrading, it is no longer autofilled

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)