### PR TITLE
Fix a misspelled method name in JobStaticRegenerateTest

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Model/Cron/JobStaticRegenerateTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/Cron/JobStaticRegenerateTest.php
@@ -76,7 +76,7 @@ class JobStaticRegenerateTest extends \PHPUnit\Framework\TestCase
             ->method('getModeObject')
             ->will($this->returnValue($modeObjectMock));
 
-        $statusObject = $this->getStatucObjectMock(['add']);
+        $statusObject = $this->getStatusObjectMock(['add']);
         $statusObject
             ->expects($this->exactly(3))
             ->method('add');
@@ -124,7 +124,7 @@ class JobStaticRegenerateTest extends \PHPUnit\Framework\TestCase
             ->method('getModeObject')
             ->will($this->returnValue($modeObjectMock));
 
-        $statusObject = $this->getStatucObjectMock(['toggleUpdateError']);
+        $statusObject = $this->getStatusObjectMock(['toggleUpdateError']);
         $statusObject
             ->expects($this->once())
             ->method('toggleUpdateError');
@@ -161,7 +161,7 @@ class JobStaticRegenerateTest extends \PHPUnit\Framework\TestCase
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|\Magento\Setup\Model\Cron\Status
      */
-    protected function getStatucObjectMock($methods = null)
+    protected function getStatusObjectMock($methods = null)
     {
         return $this->createPartialMock(\Magento\Setup\Model\Cron\Status::class, $methods);
     }


### PR DESCRIPTION
### Description
Found a misspelled method name in
\Magento\Setup\Test\Unit\Model\Cron\JobStaticRegenerateTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
