### PR TITLE
Fix JS address converter function from mutating its argument

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/address-converter.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/address-converter.js
@@ -72,19 +72,19 @@ define([
                 output = {},
                 streetObject;
 
-            if ($.isArray(addrs.street)) {
-                streetObject = {};
-                addrs.street.forEach(function (value, index) {
-                    streetObject[index] = value;
-                });
-                addrs.street = streetObject;
-            }
-
             $.each(addrs, function (key) {
                 if (addrs.hasOwnProperty(key) && !$.isFunction(addrs[key])) {
                     output[self.toUnderscore(key)] = addrs[key];
                 }
             });
+
+            if ($.isArray(addrs.street)) {
+                streetObject = {};
+                addrs.street.forEach(function (value, index) {
+                    streetObject[index] = value;
+                });
+                output.street = streetObject;
+            }
 
             return output;
         },


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Don't mutate the function's argument `addrs`.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13216: `quoteAddressToFormAddressData` mutates the argument

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Require `'Magento_Checkout/js/model/address-converter'` inside any JavaScript module.
2. Call `quoteAddressToFormAddressData` method with some `address`.
3. `address.street` should remain as an array. Eg. `['Sesame Street']`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] ~All new or changed code is covered with unit/integration tests (if applicable)~
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
