### PR TITLE
Fix a misspelled method name in TypeTest

### DIFF
--- a/app/code/Magento/Bundle/Test/Unit/Model/Product/TypeTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Product/TypeTest.php
@@ -1365,7 +1365,7 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     /**
      * @return void
      */
-    public function testPrepareForCartAdvancedAllrequiredOption()
+    public function testPrepareForCartAdvancedAllRequiredOption()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|DefaultType $group */
         $group = $this->getMockBuilder(\Magento\Catalog\Model\Product\Option\Type\DefaultType::class)


### PR DESCRIPTION
### Description
Found a misspelled method name in
\Magento\Bundle\Test\Unit\Model\Product\TypeTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
