### PR TITLE
Update status of cronjob to missed correctly for old pending schedules

### DIFF
--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -81,8 +81,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 ['status' => new \Zend_Db_Expr($connection->quote($newStatus))]
             )
             ->where('current.schedule_id = ?', $scheduleId)
-            ->where('current.status = ?', $currentStatus)
-            ->where('existing.schedule_id IS NULL');
+            ->where('current.status = ?', $currentStatus);
 
         $update = $connection->updateFromSelect($selectIfUnlocked, ['current' => $this->getTable('cron_schedule')]);
         $result = $connection->query($update)->rowCount();


### PR DESCRIPTION
### Description
When cron_schedule table is full of old pending schedules, it's not correctly set to missed and that makes cron job working slower and slower.

### Fixed Issues (if relevant)
1. magento/magento2#11002: cron_schedule forever increasing in size. Lots of pending jobs never cleared

### Manual testing scenarios
1. Fulfill cron_schedule with a lot of pending schedules older than 7 days
2. Run "magento cron:run"
3. Check if all old cron_schedule status are changed to missed. 

Before this fix, these status stays in "pending" which makes fetching table very long when it's big.

### Contribution checklist
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds on Travis CI are green)
