### PR TITLE
Tiered pricing and quantity Increments do not work with decimal inventory MAGETWO-86164 (both front-end and back-end)

### DIFF
--- a/app/code/Magento/Bundle/Helper/Data.php
+++ b/app/code/Magento/Bundle/Helper/Data.php
@@ -26,6 +26,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Catalog\Model\ProductTypes\ConfigInterface $config
     ) {
         $this->config = $config;
+
         parent::__construct($context);
     }
 

--- a/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/BundleDataProviderTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/BundleDataProviderTest.php
@@ -7,10 +7,10 @@ namespace Magento\Bundle\Test\Unit\Ui\DataProvider\Product;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Bundle\Ui\DataProvider\Product\BundleDataProvider;
-use Magento\Framework\App\RequestInterface;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Bundle\Helper\Data;
+use Magento\CatalogInventory\Api\StockStateInterface;
 
 class BundleDataProviderTest extends \PHPUnit\Framework\TestCase
 {
@@ -20,11 +20,6 @@ class BundleDataProviderTest extends \PHPUnit\Framework\TestCase
      * @var ObjectManager
      */
     protected $objectManager;
-
-    /**
-     * @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $requestMock;
 
     /**
      * @var CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
@@ -42,14 +37,20 @@ class BundleDataProviderTest extends \PHPUnit\Framework\TestCase
     protected $dataHelperMock;
 
     /**
+     * @var StockStateInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $stockStateMock;
+
+    /**
      * @return void
      */
     protected function setUp()
     {
         $this->objectManager = new ObjectManager($this);
 
-        $this->requestMock = $this->getMockBuilder(RequestInterface::class)
+        $this->stockStateMock = $this->getMockBuilder(StockStateInterface::class)
             ->getMockForAbstractClass();
+
         $this->collectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(
@@ -86,8 +87,8 @@ class BundleDataProviderTest extends \PHPUnit\Framework\TestCase
             'primaryFieldName' => 'testPrimaryFieldName',
             'requestFieldName' => 'testRequestFieldName',
             'collectionFactory' => $this->collectionFactoryMock,
-            'request' => $this->requestMock,
             'dataHelper' =>  $this->dataHelperMock,
+            'stockState' => $this->stockStateMock,
             'addFieldStrategies' => [],
             'addFilterStrategies' => [],
             'meta' => [],
@@ -95,6 +96,11 @@ class BundleDataProviderTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
+    /**
+     * Testing getData() method
+     *
+     * @return void
+     */
     public function testGetData()
     {
         $items = ['testProduct1', 'testProduct2'];
@@ -127,6 +133,11 @@ class BundleDataProviderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedData, $this->getModel()->getData());
     }
 
+    /**
+     * Testing getCollection() method
+     *
+     * @return void
+     */
     public function testGetCollection()
     {
         $this->assertInstanceOf(Collection::class, $this->getModel()->getCollection());

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
@@ -69,7 +69,7 @@ class BundlePanel extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function modifyMeta(array $meta)
@@ -220,7 +220,8 @@ class BundlePanel extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $data
+     * @return array
      */
     public function modifyData(array $data)
     {
@@ -377,6 +378,7 @@ class BundlePanel extends AbstractModifier
                                                     'selection_price_type' => '',
                                                     'selection_price_value' => '',
                                                     'selection_qty' => '',
+                                                    'selection_qty_is_integer' => 'selection_qty_is_integer',
                                                 ],
                                                 'links' => ['insertData' => '${ $.provider }:${ $.dataProvider }'],
                                                 'imports' => [
@@ -682,10 +684,11 @@ class BundlePanel extends AbstractModifier
                                 'validation' => [
                                     'required-entry' => true,
                                     'validate-number' => true,
+                                    'validate-digits' => true,
                                     'validate-greater-than-zero' => true
                                 ],
                                 'imports' => [
-                                    'isInteger' => '${ $.provider }:${ $.parentScope }.selection_qty_is_integer'
+                                    'validateDigits' => '${ $.provider }:${ $.parentScope }.selection_qty_is_integer',
                                 ],
                             ],
                         ],

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePrice.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePrice.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Bundle\Ui\DataProvider\Product\Form\Modifier;
 
-use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
-use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+use Magento\Framework\Stdlib\ArrayManager;
 
 /**
  * Customize Price field
@@ -41,7 +41,7 @@ class BundlePrice extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function modifyMeta(array $meta)
     {
@@ -94,7 +94,8 @@ class BundlePrice extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $data
+     * @return array
      */
     public function modifyData(array $data)
     {

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundleWeight.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundleWeight.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Bundle\Ui\DataProvider\Product\Form\Modifier;
 
-use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Framework\Stdlib\ArrayManager;
 
 /**
@@ -30,7 +30,7 @@ class BundleWeight extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function modifyMeta(array $meta)
     {
@@ -76,12 +76,13 @@ class BundleWeight extends AbstractModifier
                 ]
             ]
         );
-        
+
         return $meta;
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $data
+     * @return array
      */
     public function modifyData(array $data)
     {

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/Composite.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/Composite.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\Bundle\Ui\DataProvider\Product\Form\Modifier;
 
+use Magento\Bundle\Api\ProductOptionRepositoryInterface;
+use Magento\Bundle\Model\Product\Type;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Ui\DataProvider\Modifier\ModifierInterface;
-use Magento\Bundle\Model\Product\Type;
-use Magento\Bundle\Api\ProductOptionRepositoryInterface;
-use Magento\Catalog\Api\ProductRepositoryInterface;
 
 /**
  * Class Bundle customizes Bundle product creation flow
@@ -67,7 +67,7 @@ class Composite extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function modifyMeta(array $meta)
     {
@@ -87,7 +87,8 @@ class Composite extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $data
+     * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/StockData.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/StockData.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Bundle\Ui\DataProvider\Product\Form\Modifier;
 
+use Magento\Bundle\Model\Product\Type;
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
-use Magento\Bundle\Model\Product\Type;
 
 /**
  * Class StockData hides unnecessary fields in Advanced Inventory Modal
@@ -28,7 +28,8 @@ class StockData extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $data
+     * @return array
      */
     public function modifyData(array $data)
     {
@@ -36,7 +37,8 @@ class StockData extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $meta
+     * @return array
      */
     public function modifyMeta(array $meta)
     {

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Listing/Collector/BundlePrice.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Listing/Collector/BundlePrice.php
@@ -10,9 +10,9 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\Data\ProductRender\PriceInfoInterface;
 use Magento\Catalog\Api\Data\ProductRender\PriceInfoInterfaceFactory;
 use Magento\Catalog\Api\Data\ProductRenderInterface;
+use Magento\Catalog\Model\ProductRender\FormattedPriceInfoBuilder;
 use Magento\Catalog\Ui\DataProvider\Product\ProductRenderCollectorInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Magento\Catalog\Model\ProductRender\FormattedPriceInfoBuilder;
 
 /**
  * Collect information about bundle price

--- a/app/code/Magento/Bundle/view/adminhtml/web/js/components/bundle-option-qty.js
+++ b/app/code/Magento/Bundle/view/adminhtml/web/js/components/bundle-option-qty.js
@@ -13,7 +13,8 @@ define([
             valueUpdate: 'input',
             isInteger: true,
             validation: {
-                'validate-number': true
+                'validate-number': true,
+                'validate-digits': true
             }
         },
 
@@ -32,6 +33,16 @@ define([
             var notEqual = this.value() !== this.initialValue.toString();
 
             return !this.visible() ? false : notEqual;
+        },
+
+        /**
+         * Update field validation rules
+         *
+         * @param {Boolean} value
+         */
+        validateDigits: function (value) {
+            this.isInteger = value;
+            this.validation['validate-digits'] = this.isInteger;
         }
 
     });

--- a/app/code/Magento/CatalogInventory/Api/StockQtyDecimalInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockQtyDecimalInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogInventory\Api;
+
+/**
+ *  StockQtyDecimalInterface
+ */
+interface StockQtyDecimalInterface
+{
+    /**
+     * Check whenever product qty is decimal
+     *
+     * @param int $productId
+     * @param string|int|null $scopeId
+     *
+     * @return bool
+     */
+    public function isStockQtyDecimal(int $productId, $scopeId = null): bool;
+}

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -402,12 +402,11 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
                     $this->qtyIncrements = $this->stockConfiguration->getQtyIncrements($this->getStoreId());
                 } else {
                     $this->qtyIncrements = $this->getData(static::QTY_INCREMENTS);
-                }
 
-                if ($this->getIsQtyDecimal()) { // Cast accordingly to decimal qty usage
-                    $this->qtyIncrements = (float) $this->qtyIncrements;
-                } else {
-                    $this->qtyIncrements = (int) $this->qtyIncrements;
+                    // set qty_increment int type if is_qty_decimal is false
+                    if (!$this->getIsQtyDecimal()) {
+                        $this->qtyIncrements = (int) $this->qtyIncrements;
+                    }
                 }
             }
             if ($this->qtyIncrements <= 0) {

--- a/app/code/Magento/CatalogInventory/Model/StockState.php
+++ b/app/code/Magento/CatalogInventory/Model/StockState.php
@@ -5,15 +5,17 @@
  */
 namespace Magento\CatalogInventory\Model;
 
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\CatalogInventory\Api\StockStateInterface;
+use Magento\CatalogInventory\Api\StockQtyDecimalInterface;
 use Magento\CatalogInventory\Model\Spi\StockRegistryProviderInterface;
 use Magento\CatalogInventory\Model\Spi\StockStateProviderInterface;
 
 /**
  * Interface StockState
  */
-class StockState implements StockStateInterface
+class StockState implements StockStateInterface, StockQtyDecimalInterface
 {
     /**
      * @var StockStateProviderInterface
@@ -155,5 +157,20 @@ class StockState implements StockStateInterface
         // }
         $stockItem = $this->stockRegistryProvider->getStockItem($productId, $scopeId);
         return $this->stockStateProvider->checkQuoteItemQty($stockItem, $itemQty, $qtyToCheck, $origQty);
+    }
+
+    /**
+     * @param int $productId
+     * @param string|int|null $scopeId
+     *
+     * @return bool
+     */
+    public function isStockQtyDecimal(int $productId, $scopeId = null): bool
+    {
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
+        /** @var StockItemInterface $stockItem */
+        $stockItem = $this->stockRegistryProvider->getStockItem($productId, $scopeId);
+
+        return $stockItem->getIsQtyDecimal();
     }
 }

--- a/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
@@ -578,6 +578,7 @@
                         <dataScope>qty_increments</dataScope>
                         <imports>
                             <link name="handleChanges">${$.provider}:data.product.stock_data.is_qty_decimal</link>
+                            <link name="changeValueType">${$.provider}:data.product.stock_data.enable_qty_increments</link>
                         </imports>
                     </settings>
                 </field>

--- a/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty-validator-changer.js
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/web/js/components/qty-validator-changer.js
@@ -20,8 +20,24 @@ define([
             var isDigits = value !== 1;
 
             this.validation['validate-integer'] = isDigits;
+            this.validation['validate-digits'] = isDigits;
             this.validation['less-than-equals-to'] = isDigits ? 99999999 : 99999999.9999;
             this.validate();
+        },
+
+        /**
+         * Change input value type when "Enable Qty Increments" is "No"
+         *
+         * @param {Number|undefined} value
+         */
+        changeValueType: function (value) {
+            var isEnableQtyIncrements = value === 1;
+
+            if (!isEnableQtyIncrements && typeof this.value() !== 'undefined') {
+                if (this.value().length) {
+                    this.value(parseInt(this.value(), 10));
+                }
+            }
         }
     });
 });


