### PR TITLE
change visibility of private method

### DIFF
--- a/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
+++ b/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
@@ -154,7 +154,7 @@ class Topmenu
      * @param bool $isParentActive
      * @return array
      */
-    private function getCategoryAsArray($category, $currentCategory, $isParentActive)
+    protected function getCategoryAsArray($category, $currentCategory, $isParentActive)
     {
         return [
             'name' => $category->getName(),


### PR DESCRIPTION
changing visibility of method getCategoryAsArray in order to be able to override this function in a module instead of copying the whole file.

use case: extend menu with attribute (see https://magento.stackexchange.com/questions/147114/magento-2-1-add-custom-category-attribute-to-topmenu-classes/187120) where the collection can be adapted but the resulting array which is available later in the template/block is not accessable

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
