### PR TITLE
Fix a misspelled variable name in SaveHandler

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/SaveHandler.php
@@ -97,8 +97,8 @@ class SaveHandler
 
         try {
             $linkTypesToId = $this->linkTypeProvider->getLinkTypes();
-            $prodyctHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
-            $productData = $prodyctHydrator->extract($product);
+            $productHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
+            $productData = $productHydrator->extract($product);
             $this->linkResource->saveProductLinks(
                 $productData[$this->metadataPool->getMetadata(ProductInterface::class)->getLinkField()],
                 $links,


### PR DESCRIPTION
### Description
Found a misspelled variable name in \Magento\Catalog\Model\ResourceModel\Product\Link\SaveHandler::execute

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
