### PR TITLE
In checkout->multishipping-> new addres clean region when select country without dropdown for states

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -196,7 +196,7 @@ define([
                 label.attr('for', regionList.attr('id'));
             } else {
                 this._removeSelectOptions(regionList);
-                
+
                 if (this.options.isRegionRequired) {
                     regionInput.addClass('required-entry').removeAttr('disabled');
                     requiredLabel.addClass('required');

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -195,6 +195,7 @@ define([
                 regionInput.hide();
                 label.attr('for', regionList.attr('id'));
             } else {
+                this._removeSelectOptions(regionList);
                 if (this.options.isRegionRequired) {
                     regionInput.addClass('required-entry').removeAttr('disabled');
                     requiredLabel.addClass('required');

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -196,6 +196,7 @@ define([
                 label.attr('for', regionList.attr('id'));
             } else {
                 this._removeSelectOptions(regionList);
+                
                 if (this.options.isRegionRequired) {
                     regionInput.addClass('required-entry').removeAttr('disabled');
                     requiredLabel.addClass('required');


### PR DESCRIPTION
### Description
In checkout->multishipping-> new addres clean region when select country without dropdown for states. 

Before, when you select a country without dropdown for region, the region_id wasn't clean.

### Fixed Issues 
1. magento/magento2#8621: M2.1 Multishipping Checkout step New Address - Old State is saved when country is changed 

### Manual testing scenarios

1. Add multiple product to cart (minimum 2 product or 1 product with quantity 2) .
2. Check Out with Multiple Addresses.
3. Now Click on Enter a New Address button.
4. Now fill the form with Country : United States and select State : New Jersey
5. Others fields value can be anything you like
6. Now before saving the form, do change in country and State.
7. Select Country : Australia and set State: NSW
8. No Click on Save Address Button.
9. You will be redirected to Ship to Multiple Addresses page.
10. In address dropdown, look for Address you just saved. You will see "New Jersey" in address dropdown.
11. But we saved "NSW" as State from Multishipping New Address form.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
