### PR TITLE
Fix a misspelled method name in GiftMessage

### DIFF
--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -278,7 +278,8 @@ class Inline extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @deprecated Misspelled method - use getItemsHasMessages() instead
+     * @deprecated Misspelled method
+     * @see getItemsHasMessages
      */
     public function getItemsHasMesssages()
     {

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -283,7 +283,7 @@ class Inline extends \Magento\Framework\View\Element\Template
      * @return bool
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
      */
-    public function getItemsHasMesssages()
+    public function getItemsHasMessages()
     {
         foreach ($this->getItems() as $item) {
             if ($item->getGiftMessageId()) {

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -278,6 +278,14 @@ class Inline extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * @deprecated Misspelled method - use getItemsHasMessages() instead
+     */
+    public function getItemsHasMesssages()
+    {
+        return $this->getItemsHasMessages();
+    }
+
+    /**
      * Check if items has messages
      *
      * @return bool


### PR DESCRIPTION

### Description
Found a misspelled method name in 
\Magento\GiftMessage\Block\Message\Inline

Fixed the method name and deprecated misspelled method to ensure backwards compatibility

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
