### PR TITLE
Fix a misspelled variable name in Http

### DIFF
--- a/lib/internal/Magento/Framework/App/Response/Http.php
+++ b/lib/internal/Magento/Framework/App/Response/Http.php
@@ -91,8 +91,8 @@ class Http extends \Magento\Framework\HTTP\PhpEnvironment\Response
     {
         $varyString = $this->context->getVaryString();
         if ($varyString) {
-            $sensitiveCookMetadata = $this->cookieMetadataFactory->createSensitiveCookieMetadata()->setPath('/');
-            $this->cookieManager->setSensitiveCookie(self::COOKIE_VARY_STRING, $varyString, $sensitiveCookMetadata);
+            $sensitiveCookieMetadata = $this->cookieMetadataFactory->createSensitiveCookieMetadata()->setPath('/');
+            $this->cookieManager->setSensitiveCookie(self::COOKIE_VARY_STRING, $varyString, $sensitiveCookieMetadata);
         } elseif ($this->request->get(self::COOKIE_VARY_STRING)) {
             $cookieMetadata = $this->cookieMetadataFactory->createSensitiveCookieMetadata()->setPath('/');
             $this->cookieManager->deleteCookie(self::COOKIE_VARY_STRING, $cookieMetadata);


### PR DESCRIPTION
### Description
Found a misspelled variable name in 
\Magento\Framework\App\Response\Http::sendVary

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
