### PR TITLE
Allow negative price for custom option: fixes #7333 in GitHub (internal MAGETWO-60573)

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
@@ -132,7 +132,7 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
      */
     protected function validateOptionValue(Option $option)
     {
-        return $this->isInRange($option->getPriceType(), $this->priceTypes) && !$this->isNegative($option->getPrice());
+        return $this->isInRange($option->getPriceType(), $this->priceTypes);
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Option/Validator/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Validator/Select.php
@@ -83,7 +83,7 @@ class Select extends DefaultValidator
         if (!$priceType && !$price) {
             return true;
         }
-        if (!$this->isInRange($priceType, $this->priceTypes) || $this->isNegative($price)) {
+        if (!$this->isInRange($priceType, $this->priceTypes)) {
             return false;
         }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
@@ -84,7 +84,7 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
         $valueMock->expects($this->once())->method('getTitle')->will($this->returnValue($title));
         $valueMock->expects($this->any())->method('getType')->will($this->returnValue($type));
         $valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue($priceType));
-        $valueMock->expects($this->never())->method('getPrice')->will($this->returnValue($price));
+        $valueMock->expects($this->never())->method('getPrice');
         $valueMock->expects($this->once())->method('getProduct')->will($this->returnValue($product));
         $this->assertEquals($result, $this->validator->isValid($valueMock));
         $this->assertEquals($messages, $this->validator->getMessages());
@@ -152,7 +152,7 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
         $valueMock->expects($this->once())->method('getTitle')->will($this->returnValue($title));
         $valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue($type));
         $valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue($priceType));
-        $valueMock->expects($this->never())->method('getPrice')->will($this->returnValue($price));
+        $valueMock->expects($this->never())->method('getPrice');
         $valueMock->expects($this->once())->method('getProduct')->will($this->returnValue($product));
 
         $messages = [

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
@@ -84,7 +84,7 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
         $valueMock->expects($this->once())->method('getTitle')->will($this->returnValue($title));
         $valueMock->expects($this->any())->method('getType')->will($this->returnValue($type));
         $valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue($priceType));
-        $valueMock->expects($this->once())->method('getPrice')->will($this->returnValue($price));
+        $valueMock->expects($this->never())->method('getPrice')->will($this->returnValue($price));
         $valueMock->expects($this->once())->method('getProduct')->will($this->returnValue($product));
         $this->assertEquals($result, $this->validator->isValid($valueMock));
         $this->assertEquals($messages, $this->validator->getMessages());
@@ -129,7 +129,7 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
      * Data provider for testValidationNegativePrice
      * @return array
      */
-    public function validationNegativePriceDataProvider()
+    public function negativePriceIsValidDataProvider()
     {
         return [
             ['option_title', 'name 1.1', 'fixed', -12, new \Magento\Framework\DataObject(['store_id' => 1])],
@@ -143,22 +143,22 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
      * @param $priceType
      * @param $price
      * @param $product
-     * @dataProvider validationNegativePriceDataProvider
+     * @dataProvider negativePriceIsValidDataProvider
      */
-    public function testValidationNegativePrice($title, $type, $priceType, $price, $product)
+    public function testNegativePriceIsValid($title, $type, $priceType, $price, $product)
     {
         $methods = ['getTitle', 'getType', 'getPriceType', 'getPrice', '__wakeup', 'getProduct'];
         $valueMock = $this->createPartialMock(\Magento\Catalog\Model\Product\Option::class, $methods);
         $valueMock->expects($this->once())->method('getTitle')->will($this->returnValue($title));
         $valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue($type));
         $valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue($priceType));
-        $valueMock->expects($this->once())->method('getPrice')->will($this->returnValue($price));
+        $valueMock->expects($this->never())->method('getPrice')->will($this->returnValue($price));
         $valueMock->expects($this->once())->method('getProduct')->will($this->returnValue($product));
 
         $messages = [
             'option values' => 'Invalid option value',
         ];
-        $this->assertFalse($this->validator->isValid($valueMock));
-        $this->assertEquals($messages, $this->validator->getMessages());
+        $this->assertTrue($this->validator->isValid($valueMock));
+        $this->assertNotEquals($messages, $this->validator->getMessages());
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
@@ -60,10 +60,10 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
     {
         $mess = ['option required fields' => 'Missed values for option required fields'];
         return [
-            ['option_title', 'name 1.1', 'fixed', 10, new \Magento\Framework\DataObject(['store_id' => 1]), [], true],
-            ['option_title', 'name 1.1', 'fixed', 10, new \Magento\Framework\DataObject(['store_id' => 0]), [], true],
-            [null, 'name 1.1', 'fixed', 10, new \Magento\Framework\DataObject(['store_id' => 1]), [], true],
-            [null, 'name 1.1', 'fixed', 10, new \Magento\Framework\DataObject(['store_id' => 0]), $mess, false],
+            ['option_title', 'name 1.1', 'fixed', new \Magento\Framework\DataObject(['store_id' => 1]), [], true],
+            ['option_title', 'name 1.1', 'fixed', new \Magento\Framework\DataObject(['store_id' => 0]), [], true],
+            [null, 'name 1.1', 'fixed', new \Magento\Framework\DataObject(['store_id' => 1]), [], true],
+            [null, 'name 1.1', 'fixed', new \Magento\Framework\DataObject(['store_id' => 0]), $mess, false],
         ];
     }
 
@@ -71,13 +71,12 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
      * @param $title
      * @param $type
      * @param $priceType
-     * @param $price
      * @param $product
      * @param $messages
      * @param $result
      * @dataProvider isValidTitleDataProvider
      */
-    public function testIsValidTitle($title, $type, $priceType, $price, $product, $messages, $result)
+    public function testIsValidTitle($title, $type, $priceType, $product, $messages, $result)
     {
         $methods = ['getTitle', 'getType', 'getPriceType', 'getPrice', '__wakeup', 'getProduct'];
         $valueMock = $this->createPartialMock(\Magento\Catalog\Model\Product\Option::class, $methods);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/DefaultValidatorTest.php
@@ -195,5 +195,4 @@ class DefaultValidatorTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->validator->isValid($valueMock));
         $this->assertEquals($messages, $this->validator->getMessages());
     }
