### PR TITLE
Fix a misspelled property name in CookieTester

### DIFF
--- a/dev/tests/api-functional/_files/Magento/TestModule1/Controller/CookieTester.php
+++ b/dev/tests/api-functional/_files/Magento/TestModule1/Controller/CookieTester.php
@@ -42,7 +42,7 @@ abstract class CookieTester implements \Magento\Framework\App\ActionInterface
         CookieMetadataFactory $cookieMetadataFactory
     ) {
         $this->cookieManager = $cookieManager;
-        $this->cookieMetadataFacory = $cookieMetadataFactory;
+        $this->cookieMetadataFactory = $cookieMetadataFactory;
         $this->_response = $context->getResponse();
         $this->request = $context->getRequest();
     }
@@ -52,7 +52,7 @@ abstract class CookieTester implements \Magento\Framework\App\ActionInterface
      */
     protected function getCookieMetadataFactory()
     {
-        return $this->cookieMetadataFacory;
+        return $this->cookieMetadataFactory;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Found a misspelled property name in
\Magento\TestModule1\Controller\CookieTester

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
