### PR TITLE
Solve problem saving empty swatches in admin

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -110,6 +110,11 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
                 $options
             );
             $valueOptions = (isset($options['value']) && is_array($options['value'])) ? $options['value'] : [];
+            foreach (array_keys($valueOptions) as $key) {
+                if (!empty($options['delete'][$key])) {
+                    unset($valueOptions[$key]);
+                }
+            }
             $this->checkEmptyOption($response, $valueOptions);
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -110,6 +110,11 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
                 $options
             );
             $valueOptions = (isset($options['value']) && is_array($options['value'])) ? $options['value'] : [];
+            foreach ($valueOptions as $key => $val) {
+                if (isset($options['delete'][$key]) && $options['delete'][$key]) {
+                    unset($valueOptions[$key]);
+                }
+            }
             $this->checkEmptyOption($response, $valueOptions);
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -110,7 +110,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
                 $options
             );
             $valueOptions = (isset($options['value']) && is_array($options['value'])) ? $options['value'] : [];
-            foreach ($valueOptions as $key => $val) {
+            foreach ($valueOptions as $key => $valueOption) {
                 if (isset($options['delete'][$key]) && $options['delete'][$key]) {
                     unset($valueOptions[$key]);
                 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -110,8 +110,8 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
                 $options
             );
             $valueOptions = (isset($options['value']) && is_array($options['value'])) ? $options['value'] : [];
-            foreach ($valueOptions as $key => $valueOption) {
-                if (isset($options['delete'][$key]) && $options['delete'][$key]) {
+            foreach (array_keys($valueOptions) as $key) {
+                if (!empty($options['delete'][$key])) {
                     unset($valueOptions[$key]);
                 }
             }

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Attribute/ValidateTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Attribute/ValidateTest.php
@@ -249,6 +249,20 @@ class ValidateTest extends AttributeTest
                     ]
                 ], false
             ],
+            'empty and deleted' => [
+                [
+                    'value' => [
+                        "option_0" => [1, 0],
+                        "option_1" => [2, 0],
+                        "option_2" => ["", ""],
+                    ],
+                    'delete' => [
+                        "option_0" => "",
+                        "option_1" => "",
+                        "option_2" => "1",
+                    ]
+                ], false
+            ],
         ];
     }
 
@@ -321,7 +335,34 @@ class ValidateTest extends AttributeTest
                 (object) [
                     'error' => false,
                 ]
-            ]
+            ],
+            'empty admin scope options and deleted' => [
+                [
+                    'value' => [
+                        "option_0" => [''],
+                    ],
+                    'delete' => [
+                        'option_0' => '1',
+                    ],
+                ],
+                (object) [
+                    'error' => false,
+                ],
+            ],
+            'empty admin scope options and not deleted' => [
+                [
+                    'value' => [
+                        "option_0" => [''],
+                    ],
+                    'delete' => [
+                        'option_0' => '0',
+                    ],
+                ],
+                (object) [
+                    'error' => true,
+                    'message' => 'The value of Admin scope can\'t be empty.',
+                ],
+            ],
         ];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Attribute/ValidateTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Attribute/ValidateTest.php
@@ -249,6 +249,20 @@ class ValidateTest extends AttributeTest
                     ]
                 ], false
             ],
+            'empty and deleted' => [
+                [
+                    'value' => [
+                        "option_0" => [1, 0],
+                        "option_1" => [2, 0],
+                        "option_2" => ["", ""],
+                    ],
+                    'delete' => [
+                        "option_0" => "",
+                        "option_2" => "",
+                        "option_1" => "1",
+                    ]
+                ], true
+            ],
         ];
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Attribute/ValidateTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Attribute/ValidateTest.php
@@ -258,10 +258,10 @@ class ValidateTest extends AttributeTest
                     ],
                     'delete' => [
                         "option_0" => "",
-                        "option_2" => "",
-                        "option_1" => "1",
+                        "option_1" => "",
+                        "option_2" => "1",
                     ]
-                ], true
+                ], false
             ],
         ];
     }


### PR DESCRIPTION
### Description
Solve problem saving empty swatches in admin remving html ement instead of add hidden.

### Fixed Issues (if relevant)

1. Swatch Attribute is not getting save while deleting a swatch row with empty admin scope text #13117

### Manual testing scenarios

1. Login to admin and Goto Store- >Attribute->Product
2. Find a attribute like color
3. Open color attribute and make it to Visual Swatch type
4. In Manage Swatches section add color swatches
5. Now Click on Add Swatch button, a row will appear just remove it without filling anything into it.
6. Now is saved. Before it throws: The value of Admin scope can't be empty.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
