### PR TITLE
Fixed typo in event name

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -204,6 +204,12 @@ class DataProvider
             /** @var \Magento\Eav\Model\Entity\Attribute[] $attributes */
             $attributes = $productAttributes->getItems();
 
+            /** @deprecated */
+            $this->eventManager->dispatch(
+                'catelogsearch_searchable_attributes_load_after',
+                ['engine' => $this->engine, 'attributes' => $attributes]
+            );
+            
             $this->eventManager->dispatch(
                 'catalogsearch_searchable_attributes_load_after',
                 ['engine' => $this->engine, 'attributes' => $attributes]

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -205,7 +205,7 @@ class DataProvider
             $attributes = $productAttributes->getItems();
 
             $this->eventManager->dispatch(
-                'catelogsearch_searchable_attributes_load_after',
+                'catalogsearch_searchable_attributes_load_after',
                 ['engine' => $this->engine, 'attributes' => $attributes]
             );
 


### PR DESCRIPTION
There is a typo in a event name, changed "catelog" to "catalog". Checked complete Magento core code and the wrongly spelled "catelog" string is not found in other places, so this is safe to merge. 