### PR TITLE
Experius 2.1 patch empty country options in checkout

### DIFF
--- a/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
@@ -1,4 +1,4 @@
-<?php
+site <?php
 /**
  * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -237,7 +237,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      * @param string|boolean $emptyLabel
      * @return array
      */
-    public function toOptionArray($emptyLabel = ' ')
+    public function toOptionArray($emptyLabel = false)
     {
         $options = $this->_toOptionArray('country_id', 'name', ['title' => 'iso2_code']);
 

--- a/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
@@ -1,4 +1,4 @@
-site <?php
+<?php
 /**
  * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.


### PR DESCRIPTION
In the checkout, the country select contains empty values. This commit will fix this issue.

### Description
In the country select option in the checkout there are empty values.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Enable country in checkout
2. Have at least 2 or more available countries configured
3. Add a product to your cart
4. Go to the checkout
5. Open the country select
![country](https://user-images.githubusercontent.com/5173161/35389656-d71cd158-01d8-11e8-9e50-3e9e49122996.png)


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x ] All automated tests passed successfully (all builds on Travis CI are green)
