### PR TITLE
Visual swatch images/colors were not visible in backoffice

### DIFF
--- a/app/code/Magento/Swatches/Block/Adminhtml/Attribute/Edit/Options/Visual.php
+++ b/app/code/Magento/Swatches/Block/Adminhtml/Attribute/Edit/Options/Visual.php
@@ -85,14 +85,14 @@ class Visual extends AbstractSwatch
      *
      * @codeCoverageIgnore
      * @param null $swatchStoreValue
-     * @return string
+     * @return array
      */
     protected function reformatSwatchLabels($swatchStoreValue = null)
     {
         if ($swatchStoreValue === null) {
             return;
         }
-        $newSwatch = '';
+        $newSwatch = [];
         foreach ($swatchStoreValue as $key => $value) {
             if ($value[0] == '#') {
                 $newSwatch[$key] = 'background: '.$value;


### PR DESCRIPTION
Visual swatch images/colors were not visible in backoffice

### Description
In `app/code/Magento/Swatches/Block/Adminhtml/Attribute/Edit/Options/Visual.php` at line 95: $newSwatch was initialized as a string but it was used as an array in both the function body and in the calling function.
This resulted in $newSwatch was always set to "b" (the first letter of "background"), and so the view did not get a correct value for `style="background: url('xxxxx.xxx'); background-size: cover;"`
This issue is only visible for PHP 7

### Fixed Issues (if relevant)
I fixed it before posting an issue. Maybe there is one but I could not find it.

### Manual testing scenarios
1. Install Magento 2.2.2 on a PHP 7.1.12 server
2. Add a visual swatch product attribute
3. Add some visual swatch options with an image or a color
4. Save and continue edit
5. Visual swatch images are now visible and were not before the fix

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
