### PR TITLE
Fix URL passed to static.php in PHP in-development server

### DIFF
--- a/phpserver/README.md
+++ b/phpserver/README.md
@@ -31,7 +31,7 @@ For more informations about the installation process using the CLI, you can cons
 
 ### How to run Magento
 
-Example usage: ```php -S 127.0.0.1:8082 -t ./pub/ ./phpserver/router.php```
+Example usage: ```php -S 127.0.0.1:8082 -t ./pub/ ../phpserver/router.php```
 
 ### What exactly the script does
 

--- a/phpserver/router.php
+++ b/phpserver/router.php
@@ -103,6 +103,7 @@ if (php_sapi_name() === 'cli-server') {
         } else {
             $debug('file does not exist');
             if (strpos($route, 'static/') === 0) {
+                $route = preg_replace('#static/#', '', $route, 1);
                 $_GET['resource'] = $route;
                 $debug("static: $route");
                 include($magentoPackagePubDir.'/static.php');


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

Unresolved static assets are generated by passing some part of URL as `resource=` parameter to `pub/static.php`. But PHP in-development server's router, `router.php`, wrongly passes the parameter.

Instead of `frontend/Magento/luma/en_US/images/logo.svg`, PHP in-development server's router uses `static/frontend/Magento/luma/en_US/images/logo.svg` for `resource=` parameter.

Because of that, resources can't be resolved when Magento runs on PHP in-development server.

### Description
<!--- Provide a description of the changes proposed in the pull request -->

This pull request removes `static/` string from the `resource=` parameter, so `static.php` can generate the specified resource correctly.

This pull request also changes command to start PHP in-development server in the documentation. The previous command in the documentation is:
```
$ php -S 127.0.0.1:8082 -t ./pub/ ./phpserver/router.php
```
which results an error because PHP is unable to find `router.php`.
```
PHP 7.1.13 Development Server started at Thu Jan 25 19:50:01 2018
Listening on http://127.0.0.1:8082
Document root is /mnt/d/Projects/Magento/magento2/pub
Press Ctrl-C to quit.
[Thu Jan 25 19:50:07 2018] PHP Warning:  Unknown: failed to open stream: No such file or directory in Unknown on line 0
[Thu Jan 25 19:50:07 2018] PHP Fatal error:  Unknown: Failed opening required '/mnt/d/Projects/Magento/magento2/pub/./phpserver/router.php' (include_path='.:') in Unknown on line 0
```


<!-- ### Fixed Issues (if relevant) -->
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
<!-- 1. magento/magento2#<issue_number>: Issue title -->
<!-- 2. ... -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Get a freshly cloned Magento repository.
2. Run `composer install`.
3. Setup Magento using `php bin/magento setup:install` as specified in [the documentation](https://github.com/nieltg/magento2/blob/c4fbc5c115d79b5d69f9ae909700e446422e9976/phpserver/README.md).
4. Start PHP in-development server using `php -S 127.0.0.1:8082 -t ./pub/ ../phpserver/router.php`.

<!-- ### Contribution checklist -->
<!-- - [x] Pull request has a meaningful description of its purpose -->
<!-- - [x] All commits are accompanied by meaningful commit messages -->
<!-- - [x] All new or changed code is covered with unit/integration tests (if applicable) -->
<!-- - [x] All automated tests passed successfully (all builds on Travis CI are green) -->
