### PR TITLE
[FEATURE] added ability to create default/fixed value nodes during XSD Schema Validation

### DIFF
--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -313,7 +313,7 @@ class Dom
         libxml_set_external_entity_loader([self::$urnResolver, 'registerEntityLoader']);
         $errors = [];
         try {
-            $result = $dom->schemaValidate($schema);
+            $result = $dom->schemaValidate($schema, LIBXML_SCHEMA_CREATE);
             if (!$result) {
                 $errors = self::getXmlErrors($errorFormat);
             }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
@@ -135,6 +135,43 @@ class DomTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * @param string $xml
+     * @param string $expectedValue
+     * @dataProvider validateWithDefaultValueDataProvider
+     */
+    public function testValidateWithDefaultValue($xml, $expectedValue) {
+        if (!function_exists('libxml_set_external_entity_loader')) {
+            $this->markTestSkipped('Skipped on HHVM. Will be fixed in MAGETWO-45033');
+        }
+        $dom = new \Magento\Framework\Config\Dom($xml, $this->validationStateMock);
+        $dom->validate(__DIR__ . '/_files/sample.xsd', $actualErrors);
+
+        $actualValue = $dom->getDom()
+            ->getElementsByTagName('root')->item(0)
+            ->getElementsByTagName('node')->item(0)
+            ->getAttribute('attribute_with_default_value');
+
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+
+    /**
+     * @return array
+     */
+    public function validateWithDefaultValueDataProvider()
+    {
+        return [
+            'default_value' => [
+                '<root><node id="id1"/></root>',
+                'default_value'
+            ],
+            'custom_value' => [
+                '<root><node id="id1" attribute_with_default_value="non_default_value"/></root>',
+                'non_default_value'
+            ],
+        ];
+    }
+
     public function testValidateCustomErrorFormat()
     {
         $xml = '<root><unknown_node/></root>';

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
@@ -144,6 +144,9 @@ class DomTest extends \PHPUnit\Framework\TestCase
         if (!function_exists('libxml_set_external_entity_loader')) {
             $this->markTestSkipped('Skipped on HHVM. Will be fixed in MAGETWO-45033');
         }
+
+        $actualErrors = [];
+
         $dom = new \Magento\Framework\Config\Dom($xml, $this->validationStateMock);
         $dom->validate(__DIR__ . '/_files/sample.xsd', $actualErrors);
 
@@ -152,6 +155,7 @@ class DomTest extends \PHPUnit\Framework\TestCase
             ->getElementsByTagName('node')->item(0)
             ->getAttribute('attribute_with_default_value');
 
+        $this->assertEmpty($actualErrors);
         $this->assertEquals($expectedValue, $actualValue);
     }
 

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
@@ -140,7 +140,8 @@ class DomTest extends \PHPUnit\Framework\TestCase
      * @param string $expectedValue
      * @dataProvider validateWithDefaultValueDataProvider
      */
-    public function testValidateWithDefaultValue($xml, $expectedValue) {
+    public function testValidateWithDefaultValue($xml, $expectedValue)
+    {
         if (!function_exists('libxml_set_external_entity_loader')) {
             $this->markTestSkipped('Skipped on HHVM. Will be fixed in MAGETWO-45033');
         }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/sample.xsd
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/sample.xsd
@@ -21,6 +21,7 @@
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="id" type="xs:string" use="required"/>
+                <xs:attribute name="attribute_with_default_value" type="xs:string" default="default_value"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
### Description

This feature adds the functionality / ability to use defined default values from xsd schemas in xml config nodes.

This was probably not implemented due to backwards-compatibility to PHP 5.4
The constant `LIBXML_SCHEMA_CREATE` was introduced in Libxml >= 2.6.14 (as of PHP >= 5.5.2)

As of now magento 2 has a php requirement of `7.0.2|7.0.4|~7.0.6|~7.1.0` and it should be safe to use that extended functionality to harness the full power of XSD-Schemas.

Changes applied to ` \Magento\Framework\Config\Dom::validateDomDocument`
Tests supplied in `\Magento\Framework\Config\Test\Unit\DomTest::testValidateWithDefaultValue`

See [DOMDocument::schemaValidate
](http://php.net/manual/en/domdocument.schemavalidate.php)

### Fixed Issues

XSD schemas can define default values for `xs:attribute` nodes, but the xsd-based schema validation does not merge the defined default values into the XML ``\DomDocument``  (the attribute node is not even created when xsd defines a default value but the xml document does not no reference it explicitly)
