### PR TITLE
Fix a misspelled method name in ConfigTest

### DIFF
--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/ConfigTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/ConfigTest.php
@@ -96,7 +96,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->menuMock, $this->model->getMenu());
     }
 
-    public function testGetMenuWithNotCachedObjectBuidlsObject()
+    public function testGetMenuWithNotCachedObjectBuildsObject()
     {
         $this->cacheInstanceMock->expects(
             $this->at(0)


### PR DESCRIPTION
### Description
Found a misspelled method name in
\Magento\Backend\Test\Unit\Model\Menu\ConfigTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
