### PR TITLE
Remove zend json from json result controller

### DIFF
--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -52,9 +52,13 @@ class Json extends AbstractResult
      * @param boolean $cycleCheck Optional; whether or not to check for object recursion; off by default
      * @param array $options Additional options used during encoding
      * @return $this
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {
+        if ($data instanceof \Magento\Framework\DataObject) {
+            $data = $data->toArray();
+        }
         $this->json = $this->serializer->serialize($data);
         return $this;
     }

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -29,11 +29,20 @@ class Json extends AbstractResult
     protected $json;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\Translate\InlineInterface $translateInline
      */
-    public function __construct(InlineInterface $translateInline)
-    {
+    public function __construct(
+        InlineInterface $translateInline,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+    ) {
         $this->translateInline = $translateInline;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -46,7 +55,7 @@ class Json extends AbstractResult
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {
-        $this->json = \Zend_Json::encode($data, $cycleCheck, $options);
+        $this->json = $this->serializer->serialize($data);
         return $this;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR is a reworking of https://github.com/magento/magento2/pull/10367
Since Zend_Json should no longer be used update to the `\Magento\Framework\Serialize\Serializer\Json` instead. So that we do not break backwards compatibility we will need to allow for the type `\Magento\Framework\DataObject` to be passed into the method and but we need to convert this into an array first.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Check that controllers with result json work with setting data as multiple types.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
