### PR TITLE
Fix a misspelled variable name in DeleteHandler

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/DeleteHandler.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Link/DeleteHandler.php
@@ -72,8 +72,8 @@ class DeleteHandler
         $linkedProduct = $this->productRepository->get($entity->getLinkedProductSku());
         $product = $this->productRepository->get($entity->getSku());
         $linkTypesToId = $this->linkTypeProvider->getLinkTypes();
-        $prodyctHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
-        $productData = $prodyctHydrator->extract($product);
+        $productHydrator = $this->metadataPool->getHydrator(ProductInterface::class);
+        $productData = $productHydrator->extract($product);
         $linkId = $this->linkResource->getProductLinkId(
             $productData[$this->metadataPool->getMetadata(ProductInterface::class)->getLinkField()],
             $linkedProduct->getId(),


### PR DESCRIPTION
### Description
Found a misspelled variable name in \Magento\Catalog\Model\ResourceModel\Product\Link\DeleteHandler::execute

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
