### PR TITLE
Translate attribute label with default translation helper function

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
@@ -490,6 +490,10 @@ class EavTest extends AbstractModifierTest
             ->method('getNote')
             ->willReturn($note);
 
+        $this->productAttributeMock->expects($this->any())
+            ->method('getDefaultFrontendLabel')
+            ->willReturn(new Phrase('mylabel'));
+
         $attributeMock = $this->getMockBuilder(AttributeInterface::class)
             ->setMethods(['getValue'])
             ->disableOriginalConstructor()
@@ -561,7 +565,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => true,
                 'notice'      => null,
                 'default'     => null,
-                'label'       => new Phrase(''),
+                'label'       => new Phrase('mylabel'),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -588,7 +592,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => null,
                 'default'     => null,
-                'label'       => new Phrase(''),
+                'label'       => new Phrase('mylabel'),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -615,7 +619,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => null,
                 'default'     => 'required_value',
-                'label'       => new Phrase(''),
+                'label'       => new Phrase('mylabel'),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -642,7 +646,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => null,
                 'default'     => 'required_value',
-                'label'       => new Phrase(''),
+                'label'       => new Phrase('mylabel'),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -669,7 +673,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => __('example notice'),
                 'default'     => 'required_value',
-                'label'       => new Phrase(''),
+                'label'       => new Phrase('mylabel'),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',

--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EavTest.php
@@ -187,7 +187,7 @@ class EavTest extends AbstractModifierTest
      * @var ObjectManager
      */
     protected $objectManager;
-    
+
     /**
      * @var Eav
      */
@@ -324,7 +324,7 @@ class EavTest extends AbstractModifierTest
         $this->eavAttributeMock->expects($this->any())
             ->method('load')
             ->willReturnSelf();
-        
+
         $this->eav =$this->getModel();
         $this->objectManager->setBackwardCompatibleProperty(
             $this->eav,
@@ -561,7 +561,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => true,
                 'notice'      => null,
                 'default'     => null,
-                'label'       => null,
+                'label'       => new Phrase(''),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -588,7 +588,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => null,
                 'default'     => null,
-                'label'       => null,
+                'label'       => new Phrase(''),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -615,7 +615,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => null,
                 'default'     => 'required_value',
-                'label'       => null,
+                'label'       => new Phrase(''),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -642,7 +642,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => null,
                 'default'     => 'required_value',
-                'label'       => null,
+                'label'       => new Phrase(''),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',
@@ -669,7 +669,7 @@ class EavTest extends AbstractModifierTest
                 'required'    => false,
                 'notice'      => __('example notice'),
                 'default'     => 'required_value',
-                'label'       => null,
+                'label'       => new Phrase(''),
                 'code'        => 'code',
                 'source'      => 'product-details',
                 'scopeLabel'  => '',

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -580,7 +580,7 @@ class Eav extends AbstractModifier
             'required' => $attribute->getIsRequired(),
             'notice' => $attribute->getNote() === null ? null : __($attribute->getNote()),
             'default' => (!$this->isProductExists()) ? $attribute->getDefaultValue() : null,
-            'label' => $attribute->getDefaultFrontendLabel(),
+            'label' => __($attribute->getDefaultFrontendLabel()),
             'code' => $attribute->getAttributeCode(),
             'source' => $groupCode,
             'scopeLabel' => $this->getScopeLabel($attribute),

--- a/dev/tests/integration/testsuite/Magento/Setup/Module/I18n/Dictionary/GeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Setup/Module/I18n/Dictionary/GeneratorTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Setup\Module\I18n\Dictionary;
 
 use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Setup\Module\I18n\Dictionary\Generator;
 use Magento\Setup\Module\I18n\ServiceLocator;
 
 class GeneratorTest extends \PHPUnit\Framework\TestCase
@@ -46,6 +47,7 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
         $paths = $reflection->getProperty('paths');
         $paths->setAccessible(true);
         $this->backupRegistrar = $paths->getValue();
+        $paths->setValue(['module' => [], 'theme' => []]);
         $paths->setAccessible(false);
 
         $this->testDir = realpath(__DIR__ . '/_files');


### PR DESCRIPTION
Adds the translation function to customer attribute labels in Magento
admin. This gives a chance to translate a label in the locale of a
backend user.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
A custom attribute is created.
We have different frontend labels for the attribute. Store views with different locale settings exist.
Admin users are speaking different languages and need a localized attribute label.
This is not possible.


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13251: Unable to translate custom attributes in admin backend

### Manual testing scenarios
1. Create an custom attribute with different frontend labels.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
