### PR TITLE
Add the possibility to begin htmlClass with a - or _

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -112,7 +112,7 @@
 
     <xs:simpleType name="htmlClassType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z][a-zA-Z\d\-_]*(\s[a-zA-Z][a-zA-Z\d\-_]*)*"/>
+            <xs:pattern value="[a-zA-Z\-_][a-zA-Z\d\-_]*(\s[a-zA-Z\-_][a-zA-Z\d\-_]*)*"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -112,7 +112,7 @@
 
     <xs:simpleType name="htmlClassType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z\-_][a-zA-Z\d\-_]*(\s[a-zA-Z\-_][a-zA-Z\d\-_]*)*"/>
+            <xs:pattern value="[a-zA-Z\-_][a-zA-Z\d\-_:]*(\s[a-zA-Z\-_][a-zA-Z\d\-_:]*)*"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Hello

### Description
In the `htmlClass` xsd, the pattern should accept `-` or `_` as valid characters. It's valid when I test it with the W3C website.

### Manual testing scenarios
1. Create or update a container in a layout file and set the `htmlClass` to `-myclass`. It should not raise an error in developer mode.