### PR TITLE
Small refactor of getFrontName

### DIFF
--- a/lib/internal/Magento/Framework/View/Context.php
+++ b/lib/internal/Magento/Framework/View/Context.php
@@ -332,15 +332,11 @@ class Context
     }
 
     /**
-     * Retrieve the module name
-     *
-     * @return string
-     *
-     * @todo alias of getModuleName
+     * @see getModuleName
      */
     public function getFrontName()
     {
-        return $this->getRequest()->getModuleName();
+        return $this->getModuleName();
     }
 
     /**


### PR DESCRIPTION
### Description
getFrontName is an alias of getModuleName so we might as well return it's return value.
Both seems to be in use, but maybe one or the other should be deprecated?

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
