### PR TITLE
Fix a misspelled method name in CanVoidHandlerTest

### DIFF
--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Config/CanVoidHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Config/CanVoidHandlerTest.php
@@ -39,7 +39,7 @@ class CanVoidHandlerTest extends \PHPUnit\Framework\TestCase
         static::assertFalse($voidHandler->handle($subject));
     }
 
-    public function testHandleSomeAmoutWasPaid()
+    public function testHandleSomeAmountWasPaid()
     {
         $paymentDO = $this->createMock(PaymentDataObjectInterface::class);
         $subject = [


### PR DESCRIPTION
### Description
Found a misspelled method name in
\Magento\Braintree\Test\Unit\Gateway\Config\CanVoidHandlerTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
