### PR TITLE
Optimization: magento/module-eav is_null change to strict comparison …

### DIFF
--- a/app/code/Magento/Eav/Model/Attribute.php
+++ b/app/code/Magento/Eav/Model/Attribute.php
@@ -62,7 +62,7 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute
      */
     public function getWebsite()
     {
-        if (is_null($this->_website)) {
+        if ($this->_website === null) {
             $this->_website = $this->_storeManager->getWebsite();
         }
 
@@ -88,7 +88,7 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute
     public function getUsedInForms()
     {
         $forms = $this->getData('used_in_forms');
-        if (is_null($forms)) {
+        if ($forms === null) {
             $forms = $this->_getResource()->getUsedInForms($this);
             $this->setData('used_in_forms', $forms);
         }

--- a/app/code/Magento/Eav/Model/Attribute/Data/AbstractData.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/AbstractData.php
@@ -205,7 +205,7 @@ abstract class AbstractData
      */
     public function getExtractedData($index = null)
     {
-        if (!is_null($index)) {
+        if ($index !== null) {
             if (isset($this->_extractedData[$index])) {
                 return $this->_extractedData[$index];
             }
@@ -262,9 +262,9 @@ abstract class AbstractData
      */
     protected function _dateFilterFormat($format = null)
     {
-        if (is_null($format)) {
+        if ($format === null) {
             // get format
-            if (is_null($this->_dateFilterFormat)) {
+            if ($this->_dateFilterFormat === null) {
                 $this->_dateFilterFormat = \IntlDateFormatter::SHORT;
             }
             return $this->_localeDate->getDateFormat($this->_dateFilterFormat);

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -1294,7 +1294,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
                 $origData = $this->_getOrigObject($newObject)->getOrigData();
             }
 
-            if (is_null($origData)) {
+            if ($origData === null) {
                 $origData = [];
             }
 

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -49,7 +49,7 @@ class Datetime extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBacke
                 throw new \Magento\Framework\Exception\LocalizedException(__('Invalid date'));
             }
 
-            if (is_null($value)) {
+            if ($value === null) {
                 $value = $object->getData($attributeName);
             }
 


### PR DESCRIPTION
Hello,
This is the one of the optimization PR linked with the `is_null()` change. I decided to do them per module just to avoid any mistake during delivery and review.
Best regards,
Alex

### Description
**Micro-optimizations for Magento\EAV**
Magento2 has next sniff [MicroOptimizations](https://github.com/magento/magento2/blob/2.2-develop/dev/tests/static/framework/Magento/Sniffs/MicroOptimizations/IsNullSniff.php) It checks next: `is_null must be avoided. Use strict comparison instead.`
Some classes are under `// @codingStandardsIgnoreFile` such as Magento\Eav module models and cannot be checked during static tests. In this PR I replaced `is_null` with strict comparison only for models in Magento\Eav module.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
