### PR TITLE
Fix a misspelled variable name in ProductsRenderInfoSectionTest

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/CustomerData/ProductsRenderInfoSectionTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/CustomerData/ProductsRenderInfoSectionTest.php
@@ -134,7 +134,7 @@ class ProductsRenderInfoSectionTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('create')
             ->willReturn($filterMock);
-        $searchCritera = $this->createMock(SearchCriteria::class);
+        $searchCriteria = $this->createMock(SearchCriteria::class);
         $this->searchCriteriaBuilderMock
             ->expects($this->once())
             ->method('addFilters')
@@ -142,10 +142,10 @@ class ProductsRenderInfoSectionTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->once())
             ->method('create')
-            ->willReturn($searchCritera);
+            ->willReturn($searchCriteria);
         $this->productRenderRepositoryMock->expects($this->once())
             ->method('getList')
-            ->with($searchCritera, 3, 'UAH')
+            ->with($searchCriteria, 3, 'UAH')
             ->willReturn($searchResult);
         $searchResult->expects($this->any())
             ->method('getItems')


### PR DESCRIPTION
### Description
Found a misspelled variable name in
\Magento\Catalog\Test\Unit\CustomerData\ProductsRenderInfoSectionTest

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
