### PR TITLE
Product Link Save Handler - Remove not used constructor dependency

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Link/SaveHandler.php
@@ -31,27 +31,19 @@ class SaveHandler
     private $linkResource;
 
     /**
-     * @var linkTypeProvider
-     */
-    private $linkTypeProvider;
-
-    /**
      * SaveHandler constructor.
      * @param MetadataPool $metadataPool
      * @param Link $linkResource
      * @param ProductLinkRepositoryInterface $productLinkRepository
-     * @param \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
      */
     public function __construct(
         MetadataPool $metadataPool,
         Link $linkResource,
-        ProductLinkRepositoryInterface $productLinkRepository,
-        \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
+        ProductLinkRepositoryInterface $productLinkRepository
     ) {
         $this->metadataPool = $metadataPool;
         $this->linkResource = $linkResource;
         $this->productLinkRepository = $productLinkRepository;
-        $this->linkTypeProvider = $linkTypeProvider;
     }
 
     /**


### PR DESCRIPTION
### Description
In https://github.com/magento/magento2/pull/12650 was introduced new dependency to ```\Magento\Catalog\Model\Product\Link\SaveHandler::__construct```.
There were 2 issues:
1. These changes were not backward compatible and could brake someone who decides extend this class (it is strongly not recommended)
2. This dependency wasn't used anywhere.

This PR just removing it. Changes from https://github.com/magento/magento2/pull/12650 weren't included to any release, so removing this dependency is safe.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
