### PR TITLE
Optimization: magento/module-tax is_null change to strict comparison

### DIFF
--- a/app/code/Magento/Tax/Model/Calculation/Rate.php
+++ b/app/code/Magento/Tax/Model/Calculation/Rate.php
@@ -227,7 +227,7 @@ class Rate extends \Magento\Framework\Model\AbstractExtensibleModel implements T
      */
     public function saveTitles($titles = null)
     {
-        if (is_null($titles)) {
+        if ($titles === null) {
             $titles = $this->getTitle();
         }
 
@@ -256,7 +256,7 @@ class Rate extends \Magento\Framework\Model\AbstractExtensibleModel implements T
      */
     public function getTitleModel()
     {
-        if (is_null($this->_titleModel)) {
+        if ($this->_titleModel === null) {
             $this->_titleModel = $this->_titleFactory->create();
         }
         return $this->_titleModel;
@@ -270,7 +270,7 @@ class Rate extends \Magento\Framework\Model\AbstractExtensibleModel implements T
         if ($this->getData(self::KEY_TITLES)) {
             return $this->getData(self::KEY_TITLES);
         }
-        if (is_null($this->_titles)) {
+        if ($this->_titles === null) {
             $this->_titles = $this->getTitleModel()->getCollection()->loadByRateId($this->getId())->getItems();
         }
         return $this->_titles;

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/CommonTaxCollector.php
@@ -771,7 +771,7 @@ class CommonTaxCollector extends AbstractTotal
                 $previouslyAppliedTaxes[$row['id']] = $row;
             }
 
-            if (!is_null($row['percent'])) {
+            if ($row['percent'] !== null) {
                 $row['percent'] = $row['percent'] ? $row['percent'] : 1;
                 $rate = $rate ? $rate : 1;
 


### PR DESCRIPTION
Hello,
This is the one of the optimization PR linked with the `is_null()` change. I decided to do them per module just to avoid any mistake during delivery and review.
Best regards,
Alex

### Description
**Micro-optimizations for Magento\Tax**
Magento2 has next sniff [MicroOptimizations](https://github.com/magento/magento2/blob/2.2-develop/dev/tests/static/framework/Magento/Sniffs/MicroOptimizations/IsNullSniff.php) It checks next: `is_null must be avoided. Use strict comparison instead.`
Some classes are under `// @codingStandardsIgnoreFile` such as Magento\Tax module models and cannot be checked during static tests. In this PR I replaced `is_null` with strict comparison only for models in Magento\Tax module.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
