### PR TITLE
Get current order ID on success page

### DIFF
--- a/app/code/Magento/Checkout/Model/Session.php
+++ b/app/code/Magento/Checkout/Model/Session.php
@@ -439,7 +439,12 @@ class Session extends \Magento\Framework\Session\SessionManager
      */
     public function clearHelperData()
     {
-        $this->setRedirectUrl(null)->setLastOrderId(null)->setLastRealOrderId(null)->setAdditionalMessages(null);
+        $this->setRedirectUrl(null)
+            ->setLastOrderId(null)
+            ->setLastOrderIds(null)
+            ->setLastRealOrderId(null)
+            ->setAdditionalMessages(null);
+
     }
 
     /**

--- a/app/code/Magento/Checkout/Model/Type/Onepage.php
+++ b/app/code/Magento/Checkout/Model/Type/Onepage.php
@@ -735,9 +735,11 @@ class Onepage
                 }
             }
 
+
             // add order information to the session
             $this->_checkoutSession
                 ->setLastOrderId($order->getId())
+                ->setLastOrderIds([$order->getId() => $order->getIncrementId()])
                 ->setRedirectUrl($redirectUrl)
                 ->setLastRealOrderId($order->getIncrementId())
                 ->setLastOrderStatus($order->getStatus());

--- a/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
+++ b/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
@@ -770,7 +770,8 @@ class Multishipping extends \Magento\Framework\DataObject
             }
 
             $this->_session->setOrderIds($orderIds);
-            $this->_checkoutSession->setLastQuoteId($this->getQuote()->getId());
+            $this->_checkoutSession->setLastQuoteId($this->getQuote()->getId())
+                ->setLastOrderIds($orderIds);
 
             $this->getQuote()->setIsActive(false);
             $this->quoteRepository->save($this->getQuote());

--- a/app/code/Magento/Paypal/Controller/Express/AbstractExpress/PlaceOrder.php
+++ b/app/code/Magento/Paypal/Controller/Express/AbstractExpress/PlaceOrder.php
@@ -90,7 +90,9 @@ class PlaceOrder extends \Magento\Paypal\Controller\Express\AbstractExpress
             // an order may be created
             $order = $this->_checkout->getOrder();
             if ($order) {
-                $this->_getCheckoutSession()->setLastOrderId($order->getId())
+                $this->_getCheckoutSession()
+                    ->setLastOrderId($order->getId())
+                    ->setLastOrderIds([$order->getId() => $order->getIncrementId()])
                     ->setLastRealOrderId($order->getIncrementId())
                     ->setLastOrderStatus($order->getStatus());
             }

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -369,11 +369,12 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
             );
         }
 
-        $this->checkoutSession->setLastQuoteId($quote->getId());
-        $this->checkoutSession->setLastSuccessQuoteId($quote->getId());
-        $this->checkoutSession->setLastOrderId($order->getId());
-        $this->checkoutSession->setLastRealOrderId($order->getIncrementId());
-        $this->checkoutSession->setLastOrderStatus($order->getStatus());
+        $this->checkoutSession->setLastQuoteId($quote->getId())
+            ->setLastSuccessQuoteId($quote->getId())
+            ->setLastOrderId($order->getId())
+            ->setLastOrderIds([$order->getId() => $order->getIncrementId()])
+            ->setLastRealOrderId($order->getIncrementId())
+            ->setLastOrderStatus($order->getStatus());
 
         $this->eventManager->dispatch('checkout_submit_all_after', ['order' => $order, 'quote' => $quote]);
         return $order->getId();


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Currently, Magento is using a mixture of observer or Magento\Checkout\Model\Session to return order id on success page which make some implementation difficult because the session method does not support multi-shipping.

This PR will make it more consistent to access order id using ``Magento\Checkout\Model\Session::getLastOrderIds()`` which return an array ([order_id => increment_id]) to support mutlishipping 

See

Session - https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/Block/Registration.php#L119

Observer - https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/GoogleAnalytics/Observer/SetGoogleAnalyticsOnOrderSuccessPageViewObserver.php#L57


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. not needed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