### PR DESCRIPTION
## Description
All issues below are described in #12914 

## Fixed Issues

### [1] Cannot close *Advanced Inventory* pop-up after setting *Qty Uses Decimals* to *No* and having *Enable Qty Increments* enabled

#### Steps to reproduce:
1. Create new product/ edit existing one
2. Open **Advanced Inventory** pop-up  under  **Quantity**
3. Set **Qty Uses Decimals** to *Yes*
4. Set **Qty** value to decimal value
5. Set **Enable Qty Increments** to *Yes*
6. Set  **Qty Increments** a decimal value
7. Press DONE (may skip this step)
8. Open **Advanced Inventory** pop-up  under  **Quantity** (optional if 7 was skipped)
9. Set Set **Qty Uses Decimals** to *No*
10. Set **Qty** value to integer value
11. Set **Enable Qty Increments** to *No*
12. Press DONE or the X icon to close the button

#### Expected Result
Close the **Advanced Inventory** pop-up

#### Actual result
Pop-up not closed and no errors are visible

### [2] Product Tiered Pricing Issue

**Steps to reproduce**
1. Create Simple Product
2. Set Inventory to 100
3. Set "Qty Uses Decimals" in Advanced Inventory to "Yes"
4. Set Base Price to 3.99
5. Open Advanced Pricing tab
6. Set a Tiered Price for Qty of .5 and price of 2.99
7. Save

