### PR TITLE
Quote string for special characters. Fixes #3214

### DIFF
--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -938,7 +938,7 @@ class Files
                     $themePath . "/*_*/web/i18n/{$locale}"
                 ];
                 $this->_accumulateFilesByPatterns($paths, $filePattern, $files);
-                $regex = '#^' . $themePath .
+                $regex = '#^' . preg_quote($themePath) .
                     '/((?P<module>[a-z\d]+_[a-z\d]+)/)?web/(i18n/(?P<locale>[a-z_]+)/)?(?P<path>.+)$#i';
                 foreach ($files as $file) {
                     if (preg_match($regex, $file, $matches)) {

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -938,7 +938,7 @@ class Files
                     $themePath . "/*_*/web/i18n/{$locale}"
                 ];
                 $this->_accumulateFilesByPatterns($paths, $filePattern, $files);
-                $regex = '#^' . preg_quote($themePath) .
+                $regex = '#^' . preg_quote($themePath, '#') .
                     '/((?P<module>[a-z\d]+_[a-z\d]+)/)?web/(i18n/(?P<locale>[a-z_]+)/)?(?P<path>.+)$#i';
                 foreach ($files as $file) {
                     if (preg_match($regex, $file, $matches)) {


### PR DESCRIPTION
The path might contain regular expression character (i.e `(`)  which might cause UnexpectedValueException "Could not parse theme static file". Refer to #3214

### Description
Fix issue of UnexpectedValueException "Could not parse theme static file" when 'bin/magento setup:static-content:deploy -f' is executed. This will also cause of missing static files.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#3214: Deploying Static Files. Could not parse theme static file

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Put the Magento Application instance into the folder: C:/Program Files (x86)
2. Run `bin/magento setup:static-content:deploy -f`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
