### PR TITLE
Optimization: magento/module-catalog is_null change to strict comparison

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -228,7 +228,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     public function getLoadTreeUrl($expanded = null)
     {
         $params = ['_current' => true, 'id' => null, 'store' => null];
-        if (($expanded === null) && $this->_backendSession->getIsTreeWasExpanded() || $expanded == true) {
+        if ($expanded === null && $this->_backendSession->getIsTreeWasExpanded() || $expanded == true) {
             $params['expand_all'] = true;
         }
         return $this->getUrl('*/*/categoriesJson', $params);

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -228,7 +228,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     public function getLoadTreeUrl($expanded = null)
     {
         $params = ['_current' => true, 'id' => null, 'store' => null];
-        if (is_null($expanded) && $this->_backendSession->getIsTreeWasExpanded() || $expanded == true) {
+        if (($expanded === null) && $this->_backendSession->getIsTreeWasExpanded() || $expanded == true) {
             $params['expand_all'] = true;
         }
         return $this->getUrl('*/*/categoriesJson', $params);

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -313,9 +313,9 @@ class Option extends Widget
                     $value['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
                         $option->getOptionId(),
                         'title',
-                        is_null($option->getStoreTitle())
+                        $option->getStoreTitle() === null
                     );
-                    $value['scopeTitleDisabled'] = is_null($option->getStoreTitle()) ? 'disabled' : null;
+                    $value['scopeTitleDisabled'] = ($option->getStoreTitle() === null) ? 'disabled' : null;
                 }
 
                 if ($option->getGroupByType() == ProductCustomOptionInterface::OPTION_GROUP_SELECT) {
@@ -341,22 +341,22 @@ class Option extends Widget
                             $value['optionValues'][$i]['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
                                 $_value->getOptionId(),
                                 'title',
-                                is_null($_value->getStoreTitle()),
+                                $_value->getStoreTitle() === null,
                                 $_value->getOptionTypeId()
                             );
-                            $value['optionValues'][$i]['scopeTitleDisabled'] = is_null(
-                                $_value->getStoreTitle()
+                            $value['optionValues'][$i]['scopeTitleDisabled'] = (
+                                $_value->getStoreTitle() === null
                             ) ? 'disabled' : null;
                             if ($scope == \Magento\Store\Model\Store::PRICE_SCOPE_WEBSITE) {
                                 $value['optionValues'][$i]['checkboxScopePrice'] = $this->getCheckboxScopeHtml(
                                     $_value->getOptionId(),
                                     'price',
-                                    is_null($_value->getstorePrice()),
+                                    $_value->getstorePrice() === null,
                                     $_value->getOptionTypeId(),
                                     ['$(this).up(1).previous()']
                                 );
-                                $value['optionValues'][$i]['scopePriceDisabled'] = is_null(
-                                    $_value->getStorePrice()
+                                $value['optionValues'][$i]['scopePriceDisabled'] = (
+                                    $_value->getStorePrice() === null
                                 ) ? 'disabled' : null;
                             }
                         }
@@ -379,9 +379,9 @@ class Option extends Widget
                         $value['checkboxScopePrice'] = $this->getCheckboxScopeHtml(
                             $option->getOptionId(),
                             'price',
-                            is_null($option->getStorePrice())
+                            $option->getStorePrice() === null
                         );
-                        $value['scopePriceDisabled'] = is_null($option->getStorePrice()) ? 'disabled' : null;
+                        $value['scopePriceDisabled'] = ($option->getStorePrice() === null) ? 'disabled' : null;
                     }
                 }
                 $values[] = new \Magento\Framework\DataObject($value);

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -315,7 +315,7 @@ class Option extends Widget
                         'title',
                         $option->getStoreTitle() === null
                     );
-                    $value['scopeTitleDisabled'] = ($option->getStoreTitle() === null) ? 'disabled' : null;
+                    $value['scopeTitleDisabled'] = $option->getStoreTitle() === null ? 'disabled' : null;
                 }
 
                 if ($option->getGroupByType() == ProductCustomOptionInterface::OPTION_GROUP_SELECT) {
@@ -381,7 +381,7 @@ class Option extends Widget
                             'price',
                             $option->getStorePrice() === null
                         );
-                        $value['scopePriceDisabled'] = ($option->getStorePrice() === null) ? 'disabled' : null;
+                        $value['scopePriceDisabled'] = $option->getStorePrice() === null ? 'disabled' : null;
                     }
                 }
                 $values[] = new \Magento\Framework\DataObject($value);

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
@@ -121,7 +121,7 @@ class Related extends \Magento\Catalog\Block\Product\AbstractProduct implements 
          * getIdentities() depends on _itemCollection populated, but it can be empty if the block is hidden
          * @see https://github.com/magento/magento2/issues/5897
          */
