### PR TITLE
Fix a misspelled variable name in TransactionsCollectionTest

### DIFF
--- a/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
@@ -125,7 +125,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetItemsWithLimit()
     {
-        $transations = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
+        $transactions = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
 
         $this->filterMapperMock->expects($this->once())
             ->method('getFilter')
@@ -133,7 +133,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
 
         $this->braintreeAdapterMock->expects($this->once())
             ->method('search')
-            ->willReturn($transations);
+            ->willReturn($transactions);
 
         $this->entityFactoryMock->expects($this->exactly(TransactionsCollection::TRANSACTION_MAXIMUM_COUNT))
             ->method('create')
@@ -157,7 +157,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetItemsWithNullLimit()
     {
-        $transations = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
+        $transactions = range(1, TransactionsCollection::TRANSACTION_MAXIMUM_COUNT + 10);
 
         $this->filterMapperMock->expects($this->once())
             ->method('getFilter')
@@ -165,7 +165,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
 
         $this->braintreeAdapterMock->expects($this->once())
             ->method('search')
-            ->willReturn($transations);
+            ->willReturn($transactions);
 
         $this->entityFactoryMock->expects($this->exactly(TransactionsCollection::TRANSACTION_MAXIMUM_COUNT))
             ->method('create')


### PR DESCRIPTION
### Description
Found a misspelled variable name in
\Magento\Braintree\Test\Unit\Model\Report\TransactionsCollectionTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
