### PR TITLE
[2.3-develop] Fix missing discount label in checkout

### DIFF
--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
@@ -45,6 +45,23 @@ define([
         },
 
         /**
+         * Get discount title
+         *
+         * @returns {null|string}
+         */
+        getTitle: function () {
+            if (!this.totals()) {
+                return null;
+            }
+
+            var discountSegments = this.totals()['total_segments'].filter(function (segment) {
+                return (segment.code === 'discount');
+            });
+
+            return discountSegments.length ? discountSegments[0].title : null;
+        },
+
+        /**
          * @return {Number}
          */
         getPureValue: function () {

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
@@ -47,10 +47,11 @@ define([
         /**
          * Get discount title
          *
-         * @returns {null|string}
+         * @returns {null|String}
          */
         getTitle: function () {
             var discountSegments;
+
             if (!this.totals()) {
                 return null;
             }

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
@@ -50,12 +50,13 @@ define([
          * @returns {null|string}
          */
         getTitle: function () {
+            var discountSegments;
             if (!this.totals()) {
                 return null;
             }
 
-            var discountSegments = this.totals()['total_segments'].filter(function (segment) {
-                return (segment.code === 'discount');
+            discountSegments = this.totals()['total_segments'].filter(function (segment) {
+                return segment.code === 'discount';
             });
 
             return discountSegments.length ? discountSegments[0].title : null;

--- a/app/code/Magento/SalesRule/view/frontend/web/template/cart/totals/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/cart/totals/discount.html
@@ -7,7 +7,7 @@
 <!-- ko if: isDisplayed() -->
 <tr class="totals">
     <th colspan="1" style="" class="mark" scope="row">
-        <span class="title" data-bind="text: title"></span>
+        <span class="title" data-bind="text: getTitle()"></span>
         <span class="discount coupon" data-bind="text: getCouponLabel()"></span>
     </th>
     <td class="amount" data-bind="attr: {'data-th': title}">

--- a/app/code/Magento/SalesRule/view/frontend/web/template/summary/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/summary/discount.html
@@ -7,7 +7,7 @@
 <!-- ko if: isDisplayed() -->
 <tr class="totals discount">
     <th class="mark" scope="row">
-        <span class="title" data-bind="text: title"></span>
+        <span class="title" data-bind="text: getTitle()"></span>
         <span class="discount coupon" data-bind="text: getCouponCode()"></span>
     </th>
     <td class="amount">

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_cart.less
@@ -80,6 +80,10 @@
             margin-bottom: 0;
             overflow: inherit;
         }
+
+        .discount.coupon {
+            display: none;
+        }
     }
 
     //  Products table

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -49,6 +49,10 @@
             }
         }
 
+        .discount.coupon {
+            display: none;
+        }
+
         .grand.incl {
             & + .grand.excl {
                 .mark,

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -162,6 +162,10 @@
                 text-align: left;
             }
         }
+
+        .discount.coupon {
+            display: none;
+        }
     }
 
     //  Products table

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -49,6 +49,10 @@
             }
         }
 
+        .discount.coupon {
+            display: none;
+        }
+
         .grand.incl {
             & + .grand.excl {
                 .mark,


### PR DESCRIPTION
### Description
The discount label was not being shown in the shopping cart totals description
Continuing of https://github.com/magento/magento2/pull/11883

### Fixed Issues
1. magento/magento2#11497: Discount Rule does not show Default Rule Label
2. magento/magento2#11428: Cart Price Rule Label is not working

### Manual testing scenarios
1. Add a discount to quote
2. Go to the shopping cart and now see the discount label in the totals description

### Related PRs
https://github.com/magento/magento2/pull/13141
https://github.com/magento/magento2/pull/13223

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
