### PR TITLE
Fix a misspelled method name in Bundle

### DIFF
--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -319,6 +319,13 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
     }
 
     /**
+     * @deprecated Misspelled method - use retrieveProductsByCachedSkus() instead
+     */
+    protected function retrieveProducsByCachedSkus() {
+        return $this->retrieveProductsByCachedSkus();
+    }
+
+    /**
      * Retrieve mapping between skus and products.
      *
      * @return \Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -323,7 +323,7 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
      *
      * @return \Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType
      */
-    protected function retrieveProducsByCachedSkus()
+    protected function retrieveProductsByCachedSkus()
     {
         $this->_cachedSkuToProducts = $this->connection->fetchPairs(
             $this->connection->select()->from(
@@ -368,7 +368,7 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
                     $this->parseSelections($rowData, $productData[$this->getProductEntityLinkField()]);
                 }
                 if (!empty($this->_cachedOptions)) {
-                    $this->retrieveProducsByCachedSkus();
+                    $this->retrieveProductsByCachedSkus();
                     $this->populateExistingOptions();
                     $this->insertOptions();
                     $this->insertSelections();

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -319,7 +319,8 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
     }
 
     /**
-     * @deprecated Misspelled method - use retrieveProductsByCachedSkus() instead
+     * @deprecated Misspelled method
+     * @see retrieveProductsByCachedSkus
      */
     protected function retrieveProducsByCachedSkus()
     {

--- a/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
+++ b/app/code/Magento/BundleImportExport/Model/Import/Product/Type/Bundle.php
@@ -321,7 +321,8 @@ class Bundle extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abst
     /**
      * @deprecated Misspelled method - use retrieveProductsByCachedSkus() instead
      */
-    protected function retrieveProducsByCachedSkus() {
+    protected function retrieveProducsByCachedSkus()
+    {
         return $this->retrieveProductsByCachedSkus();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Found a misspelled method name in \Magento\BundleImportExport\Model\Import\Product\Type\Bundle

Even though it is a private method the backwards compatibility is ensured by deprecating the misspelled method
<!--- Provide a description of the changes proposed in the pull request -->

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
