### PR TITLE
Problem With Symlinks When Linking a Module Directory Out of Magento Root Directory #13375

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -104,26 +104,37 @@ class Validator
     public function isValid($filename)
     {
         $filename = str_replace('\\', '/', $filename);
+        
         if (!isset($this->_templatesValidationResults[$filename])) {
-            if ($this->_isAllowSymlinks && $this->isOutsourceFile($filename)) {
-                $result = true;
-
-                if (!file_exists($filename) || !is_readable($filename)) {
-                    $result = false;
-                }
-
-                $this->_templatesValidationResults[$filename] = $result;
-            } else {
-                $this->_templatesValidationResults[$filename] =
-                    ($this->isPathInDirectories($filename, $this->_compiledDir)
-                        || $this->isPathInDirectories($filename, $this->moduleDirs)
-                        || $this->isPathInDirectories($filename, $this->_themesDir)
-                        || $this->_isAllowSymlinks)
-                    && $this->getRootDirectory()->isFile($this->getRootDirectory()->getRelativePath($filename));
-            }
+            $this->setTemplateValidationResults($filename);
         }
 
         return $this->_templatesValidationResults[$filename];
+    }
+
+    /**
+     * @param string $filename
+     * @return void
+     */
+    private function setTemplateValidationResults($filename)
+    {
+        if ($this->_isAllowSymlinks && $this->isOutsourceFile($filename)) {
+            $result = true;
+
+            if (!file_exists($filename) || !is_readable($filename)) {
+                $result = false;
+            }
+
+            $this->_templatesValidationResults[$filename] = $result;
+            return;
+        }
+
+        $this->_templatesValidationResults[$filename] =
+            ($this->isPathInDirectories($filename, $this->_compiledDir)
+                || $this->isPathInDirectories($filename, $this->moduleDirs)
+                || $this->isPathInDirectories($filename, $this->_themesDir)
+                || $this->_isAllowSymlinks)
+            && $this->getRootDirectory()->isFile($this->getRootDirectory()->getRelativePath($filename));
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -113,6 +113,8 @@ class Validator
     }
 
     /**
+     * Set template validation results for filename
+     *
      * @param string $filename
      * @return void
      */
@@ -141,10 +143,9 @@ class Validator
      * Checks if the filename is out of Magento's root installation.
      *
      * @param string $filename
-     *
      * @return bool
      */
-    protected function isOutsourceFile($filename)
+    private function isOutsourceFile($filename)
     {
         $isOutsourceFile = strpos($filename, $this->getRootDirectory()->getAbsolutePath());
         return !($isOutsourceFile === 0);

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -126,7 +126,6 @@ class Validator
         return $this->_templatesValidationResults[$filename];
     }
 
-
     /**
      * Checks if the filename is out of Magento's root installation.
      *
@@ -139,7 +138,6 @@ class Validator
         $isOutsourceFile = strpos($filename, $this->getRootDirectory()->getAbsolutePath());
         return !($isOutsourceFile === 0);
     }
-
 
     /**
      * Checks whether path related to the directory

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -105,12 +105,6 @@ class Validator
     {
         $filename = str_replace('\\', '/', $filename);
         if (!isset($this->_templatesValidationResults[$filename])) {
-            /**
-             * Whether the file is out of Magento and Symlinks is allowed.
-             * Fix for issue 13375.
-             *
-             * @author Tiago Sampaio <tiago@tiagosampaio.com>
-             */
             if ($this->_isAllowSymlinks && $this->isOutsourceFile($filename)) {
                 $result = true;
 


### PR DESCRIPTION
- Fix the issue 13375. When using symlink to link a complete module which has template files, Magento doesn't recognise the file template correctly.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When using symlink to link a complete module which has template files, Magento doesn't recognise the file template correctly.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13375: Problem With Symlinks When Linking a Module Directory Out of Magento Root Directory

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Enable symlink option in admin system.
2. Create a module out of Magento's root directory with a template file and a controller.
3. When Magento tries to render the template file it was not being recognised as a valid template file because it was out of Magento's root directory. Not it works fine.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
