### PR TITLE
Remove redundant code for clarity

### DIFF
--- a/app/code/Magento/AdminNotification/Model/Feed.php
+++ b/app/code/Magento/AdminNotification/Model/Feed.php
@@ -214,9 +214,6 @@ class Feed extends \Magento\Framework\Model\AbstractModel
         );
         $curl->write(\Zend_Http_Client::GET, $this->getFeedUrl(), '1.0');
         $data = $curl->read();
-        if ($data === false) {
-            return false;
-        }
         $data = preg_split('/^\r?$/m', $data, 2);
         $data = trim($data[1]);
         $curl->close();


### PR DESCRIPTION
### Description
[`$curl->read()`](https://github.com/magento/magento2/blob/2.3-develop/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php#L204) will always return a string even if `curl_exec` fails because there is `preg_replace` at the end. Because the [`$data`](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/AdminNotification/Model/Feed.php#L216) can never be identical to `false` so I think this redundant piece of code should be removed.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
