### PR TITLE
Edited doc block of the walk method in a Collection

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -492,7 +492,7 @@ class Collection implements \IteratorAggregate, \Countable, ArrayInterface, Coll
      *
      * Returns array with results of callback for each item
      *
-     * @param string $callback
+     * @param callable $callback
      * @param array $args
      * @return array
      */


### PR DESCRIPTION
### Description
Edited doc block of the walk method in a Collection to reflect that this method will accept an array.

The following callback is created by passing an array that consists of an object and a string. The method of that object will be used in the callback, and each model in the collection will be passed to the method as the first parameter. While this results in a successful callback, the doc block of the walk method of a collection incorrectly reports that it will only accept a string, while the following example uses an array.

```php
<?php
    public function example()
    {
        /** @var \Magento\Customer\Model\ResourceModel\Customer\Collection $customerCollection */
        $customerCollection = $this->getCustomerCollection();
        $customerCollection->walk([$this, 'changeFirstname']);
        $customerCollection->save();
    }

    public function changeFirstname(\Magento\Customer\Model\Customer\Interceptor $customer)
    {
        $customer->setFirstname('Testing');
    }
```

### Manual testing scenarios
Code is provided above to show a scenario where the doc block does not reflect what it will actually accept. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)