### PR TITLE
#13354 - [Improvement] Add HTML attributes to containers

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout.php
+++ b/lib/internal/Magento/Framework/View/Layout.php
@@ -598,9 +598,11 @@ class Layout extends \Magento\Framework\Simplexml\Config implements \Magento\Fra
             $htmlClass = ' class="' . $htmlClass . '"';
         }
 
+        $htmlAttributes = $this->structure->getAttribute($name, Element::CONTAINER_OPT_HTML_ATTRIBUTES);
+
         $htmlTag = $this->structure->getAttribute($name, Element::CONTAINER_OPT_HTML_TAG);
 
-        $html = sprintf('<%1$s%2$s%3$s>%4$s</%1$s>', $htmlTag, $htmlId, $htmlClass, $html);
+        $html = sprintf('<%1$s%2$s%3$s%4$s>%5$s</%1$s>', $htmlTag, $htmlId, $htmlClass, $htmlAttributes, $html);
 
         return $html;
     }

--- a/lib/internal/Magento/Framework/View/Layout/Element.php
+++ b/lib/internal/Magento/Framework/View/Layout/Element.php
@@ -54,6 +54,8 @@ class Element extends \Magento\Framework\Simplexml\Element
 
     const CONTAINER_OPT_HTML_ID = 'htmlId';
 
+    const CONTAINER_OPT_HTML_ATTRIBUTES = 'htmlAttributes';
+
     const CONTAINER_OPT_LABEL = 'label';
 
     /**#@-*/

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
@@ -25,6 +25,7 @@ class Container implements Layout\ReaderInterface
     const CONTAINER_OPT_HTML_TAG = 'htmlTag';
     const CONTAINER_OPT_HTML_CLASS = 'htmlClass';
     const CONTAINER_OPT_HTML_ID = 'htmlId';
+    const CONTAINER_OPT_HTML_ATTRIBUTES = 'htmlAttributes';
     const CONTAINER_OPT_LABEL = 'label';
     const CONTAINER_OPT_DISPLAY = 'display';
     /**#@-*/
@@ -113,11 +114,12 @@ class Container implements Layout\ReaderInterface
             }
         } else {
             $elementData['attributes'] = [
-                self::CONTAINER_OPT_HTML_TAG   => (string)$currentElement[self::CONTAINER_OPT_HTML_TAG],
-                self::CONTAINER_OPT_HTML_ID    => (string)$currentElement[self::CONTAINER_OPT_HTML_ID],
-                self::CONTAINER_OPT_HTML_CLASS => (string)$currentElement[self::CONTAINER_OPT_HTML_CLASS],
-                self::CONTAINER_OPT_LABEL      => (string)$currentElement[self::CONTAINER_OPT_LABEL],
-                self::CONTAINER_OPT_DISPLAY    => (string)$currentElement[self::CONTAINER_OPT_DISPLAY],
+                self::CONTAINER_OPT_HTML_TAG        => (string)$currentElement[self::CONTAINER_OPT_HTML_TAG],
+                self::CONTAINER_OPT_HTML_ID         => (string)$currentElement[self::CONTAINER_OPT_HTML_ID],
+                self::CONTAINER_OPT_HTML_CLASS      => (string)$currentElement[self::CONTAINER_OPT_HTML_CLASS],
+                self::CONTAINER_OPT_HTML_ATTRIBUTES => (string)$currentElement[self::CONTAINER_OPT_HTML_ATTRIBUTES],
+                self::CONTAINER_OPT_LABEL           => (string)$currentElement[self::CONTAINER_OPT_LABEL],
+                self::CONTAINER_OPT_DISPLAY         => (string)$currentElement[self::CONTAINER_OPT_DISPLAY],
             ];
         }
         $scheduledStructure->setStructureElementData($containerName, $elementData);

--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -118,7 +118,7 @@
 
     <xs:simpleType name="htmlAttributesType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-z][a-z\d\-_]*(\s[a-z][a-z\d\-_]*)*"/>
+            <xs:pattern value="[a-z][a-z\d\-_:=']*(\s[a-z][a-z\d\-_:=']*)*"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -116,6 +116,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="htmlAttributesType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-z][a-z\d\-_]*(\s[a-z][a-z\d\-_]*)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="htmlTagType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="aside"/>
@@ -165,6 +171,7 @@
         <xs:attribute type="htmlTagType" name="htmlTag"/>
         <xs:attribute type="htmlClassType" name="htmlClass"/>
         <xs:attribute type="htmlIdentifierType" name="htmlId"/>
+        <xs:attribute type="htmlAttributesType" name="htmlAttributes"/>
     </xs:complexType>
 
     <xs:complexType name="blockType" mixed="true">
@@ -329,6 +336,7 @@
         <xs:attribute type="htmlTagType" name="htmlTag"/>
         <xs:attribute type="htmlClassType" name="htmlClass"/>
         <xs:attribute type="htmlIdentifierType" name="htmlId"/>