-        if (is_null($this->_itemCollection)) {
+        if ($this->_itemCollection === null) {
             $this->_prepareData();
         }
         return $this->_itemCollection;

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
@@ -140,7 +140,7 @@ class Upsell extends \Magento\Catalog\Block\Product\AbstractProduct implements \
          * getIdentities() depends on _itemCollection populated, but it can be empty if the block is hidden
          * @see https://github.com/magento/magento2/issues/5897
          */
-        if (is_null($this->_itemCollection)) {
+        if ($this->_itemCollection === null) {
             $this->_prepareData();
         }
         return $this->_itemCollection;
@@ -151,7 +151,7 @@ class Upsell extends \Magento\Catalog\Block\Product\AbstractProduct implements \
      */
     public function getItems()
     {
-        if (is_null($this->_items)) {
+        if ($this->_items === null) {
             $this->_items = $this->getItemCollection()->getItems();
         }
         return $this->_items;

--- a/app/code/Magento/Catalog/Model/Config.php
+++ b/app/code/Magento/Catalog/Model/Config.php
@@ -407,7 +407,7 @@ class Config extends \Magento\Eav\Model\Config
      */
     public function getProductAttributes()
     {
-        if (is_null($this->_productAttributes)) {
+        if ($this->_productAttributes === null) {
             $this->_productAttributes = array_keys($this->getAttributesUsedInProductListing());
         }
         return $this->_productAttributes;
@@ -430,7 +430,7 @@ class Config extends \Magento\Eav\Model\Config
      */
     public function getAttributesUsedInProductListing()
     {
-        if (is_null($this->_usedInProductListing)) {
+        if ($this->_usedInProductListing === null) {
             $this->_usedInProductListing = [];
             $entityType = \Magento\Catalog\Model\Product::ENTITY;
             $attributesData = $this->_getResource()->setStoreId($this->getStoreId())->getAttributesUsedInListing();
@@ -453,7 +453,7 @@ class Config extends \Magento\Eav\Model\Config
      */
     public function getAttributesUsedForSortBy()
     {
-        if (is_null($this->_usedForSortBy)) {
+        if ($this->_usedForSortBy === null) {
             $this->_usedForSortBy = [];
             $entityType = \Magento\Catalog\Model\Product::ENTITY;
             $attributesData = $this->_getResource()->getAttributesUsedForSortBy();

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Price.php
@@ -150,7 +150,7 @@ class Price extends \Magento\Catalog\Model\Layer\Filter\AbstractFilter
     public function getCustomerGroupId()
     {
         $customerGroupId = $this->_getData('customer_group_id');
-        if (is_null($customerGroupId)) {
+        if ($customerGroupId === null) {
             $customerGroupId = $this->_customerSession->getCustomerGroupId();
         }
 
@@ -176,7 +176,7 @@ class Price extends \Magento\Catalog\Model\Layer\Filter\AbstractFilter
     public function getCurrencyRate()
     {
         $rate = $this->_getData('currency_rate');
-        if (is_null($rate)) {
+        if ($rate === null) {
             $rate = $this->_storeManager->getStore($this->getStoreId())
                 ->getCurrentCurrencyRate();
         }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/GroupPrice/AbstractGroupPrice.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/GroupPrice/AbstractGroupPrice.php
@@ -91,7 +91,7 @@ abstract class AbstractGroupPrice extends Price
      */
     protected function _getWebsiteCurrencyRates()
     {
-        if (is_null($this->_rates)) {
+        if ($this->_rates === null) {
             $this->_rates = [];
             $baseCurrency = $this->_config->getValue(
                 \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_BASE,

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -179,7 +179,7 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
      */
     public function getProduct()
     {
-        if (is_null($this->_product)) {
+        if ($this->_product === null) {
             $this->_product = $this->getOption()->getProduct();
         }
         return $this->_product;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1466,10 +1466,10 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     {
         $this->_productLimitationFilters->setUsePriceIndex(true);
 
-        if (!isset($this->_productLimitationFilters['customer_group_id']) && ($customerGroupId === null)) {
+        if (!isset($this->_productLimitationFilters['customer_group_id']) && $customerGroupId === null) {
             $customerGroupId = $this->_customerSession->getCustomerGroupId();
         }
-        if (!isset($this->_productLimitationFilters['website_id']) && ($websiteId === null)) {
+        if (!isset($this->_productLimitationFilters['website_id']) && $websiteId === null) {
             $websiteId = $this->_storeManager->getStore($this->getStoreId())->getWebsiteId();
         }
 

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1092,7 +1092,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     protected function _getSelectCountSql($select = null, $resetLeftJoins = true)
     {
         $this->_renderFilters();
-        $countSelect = ($select === null) ? $this->_getClearSelect() : $this->_buildClearSelect($select);
+        $countSelect = $select === null ? $this->_getClearSelect() : $this->_buildClearSelect($select);
         $countSelect->columns('COUNT(DISTINCT e.entity_id)');
         if ($resetLeftJoins) {
             $countSelect->resetJoinLeft();

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1092,7 +1092,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     protected function _getSelectCountSql($select = null, $resetLeftJoins = true)
     {
         $this->_renderFilters();
-        $countSelect = is_null($select) ? $this->_getClearSelect() : $this->_buildClearSelect($select);
+        $countSelect = ($select === null) ? $this->_getClearSelect() : $this->_buildClearSelect($select);
         $countSelect->columns('COUNT(DISTINCT e.entity_id)');
         if ($resetLeftJoins) {
             $countSelect->resetJoinLeft();
@@ -1435,7 +1435,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $ids = $this->_allIdsCache;
         }
 
-        if (is_null($ids)) {
+        if ($ids === null) {
             $ids = $this->getAllIds();
             $this->setAllIdsCache($ids);
         }
@@ -1466,17 +1466,17 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     {
         $this->_productLimitationFilters->setUsePriceIndex(true);
 
-        if (!isset($this->_productLimitationFilters['customer_group_id']) && is_null($customerGroupId)) {
+        if (!isset($this->_productLimitationFilters['customer_group_id']) && ($customerGroupId === null)) {
             $customerGroupId = $this->_customerSession->getCustomerGroupId();
         }
-        if (!isset($this->_productLimitationFilters['website_id']) && is_null($websiteId)) {
+        if (!isset($this->_productLimitationFilters['website_id']) && ($websiteId === null)) {
             $websiteId = $this->_storeManager->getStore($this->getStoreId())->getWebsiteId();
         }
 
-        if (!is_null($customerGroupId)) {
+        if ($customerGroupId !== null) {
             $this->_productLimitationFilters['customer_group_id'] = $customerGroupId;
         }
-        if (!is_null($websiteId)) {
+        if ($websiteId !== null) {
             $this->_productLimitationFilters['website_id'] = $websiteId;
         }
 
@@ -2347,7 +2347,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     public function getMaxPrice()
     {
-        if (is_null($this->_maxPrice)) {
+        if ($this->_maxPrice === null) {
             $this->_prepareStatisticsData();
         }
 
@@ -2361,7 +2361,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     public function getMinPrice()
     {
-        if (is_null($this->_minPrice)) {
+        if ($this->_minPrice === null) {
             $this->_prepareStatisticsData();
         }
 
@@ -2375,7 +2375,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     public function getPriceStandardDeviation()
     {
-        if (is_null($this->_priceStandardDeviation)) {
+        if ($this->_priceStandardDeviation === null) {
             $this->_prepareStatisticsData();
         }
 
@@ -2389,7 +2389,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     public function getPricesCount()
     {
-        if (is_null($this->_pricesCount)) {
+        if ($this->_pricesCount === null) {
             $this->_prepareStatisticsData();
         }
 


### PR DESCRIPTION
Hello,
This is the one of the optimization PR linked with the `is_null()` change. I decided to do them per module just to avoid any mistake during delivery and review.
Best regards,
Alex

### Description
**Micro-optimizations for Magento\Catalog**
Magento2 has next sniff [MicroOptimizations](https://github.com/magento/magento2/blob/2.2-develop/dev/tests/static/framework/Magento/Sniffs/MicroOptimizations/IsNullSniff.php) It checks next: `is_null must be avoided. Use strict comparison instead.`
Some classes are under `// @codingStandardsIgnoreFile` such as Magento\Catalog module models, block and cannot be checked during static tests. In this PR I replaced `is_null` with strict comparison only for models and block in Magento\Catalog module.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
