### PR TITLE
Get sorted module name list by sequence

### DIFF
--- a/lib/internal/Magento/Framework/Module/ModuleList.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList.php
@@ -98,11 +98,11 @@ class ModuleList implements ModuleListInterface
      */
     public function getNames()
     {
-        $this->loadConfigData();
-        if (!$this->configData) {
+        $this->getAll();
+        if (!$this->enabled) {
             return [];
         }
-        $result = array_keys(array_filter($this->configData));
+        $result = array_keys(array_filter($this->enabled));
         return $result;
     }
 


### PR DESCRIPTION
Load and merge xml files by sequence.

### Description
Magento\Framework\Module\Dir getFiles
Use Magento/Framework/Module/ModuleList.php getNames

Which return enabled module list (sorted as they are in 'app/etc/config.php' file).

This fix return same list but sorted by sequence.

### Manual testing scenarios
1. Create module.
2. append etc/frontend/di.xml file with:
`    <type name="Magento\Framework\App\RouterList">
        <arguments>
            <argument name="routerList" xsi:type="array">
                <item name="urlrewrite" xsi:type="array">
                    <item name="class" xsi:type="string">Magento\UrlRewrite\Controller\Router</item>
                    <item name="disable" xsi:type="boolean">false</item>
                    <item name="sortOrder" xsi:type="string">1</item>
                </item>
            </argument>
        </arguments>
    </type>
`
3. append etc/module.xml with
`    <module name="Module_Name" setup_version="1.0.0">
        <sequence>
            <module name="Magento_UrlRewrite" />
        </sequence>
    </module>
`
4. Debug Magento\Framework\App\RouteList Line 39 variable $this->routerList
