### PR TITLE
remove changes of MAGETWO-69567

### DIFF
--- a/lib/web/fotorama/fotorama.js
+++ b/lib/web/fotorama/fotorama.js
@@ -1217,14 +1217,6 @@ fotoramaVersion = '4.6.4';
         stopPropagation && e.stopPropagation && e.stopPropagation();
     }
 
-    function stubEvent($el, eventType) {
-        $el.on(eventType, function (e) {
-            stopEvent(e, true);
-
-            return false;
-        });
-    }
-
     function getDirectionSign(forward) {
         return forward ? '>' : '<';
     }
@@ -2158,11 +2150,6 @@ fotoramaVersion = '4.6.4';
             if (o_allowFullScreen) {
                 $fullscreenIcon.prependTo($stage);
                 o_nativeFullScreen = FULLSCREEN && o_allowFullScreen === 'native';
-
-                // Due 300ms click delay on mobile devices
-                // we stub touchend and fallback to click.
-                // MAGETWO-69567
-                stubEvent($fullscreenIcon, 'touchend');
             } else {
                 $fullscreenIcon.detach();
                 o_nativeFullScreen = false;


### PR DESCRIPTION
Undo changes of MAGETWO-69567

### Description
Previous changes in the fotorama gallery plugin causes problems on iOS devices.

### Fixed Issues (if relevant)
1. magento/magento2#13226: Can't close full screen gallery on iOS devices

### Manual testing scenarios
1. Start Apple Simulator (https://developer.apple.com/library/content/documentation/IDEs/Conceptual/iOS_Simulator_Guide/Introduction/Introduction.html)
2. Run Safari and open any product detail page
3. Tap on the image to open the product image in fullscreen mode
4. Tap on the close button in the upper right corner
5. Gallery closes and you can see the product detail page again

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)