### PR TITLE
Optimization: module-sales is_null change to strict comparison instead

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -681,7 +681,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
      */
     public function getCustomerWishlist($cacheReload = false)
     {
-        if (!is_null($this->_wishlist) && !$cacheReload) {
+        if (($this->_wishlist !== null) && !$cacheReload) {
             return $this->_wishlist;
         }
 
@@ -708,7 +708,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
      */
     public function getCustomerCart()
     {
-        if (!is_null($this->_cart)) {
+        if ($this->_cart !== null) {
             return $this->_cart;
         }
 
@@ -736,7 +736,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
      */
     public function getCustomerCompareList()
     {
-        if (!is_null($this->_compareList)) {
+        if ($this->_compareList !== null) {
             return $this->_compareList;
         }
         $customerId = (int)$this->getSession()->getCustomerId();
@@ -807,7 +807,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
                     break;
                 case 'cart':
                     $cart = $this->getCustomerCart();
-                    if ($cart && is_null($item->getOptionByCode('additional_options'))) {
+                    if ($cart && ($item->getOptionByCode('additional_options') === null)) {
                         //options and info buy request
                         $product = $this->_objectManager->create(
                             \Magento\Catalog\Model\Product::class
@@ -1727,7 +1727,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         }
         $data = $form->restoreData($data);
         foreach ($data as $key => $value) {
-            if (!is_null($value)) {
+            if ($value !== null) {
                 unset($data[$key]);
             }
         }
@@ -1851,12 +1851,12 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
 
         switch ($addressType) {
             case \Magento\Quote\Model\Quote\Address::ADDRESS_TYPE_BILLING:
-                if (is_null($customer->getDefaultBilling())) {
+                if ($customer->getDefaultBilling() === null) {
                     $customerAddress->setIsDefaultBilling(true);
                 }
                 break;
             case \Magento\Quote\Model\Quote\Address::ADDRESS_TYPE_SHIPPING:
-                if (is_null($customer->getDefaultShipping())) {
+                if ($customer->getDefaultShipping() === null) {
                     $customerAddress->setIsDefaultShipping(true);
                 }
                 break;
@@ -1948,7 +1948,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
     protected function _validate()
     {
         $customerId = $this->getSession()->getCustomerId();
-        if (is_null($customerId)) {
+        if ($customerId === null) {
             throw new \Magento\Framework\Exception\LocalizedException(__('Please select a customer'));
         }
 

--- a/app/code/Magento/Sales/Model/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo.php
@@ -431,7 +431,7 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
             /**
              * If we not retrieve negative answer from payment yet
              */
-            if (is_null($canVoid)) {
+            if ($canVoid === null) {
                 $canVoid = $this->getOrder()->getPayment()->canVoid();
                 if ($canVoid === false) {
                     $this->setCanVoidFlag(false);
@@ -451,7 +451,7 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
      */
     public static function getStates()
     {
-        if (is_null(static::$_states)) {
+        if (static::$_states === null) {
             static::$_states = [
                 self::STATE_OPEN => __('Pending'),
                 self::STATE_REFUNDED => __('Refunded'),
@@ -469,11 +469,11 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
      */
     public function getStateName($stateId = null)
     {
-        if (is_null($stateId)) {
+        if ($stateId === null) {
             $stateId = $this->getState();
         }
 
-        if (is_null(static::$_states)) {
+        if (static::$_states === null) {
             static::getStates();
         }
         if (isset(static::$_states[$stateId])) {

--- a/app/code/Magento/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/Transaction.php
@@ -733,7 +733,7 @@ class Transaction extends AbstractModel implements TransactionInterface
      */
     public function getOrderWebsiteId()
     {
-        if (is_null($this->_orderWebsiteId)) {
+        if ($this->_orderWebsiteId === null) {
             $this->_orderWebsiteId = (int)$this->getResource()->getOrderWebsiteId($this->getOrderId());
         }
         return $this->_orderWebsiteId;

--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -804,7 +804,7 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
             throw new \Magento\Framework\Exception\LocalizedException(__('We found an invalid renderer model.'));
         }
 
-        if (is_null($this->_renderers[$type]['renderer'])) {
+        if ($this->_renderers[$type]['renderer'] === null) {
             $this->_renderers[$type]['renderer'] = $this->_pdfItemsFactory->get($this->_renderers[$type]['model']);
         }
 

--- a/app/code/Magento/Sales/Model/ResourceModel/Report/Bestsellers/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Report/Bestsellers/Collection.php
@@ -255,8 +255,8 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Report\Collection\Ab
             $selectUnions = [];
 
             // apply date boundaries (before calling $this->_applyDateRangeFilter())
-            $periodFrom = !is_null($this->_from) ? new \DateTime($this->_from) : null;
-            $periodTo = !is_null($this->_to) ? new \DateTime($this->_to) : null;
+            $periodFrom = ($this->_from !== null) ? new \DateTime($this->_from) : null;
+            $periodTo = ($this->_to !== null) ? new \DateTime($this->_to) : null;
             if ('year' == $this->_period) {
                 if ($periodFrom) {
                     // not the first day of the year


### PR DESCRIPTION
### Description
**Micro-optimizations for Sales module models**
Magento2 has next sniff [MicroOptimizations](https://github.com/magento/magento2/blob/2.2-develop/dev/tests/static/framework/Magento/Sniffs/MicroOptimizations/IsNullSniff.php) It checks next: `is_null must be avoided. Use strict comparison instead.`
Some classes are under `// @codingStandardsIgnoreFile` such as Sales module models and cannot be checked during static tests. In this PR I replaced `is_null` with strict comparison only for models in Sales module.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
