### PR TITLE
Fix "cataloginventory_stock" $_eventPrefix and  $_eventObject attribute name

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock.php
@@ -24,7 +24,7 @@ class Stock extends AbstractExtensibleModel implements StockInterface
      *
      * @var string
      */
-    protected $eventPrefix = 'cataloginventory_stock';
+    protected $_eventPrefix = 'cataloginventory_stock';
 
     /**
      * Parameter name in event
@@ -32,7 +32,7 @@ class Stock extends AbstractExtensibleModel implements StockInterface
      *
      * @var string
      */
-    protected $eventObject = 'stock';
+    protected $_eventObject = 'stock';
 
     const BACKORDERS_NO = 0;
 

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -32,7 +32,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
      *
      * @var string
      */
-    protected $eventPrefix = 'cataloginventory_stock_item';
+    protected $_eventPrefix = 'cataloginventory_stock_item';
 
     const WEBSITE_ID = 'website_id';
 
@@ -43,7 +43,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
      *
      * @var string
      */
-    protected $eventObject = 'item';
+    protected $_eventObject = 'item';
 
     /**
      * Store model manager

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Stock/ItemTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Stock/ItemTest.php
@@ -72,33 +72,47 @@ class ItemTest extends \PHPUnit_Framework_TestCase
      */
     protected $storeId = 111;
 
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventDispatcher;
+
     protected function setUp()
     {
+        $this->eventDispatcher = $this->getMockBuilder(\Magento\Framework\Event\ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['dispatch'])
+            ->getMock();
+
         $this->context = $this->getMock(
-            '\Magento\Framework\Model\Context',
+            \Magento\Framework\Model\Context::class,
             ['getEventDispatcher'],
             [],
             '',
             false
         );
+        $this->context->expects($this->any())->method('getEventDispatcher')->willReturn($this->eventDispatcher);
 
         $this->registry = $this->getMock(
-            '\Magento\Framework\Registry',
+            \Magento\Framework\Registry::class,
             [],
             [],
             '',
             false
         );
 
-        $this->customerSession = $this->getMock('Magento\Customer\Model\Session', [], [], '', false);
+        $this->customerSession = $this->getMock(\Magento\Customer\Model\Session::class, [], [], '', false);
 
-        $store = $this->getMock('Magento\Store\Model\Store', ['getId', '__wakeup'], [], '', false);
+        $store = $this->getMock(\Magento\Store\Model\Store::class, ['getId', '__wakeup'], [], '', false);
         $store->expects($this->any())->method('getId')->willReturn($this->storeId);
-        $this->storeManager = $this->getMockForAbstractClass('Magento\Store\Model\StoreManagerInterface', ['getStore']);
+        $this->storeManager = $this->getMockForAbstractClass(
+            \Magento\Store\Model\StoreManagerInterface::class,
+            ['getStore']
+        );
         $this->storeManager->expects($this->any())->method('getStore')->willReturn($store);
 
         $this->stockConfiguration = $this->getMock(
-            '\Magento\CatalogInventory\Api\StockConfigurationInterface',
+            \Magento\CatalogInventory\Api\StockConfigurationInterface::class,
             [],
             [],
             '',
@@ -106,11 +120,11 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->stockItemRepository = $this->getMockForAbstractClass(
-            '\Magento\CatalogInventory\Api\StockItemRepositoryInterface'
+            \Magento\CatalogInventory\Api\StockItemRepositoryInterface::class
         );
 
         $this->resource = $this->getMock(
-            'Magento\CatalogInventory\Model\ResourceModel\Stock\Item',
+            \Magento\CatalogInventory\Model\ResourceModel\Stock\Item::class,
             [],
             [],
             '',
@@ -118,7 +132,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->resourceCollection = $this->getMock(
-            'Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Collection',
+            \Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Collection::class,
             [],
             [],
             '',
@@ -128,7 +142,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         $this->objectManagerHelper = new ObjectManagerHelper($this);
 
         $this->item = $this->objectManagerHelper->getObject(
-            'Magento\CatalogInventory\Model\Stock\Item',
+            \Magento\CatalogInventory\Model\Stock\Item::class,
             [
                 'context' => $this->context,
                 'registry' => $this->registry,
@@ -171,7 +185,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
     public function testSetProduct()
     {
         $product = $this->getMock(
-            'Magento\Catalog\Model\Product',
+            \Magento\Catalog\Model\Product::class,
             [
                 'getId',
                 'getName',
@@ -455,6 +469,45 @@ class ItemTest extends \PHPUnit_Framework_TestCase
                 ],
                 3
             ],
+        ];
+    }
+
+    /**
+     * We want to ensure that property $_eventPrefix used during event dispatching
+     *
+     * @param $eventName
+     * @param $methodName
+     * @param $objectName
+     *
+     * @dataProvider eventsDataProvider
+     */
+    public function testDispatchEvents($eventName, $methodName, $objectName)
+    {
+        $isCalledWithRightPrefix = 0;
+        $isObjectNameRight = 0;
+        $this->eventDispatcher->expects($this->any())->method('dispatch')->with(
+            $this->callback(function ($arg) use (&$isCalledWithRightPrefix, $eventName) {
+                $isCalledWithRightPrefix |= ($arg === $eventName);
+                return true;
+            }),
+            $this->callback(function ($data) use (&$isObjectNameRight, $objectName) {
+                $isObjectNameRight |= isset($data[$objectName]);
+                return true;
+            })
+        );
+
+        $this->item->$methodName();
+        $this->assertTrue(
+            ($isCalledWithRightPrefix && $isObjectNameRight),
+            sprintf('Event "%s" with object name "%s" doesn\'t dispatched properly', $eventName, $objectName)
+        );
+    }
+
+    public function eventsDataProvider()
+    {
+        return [
+            ['cataloginventory_stock_item_save_before', 'beforeSave', 'item'],
+            ['cataloginventory_stock_item_save_after', 'afterSave', 'item'],
         ];
     }
 }

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/StockTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/StockTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\CatalogInventory\Test\Unit\Model;
+
+/**
+ * Class StockTest
+ */
+class StockTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Framework\Model\Context
+     */
+    private $context;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $registry;
+
+    /**
+     * @var Magento\Framework\Api\ExtensionAttributesFactory
+     */
+    private $extensionFactory;
+
+    /**
+     * @var \Magento\Framework\Model\ExtensionAttributesFactory
+     */
+    private $customAttributeFactory;
+
+    /**
+     * @var \Magento\Framework\Model\ResourceModel\AbstractResource
+     */
+    private $resource;
+
+    /**
+     * @var \Magento\Framework\Data\Collection\AbstractDb
+     */
+    private $resourceCollection;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var \Magento\CatalogInventory\Model\Stock
+     */
+    private $stockModel;
+
+    public function setUp()
+    {
+        /** @var  PHPUnit_Framework_MockObject_MockObject */
+        $this->eventDispatcher = $this->getMockBuilder(\Magento\Framework\Event\ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['dispatch'])
+            ->getMock();
+
+        $this->context = $this->getMockBuilder(\Magento\Framework\Model\Context::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getEventDispatcher'])
+            ->getMock();
+        $this->context->expects($this->any())->method('getEventDispatcher')->willReturn($this->eventDispatcher);
+
+        $this->registry = $this->getMockBuilder(\Magento\Framework\Registry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->extensionFactory = $this->getMockBuilder(\Magento\Framework\Api\ExtensionAttributesFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->customAttributeFactory = $this->getMockBuilder(\Magento\Framework\Api\AttributeValueFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIdFieldName'])
+            ->getMockForAbstractClass();
+
+        $this->resourceCollection = $this->getMockBuilder(\Magento\Framework\Data\Collection\AbstractDb::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->stockModel = new \Magento\CatalogInventory\Model\Stock(
+            $this->context,
+            $this->registry,
+            $this->extensionFactory,
+            $this->customAttributeFactory,
+            $this->resource,
+            $this->resourceCollection
+        );
+    }
+
+    /**
+     * We want to ensure that property $_eventPrefix used during event dispatching
+     *
+     * @param $eventName
+     * @param $methodName
+     * @param $objectName
+     *
+     * @dataProvider eventsDataProvider
+     */
+    public function testDispatchEvents($eventName, $methodName, $objectName)
+    {
+        $isCalledWithRightPrefix = 0;
+        $isObjectNameRight = 0;
+        $this->eventDispatcher->expects($this->any())->method('dispatch')->with(
+            $this->callback(function ($arg) use (&$isCalledWithRightPrefix, $eventName) {
+                $isCalledWithRightPrefix |= ($arg === $eventName);
+                return true;
+            }),
+            $this->callback(function ($data) use (&$isObjectNameRight, $objectName) {
+                $isObjectNameRight |= isset($data[$objectName]);
+                return true;
+            })
+        );
+
+        $this->stockModel->$methodName();
+        $this->assertTrue(
+            ($isCalledWithRightPrefix && $isObjectNameRight),
+            sprintf('Event "%s" with object name "%s" doesn\'t dispatched properly', $eventName, $objectName)
+        );
+    }
+
+    public function eventsDataProvider()
+    {
+        return [
+            ['cataloginventory_stock_save_before', 'beforeSave', 'stock'],
+            ['cataloginventory_stock_save_after', 'afterSave', 'stock'],
+        ];
+    }
+}


### PR DESCRIPTION
### Description
I can't observe "cataloginventory_stock" event because in \Magento\CatalogInventory\Model\Stock model property named $eventPrefix instead of $_eventPrefix. $eventObject also named $eventObject instead of $_eventObject

### Fixed Issues (if relevant)
1. magento/magento2#4857: "cataloginventory_stock" event

### Manual testing scenarios
1. Try to observe 'cataloginventory_stock' event and verify that your code is executed.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds on Travis CI are green)
