### PR TITLE
Fix a misspelled variable name in ViewTest

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Block/Category/ViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Category/ViewTest.php
@@ -31,9 +31,9 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     public function testGetIdentities()
     {
         $categoryTag = ['catalog_category_1'];
-        $currentCatogoryMock = $this->createMock(\Magento\Catalog\Model\Category::class);
-        $currentCatogoryMock->expects($this->once())->method('getIdentities')->will($this->returnValue($categoryTag));
-        $this->block->setCurrentCategory($currentCatogoryMock);
+        $currentCategoryMock = $this->createMock(\Magento\Catalog\Model\Category::class);
+        $currentCategoryMock->expects($this->once())->method('getIdentities')->will($this->returnValue($categoryTag));
+        $this->block->setCurrentCategory($currentCategoryMock);
         $this->assertEquals($categoryTag, $this->block->getIdentities());
     }
 }


### PR DESCRIPTION
### Description
Found a misspelled variable name in
\Magento\Catalog\Test\Unit\Block\Category\ViewTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
