### PR TITLE
Wrong store_id assigned to Customer when reading his subscription to Newsletter

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -360,7 +360,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
     {
         try {
             $customerData = $this->customerRepository->getById($customerId);
-            $customerData->setStoreId($this->_storeManager->getStore()->getId());
             $data = $this->getResource()->loadByCustomerData($customerData);
             $this->addData($data);
             if (!empty($data) && $customerData->getId() && !$this->getCustomerId()) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The issue comes in a scenario with multiple stores.

When we edit an existing customer that was previously subscribed in newsletter from backend, magento assigns to him store_id 1 also if he was created from another store (e.g store 2).

From the manage Customer page, In the Newsletter panel tab,  the label "Last Date Unsubscribed" with the date of last subscription of the user, does not appear.

 If we try to subscribe again the customer into newsletter (always from Customer page), Magento will create a duplicated entry in the database table "newsletter_subscriber"

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Create a new customer for the store view with store_id = 2 (if you have two stores, be sure to select the store view with a store_id different from 1)
2. From the customer page, Assign the customer to newsletter.
3. Edit again the customer, go to newsletter panel: The label "Last Date Unsubscribed" does not appear.
4. Subscribe again the customer and check the table newsletter_subscriber into database. You will find a duplicated entry. (If you save more times, a new row will be added)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
