### PR TITLE
Fix a misspelled constant name in Admin\Custom

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
@@ -29,7 +29,7 @@ class Custom extends \Magento\Framework\App\Config\Value
     const XML_PATH_ADMIN_SECURITY_USEFORMKEY = 'admin/security/use_form_key';
     const XML_PATH_MAINTENANCE_MODE = 'maintenance_mode';
     const XML_PATH_WEB_COOKIE_COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
-    const XML_PATH_WEB_COOKIE_COOKE_PATH = 'web/cookie/cookie_path';
+    const XML_PATH_WEB_COOKIE_COOKIE_PATH = 'web/cookie/cookie_path';
     const XML_PATH_WEB_COOKIE_COOKIE_DOMAIN = 'web/cookie/cookie_domain';
     const XML_PATH_WEB_COOKIE_HTTPONLY = 'web/cookie/cookie_httponly';
     const XML_PATH_WEB_COOKIE_RESTRICTION = 'web/cookie/cookie_restriction';

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Custom.php
@@ -29,6 +29,10 @@ class Custom extends \Magento\Framework\App\Config\Value
     const XML_PATH_ADMIN_SECURITY_USEFORMKEY = 'admin/security/use_form_key';
     const XML_PATH_MAINTENANCE_MODE = 'maintenance_mode';
     const XML_PATH_WEB_COOKIE_COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
+    /**
+     * @deprecated Misspelled constant - use XML_PATH_WEB_COOKIE_COOKIE_PATH instead
+     */
+    const XML_PATH_WEB_COOKIE_COOKE_PATH = 'web/cookie/cookie_path';
     const XML_PATH_WEB_COOKIE_COOKIE_PATH = 'web/cookie/cookie_path';
     const XML_PATH_WEB_COOKIE_COOKIE_DOMAIN = 'web/cookie/cookie_domain';
     const XML_PATH_WEB_COOKIE_HTTPONLY = 'web/cookie/cookie_httponly';


### PR DESCRIPTION
### Description
Found a misspelled constant name in
\Magento\Config\Model\Config\Backend\Admin\Custom

I left the misspelled constant in it to ensure backwards compatibility

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
