### PR TITLE
Added support for PHP paths with spaces in Magento CLI

### DIFF
--- a/app/code/Magento/Deploy/Model/Filesystem.php
+++ b/app/code/Magento/Deploy/Model/Filesystem.php
@@ -115,7 +115,7 @@ class Filesystem
         $this->userCollection = $userCollection;
         $this->locale = $locale;
         $this->functionCallPath =
-            '"' . PHP_BINARY . '"' . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
+	        escapeshellcmd(PHP_BINARY) . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
     }
 
     /**

--- a/app/code/Magento/Deploy/Model/Filesystem.php
+++ b/app/code/Magento/Deploy/Model/Filesystem.php
@@ -115,7 +115,7 @@ class Filesystem
         $this->userCollection = $userCollection;
         $this->locale = $locale;
         $this->functionCallPath =
-	        escapeshellcmd(PHP_BINARY) . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
+            '"' . PHP_BINARY . '"' . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
     }
 
     /**

--- a/app/code/Magento/Deploy/Model/Filesystem.php
+++ b/app/code/Magento/Deploy/Model/Filesystem.php
@@ -115,7 +115,7 @@ class Filesystem
         $this->userCollection = $userCollection;
         $this->locale = $locale;
         $this->functionCallPath =
-            PHP_BINARY . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
+            '"' . PHP_BINARY . '"' . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
     }
 
     /**

--- a/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
@@ -107,7 +107,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->cmdPrefix = escapeshellcmd(PHP_BINARY)  . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
+        $this->cmdPrefix = '"' . PHP_BINARY . "'" . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
     }
 
     public function testRegenerateStatic()

--- a/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
@@ -107,7 +107,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->cmdPrefix = '"' . PHP_BINARY . "'" . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
+        $this->cmdPrefix = escapeshellcmd(PHP_BINARY)  . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
     }
 
     public function testRegenerateStatic()

--- a/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
@@ -107,7 +107,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->cmdPrefix = PHP_BINARY . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
+        $this->cmdPrefix = '"' . PHP_BINARY . "'" . ' -f ' . BP . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'magento ';
     }
 
     public function testRegenerateStatic()


### PR DESCRIPTION
## Support for PHP paths that include spaces in the Magento CLI

### Description
Found that some Magento CLI commands (`bin/magento deploy:mode:set production` for example) caused another command to be run, which is all good and fine except because it is then executed at a low level `exec` function call, if the PHP_BINARY variable had a space in it, it would cause it to break.

Originally solved it simply escaping all spaces in the final command string, but that's a terrible security principle, not to mention it causes any arguments to not be recognised.

End solution seems to be as simple as wrapping the `\Magento\Deploy\Model\Filesystem::$functionCallPath` in quotes.

Note: If the current state of having M2 running on Windows is that it won't happen that's a real shame, but as far as I know you can have spaces in filepaths on OSX or *nix (you probably wouldn't, but it's at least possible)

### Fixed Issues (if relevant)
Rather than creating an issue, I just solved it with a PR because it is so simple

### Manual testing scenarios
1. Have a space in your php path
2. Run `bin/magento deploy:mode:set production -vvv`
3. See that the command runs as expected

### Contribution checklist
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
