### PR TITLE
Moving design logic to DesignResolver

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -173,6 +173,7 @@
     <preference for="Magento\Framework\View\Page\FaviconInterface" type="Magento\Theme\Model\Favicon\Favicon" />
     <preference for="Magento\Framework\View\Element\Message\InterpretationStrategyInterface" type="Magento\Framework\View\Element\Message\InterpretationMediator" />
     <preference for="Magento\Framework\Indexer\Config\DependencyInfoProviderInterface" type="Magento\Framework\Indexer\Config\DependencyInfoProvider" />
+    <preference for="Magento\Framework\Config\DesignResolverInterface" type="\Magento\Framework\Config\View\DesignResolver" />
     <preference for="Magento\Framework\Webapi\CustomAttribute\ServiceTypeListInterface" type="Magento\Eav\Model\TypeLocator\ComplexType"/>
     <type name="Magento\Framework\Model\ResourceModel\Db\TransactionManager" shared="false" />
     <type name="Magento\Framework\Acl\Data\Cache">
@@ -1145,7 +1146,7 @@
             <argument name="fileName" xsi:type="string">view.xml</argument>
             <argument name="converter" xsi:type="object">Magento\Framework\Config\Converter</argument>
             <argument name="schemaLocator" xsi:type="object">Magento\Framework\Config\SchemaLocator</argument>
-            <argument name="fileResolver" xsi:type="object">Magento\Framework\Config\FileResolver</argument>
+            <argument name="fileResolver" xsi:type="object">Magento\Framework\Config\View\DesignResolver</argument>
         </arguments>
     </type>
     <type name="Magento\Framework\DB\SelectFactory">

--- a/lib/internal/Magento/Framework/Config/FileResolver.php
+++ b/lib/internal/Magento/Framework/Config/FileResolver.php
@@ -8,11 +8,10 @@
 namespace Magento\Framework\Config;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Module\Dir\Reader as DirReader;
-use Magento\Framework\View\Design\Fallback\RulePool;
 use Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface;
-use Magento\Framework\View\Design\ThemeInterface;
 use Magento\Framework\View\DesignInterface;
 
 /**
@@ -25,39 +24,45 @@ class FileResolver implements \Magento\Framework\Config\FileResolverInterface, D
      * Module configuration file reader
      *
      * @var DirReader
+     * @deprecated
      */
     protected $moduleReader;
 
     /**
      * @var \Magento\Framework\Config\FileIteratorFactory
+     * @deprecated
      */
     protected $iteratorFactory;
 
     /**
      * @var \Magento\Framework\View\DesignInterface
+     * @deprecated
      */
     protected $currentTheme;
 
     /**
      * @var string
+     * @deprecated
      */
     protected $area;
 
     /**
      * @var Filesystem\Directory\ReadInterface
+     * @deprecated
      */
     protected $rootDirectory;
 
     /**
      * @var \Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface
+     * @deprecated
      */
     protected $resolver;
 
     /**
-     * @var DirectoryList
-     * @deprecated Unused class property
+     * @var DesignResolverInterface
+     * @deprecated
      */
