### PR TITLE
magento/magento2#13295:Order grid page showing previous order id in URL while coming back from order view page

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -5,6 +5,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Sales\Block\Adminhtml\Order;
 
 /**
@@ -231,8 +232,8 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
         }
 
         if ($this->_isAllowedAction(
-            'Magento_Sales::ship'
-        ) && $order->canShip() && !$order->getForcedShipmentWithInvoice()
+                'Magento_Sales::ship'
+            ) && $order->canShip() && !$order->getForcedShipmentWithInvoice()
         ) {
             $this->addButton(
                 'order_ship',
@@ -245,10 +246,10 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
         }
 
         if ($this->_isAllowedAction(
-            'Magento_Sales::reorder'
-        ) && $this->_reorderHelper->isAllowed(
-            $order->getStore()
-        ) && $order->canReorderIgnoreSalable()
+                'Magento_Sales::reorder'
+            ) && $this->_reorderHelper->isAllowed(
+                $order->getStore()
+            ) && $order->canReorderIgnoreSalable()
         ) {
             $this->addButton(
                 'order_reorder',
@@ -315,7 +316,11 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
      */
     public function getUrl($params = '', $params2 = [])
     {
-        $params2['order_id'] = $this->getOrderId();
+        if ('index' === $params2['action'] && isset($params2['action'])) {
+            return parent::getUrl($params, $params2);
+        } else {
+            $params2['order_id'] = $this->getOrderId();
+        }
         return parent::getUrl($params, $params2);
     }
 
@@ -451,7 +456,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             return $this->getOrder()->getBackUrl();
         }
 
-        return $this->getUrl('sales/*/');
+        return $this->getUrl('sales/*/', ['action' => 'index']);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -314,7 +314,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
      */
     public function getUrl($params = '', $params2 = [])
     {
-        if ('index' === $params2['action'] && isset($params2['action'])) {
+        if (isset($params2['action']) && $params2['action'] === 'index') {
             return parent::getUrl($params, $params2);
         } else {
             $params2['order_id'] = $this->getOrderId();

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -231,9 +231,9 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             );
         }
 
-        if ($this->_isAllowedAction(
-                'Magento_Sales::ship'
-            ) && $order->canShip() && !$order->getForcedShipmentWithInvoice()
+        if (!$order->getForcedShipmentWithInvoice()
+            && $this->_isAllowedAction('Magento_Sales::ship')
+            && $order->canShip()
         ) {
             $this->addButton(
                 'order_ship',
@@ -245,11 +245,9 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             );
         }
 
-        if ($this->_isAllowedAction(
-                'Magento_Sales::reorder'
-            ) && $this->_reorderHelper->isAllowed(
-                $order->getStore()
-            ) && $order->canReorderIgnoreSalable()
+        if ($order->canReorderIgnoreSalable()
+            && $this->_reorderHelper->isAllowed($order->getStore())
+            && $this->_isAllowedAction('Magento_Sales::reorder')
         ) {
             $this->addButton(
                 'order_reorder',

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -245,11 +245,9 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             );
         }
 
-        if ($this->_isAllowedAction(
-                'Magento_Sales::reorder'
-            ) && $this->_reorderHelper->isAllowed(
-                $order->getStore()
-            ) && $order->canReorderIgnoreSalable()
+        if ($this->_isAllowedAction('Magento_Sales::reorder')
+            && $this->_reorderHelper->isAllowed($order->getStore())
+            && $order->canReorderIgnoreSalable()
         ) {
             $this->addButton(
                 'order_reorder',

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -231,8 +231,8 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             );
         }
 
-        if (!$order->getForcedShipmentWithInvoice()
-            && $this->_isAllowedAction('Magento_Sales::ship')
+        if ($this->_isAllowedAction('Magento_Sales::ship')
+            && !$order->getForcedShipmentWithInvoice()
             && $order->canShip()
         ) {
             $this->addButton(

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -314,11 +314,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
      */
     public function getUrl($params = '', $params2 = [])
     {
-        if (isset($params2['action']) && $params2['action'] === 'index') {
-            return parent::getUrl($params, $params2);
-        } else {
-            $params2['order_id'] = $this->getOrderId();
-        }
+        $params2['order_id'] = $this->getOrderId();
         return parent::getUrl($params, $params2);
     }
 

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -245,9 +245,11 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             );
         }
 
-        if ($order->canReorderIgnoreSalable()
-            && $this->_reorderHelper->isAllowed($order->getStore())
-            && $this->_isAllowedAction('Magento_Sales::reorder')
+        if ($this->_isAllowedAction(
+                'Magento_Sales::reorder'
+            ) && $this->_reorderHelper->isAllowed(
+                $order->getStore()
+            ) && $order->canReorderIgnoreSalable()
         ) {
             $this->addButton(
                 'order_reorder',
@@ -454,7 +456,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
             return $this->getOrder()->getBackUrl();
         }
 
-        return $this->getUrl('sales/*/', ['action' => 'index']);
+        return $this->_urlBuilder->getUrl('sales/*/');
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
…RL while coming back from order view page

fixed an issue with order id in URL when returning back to order grid page
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Changes are related to back URL being fetched wrong when order view page is opened. If the action button is clicked then on order grid page, it showed old order id in the URL. Which is being resolved.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13295: Order grid page showing previous order id in URL while coming back from order view page

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open Order Page From order grid page
2. After order view page is opened click on the back button provided on action bar
3. When Order Grid page is opened then check the URL, it shouldn't have the order id in it.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
