### PR TITLE
Add getters to product image builder

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
@@ -146,6 +146,7 @@ class ImageBuilder
                 'custom_attributes' => $this->getCustomAttributes(),
                 'resized_image_width' => $imagesize[0],
                 'resized_image_height' => $imagesize[1],
+                'product_id' => $this->product->getId()
             ],
         ];
 

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
@@ -252,6 +252,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
                     'custom_attributes' => '',
                     'resized_image_width' => 100,
                     'resized_image_height' => 100,
+                    'product_id' => null
                 ],
             ],
         ];
@@ -286,6 +287,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
                     'custom_attributes' => 'name_1="value_1" name_2="value_2"',
                     'resized_image_width' => 120,
                     'resized_image_height' => 70,
+                    'product_id' => null
                 ],
             ],
         ];


### PR DESCRIPTION
Hello,

### Description
I have added the attributes getter into the product image builder, class `Magento\Catalog\Block\Product\ImageBuilder` in order to get them in a plugin for example. We may want to add some attributes and use `$subject->getProduct()` to get product's data.

### Fixed Issues (if relevant)
N/A.

### Manual testing scenarios
N/A.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
