### PR TITLE
Translate time zone label according to current locale in Stores > Configuration > Advanced Reporting

### DIFF
--- a/app/code/Magento/Analytics/Block/Adminhtml/System/Config/CollectionTimeLabel.php
+++ b/app/code/Magento/Analytics/Block/Adminhtml/System/Config/CollectionTimeLabel.php
@@ -5,13 +5,35 @@
  */
 namespace Magento\Analytics\Block\Adminhtml\System\Config;
 
+use Magento\Framework\App\ObjectManager;
+
 /**
  * Provides label with default Time Zone
  */
 class CollectionTimeLabel extends \Magento\Config\Block\System\Config\Form\Field
 {
     /**
-     * Add default time zone to comment
+     * @var \Magento\Framework\Locale\ResolverInterface
+     */
+    private $localeResolver;
+
+    /**
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param array $data
+     * @param \Magento\Framework\Locale\ResolverInterface|null $localeResolver
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        array $data = [],
+        \Magento\Framework\Locale\ResolverInterface $localeResolver = null
+    ) {
+        $this->localeResolver = $localeResolver ?:
+            ObjectManager::getInstance()->get(\Magento\Framework\Locale\ResolverInterface::class);
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Add current time zone to comment, properly translated according to locale
      *
      * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
      * @return string
@@ -19,7 +41,9 @@ class CollectionTimeLabel extends \Magento\Config\Block\System\Config\Form\Field
     public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
     {
         $timeZoneCode = $this->_localeDate->getConfigTimezone();
-        $getLongTimeZoneName = \IntlTimeZone::createTimeZone($timeZoneCode)->getDisplayName();
+        $locale = $this->localeResolver->getLocale();
+        $getLongTimeZoneName = \IntlTimeZone::createTimeZone($timeZoneCode)
+            ->getDisplayName(false, \IntlTimeZone::DISPLAY_LONG, $locale);
         $element->setData(
             'comment',
             sprintf("%s (%s)", $getLongTimeZoneName, $timeZoneCode)


### PR DESCRIPTION
Time zone label gets translated according to operating system settings, instead of using current locale:
![captura de pantalla 2018-01-29 a las 4 15 10](https://user-images.githubusercontent.com/17545750/35492128-48bb1bba-04ab-11e8-8097-b434f7b9de49.png)

**This even can make some functional tests fail, when executed on machines with different locale options**, see \Magento\Analytics\Test\Constraint\AssertConfigAnalyticsSendingTimeAndZone::processAssert:
```
        \PHPUnit_Framework_Assert::assertEquals(
            'Eastern European Standard Time (Europe/Kiev)',
            $configAnalytics->getAnalyticsForm()->getTimeZone()
        );
```

### Description
Adapt \Magento\Analytics\Block\Adminhtml\System\Config\CollectionTimeLabel::render method to use current locale to render time zone label, as done in \Magento\Framework\Locale\TranslatedLists::getOptionTimezones

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. None AFAIK

### Manual testing scenarios
1. Change current admin user interface locale to something different of `English (United States)`, like `Spanish (Spain)`
2. In section `Stores > Configuration > Advanced Reporting`, you should see translated comment according to current locale.

Expected:
![captura de pantalla 2018-01-29 a las 4 07 22](https://user-images.githubusercontent.com/17545750/35492246-143775a4-04ac-11e8-924b-fc579377d838.png)

Current:
![captura de pantalla 2018-01-29 a las 4 08 15](https://user-images.githubusercontent.com/17545750/35492250-1b52d28e-04ac-11e8-84e5-bc4473b99837.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
