### PR TITLE
Fix a misspelled parameter name in TaxTest

### DIFF
--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/ConfigTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/ConfigTest.php
@@ -96,7 +96,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->menuMock, $this->model->getMenu());
     }
 
-    public function testGetMenuWithNotCachedObjectBuidlsObject()
+    public function testGetMenuWithNotCachedObjectBuildsObject()
     {
         $this->cacheInstanceMock->expects(
             $this->at(0)

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Config/CanVoidHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Config/CanVoidHandlerTest.php
@@ -39,7 +39,7 @@ class CanVoidHandlerTest extends \PHPUnit\Framework\TestCase
         static::assertFalse($voidHandler->handle($subject));
     }
 
-    public function testHandleSomeAmoutWasPaid()
+    public function testHandleSomeAmountWasPaid()
     {
         $paymentDO = $this->createMock(PaymentDataObjectInterface::class);
         $subject = [

--- a/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
@@ -125,7 +125,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetItemsWithLimit()
     {
-        $transations = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
+        $transactions = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
 
         $this->filterMapperMock->expects($this->once())
             ->method('getFilter')
@@ -133,7 +133,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
 
         $this->braintreeAdapterMock->expects($this->once())
             ->method('search')
-            ->willReturn($transations);
+            ->willReturn($transactions);
 
         $this->entityFactoryMock->expects($this->exactly(TransactionsCollection::TRANSACTION_MAXIMUM_COUNT))
             ->method('create')
@@ -157,7 +157,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetItemsWithNullLimit()
     {
-        $transations = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
+        $transactions = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
 
         $this->filterMapperMock->expects($this->once())
             ->method('getFilter')
@@ -165,7 +165,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
 
         $this->braintreeAdapterMock->expects($this->once())
             ->method('search')
-            ->willReturn($transations);
+            ->willReturn($transactions);
 
         $this->entityFactoryMock->expects($this->exactly(TransactionsCollection::TRANSACTION_MAXIMUM_COUNT))
             ->method('create')

--- a/app/code/Magento/Bundle/Test/Unit/Model/Product/TypeTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Product/TypeTest.php
@@ -1365,7 +1365,7 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     /**
      * @return void
      */
-    public function testPrepareForCartAdvancedAllrequiredOption()
+    public function testPrepareForCartAdvancedAllRequiredOption()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|DefaultType $group */
         $group = $this->getMockBuilder(\Magento\Catalog\Model\Product\Option\Type\DefaultType::class)

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/DeleteHandler.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/DeleteHandler.php
@@ -72,8 +72,8 @@ class DeleteHandler
         $linkedProduct = $this->productRepository->get($entity->getLinkedProductSku());
         $product = $this->productRepository->get($entity->getSku());
         $linkTypesToId = $this->linkTypeProvider->getLinkTypes();
-        $prodyctHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
-        $productData = $prodyctHydrator->extract($product);
+        $productHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
+        $productData = $productHydrator->extract($product);
         $linkId = $this->linkResource->getProductLinkId(
             $productData[$this->metadataPool->getMetadata(ProductInterface::class)->getLinkField()],
             $linkedProduct->getId(),

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/SaveHandler.php
@@ -97,8 +97,8 @@ class SaveHandler
 
         try {
             $linkTypesToId = $this->linkTypeProvider->getLinkTypes();
-            $prodyctHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
-            $productData = $prodyctHydrator->extract($product);
+            $productHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
+            $productData = $productHydrator->extract($product);
             $this->linkResource->saveProductLinks(
                 $productData[$this->metadataPool->getMetadata(ProductInterface::class)->getLinkField()],
                 $links,

--- a/app/code/Magento/Catalog/Test/Unit/Block/Category/ViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Category/ViewTest.php
@@ -31,9 +31,9 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGetIdentities()
     {
         $categoryTag = ['catalog_category_1'];
-        $currentCatogoryMock = $this->createMock(\Magento\Catalog\Model\Category::class);
-        $currentCatogoryMock->expects($this->once())->method('getIdentities')->will($this->returnValue($categoryTag));
-        $this->block->setCurrentCategory($currentCatogoryMock);
+        $currentCategoryMock = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $currentCategoryMock->expects($this->once())->method('getIdentities')->will($this->returnValue($categoryTag));
+        $this->block->setCurrentCategory($currentCategoryMock);
         $this->assertEquals($categoryTag, $this->block->getIdentities());
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/MoveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/MoveTest.php
@@ -115,7 +115,7 @@ class MoveTest extends \PHPUnit\Framework\TestCase
         $layoutMock->expects($this->once())
             ->method('getMessagesBlock')
             ->willReturn($messageBlock);
-        $wysiwigConfig = $this->getMockBuilder(\Magento\Cms\Model\Wysiwyg\Config::class)
+        $wysiwygConfig = $this->getMockBuilder(\Magento\Cms\Model\Wysiwyg\Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $registry = $this->getMockBuilder(Registry::class)
@@ -135,7 +135,7 @@ class MoveTest extends \PHPUnit\Framework\TestCase
         $this->objectManager->expects($this->any())
             ->method('get')
             ->withConsecutive([Registry::class], [Registry::class], [\Magento\Cms\Model\Wysiwyg\Config::class])
-            ->willReturnMap([[Registry::class, $registry], [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwigConfig]]);
+            ->willReturnMap([[Registry::class, $registry], [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwygConfig]]);
         $categoryMock->expects($this->once())
             ->method('move')
             ->willThrowException(new \Exception(
@@ -189,7 +189,7 @@ class MoveTest extends \PHPUnit\Framework\TestCase
         $layoutMock->expects($this->once())
             ->method('getMessagesBlock')
             ->willReturn($messageBlock);
-        $wysiwigConfig = $this->getMockBuilder(\Magento\Cms\Model\Wysiwyg\Config::class)
+        $wysiwygConfig = $this->getMockBuilder(\Magento\Cms\Model\Wysiwyg\Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $registry = $this->getMockBuilder(Registry::class)
@@ -209,7 +209,7 @@ class MoveTest extends \PHPUnit\Framework\TestCase
         $this->objectManager->expects($this->any())
             ->method('get')
             ->withConsecutive([Registry::class], [Registry::class], [\Magento\Cms\Model\Wysiwyg\Config::class])
-            ->willReturnMap([[Registry::class, $registry], [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwigConfig]]);
+            ->willReturnMap([[Registry::class, $registry], [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwygConfig]]);
         $this->messageManager->expects($this->once())
             ->method('addExceptionMessage');
         $this->messageManager->expects($this->once())
@@ -261,7 +261,7 @@ class MoveTest extends \PHPUnit\Framework\TestCase
         $layoutMock->expects($this->once())
             ->method('getMessagesBlock')
             ->willReturn($messageBlock);
-        $wysiwigConfig = $this->getMockBuilder(\Magento\Cms\Model\Wysiwyg\Config::class)
+        $wysiwygConfig = $this->getMockBuilder(\Magento\Cms\Model\Wysiwyg\Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $registry = $this->getMockBuilder(Registry::class)
@@ -281,7 +281,7 @@ class MoveTest extends \PHPUnit\Framework\TestCase
         $this->objectManager->expects($this->any())
             ->method('get')
             ->withConsecutive([Registry::class], [Registry::class], [\Magento\Cms\Model\Wysiwyg\Config::class])
-            ->willReturnMap([[Registry::class, $registry], [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwigConfig]]);
+            ->willReturnMap([[Registry::class, $registry], [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwygConfig]]);
         $this->messageManager->expects($this->once())
             ->method('getMessages')
             ->with(true)

--- a/app/code/Magento/Catalog/Test/Unit/CustomerData/ProductsRenderInfoSectionTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/CustomerData/ProductsRenderInfoSectionTest.php
@@ -134,7 +134,7 @@ class ProductsRenderInfoSectionTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('create')
             ->willReturn($filterMock);
-        $searchCritera = $this->createMock(SearchCriteria::class);
+        $searchCriteria = $this->createMock(SearchCriteria::class);
         $this->searchCriteriaBuilderMock
             ->expects($this->once())
             ->method('addFilters')
@@ -142,10 +142,10 @@ class ProductsRenderInfoSectionTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->once())
             ->method('create')
-            ->willReturn($searchCritera);
+            ->willReturn($searchCriteria);
         $this->productRenderRepositoryMock->expects($this->once())
             ->method('getList')
-            ->with($searchCritera, 3, 'UAH')
+            ->with($searchCriteria, 3, 'UAH')
             ->willReturn($searchResult);
         $searchResult->expects($this->any())
             ->method('getItems')

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
@@ -29,7 +29,7 @@ class Custom extends \Magento\Framework\App\Config\Value
     const XML_PATH_ADMIN_SECURITY_USEFORMKEY = 'admin/security/use_form_key';
     const XML_PATH_MAINTENANCE_MODE = 'maintenance_mode';
     const XML_PATH_WEB_COOKIE_COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
-    const XML_PATH_WEB_COOKIE_COOKE_PATH = 'web/cookie/cookie_path';
+    const XML_PATH_WEB_COOKIE_COOKIE_PATH = 'web/cookie/cookie_path';
     const XML_PATH_WEB_COOKIE_COOKIE_DOMAIN = 'web/cookie/cookie_domain';
     const XML_PATH_WEB_COOKIE_HTTPONLY = 'web/cookie/cookie_httponly';
     const XML_PATH_WEB_COOKIE_RESTRICTION = 'web/cookie/cookie_restriction';

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
@@ -29,6 +29,10 @@ class Custom extends \Magento\Framework\App\Config\Value
     const XML_PATH_ADMIN_SECURITY_USEFORMKEY = 'admin/security/use_form_key';
     const XML_PATH_MAINTENANCE_MODE = 'maintenance_mode';
     const XML_PATH_WEB_COOKIE_COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
+    /**
+     * @deprecated Misspelled constant - use XML_PATH_WEB_COOKIE_COOKIE_PATH instead
+     */
+    const XML_PATH_WEB_COOKIE_COOKE_PATH = 'web/cookie/cookie_path';
     const XML_PATH_WEB_COOKIE_COOKIE_PATH = 'web/cookie/cookie_path';
     const XML_PATH_WEB_COOKIE_COOKIE_DOMAIN = 'web/cookie/cookie_domain';
     const XML_PATH_WEB_COOKIE_HTTPONLY = 'web/cookie/cookie_httponly';

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -278,7 +278,8 @@ class Inline extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @deprecated Misspelled method - use getItemsHasMessages() instead
+     * @deprecated Misspelled method
+     * @see getItemsHasMessages
      */
     public function getItemsHasMesssages()
     {

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -283,7 +283,7 @@ class Inline extends \Magento\Framework\View\Element\Template
      * @return bool
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
      */
-    public function getItemsHasMesssages()
+    public function getItemsHasMessages()
     {
         foreach ($this->getItems() as $item) {
             if ($item->getGiftMessageId()) {

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -278,6 +278,14 @@ class Inline extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * @deprecated Misspelled method - use getItemsHasMessages() instead
+     */
+    public function getItemsHasMesssages()
+    {
+        return $this->getItemsHasMessages();
+    }
+
+    /**
      * Check if items has messages
      *
      * @return bool

--- a/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
@@ -251,17 +251,17 @@ class TaxTest extends \PHPUnit\Framework\TestCase
      * Test getWeeeAmountExclTax method
      *
      * @param string $productTypeId
-     * @param string $prodcuctPriceType
+     * @param string $productPriceType
      * @dataProvider getWeeeAmountExclTaxDataProvider
      */
-    public function testGetWeeeAmountExclTax($productTypeId, $prodcuctPriceType)
+    public function testGetWeeeAmountExclTax($productTypeId, $productPriceType)
     {
         $product = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
             ->setMethods(['getTypeId', 'getPriceType'])
             ->getMock();
         $product->expects($this->any())->method('getTypeId')->willReturn($productTypeId);
-        $product->expects($this->any())->method('getPriceType')->willReturn($prodcuctPriceType);
+        $product->expects($this->any())->method('getPriceType')->willReturn($productPriceType);
         $weeeDataHelper = $this->getMockBuilder(\Magento\Framework\DataObject::class)
             ->disableOriginalConstructor()
             ->setMethods(['getAmountExclTax'])

--- a/dev/tests/api-functional/_files/Magento/TestModule1/Controller/CookieTester.php
+++ b/dev/tests/api-functional/_files/Magento/TestModule1/Controller/CookieTester.php
@@ -42,7 +42,7 @@ abstract class CookieTester implements \Magento\Framework\App\ActionInterface
         CookieMetadataFactory $cookieMetadataFactory
     ) {
         $this->cookieManager = $cookieManager;
-        $this->cookieMetadataFacory = $cookieMetadataFactory;
+        $this->cookieMetadataFactory = $cookieMetadataFactory;
         $this->_response = $context->getResponse();
         $this->request = $context->getRequest();
     }
@@ -52,7 +52,7 @@ abstract class CookieTester implements \Magento\Framework\App\ActionInterface
      */
     protected function getCookieMetadataFactory()
     {
-        return $this->cookieMetadataFacory;
+        return $this->cookieMetadataFactory;
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Response/Http.php
+++ b/lib/internal/Magento/Framework/App/Response/Http.php
@@ -91,8 +91,8 @@ class Http extends \Magento\Framework\HTTP\PhpEnvironment\Response
     {
         $varyString = $this->context->getVaryString();
         if ($varyString) {
-            $sensitiveCookMetadata = $this->cookieMetadataFactory->createSensitiveCookieMetadata()->setPath('/');
-            $this->cookieManager->setSensitiveCookie(self::COOKIE_VARY_STRING, $varyString, $sensitiveCookMetadata);
+            $sensitiveCookieMetadata = $this->cookieMetadataFactory->createSensitiveCookieMetadata()->setPath('/');
+            $this->cookieManager->setSensitiveCookie(self::COOKIE_VARY_STRING, $varyString, $sensitiveCookieMetadata);
         } elseif ($this->request->get(self::COOKIE_VARY_STRING)) {
             $cookieMetadata = $this->cookieMetadataFactory->createSensitiveCookieMetadata()->setPath('/');
             $this->cookieManager->deleteCookie(self::COOKIE_VARY_STRING, $cookieMetadata);

--- a/setup/src/Magento/Setup/Test/Unit/Model/Cron/JobStaticRegenerateTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/Cron/JobStaticRegenerateTest.php
@@ -76,7 +76,7 @@ class JobStaticRegenerateTest extends \PHPUnit\Framework\TestCase
             ->method('getModeObject')
             ->will($this->returnValue($modeObjectMock));
 
-        $statusObject = $this->getStatucObjectMock(['add']);
+        $statusObject = $this->getStatusObjectMock(['add']);
         $statusObject
             ->expects($this->exactly(3))
             ->method('add');
@@ -124,7 +124,7 @@ class JobStaticRegenerateTest extends \PHPUnit\Framework\TestCase
             ->method('getModeObject')
             ->will($this->returnValue($modeObjectMock));
 
-        $statusObject = $this->getStatucObjectMock(['toggleUpdateError']);
+        $statusObject = $this->getStatusObjectMock(['toggleUpdateError']);
         $statusObject
             ->expects($this->once())
             ->method('toggleUpdateError');
@@ -161,7 +161,7 @@ class JobStaticRegenerateTest extends \PHPUnit\Framework\TestCase
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|\Magento\Setup\Model\Cron\Status
      */
-    protected function getStatucObjectMock($methods = null)
+    protected function getStatusObjectMock($methods = null)
     {
         return $this->createPartialMock(\Magento\Setup\Model\Cron\Status::class, $methods);
     }


### PR DESCRIPTION
### Description
Found a misspelled parameter name in \Magento\Weee\Test\Unit\Model\TaxTest::testGetWeeeAmountExclTax

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