-
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/FileTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/FileTest.php
@@ -59,7 +59,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $this->valueMock->expects($this->once())->method('getTitle')->will($this->returnValue('option_title'));
         $this->valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue('name 1.1'));
         $this->valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue('fixed'));
-        $this->valueMock->expects($this->once())->method('getPrice')->will($this->returnValue(10));
+        $this->valueMock->expects($this->never())->method('getPrice')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getImageSizeX')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getImageSizeY')->will($this->returnValue(15));
         $this->assertEmpty($this->validator->getMessages());
@@ -71,7 +71,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $this->valueMock->expects($this->once())->method('getTitle')->will($this->returnValue('option_title'));
         $this->valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue('name 1.1'));
         $this->valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue('fixed'));
-        $this->valueMock->expects($this->once())->method('getPrice')->will($this->returnValue(10));
+        $this->valueMock->expects($this->never())->method('getPrice')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getImageSizeX')->will($this->returnValue(-10));
         $this->valueMock->expects($this->never())->method('getImageSizeY');
         $messages = [
@@ -86,7 +86,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $this->valueMock->expects($this->once())->method('getTitle')->will($this->returnValue('option_title'));
         $this->valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue('name 1.1'));
         $this->valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue('fixed'));
-        $this->valueMock->expects($this->once())->method('getPrice')->will($this->returnValue(10));
+        $this->valueMock->expects($this->never())->method('getPrice')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getImageSizeX')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getImageSizeY')->will($this->returnValue(-10));
         $messages = [

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/SelectTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/SelectTest.php
@@ -87,7 +87,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
                 ]
             ],
             [
-                false,
+                true,
                 [
                     'title' => 'Some Title',
                     'price_type' => 'fixed',
@@ -157,7 +157,6 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     public function isValidateWithInvalidDataDataProvider()
     {
         return [
-            'invalid_price' => ['fixed', -10, 'Title'],
             'invalid_price_type' => ['some_value', '10', 'Title'],
             'empty_title' => ['fixed', 10, null]
         ];

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/TextTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/TextTest.php
@@ -59,7 +59,7 @@ class TextTest extends \PHPUnit\Framework\TestCase
         $this->valueMock->expects($this->once())->method('getTitle')->will($this->returnValue('option_title'));
         $this->valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue('name 1.1'));
         $this->valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue('fixed'));
-        $this->valueMock->expects($this->once())->method('getPrice')->will($this->returnValue(10));
+        $this->valueMock->expects($this->never())->method('getPrice')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getMaxCharacters')->will($this->returnValue(10));
         $this->assertTrue($this->validator->isValid($this->valueMock));
         $this->assertEmpty($this->validator->getMessages());
@@ -70,7 +70,7 @@ class TextTest extends \PHPUnit\Framework\TestCase
         $this->valueMock->expects($this->once())->method('getTitle')->will($this->returnValue('option_title'));
         $this->valueMock->expects($this->exactly(2))->method('getType')->will($this->returnValue('name 1.1'));
         $this->valueMock->expects($this->once())->method('getPriceType')->will($this->returnValue('fixed'));
-        $this->valueMock->expects($this->once())->method('getPrice')->will($this->returnValue(10));
+        $this->valueMock->expects($this->never())->method('getPrice')->will($this->returnValue(10));
         $this->valueMock->expects($this->once())->method('getMaxCharacters')->will($this->returnValue(-10));
         $messages = [
             'option values' => 'Invalid option value',

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
@@ -923,7 +923,7 @@ class CustomOptions extends AbstractModifier
                         'addbeforePool' => $this->productOptionsPrice->prefixesToOptionArray(),
                         'sortOrder' => $sortOrder,
                         'validation' => [
-                            'validate-zero-or-greater' => true
+                            'validate-zero-or-greater' => false
                         ],
                     ],
                 ],

--- a/app/code/Magento/Catalog/view/base/web/js/price-options.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-options.js
@@ -20,8 +20,10 @@ define([
         optionConfig: {},
         optionHandlers: {},
         optionTemplate: '<%= data.label %>' +
-        '<% if (data.finalPrice.value) { %>' +
+        '<% if (data.finalPrice.value > 0) { %>' +
         ' +<%- data.finalPrice.formatted %>' +
+        '<% } else if (data.finalPrice.value) { %>' +
+        ' <%- data.finalPrice.formatted %>' +
         '<% } %>',
         controlContainer: 'dd'
     };


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The price for custom options should be allowed to be negative. The contained changes do just that. In addition, a cosmetic problem is solved. Once options are allowed to be negative, available options (in a drop-down) add a plus sign as prefix to the price, resulting in '+-1,50 €" for a negative option price (-1,50 in this example). This is fixed as well.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#7333: Unable to set negative custom option fixed price in admin view

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add a custom option to any product.
2. Enter a negative price (for example -3) for a custom option, see #7333 for details.
3. Save the product
4. Visit the product url 
5. Take a look at the Drop-Down (select element). You'll find the option text like "+-3 €" (or dollar)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