-    private $directoryList;
+    private $designResolver;
 
     /**
      * @param DirReader $moduleReader
@@ -66,6 +71,9 @@ class FileResolver implements \Magento\Framework\Config\FileResolverInterface, D
      * @param DirectoryList $directoryList @deprecated
      * @param Filesystem $filesystem
      * @param ResolverInterface $resolver
+     * @param DesignResolverInterface $designResolver
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         DirReader $moduleReader,
@@ -73,121 +81,33 @@ class FileResolver implements \Magento\Framework\Config\FileResolverInterface, D
         DesignInterface $designInterface,
         DirectoryList $directoryList,
         Filesystem $filesystem,
-        ResolverInterface $resolver
+        ResolverInterface $resolver,
+        DesignResolverInterface $designResolver = null
     ) {
-        $this->directoryList = $directoryList;
         $this->iteratorFactory = $iteratorFactory;
         $this->moduleReader = $moduleReader;
         $this->currentTheme = $designInterface->getDesignTheme();
         $this->area = $designInterface->getArea();
         $this->rootDirectory = $filesystem->getDirectoryRead(DirectoryList::ROOT);
         $this->resolver = $resolver;
+        $this->designResolver = $designResolver ?: ObjectManager::getInstance()->get(DesignResolverInterface::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function get($filename, $scope)
     {
-        switch ($scope) {
-            case 'global':
-                $iterator = $this->moduleReader->getConfigurationFiles($filename)->toArray();
-                $themeConfigFile = $this->currentTheme->getCustomization()->getCustomViewConfigPath();
-                if ($themeConfigFile
-                    && $this->rootDirectory->isExist($this->rootDirectory->getRelativePath($themeConfigFile))
-                ) {
-                    $iterator[$this->rootDirectory->getRelativePath($themeConfigFile)] =
-                        $this->rootDirectory->readFile(
-                            $this->rootDirectory->getRelativePath(
-                                $themeConfigFile
-                            )
-                        );
-                } else {
-                    $designPath = $this->resolver->resolve(
-                        RulePool::TYPE_FILE,
-                        'etc/view.xml',
-                        $this->area,
-                        $this->currentTheme
-                    );
-                    if (file_exists($designPath)) {
-                        try {
-                            $designDom = new \DOMDocument();
-                            $designDom->load($designPath);
-                            $iterator[$designPath] = $designDom->saveXML();
-                        } catch (\Exception $e) {
-                            throw new \Magento\Framework\Exception\LocalizedException(
-                                new \Magento\Framework\Phrase('Could not read config file')
-                            );
-                        }
-                    }
-                }
-                break;
-            default:
-                $iterator = $this->iteratorFactory->create([]);
-                break;
-        }
-        return $iterator;
+        return $this->designResolver->get($filename, $scope);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated
      */
     public function getParents($filename, $scope)
     {
-        switch ($scope) {
-            case 'global':
-                $iterator = $this->moduleReader->getConfigurationFiles($filename)->toArray();
-                $designPath = $this->resolver->resolve(
-                    RulePool::TYPE_FILE,
-                    'etc/view.xml',
-                    $this->area,
-                    $this->currentTheme
-                );
-
-                if (file_exists($designPath)) {
-                    try {
-                        $iterator = $this->getParentConfigs($this->currentTheme, []);
-                    } catch (\Exception $e) {
-                        throw new \Magento\Framework\Exception\LocalizedException(
-                            new \Magento\Framework\Phrase('Could not read config file')
-                        );
-                    }
-                }
-                break;
-            default:
-                $iterator = $this->iteratorFactory->create([]);
-                break;
-        }
-
-        return $iterator;
-    }
-
-    /**
-     * Recursively add parent theme configs
-     *
-     * @param ThemeInterface $theme
-     * @param array $iterator
-     * @param int $index
-     * @return array
-     */
-    private function getParentConfigs(ThemeInterface $theme, array $iterator, $index = 0)
-    {
-        if ($theme->getParentTheme() && $theme->isPhysical()) {
-            $parentDesignPath = $this->resolver->resolve(
-                RulePool::TYPE_FILE,
-                'etc/view.xml',
-                $this->area,
-                $theme->getParentTheme()
-            );
-
-            $parentDom = new \DOMDocument();
-            $parentDom->load($parentDesignPath);
-
-            $iterator[$index] = $parentDom->saveXML();
-
-            $iterator = $this->getParentConfigs($theme->getParentTheme(), $iterator, ++$index);
-        }
-
-        return $iterator;
+        return $this->designResolver->getParents($filename, $scope);
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/View/DesignResolverTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/View/DesignResolverTest.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Config\Test\Unit\View;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\FileIterator;
+use Magento\Framework\Config\View\DesignResolver;
+use Magento\Framework\View\Design\Theme\CustomizationInterface;
+use Magento\Framework\View\Design\ThemeInterface;
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\Config\FileIteratorFactory;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Module\Dir\Reader as ModuleReader;
+use Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface;
+use Magento\Framework\View\DesignInterface;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+/**
+ * @inheritdoc
+ */
+class DesignResolverTest extends TestCase
+{
+    /**
+     * @var DesignResolver
+     */
+    private $designResolver;
+
+    /**
+     * @var ModuleReader|Mock
+     */
+    private $moduleReaderMock;
+
+    /**
+     * @var FileIteratorFactory|Mock
+     */
+    private $iteratorFactoryMock;
+
+    /**
+     * @var DesignInterface|Mock
+     */
+    private $designMock;
+
+    /**
+     * @var Filesystem|Mock
+     */
+    private $filesystemMock;
+
+    /**
+     * @var ResolverInterface|Mock
+     */
+    private $resolverMock;
+
+    /**
+     * @var FileIterator|Mock
+     */
+    private $fileIteratorMock;
+
+    /**
+     * @var ThemeInterface|Mock
+     */
+    private $currentThemeMock;
+
+    /**
+     * @var CustomizationInterface|Mock
+     */
+    private $customizationMock;
+
+    /**
+     * @var Filesystem\Directory\ReadInterface|Mock
+     */
+    private $directoryReadMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->moduleReaderMock = $this->createMock(ModuleReader::class);
+        $this->iteratorFactoryMock = $this->createMock(FileIteratorFactory::class);
+        $this->designMock = $this->getMockForAbstractClass(DesignInterface::class);
+        $this->filesystemMock = $this->createMock(Filesystem::class);
+        $this->resolverMock = $this->getMockForAbstractClass(ResolverInterface::class);
+        $this->fileIteratorMock = $this->createMock(FileIterator::class);
+        $this->currentThemeMock = $this->getMockBuilder(ThemeInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCustomization'])
+            ->getMockForAbstractClass();
+
+        $this->customizationMock = $this->getMockForAbstractClass(CustomizationInterface::class);
+        $this->directoryReadMock = $this->getMockForAbstractClass(Filesystem\Directory\ReadInterface::class);
+
+        $this->iteratorFactoryMock->expects($this->any())
+            ->method('create')
+            ->willReturn($this->fileIteratorMock);
+        $this->designMock->expects($this->any())
+            ->method('getDesignTheme')
+            ->willReturn($this->currentThemeMock);
+        $this->designMock->expects($this->any())
+            ->method('getArea')
+            ->willReturn('default');
+
+        $this->designResolver = new DesignResolver(
+            $this->moduleReaderMock,
+            $this->iteratorFactoryMock,
+            $this->designMock,
+            $this->filesystemMock,
+            $this->resolverMock
+        );
+    }
+
+    public function testGetWithThemeConfig()
+    {
+        $filename = 'test.xml';
+        $iterator = [];
+        $themeConfigFile = 'theme.xml';
+        $scope = 'global';
+
+        $this->moduleReaderMock->expects($this->once())
+            ->method('getConfigurationFiles')
+            ->with($filename)
+            ->willReturn($this->fileIteratorMock);
+        $this->fileIteratorMock->expects($this->once())
+            ->method('toArray')
+            ->willReturn($iterator);
+        $this->currentThemeMock->expects($this->once())
+            ->method('getCustomization')
+            ->willReturn($this->customizationMock);
+        $this->customizationMock->expects($this->once())
+            ->method('getCustomViewConfigPath')
+            ->willReturn($themeConfigFile);
+        $this->filesystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->with(DirectoryList::ROOT)
+            ->willReturn($this->directoryReadMock);
+        $this->directoryReadMock->expects($this->exactly(3))
+            ->method('getRelativePath')
+            ->with($themeConfigFile)
+            ->willReturn($themeConfigFile);
+        $this->directoryReadMock->expects($this->once())
+            ->method('isExist')
+            ->with($themeConfigFile)
+            ->willReturn(true);
+        $this->directoryReadMock->expects($this->once())
+            ->method('readFile')
+            ->with($themeConfigFile)
+            ->willReturn('some_theme_data');
+
+        $this->assertSame(['theme.xml' => 'some_theme_data'], $this->designResolver->get($filename, $scope));
+    }
+
+    public function testGetMissedThemeConfig()
+    {
+        $filename = 'test.xml';
+        $iterator = [];
+        $themeConfigFile = '';
+        $scope = 'global';
+
+        $this->moduleReaderMock->expects($this->once())
+            ->method('getConfigurationFiles')
+            ->with($filename)
+            ->willReturn($this->fileIteratorMock);
+        $this->fileIteratorMock->expects($this->once())
+            ->method('toArray')
+            ->willReturn($iterator);
+        $this->currentThemeMock->expects($this->once())
+            ->method('getCustomization')
+            ->willReturn($this->customizationMock);
+        $this->customizationMock->expects($this->once())
+            ->method('getCustomViewConfigPath')
+            ->willReturn($themeConfigFile);
+        $this->filesystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->with(DirectoryList::ROOT)
+            ->willReturn($this->directoryReadMock);
+        $this->directoryReadMock->expects($this->never())
+            ->method('getRelativePath');
+        $this->directoryReadMock->expects($this->never())
+            ->method('isExist');
+        $this->resolverMock->expects($this->once())
+            ->method('resolve')
+            ->willReturn(__DIR__ . '/_files/design.xml');
+
+        $this->assertArrayHasKey(__DIR__ . '/_files/design.xml', $this->designResolver->get($filename, $scope));
+    }
+
+    public function testGetDefault()
+    {
+        $this->assertInstanceOf(
+            FileIterator::class,
+            $this->designResolver->get('default.xml', 'default')
+        );
+    }
+
+    public function testGetParentsDefault()
+    {
+        $this->assertInstanceOf(
+            FileIterator::class,
+            $this->designResolver->get('default.xml', 'default')
+        );
+    }
+
+    public function testGetParents()
+    {
+        $filename = 'test.xml';
+        $iterator = [];
+        $scope = 'global';
+
+        $this->moduleReaderMock->expects($this->once())
+            ->method('getConfigurationFiles')
+            ->with($filename)
+            ->willReturn($this->fileIteratorMock);
+        $this->fileIteratorMock->expects($this->once())
+            ->method('toArray')
+            ->willReturn($iterator);
+        $this->resolverMock->expects($this->once())
+            ->method('resolve')
+            ->willReturn(__DIR__ . '/_files/design2.xml');
+
+        $this->assertSame(
+            $iterator,
+            $this->designResolver->getParents($filename, $scope)
+        );
+    }
+}

--- a/lib/internal/Magento/Framework/Config/Test/Unit/View/_files/design.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/View/_files/design.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+<config>
+</config>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/ViewFactoryTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/ViewFactoryTest.php
@@ -54,12 +54,12 @@ class ViewFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('setDesignTheme')
             ->with($this->theme, self::AREA);
 
-        /** @var \Magento\Framework\Config\FileResolver|\PHPUnit_Framework_MockObject_MockObject $fileResolver */
-        $fileResolver = $this->createMock(\Magento\Framework\Config\FileResolver::class);
+        /** @var \Magento\Framework\Config\View\DesignResolver|\PHPUnit_Framework_MockObject_MockObject $fileResolver */
+        $fileResolver = $this->createMock(\Magento\Framework\Config\View\DesignResolver::class);
 
         $valueMap = [
             [\Magento\Theme\Model\View\Design::class, [], $design],
-            [\Magento\Framework\Config\FileResolver::class, ['designInterface' => $design], $fileResolver],
+            [\Magento\Framework\Config\View\DesignResolver::class, ['designInterface' => $design], $fileResolver],
             [\Magento\Framework\Config\View::class, ['fileResolver' => $fileResolver], $this->view],
         ];
         $this->objectManager->expects($this->exactly(3))

--- a/lib/internal/Magento/Framework/Config/View/DesignResolver.php
+++ b/lib/internal/Magento/Framework/Config/View/DesignResolver.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Config\View;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\DesignResolverInterface;
+use Magento\Framework\Config\FileIteratorFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Module\Dir\Reader as ModuleReader;
+use Magento\Framework\Phrase;
+use Magento\Framework\View\ConfigInterface;
+use Magento\Framework\View\Design\Fallback\RulePool;
+use Magento\Framework\View\Design\FileResolution\Fallback\ResolverInterface;
+use Magento\Framework\View\Design\ThemeInterface;
+use Magento\Framework\View\DesignInterface;
+
+/**
+ * Fallback resolver for design configurations.
+ *
+ * {@inheritdoc}
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DesignResolver implements DesignResolverInterface
+{
+    /**
+     * Module configuration file reader
+     *
+     * @var ModuleReader
+     */
+    private $moduleReader;
+
+    /**
+     * @var FileIteratorFactory
+     */
+    private $iteratorFactory;
+
+    /**
+     * @var ThemeInterface
+     */
+    private $currentTheme;
+
+    /**
+     * @var string
+     */
+    private $area;
+
+    /**
+     * @var ResolverInterface
+     */
+    private $resolver;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @param ModuleReader $moduleReader
+     * @param FileIteratorFactory $iteratorFactory
+     * @param DesignInterface $design
+     * @param Filesystem $filesystem
+     * @param ResolverInterface $resolver
+     */
+    public function __construct(
+        ModuleReader $moduleReader,
+        FileIteratorFactory $iteratorFactory,
+        DesignInterface $design,
+        Filesystem $filesystem,
+        ResolverInterface $resolver
+    ) {
+        $this->moduleReader = $moduleReader;
+        $this->iteratorFactory = $iteratorFactory;
+        $this->currentTheme = $design->getDesignTheme();
+        $this->area = $design->getArea();
+        $this->filesystem = $filesystem;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get($filename, $scope)
+    {
+        switch ($scope) {
+            case Area::AREA_GLOBAL:
+                $iterator = $this->moduleReader->getConfigurationFiles($filename)->toArray();
+                $themeConfigFile = $this->currentTheme->getCustomization()->getCustomViewConfigPath();
+                $rootDirectory = $this->filesystem->getDirectoryRead(DirectoryList::ROOT);
+
+                if ($themeConfigFile
+                    && $rootDirectory->isExist($rootDirectory->getRelativePath($themeConfigFile))
+                ) {
+                    $iterator[$rootDirectory->getRelativePath($themeConfigFile)] =
+                        $rootDirectory->readFile(
+                            $rootDirectory->getRelativePath(
+                                $themeConfigFile
+                            )
+                        );
+                } else {
+                    $designPath = $this->resolver->resolve(
+                        RulePool::TYPE_FILE,
+                        ConfigInterface::CONFIG_FILE_NAME,
+                        $this->area,
+                        $this->currentTheme
+                    );
+                    if ($designPath && file_exists($designPath)) {
+                        try {
+                            $designDom = new \DOMDocument();
+                            $designDom->load($designPath);
+                            $iterator[$designPath] = $designDom->saveXML();
+                        } catch (\Exception $e) {
+                            throw new LocalizedException(
+                                new Phrase('Could not read config file')
+                            );
+                        }
+                    }
+                }
+                break;
+            default:
+                $iterator = $this->iteratorFactory->create([]);
+                break;
+        }
+
+        return $iterator;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getParents($filename, $scope)
+    {
+        switch ($scope) {
+            case Area::AREA_GLOBAL:
+                $iterator = $this->moduleReader->getConfigurationFiles($filename)->toArray();
+                $designPath = $this->resolver->resolve(
+                    RulePool::TYPE_FILE,
+                    ConfigInterface::CONFIG_FILE_NAME,
+                    $this->area,
+                    $this->currentTheme
+                );
+
+                if ($designPath && file_exists($designPath)) {
+                    try {
+                        $iterator = $this->getParentConfigs($this->currentTheme, []);
+                    } catch (\Exception $e) {
+                        throw new LocalizedException(
+                            new Phrase('Could not read config file')
+                        );
+                    }
+                }
+                break;
+            default:
+                $iterator = $this->iteratorFactory->create([]);
+                break;
+        }
+
+        return $iterator;
+    }
+
+    /**
+     * Recursively collect parent theme configs.
+     *
+     * @param ThemeInterface $theme Parent theme
+     * @param array $iterator Config iterator
+     * @param int $index Config index
+     * @return array Array of inherited configs
+     */
+    private function getParentConfigs(ThemeInterface $theme, array $iterator, $index = 0): array
+    {
+        if ($theme->getParentTheme() && $theme->isPhysical()) {
+            $parentDesignPath = $this->resolver->resolve(
+                RulePool::TYPE_FILE,
+                ConfigInterface::CONFIG_FILE_NAME,
+                $this->area,
+                $theme->getParentTheme()
+            );
+
+            $parentDom = new \DOMDocument();
+            $parentDom->load($parentDesignPath);
+
+            $iterator[$index] = $parentDom->saveXML();
+
+            $iterator = $this->getParentConfigs($theme->getParentTheme(), $iterator, ++$index);
+        }
+
+        return $iterator;
+    }
+}

--- a/lib/internal/Magento/Framework/Config/ViewFactory.php
+++ b/lib/internal/Magento/Framework/Config/ViewFactory.php
@@ -45,9 +45,9 @@ class ViewFactory
             /** @var \Magento\Theme\Model\View\Design $design */
             $design = $this->objectManager->create(\Magento\Theme\Model\View\Design::class);
             $design->setDesignTheme($arguments['themeModel'], $arguments['area']);
-            /** @var \Magento\Framework\Config\FileResolver $fileResolver */
+            /** @var \Magento\Framework\Config\View\DesignResolver $fileResolver */
             $fileResolver = $this->objectManager->create(
-                \Magento\Framework\Config\FileResolver::class,
+                \Magento\Framework\Config\View\DesignResolver::class,
                 [
                     'designInterface' => $design,
                 ]


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Currently `FileResolver` is managing design inheritance, which should be in `DesignResolver`
This PR moves design-related logic from `FileResolver` to `DesignResolver` with `DesignResolverInterface` usage.
`FileResolver` is deprecated for proper usage in future.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to `app/design/frontend/Magento/blank/etc`
2. Edit file `view.xml` and change bundle size
```
<vars module="Js_Bundle">
    <var name="bundle_size">250KB</var>
</vars>
```
3. Go to `app/design/frontend/Magento/luma/etc`
4. Edit `view.xml` file
4. Remove attribute which was changed in step `2`
5. Run static content deploy `bin/magento setup:static-content:deploy -f`
6. Open storefront and check that value of this attribute was applied from parent theme

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
