### PR TITLE
#12714 - pass parameter for export button url

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
@@ -35,7 +35,13 @@
     <listingToolbar name="listing_top">
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
-        <exportButton name="export_button"/>
+        <exportButton name="export_button">
+            <settings>
+                <additionalParams>
+                    <param xsi:type="string" active="true" name="order_id">*</param>
+                </additionalParams>
+            </settings>
+        </exportButton>
         <filterSearch name="fulltext"/>
         <filters name="listing_filters">
             <filterSelect name="store_id" provider="${ $.parentName }">

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_invoice_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_invoice_grid.xml
@@ -35,7 +35,13 @@
     <listingToolbar name="listing_top">
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
-        <exportButton name="export_button"/>
+        <exportButton name="export_button">
+            <settings>
+                <additionalParams>
+                    <param xsi:type="string" active="true" name="order_id">*</param>
+                </additionalParams>
+            </settings>
+        </exportButton>
         <filterSearch name="fulltext"/>
         <filters name="listing_filters">
             <filterSelect name="store_id" provider="${ $.parentName }">

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_shipment_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_shipment_grid.xml
@@ -35,7 +35,13 @@
     <listingToolbar name="listing_top">
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
-        <exportButton name="export_button"/>
+        <exportButton name="export_button">
+            <settings>
+                <additionalParams>
+                    <param xsi:type="string" active="true" name="order_id">*</param>
+                </additionalParams>
+            </settings>
+        </exportButton>
         <filterSearch name="fulltext"/>
         <filters name="listing_filters">
             <filterSelect name="store_id" provider="${ $.parentName }">

--- a/app/code/Magento/Ui/Component/ExportButton.php
+++ b/app/code/Magento/Ui/Component/ExportButton.php
@@ -54,16 +54,39 @@ class ExportButton extends AbstractComponent
      */
     public function prepare()
     {
+        $context = $this->getContext();
         $config = $this->getData('config');
         if (isset($config['options'])) {
             $options = [];
             foreach ($config['options'] as $option) {
-                $option['url'] = $this->urlBuilder->getUrl($option['url']);
+                $additionalParams = $this->getAdditionalParams($config, $context);
+                $option['url'] = $this->urlBuilder->getUrl($option['url'], $additionalParams);
                 $options[] = $option;
             }
             $config['options'] = $options;
             $this->setData('config', $config);
         }
         parent::prepare();
+    }
+
+    /**
+     * Get export button additional parameters
+     *
+     * @param array $config
+     * @param ContextInterface $context
+     * @return array
+     */
+    protected function getAdditionalParams($config, $context)
+    {
+        $additionalParams = [];
+        if (isset($config['additionalParams'])) {
+            foreach ($config['additionalParams'] as $paramName => $paramValue) {
+                if ('*' == $paramValue) {
+                    $paramValue = $context->getRequestParam($paramName);
+                }
+                $additionalParams[$paramName] = $paramValue;
+            }
+        }
+        return $additionalParams;
     }
 }


### PR DESCRIPTION
Extra records are in exported CSV file for order

### Description
Pass parameter to export button url, configure button in invoice, shipment and creditmemo xml file

### Fixed Issues (if relevant)
1. magento/magento2#12714: Extra records are in exported CSV file for order

### Manual testing scenarios
1. Log in to Admin
2. Go to Sales > Orders
3. Open one of the orders from preconditions
4. Go to Invoices tab
5. Click Export and select CSV
6. Open exported CSV file

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
