### PR TITLE
Switch updatecart qty input validators to dynamic instead of hardcoding

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
@@ -23,7 +23,7 @@
                            value=""
                            title="<?= /* @escapeNotVerified */ __('Qty') ?>"
                            class="input-text qty"
-                           data-validate="{'required-number':true,digits:true}"/>
+                           data-validate="<?= $block->escapeHtml(json_encode($block->getQuantityValidators())) ?>"/>
                 </div>
             </div>
             <?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Currently, the edit cart product input has hardcoded validators which differ from the main PDP page. What is the reasoning for this? This prevents custom qty validators applied on normal PDP from applying when you update said product qty.

[updateCart.phtml](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml#L26) vs [addtocart.phtml](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml#L26)

This PR matches both updatecart.phtml and addtocart.phtml qty input validators. Now when you target, `afterGetQuantityValidators` it will apply to both inputs.

Maybe I am mistaken and there is a real reason they did not originally match?

### Manual testing scenarios
1. Check DOM to see outputted validators on PDP and on PDP edit.
2. Both will match.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