### [3] Quantity increment issue

#### Steps to reproduce
1. Open Advanced Inventory
2. Set "Enable Qty Increments" to "Yes"
3. Set "Qty Increments" to ".5"
4. Save

#### Expected result
During each of the above scenarios (2,3), the product should save and allow tiered pricing and qty increments to work with decimal-based inventory

#### Actual result
Product does not save, admin user is given error stating "Please enter a valid number"


### [4] After saving a product with *Qty Decimals enabled*, *Qty Increments* and *Tier Price Quantity* are integer numbers if decimal value was given

#### Steps to reproduce
1. Create Simple Product
2. Set Inventory to 100
3. Set "Qty Uses Decimals" in Advanced Inventory to "Yes"
4. Set Base Price to 3.99
5. Open Advanced Pricing tab
6. Set a Tiered Price for Qty of 1.5 and price of 2.99
7. Save
8. Open Advanced Pricing pop-up

#### Expected result
Tier price Qty is 1.5

#### Actual result
Tier price Qty is 1


### [5] integer vs decimal numbers affects the front-end in the same way, e.g. mini cart and checkout

#### Steps to reproduce
Use the same steps from [1] or [4]

#### Expected result
In cart popup, cart page, checkout cart summary product Qty appear with decimals (if applicable)

#### Actual result
In cart popup, cart page, checkout cart summary product Qty appear without decimals
