### PR TITLE
Solve problem saving empty swatches in admin 

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -110,6 +110,11 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
                 $options
             );
             $valueOptions = (isset($options['value']) && is_array($options['value'])) ? $options['value'] : [];
+            foreach ($valueOptions as $key => $val) {
+                if (isset($options['delete'][$key]) && $options['delete'][$key]) {
+                    unset($valueOptions[$key]);
+                }
+            }
             $this->checkEmptyOption($response, $valueOptions);
         }
 

--- a/app/code/Magento/Swatches/view/adminhtml/web/js/visual.js
+++ b/app/code/Magento/Swatches/view/adminhtml/web/js/visual.js
@@ -138,7 +138,9 @@ define([
                             elementFlags[0].value = 1;
                         }
 
-                        element.remove();
+                        element.addClassName('no-display');
+                        element.addClassName('template');
+                        element.hide();
                         this.totalItems--;
                         this.updateItemsCountField();
                     }

--- a/app/code/Magento/Swatches/view/adminhtml/web/js/visual.js
+++ b/app/code/Magento/Swatches/view/adminhtml/web/js/visual.js
@@ -138,9 +138,7 @@ define([
                             elementFlags[0].value = 1;
                         }
 
-                        element.addClassName('no-display');
-                        element.addClassName('template');
-                        element.hide();
+                        element.remove();
                         this.totalItems--;
                         this.updateItemsCountField();
                     }


### PR DESCRIPTION

### Description
Solve problem saving empty swatches in admin remving html ement instead of add hidden.

### Fixed Issues (if relevant)

1. Swatch Attribute is not getting save while deleting a swatch row with empty admin scope text #13117

### Manual testing scenarios

1. Login to admin and Goto Store- >Attribute->Product
2. Find a attribute like color
3. Open color attribute and make it to Visual Swatch type
4. In Manage Swatches section add color swatches
5. Now Click on Add Swatch button, a row will appear just remove it without filling anything into it.
6. Now is saved. Before it throws: The value of Admin scope can't be empty.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
