### PR TITLE
11828 Fix issue with swatch colour block not showing in admin panel once colour selected (PHP7.1.x issue).

### DIFF
--- a/app/code/Magento/Swatches/Block/Adminhtml/Attribute/Edit/Options/Visual.php
+++ b/app/code/Magento/Swatches/Block/Adminhtml/Attribute/Edit/Options/Visual.php
@@ -84,15 +84,15 @@ class Visual extends AbstractSwatch
      * Parse swatch labels for template
      *
      * @codeCoverageIgnore
-     * @param null $swatchStoreValue
-     * @return string
+     * @param null|array $swatchStoreValue
+     * @return null|array
      */
     protected function reformatSwatchLabels($swatchStoreValue = null)
     {
         if ($swatchStoreValue === null) {
             return;
         }
-        $newSwatch = '';
+        $newSwatch = [];
         foreach ($swatchStoreValue as $key => $value) {
             if ($value[0] == '#') {
                 $newSwatch[$key] = 'background: '.$value;


### PR DESCRIPTION
### Description
Using PHP7.1.x the swatch colour block preview in the admin panel attribute will not show the actual colour as the inline style is set to style"b". This is due to PHP no longer allowing strings to be manipulated as arrays.

### Fixed Issues (if relevant)
1. magento/magento2#11828: Visual Swatches not showing swatch color in admin

### Manual testing scenarios
**Preconditions**
Magento CE 2.2
PHP 7.1.0
**Steps to reproduce**
Inside admin, go to Stores->Product and click on an attribute that contains visual swatches.
**Expected result**
Visual Swatches that have a color assigned should show that color in the swatch box.
**Actual result**
Although the color swatch values are being saved, the visual representation of the color in the box is colorless.

### Contribution checklist
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds on Travis CI are green)