+        <xs:attribute type="htmlAttributesType" name="htmlAttributes"/>
         <xs:attribute type="xs:string" name="label"/>
         <xs:attribute type="xs:boolean" name="display" default="true" use="optional"/>
         <xs:attribute type="xs:boolean" name="remove" use="optional"/>

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/ContainerTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/ContainerTest.php
@@ -144,18 +144,19 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             ],
             'referenceContainer' => [
                 'elementCurrent' => $this->getElement(
-                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" label="Add"/>',
+                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" htmlAttributes="attribute" label="Add"/>',
                     'referenceContainer'
                 ),
                 'containerName' => 'reference',
                 'structureElement' => [],
                 'expectedData' => [
                     'attributes' => [
-                        Container::CONTAINER_OPT_HTML_TAG   => 'span',
-                        Container::CONTAINER_OPT_HTML_ID    => 'id_add',
-                        Container::CONTAINER_OPT_HTML_CLASS => 'new',
-                        Container::CONTAINER_OPT_LABEL      => 'Add',
-                        Container::CONTAINER_OPT_DISPLAY    => null,
+                        Container::CONTAINER_OPT_HTML_TAG           => 'span',
+                        Container::CONTAINER_OPT_HTML_ID            => 'id_add',
+                        Container::CONTAINER_OPT_HTML_CLASS         => 'new',
+                        Container::CONTAINER_OPT_HTML_ATTRIBUTES    => 'attribute',
+                        Container::CONTAINER_OPT_LABEL              => 'Add',
+                        Container::CONTAINER_OPT_DISPLAY            => null,
                     ],
                 ],
                 'getStructureCondition' => $this->once(),
@@ -171,11 +172,12 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
                 'structureElement' => [],
                 'expectedData' => [
                     'attributes' => [
-                        Container::CONTAINER_OPT_HTML_TAG   => null,
-                        Container::CONTAINER_OPT_HTML_ID    => null,
-                        Container::CONTAINER_OPT_HTML_CLASS => null,
-                        Container::CONTAINER_OPT_LABEL      => null,
-                        Container::CONTAINER_OPT_DISPLAY    => null,
+                        Container::CONTAINER_OPT_HTML_TAG           => null,
+                        Container::CONTAINER_OPT_HTML_ID            => null,
+                        Container::CONTAINER_OPT_HTML_CLASS         => null,
+                        Container::CONTAINER_OPT_HTML_ATTRIBUTES    => null,
+                        Container::CONTAINER_OPT_LABEL              => null,
+                        Container::CONTAINER_OPT_DISPLAY            => null,
                     ],
                 ],
                 'getStructureCondition' => $this->once(),
@@ -208,7 +210,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             ],
             'referenceContainerDisplayFalse' => [
                 'elementCurrent' => $this->getElement(
-                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" label="Add"'
+                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" htmlAttributes="attribute" label="Add"'
                     . ' display="true"/>',
                     'referenceContainer'
                 ),
@@ -216,11 +218,12 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
                 'structureElement' => [],
                 'expectedData' => [
                     'attributes' => [
-                        Container::CONTAINER_OPT_HTML_TAG   => 'span',
-                        Container::CONTAINER_OPT_HTML_ID    => 'id_add',
-                        Container::CONTAINER_OPT_HTML_CLASS => 'new',
-                        Container::CONTAINER_OPT_LABEL      => 'Add',
-                        Container::CONTAINER_OPT_DISPLAY    => 'true',
+                        Container::CONTAINER_OPT_HTML_TAG           => 'span',
+                        Container::CONTAINER_OPT_HTML_ID            => 'id_add',
+                        Container::CONTAINER_OPT_HTML_CLASS         => 'new',
+                        Container::CONTAINER_OPT_HTML_ATTRIBUTES    => 'attribute',
+                        Container::CONTAINER_OPT_LABEL              => 'Add',
+                        Container::CONTAINER_OPT_DISPLAY            => 'true',
                     ],
                 ],
                 'getStructureCondition' => $this->once(),

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/ContainerTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/ContainerTest.php
@@ -144,7 +144,8 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             ],
             'referenceContainer' => [
                 'elementCurrent' => $this->getElement(
-                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" htmlAttributes="attribute" label="Add"/>',
+                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" 
+                            htmlAttributes="attribute" label="Add"/>',
                     'referenceContainer'
                 ),
                 'containerName' => 'reference',
@@ -210,8 +211,8 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             ],
             'referenceContainerDisplayFalse' => [
                 'elementCurrent' => $this->getElement(
-                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new" htmlAttributes="attribute" label="Add"'
-                    . ' display="true"/>',
+                    '<referenceContainer name="reference" htmlTag="span" htmlId="id_add" htmlClass="new"'
+                    . ' htmlAttributes="attribute" label="Add" display="true"/>',
                     'referenceContainer'
                 ),
                 'containerName' => 'reference',


### PR DESCRIPTION
Hello,

### Description
The aim of this PR is to add the possibility to add more HTML attributes to containers.
For example, I would like to create the following tags in a layout file:

```
<header class="header" id="header" data-sticky data-isheader="true">

</header>
```

### Fixed Issues (if relevant)
1. magento/magento2#13354: [Improvement] Add HTML attributes to containers

### Manual testing scenarios
1. Create or update a container and add `htmlAttributes="data-myattribute"` for example
2. Refresh cache, the created HTML tag should have the `data-myattribute` attribute

### Development status
It is currently working but I would like to discuss about attributes which have a value, ie `data-isheader="true"`.
If I want to do this, I have to create my container like this:

```
<container name="header.container" as="header_container" htmlTag="header" htmlClass="header" htmlId="header" htmlAttributes="data-sticky data-isheader='true'">
</container>
```

Notice the simple quote around `true`, it works but is not very beautiful :)

What do you guys think?

- [x] Add tests into `Magento\Framework\View\Test\Unit\Layout\Reader\ContainerTest`

Thanks!