### PR TITLE
Added function definition for setAdditionalInformation in \Magento\Sa…

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
@@ -802,7 +802,7 @@ interface OrderPaymentInterface extends \Magento\Framework\Api\ExtensibleDataInt
      */
     public function setAdditionalData($additionalData);
 
-    /**s
+    /**
      * Set Additional information about payment into Payment model
      *
      * @param string $key

--- a/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
@@ -802,6 +802,15 @@ interface OrderPaymentInterface extends \Magento\Framework\Api\ExtensibleDataInt
      */
     public function setAdditionalData($additionalData);
 
+    /**s
+     * Set Additional information about payment into Payment model
+     *
+     * @param string $key
+     * @param string|null $value
+     * @return mixed
+     */
+    public function setAdditionalInformation($key, $value = null);
+
     /**
      * Sets the credit card expiration month for the order payment.
      *


### PR DESCRIPTION
…les\Api\Data\OrderPaymentInterface

### Description
When trying to run a paid order through a \Magento\Framework\Webapi\ServiceOutputProcessor it will fail because the 'additional_information' data has no corresponding setter defined in the interface.

The ServiceOutputProcessor tries to serialize the order object based on the (api) interfaces. When it reaches the serialization of the Payment object in the order the processor will fail when the object has data for 'additional_information' (normally this contains the payment method name).

The Magento\Sales\Api\Data\OrderPaymentInterface should contain a setAdditionalInformation function definition which will be implemented by the setAdditionalInformation function defined in Magento\Payment\Model\InfoInterface

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13222

### Manual testing scenarios
1. See description and testing scenario in original issue https://github.com/magento/magento2/issues/13222

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
