### PR TITLE
Issue 11175: fix i18n:collect-phrases so it also collects "translate args"

### DIFF
--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -16,8 +16,9 @@ class Html extends AbstractAdapter
      * Covers
      * <span><!-- ko i18n: 'Next'--><!-- /ko --></span>
      * <th class="col col-method" data-bind="i18n: 'Select Method'"></th>
+     * <translate args="'Items in Cart'"/>
      */
-    const HTML_FILTER = "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/i";
+    const HTML_FILTER = "/i18n:\s?'(?<value_i18n>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)|translate args=\"'(?<value_translate_args>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)'\"/i";
 
     /**
      * {@inheritdoc}
@@ -44,8 +45,11 @@ class Html extends AbstractAdapter
 
         preg_match_all(self::HTML_FILTER, $data, $results, PREG_SET_ORDER);
         for ($i = 0; $i < count($results); $i++) {
-            if (!empty($results[$i]['value'])) {
-                $this->_addPhrase($results[$i]['value']);
+            if (!empty($results[$i]['value_i18n'])) {
+                $this->_addPhrase($results[$i]['value_i18n']);
+            }
+            if (!empty($results[$i]['value_translate_args'])) {
+                $this->_addPhrase($results[$i]['value_translate_args']);
             }
         }
     }


### PR DESCRIPTION
### Description
See issue https://github.com/magento/magento2/issues/11175
fix i18n:collect-phrases so it also collects `<translate args="'Items in Cart'"/>`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#11175: i18n:collect-phrases -m can't find many important magento phrases

### Manual testing scenarios
1. run `php bin/magento i18n:collect-phrases app/code/Magento/Checkout | grep "Items in Cart"`
Or when magento is in the vendor folder: `php bin/magento i18n:collect-phrases vendor/magento/module-checkout | grep "Item in Cart"`
2. It should return a line with: `"Items in Cart","Items in Cart"`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
