### PR TITLE
Log file path when image open throws exception

### DIFF
--- a/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
@@ -62,7 +62,10 @@ class Gd2 extends \Magento\Framework\Image\Adapter\AbstractAdapter
             throw new \OverflowException('Memory limit has been reached.');
         }
         $this->imageDestroy();
-        $this->_imageHandler = call_user_func($this->_getCallback('create'), $this->_fileName);
+        $this->_imageHandler = call_user_func(
+            $this->_getCallback('create', null, sprintf('Unsupported image format. File: %s', $this->_fileName)),
+            $this->_fileName
+        );
     }
 
     /**

--- a/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
@@ -77,7 +77,7 @@ class ImageMagick extends \Magento\Framework\Image\Adapter\AbstractAdapter
         try {
             $this->_imageHandler = new \Imagick($this->_fileName);
         } catch (\ImagickException $e) {
-            throw new \Exception('Unsupported image format.', $e->getCode(), $e);
+            throw new \Exception(sprintf('Unsupported image format. File: %s', $this->_fileName), $e->getCode(), $e);
         }
 
         $this->backgroundColor();


### PR DESCRIPTION
### Description
Log the offending file when opening an image throws an exception. The current exception message does a good job describing the problem, but does not tell you which file caused the issue. The proposed change would alter the log entry from:  
`Unsupported image format.`  
to:  
`Unsupported image format.: /path/to/my/bad/file.png`

### Fixed Issues (if relevant)
none

### Manual testing scenarios
1. Point product `small_image` to a corrupt/unsupported image.
2. Navigate to product list page containing product from step 1. The page should partially render, likely without any products.
3. View error report in `/var/report` to see the path to problem image.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
