### PR TITLE
Fix incorrect @return tag

### DIFF
--- a/app/code/Magento/Authorizenet/Controller/Directpost/Payment/Place.php
+++ b/app/code/Magento/Authorizenet/Controller/Directpost/Payment/Place.php
@@ -122,7 +122,7 @@ class Place extends Payment
     /**
      * Place order for checkout flow
      *
-     * @return string
+     * @return void
      */
     protected function placeCheckoutOrder()
     {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
`placeCheckoutOrder` method had a `@return string` in PHPDocs even though it never returns anything.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
