### PR TITLE
Fix default discount tax calculation in double

### DIFF
--- a/app/code/Magento/Tax/etc/config.xml
+++ b/app/code/Magento/Tax/etc/config.xml
@@ -20,7 +20,6 @@
                 <based_on>shipping</based_on>
                 <price_includes_tax>0</price_includes_tax>
                 <shipping_includes_tax>0</shipping_includes_tax>
-                <discount_tax>0</discount_tax>
                 <apply_tax_on>0</apply_tax_on>
             </calculation>
             <defaults>


### PR DESCRIPTION
Hello

### Description
The node `tax/calculation/discount_tax` is in double in file `Magento/Tax/etc/config.xml`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
