### PR TITLE
Product image builder - Override attributes when builder used multiple times

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
@@ -6,6 +6,7 @@
 namespace Magento\Catalog\Block\Product;
 
 use Magento\Catalog\Helper\ImageFactory as HelperFactory;
+use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Image\NotLoadInfoImageException;
 
 class ImageBuilder
@@ -21,7 +22,7 @@ class ImageBuilder
     protected $helperFactory;
 
     /**
-     * @var \Magento\Catalog\Model\Product
+     * @var Product
      */
     protected $product;
 
@@ -50,10 +51,10 @@ class ImageBuilder
     /**
      * Set product
      *
-     * @param \Magento\Catalog\Model\Product $product
+     * @param Product $product
      * @return $this
      */
-    public function setProduct(\Magento\Catalog\Model\Product $product)
+    public function setProduct(Product $product)
     {
         $this->product = $product;
         return $this;
@@ -79,9 +80,7 @@ class ImageBuilder
      */
     public function setAttributes(array $attributes)
     {
-        if ($attributes) {
-            $this->attributes = $attributes;
-        }
+        $this->attributes = $attributes;
         return $this;
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
@@ -197,58 +197,30 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function createDataProvider()
+    public function createDataProvider(): array
+    {
+        return [
+            $this->getTestDataWithoutAttributes(),
+            $this->getTestDataWithAttributes(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function createMultipleCallsDataProvider(): array
     {
         return [
             [
-                'data' => [
-                    'frame' => 0,
-                    'url' => 'test_url_1',
-                    'width' => 100,
-                    'height' => 100,
-                    'label' => 'test_label',
-                    'custom_attributes' => [],
-                    'imagesize' => [100, 100],
-                ],
-                'expected' => [
-                    'data' => [
-                        'template' => 'Magento_Catalog::product/image_with_borders.phtml',
-                        'image_url' => 'test_url_1',
-                        'width' => 100,
-                        'height' => 100,
-                        'label' => 'test_label',
-                        'ratio' => 1,
-                        'custom_attributes' => '',
-                        'resized_image_width' => 100,
-                        'resized_image_height' => 100,
-                    ],
+                [
+                    'without_attributes' => $this->getTestDataWithoutAttributes(),
+                    'with_attributes' => $this->getTestDataWithAttributes(),
                 ],
             ],
             [
-                'data' => [
-                    'frame' => 1,
-                    'url' => 'test_url_2',
-                    'width' => 100,
-                    'height' => 50,
-                    'label' => 'test_label_2',
-                    'custom_attributes' => [
-                        'name_1' => 'value_1',
-                        'name_2' => 'value_2',
-                    ],
-                    'imagesize' => [120, 70],
-                ],
-                'expected' => [
-                    'data' => [
-                        'template' => 'Magento_Catalog::product/image.phtml',
-                        'image_url' => 'test_url_2',
-                        'width' => 100,
-                        'height' => 50,
-                        'label' => 'test_label_2',
-                        'ratio' => 0.5,
-                        'custom_attributes' => 'name_1="value_1" name_2="value_2"',
-                        'resized_image_width' => 120,
-                        'resized_image_height' => 70,
-                    ],
+                [
+                    'with_attributes' => $this->getTestDataWithAttributes(),
+                    'without_attributes' => $this->getTestDataWithoutAttributes(),
                 ],
             ],
         ];
@@ -257,117 +229,63 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function createMultipleCallsDataProvider()
+    private function getTestDataWithoutAttributes(): array
     {
         return [
-            [
-                [
-                    'without_attributes' => [
-                        'data' => [
-                            'frame' => 0,
-                            'url' => 'test_url_1',
-                            'width' => 100,
-                            'height' => 100,
-                            'label' => 'test_label',
-                            'custom_attributes' => [],
-                            'imagesize' => [100, 100],
-                        ],
-                        'expected' => [
-                            'data' => [
-                                'template' => 'Magento_Catalog::product/image_with_borders.phtml',
-                                'image_url' => 'test_url_1',
-                                'width' => 100,
-                                'height' => 100,
-                                'label' => 'test_label',
-                                'ratio' => 1,
-                                'custom_attributes' => '',
-                                'resized_image_width' => 100,
-                                'resized_image_height' => 100,
-                            ],
-                        ],
-                    ],
-                    'with_attributes' => [
-                        'data' => [
-                            'frame' => 1,
-                            'url' => 'test_url_2',
-                            'width' => 100,
-                            'height' => 50,
-                            'label' => 'test_label_2',
-                            'custom_attributes' => [
-                                'name_1' => 'value_1',
-                                'name_2' => 'value_2',
-                            ],
-                            'imagesize' => [120, 70],
-                        ],
-                        'expected' => [
-                            'data' => [
-                                'template' => 'Magento_Catalog::product/image.phtml',
-                                'image_url' => 'test_url_2',
-                                'width' => 100,
-                                'height' => 50,
-                                'label' => 'test_label_2',
-                                'ratio' => 0.5,
-                                'custom_attributes' => 'name_1="value_1" name_2="value_2"',
-                                'resized_image_width' => 120,
-                                'resized_image_height' => 70,
-                            ],
-                        ],
-                    ],
+            'data' => [
+                'frame' => 0,
+                'url' => 'test_url_1',
+                'width' => 100,
+                'height' => 100,
+                'label' => 'test_label',
+                'custom_attributes' => [],
+                'imagesize' => [100, 100],
+            ],
+            'expected' => [
+                'data' => [
+                    'template' => 'Magento_Catalog::product/image_with_borders.phtml',
+                    'image_url' => 'test_url_1',
+                    'width' => 100,
+                    'height' => 100,
+                    'label' => 'test_label',
+                    'ratio' => 1,
+                    'custom_attributes' => '',
+                    'resized_image_width' => 100,
+                    'resized_image_height' => 100,
                 ],
             ],
-            [
-                [
-                    'with_attributes' => [
-                        'data' => [
-                            'frame' => 1,
-                            'url' => 'test_url_2',
-                            'width' => 100,
-                            'height' => 50,
-                            'label' => 'test_label_2',
-                            'custom_attributes' => [
-                                'name_1' => 'value_1',
-                                'name_2' => 'value_2',
-                            ],
-                            'imagesize' => [120, 70],
-                        ],
-                        'expected' => [
-                            'data' => [
-                                'template' => 'Magento_Catalog::product/image.phtml',
-                                'image_url' => 'test_url_2',
-                                'width' => 100,
-                                'height' => 50,
-                                'label' => 'test_label_2',
-                                'ratio' => 0.5,
-                                'custom_attributes' => 'name_1="value_1" name_2="value_2"',
-                                'resized_image_width' => 120,
-                                'resized_image_height' => 70,
-                            ],
-                        ],
-                    ],
-                    'without_attributes' => [
-                        'data' => [
-                            'frame' => 0,
-                            'url' => 'test_url_1',
-                            'width' => 100,
-                            'height' => 100,
-                            'label' => 'test_label',
-                            'custom_attributes' => [],
-                            'imagesize' => [100, 100],
-                        ],
-                        'expected' => [
-                            'data' => [
-                                'template' => 'Magento_Catalog::product/image_with_borders.phtml',
-                                'image_url' => 'test_url_1',
-                                'width' => 100,
-                                'height' => 100,
-                                'label' => 'test_label',
-                                'ratio' => 1,
-                                'custom_attributes' => '',
-                                'resized_image_width' => 100,
-                                'resized_image_height' => 100,
-                            ],
-                        ],
-                    ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getTestDataWithAttributes(): array
+    {
+        return [
+            'data' => [
+                'frame' => 1,
+                'url' => 'test_url_2',
+                'width' => 100,
+                'height' => 50,
+                'label' => 'test_label_2',
+                'custom_attributes' => [
+                    'name_1' => 'value_1',
+                    'name_2' => 'value_2',
+                ],
+                'imagesize' => [120, 70],
+            ],
+            'expected' => [
+                'data' => [
+                    'template' => 'Magento_Catalog::product/image.phtml',
+                    'image_url' => 'test_url_2',
+                    'width' => 100,
+                    'height' => 50,
+                    'label' => 'test_label_2',
+                    'ratio' => 0.5,
+                    'custom_attributes' => 'name_1="value_1" name_2="value_2"',
+                    'resized_image_width' => 120,
+                    'resized_image_height' => 70,
                 ],
             ],
         ];

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
@@ -29,24 +29,16 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->helperFactory = $this->getMockBuilder(\Magento\Catalog\Helper\ImageFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
+        $this->helperFactory = $this->createPartialMock(\Magento\Catalog\Helper\ImageFactory::class, ['create']);
 
-        $this->imageFactory = $this->getMockBuilder(ImageFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
+        $this->imageFactory = $this->createPartialMock(ImageFactory::class, ['create']);
 
         $this->model = new ImageBuilder($this->helperFactory, $this->imageFactory);
     }
 
     public function testSetProduct()
     {
-        $productMock = $this->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $productMock = $this->createMock(Product::class);
 
         $this->assertInstanceOf(
             ImageBuilder::class,
@@ -83,13 +75,9 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $imageId = 'test_image_id';
 
-        $productMock = $this->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $productMock = $this->createMock(Product::class);
 
-        $helperMock = $this->getMockBuilder(Image::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $helperMock = $this->createMock(Image::class);
         $helperMock->expects($this->once())
             ->method('init')
             ->with($productMock, $imageId)
@@ -118,9 +106,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($helperMock);
 
-        $imageMock = $this->getMockBuilder(\Magento\Catalog\Block\Product\Image::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $imageMock = $this->createMock(\Magento\Catalog\Block\Product\Image::class);
 
         $this->imageFactory->expects($this->once())
             ->method('create')
@@ -144,13 +130,9 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
 
         $imageId = 'test_image_id';
 
-        $productMock = $this->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $productMock = $this->createMock(Product::class);
 
-        $helperMock = $this->getMockBuilder(Image::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $helperMock = $this->createMock(Image::class);
         $helperMock->expects($this->exactly(2))
             ->method('init')
             ->with($productMock, $imageId)
@@ -188,9 +170,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($helperMock);
 
-        $imageMock = $this->getMockBuilder(\Magento\Catalog\Block\Product\Image::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $imageMock = $this->createMock(\Magento\Catalog\Block\Product\Image::class);
 
         $this->imageFactory->expects($this->at(0))
             ->method('create')

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
@@ -164,10 +164,20 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
             ->willReturnOnConsecutiveCalls($firstCall['data']['url'], $secondCall['data']['url']);
         $helperMock->expects($this->exactly(4))
             ->method('getWidth')
-            ->willReturnOnConsecutiveCalls($firstCall['data']['width'], $firstCall['data']['width'], $secondCall['data']['width'], $secondCall['data']['width']);
+            ->willReturnOnConsecutiveCalls(
+                $firstCall['data']['width'],
+                $firstCall['data']['width'],
+                $secondCall['data']['width'],
+                $secondCall['data']['width']
+            );
         $helperMock->expects($this->exactly(4))
             ->method('getHeight')
-            ->willReturnOnConsecutiveCalls($firstCall['data']['height'], $firstCall['data']['height'], $secondCall['data']['height'], $secondCall['data']['height']);
+            ->willReturnOnConsecutiveCalls(
+                $firstCall['data']['height'],
+                $firstCall['data']['height'],
+                $secondCall['data']['height'],
+                $secondCall['data']['height']
+            );
         $helperMock->expects($this->exactly(2))
             ->method('getLabel')
             ->willReturnOnConsecutiveCalls($firstCall['data']['label'], $secondCall['data']['label']);


### PR DESCRIPTION
### Description
Image builder is used few times with different parameters in [```\Magento\Catalog\Block\Product\AbstractProduct::getImage```](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/Block/Product/AbstractProduct.php#L511-L517).
In case when on first call $attributes was set to not empty array, on second call - $attributes is empty array - builder re-used attributes from first call, as result - we will get unexpected result - attributes will be re-used from 1st call.  
```php
$this->imageBuilder->setProduct($product)
    ->setImageId($imageId)
    ->setAttributes($attributes)
    ->create();
```

As builder designed to be used multiple times - let's remove check that attributes array is not empty.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
See description

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
