### PR TITLE
Allow import of empty attributes

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -909,6 +909,19 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     }
 
     /**
+     * Return empty attribute value constant
+     *
+     * @return string
+     */
+    public function getEmptyAttributeValueConstant()
+    {
+        if (!empty($this->_parameters[Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT])) {
+            return $this->_parameters[Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT];
+        }
+        return Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT;
+    }
+
+    /**
      * Retrieve instance of product custom options import entity
      *
      * @return \Magento\CatalogImportExport\Model\Import\Product\Option

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
@@ -1090,7 +1090,7 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         // Parse custom options.
         $rowData = $this->_parseCustomOptions($rowData);
         $multiRow = [];
-        if (empty($rowData['custom_options'])) {
+        if (empty($rowData['custom_options']) || !is_array($rowData['custom_options'])) {
             return $multiRow;
         }
 
@@ -1923,7 +1923,8 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     protected function _parseCustomOptions($rowData)
     {
         $beforeOptionValueSkuDelimiter = ';';
-        if (empty($rowData['custom_options'])) {
+        if (empty($rowData['custom_options'])
+            || $rowData['custom_options'] === \Magento\ImportExport\Model\Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT) {
             return $rowData;
         }
         $rowData['custom_options'] = str_replace(

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
@@ -1236,7 +1236,13 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $multiRowData = $this->_getMultiRowFormat($rowData);
                 if (!empty($rowData[self::COLUMN_SKU]) && isset($this->_productsSkuToId[$rowData[self::COLUMN_SKU]])) {
                     $this->_rowProductId = $this->_productsSkuToId[$rowData[self::COLUMN_SKU]];
-                    if (array_key_exists('custom_options', $rowData) && trim($rowData['custom_options']) === '') {
+                    if (
+                        array_key_exists('custom_options', $rowData)
+                        && (
+                            trim($rowData['custom_options']) === ''
+                            || trim ($rowData['custom_options']) === $this->_productEntity->getEmptyAttributeValueConstant()
+                        )
+                    ) {
                         $optionsToRemove[] = $this->_rowProductId;
                     }
                 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
@@ -13,6 +13,7 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Product\Option\Value\Collection as ProductOptionValueCollection;
 use Magento\Catalog\Model\ResourceModel\Product\Option\Value\CollectionFactory as ProductOptionValueCollectionFactory;
 use Magento\Store\Model\Store;
+use Magento\ImportExport\Model\Import;
 
 /**
  * Entity class which provide possibility to import product custom options
@@ -1924,7 +1925,7 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $beforeOptionValueSkuDelimiter = ';';
         if (empty($rowData['custom_options'])
-            || $rowData['custom_options'] === \Magento\ImportExport\Model\Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT) {
+            || $rowData['custom_options'] === Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT) {
             return $rowData;
         }
         $rowData['custom_options'] = str_replace(

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
@@ -1236,11 +1236,10 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $multiRowData = $this->_getMultiRowFormat($rowData);
                 if (!empty($rowData[self::COLUMN_SKU]) && isset($this->_productsSkuToId[$rowData[self::COLUMN_SKU]])) {
                     $this->_rowProductId = $this->_productsSkuToId[$rowData[self::COLUMN_SKU]];
-                    if (
-                        array_key_exists('custom_options', $rowData)
+                    if (array_key_exists('custom_options', $rowData)
                         && (
-                            trim($rowData['custom_options']) === ''
-                            || trim ($rowData['custom_options']) === $this->_productEntity->getEmptyAttributeValueConstant()
+                            trim($rowData['custom_options']) === '' ||
+                            trim($rowData['custom_options']) === $this->_productEntity->getEmptyAttributeValueConstant()
                         )
                     ) {
                         $optionsToRemove[] = $this->_rowProductId;

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -444,7 +444,11 @@ abstract class AbstractType
         $error = false;
         $rowScope = $this->_entityModel->getRowScope($rowData);
         if (\Magento\CatalogImportExport\Model\Import\Product::SCOPE_NULL != $rowScope
-            && !empty($rowData[\Magento\CatalogImportExport\Model\Import\Product::COL_SKU])
+            && (
+                !empty($rowData[\Magento\CatalogImportExport\Model\Import\Product::COL_SKU])
+                || $rowData[\Magento\CatalogImportExport\Model\Import\Product::COL_SKU]
+                    !== $this->_entityModel->getEmptyAttributeValueConstant()
+            )
         ) {
             foreach ($this->_getProductAttributes($rowData) as $attrCode => $attrParams) {
                 // check value for non-empty in the case of required attribute?

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -538,7 +538,9 @@ abstract class AbstractType
                 unset($rowData[$attrCode]);
             }
 
-            if (isset($rowData[$attrCode]) && $rowData[$attrCode] === $this->_entityModel->getEmptyAttributeValueConstant()) {
+            if (isset($rowData[$attrCode])
+                && $rowData[$attrCode] === $this->_entityModel->getEmptyAttributeValueConstant())
+            {
                 $rowData[$attrCode] = null;
             }
         }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -444,11 +444,7 @@ abstract class AbstractType
         $error = false;
         $rowScope = $this->_entityModel->getRowScope($rowData);
         if (\Magento\CatalogImportExport\Model\Import\Product::SCOPE_NULL != $rowScope
-            && (
-                !empty($rowData[\Magento\CatalogImportExport\Model\Import\Product::COL_SKU])
-                || $rowData[\Magento\CatalogImportExport\Model\Import\Product::COL_SKU]
-                    !== $this->_entityModel->getEmptyAttributeValueConstant()
-            )
+            && !empty($rowData[\Magento\CatalogImportExport\Model\Import\Product::COL_SKU])
         ) {
             foreach ($this->_getProductAttributes($rowData) as $attrCode => $attrParams) {
                 // check value for non-empty in the case of required attribute?

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -539,8 +539,8 @@ abstract class AbstractType
             }
 
             if (isset($rowData[$attrCode])
-                && $rowData[$attrCode] === $this->_entityModel->getEmptyAttributeValueConstant())
-            {
+                && $rowData[$attrCode] === $this->_entityModel->getEmptyAttributeValueConstant()
+            ) {
                 $rowData[$attrCode] = null;
             }
         }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -537,6 +537,10 @@ abstract class AbstractType
             if (!$attrParams['is_static'] && !isset($rowData[$attrCode])) {
                 unset($rowData[$attrCode]);
             }
+
+            if (isset($rowData[$attrCode]) && $rowData[$attrCode] === $this->_entityModel->getEmptyAttributeValueConstant()) {
+                $rowData[$attrCode] = null;
+            }
         }
         return $rowData;
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
@@ -150,7 +150,12 @@ class Validator extends AbstractValidator implements RowValidatorInterface
             $doCheck = true;
         }
 
-        return $doCheck ? isset($rowData[$attrCode]) && strlen(trim($rowData[$attrCode])) : true;
+        if ($doCheck === true) {
+            return isset($rowData[$attrCode])
+                && strlen(trim($rowData[$attrCode]))
+                && trim($rowData[$attrCode]) !== $this->context->getEmptyAttributeValueConstant();
+        }
+        return true;
     }
 
     /**

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
@@ -188,6 +188,11 @@ class Validator extends AbstractValidator implements RowValidatorInterface
         if (!strlen(trim($rowData[$attrCode]))) {
             return true;
         }
+
+        if ($rowData[$attrCode] === $this->context->getEmptyAttributeValueConstant() && !$attrParams['is_required']) {
+            return true;
+        }
+
         switch ($attrParams['type']) {
             case 'varchar':
             case 'text':

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Quantity.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Quantity.php
@@ -18,7 +18,9 @@ class Quantity extends AbstractImportValidator implements RowValidatorInterface
     public function isValid($value)
     {
         $this->_clearMessages();
-        if (!empty($value['qty']) && !is_numeric($value['qty'])) {
+        if (!empty($value['qty']) && (!is_numeric($value['qty'])
+            && $value['qty'] !== $this->context->getEmptyAttributeValueConstant())
+        ) {
             $this->_addMessages(
                 [
                     sprintf(

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Weight.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Weight.php
@@ -15,7 +15,9 @@ class Weight extends AbstractImportValidator implements RowValidatorInterface
     public function isValid($value)
     {
         $this->_clearMessages();
-        if (!empty($value['weight']) && (!is_numeric($value['weight']) || $value['weight'] < 0)) {
+        if (!empty($value['weight']) && (!is_numeric($value['weight']) || $value['weight'] < 0)
+            && $value['weight'] !== $this->context->getEmptyAttributeValueConstant()
+        ) {
             $this->_addMessages(
                 [
                     sprintf(

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/WeightTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/WeightTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\CatalogImportExport\Test\Unit\Model\Import\Product\Validator;
 
 use Magento\CatalogImportExport\Model\Import\Product;

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/WeightTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/WeightTest.php
@@ -6,22 +6,22 @@
 namespace Magento\CatalogImportExport\Test\Unit\Model\Import\Product\Validator;
 
 use Magento\CatalogImportExport\Model\Import\Product;
-use Magento\CatalogImportExport\Model\Import\Product\Validator\Quantity;
+use Magento\CatalogImportExport\Model\Import\Product\Validator\Weight;
 use Magento\ImportExport\Model\Import;
 
 /**
- * Class QuantityTest
+ * Class WeightTest
  */
-class QuantityTest extends \PHPUnit\Framework\TestCase
+class WeightTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var Quantity
+     * @var Weight
      */
-    private $quantity;
+    private $weight;
 
     protected function setUp()
     {
-        $this->quantity = new Quantity();
+        $this->weight = new Weight();
 
         $contextStub = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -31,7 +31,7 @@ class QuantityTest extends \PHPUnit\Framework\TestCase
             ->willReturn(Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT);
 
         $contextStub->method('retrieveMessageTemplate')->willReturn(null);
-        $this->quantity->init($contextStub);
+        $this->weight->init($contextStub);
     }
 
     /**
@@ -41,7 +41,7 @@ class QuantityTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsValid($expectedResult, $value)
     {
-        $result = $this->quantity->isValid($value);
+        $result = $this->weight->isValid($value);
         $this->assertEquals($expectedResult, $result);
     }
 
@@ -51,17 +51,17 @@ class QuantityTest extends \PHPUnit\Framework\TestCase
     public function isValidDataProvider()
     {
         return [
-            [true, ['qty' => 0]],
-            [true, ['qty' => 1]],
-            [true, ['qty' => 5]],
-            [true, ['qty' => -1]],
-            [true, ['qty' => -10]],
-            [true, ['qty' => '']],
-            [false, ['qty' => 'abc']],
-            [false, ['qty' => true]],
-            [false, ['qty' => true]],
-            [true, ['qty' => Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT]],
-            [false, ['qty' => '__EMPTY__VALUE__TEST__']],
+            [true, ['weight' => 0]],
+            [true, ['weight' => 1]],
+            [true, ['weight' => 5]],
+            [false, ['weight' => -1]],
+            [false, ['weight' => -10]],
+            [true, ['weight' => '']],
+            [false, ['weight' => 'abc']],
+            [false, ['weight' => true]],
+            [false, ['weight' => true]],
+            [true, ['weight' => Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT]],
+            [false, ['weight' => '__EMPTY__VALUE__TEST__']],
         ];
     }
 }

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -600,6 +600,28 @@ class ProductTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
         );
     }
 
+    public function testGetEmptyAttributeValueConstantDefault()
+    {
+        $this->setPropertyValue($this->importProduct, '_parameters', null);
+        $this->assertEquals(
+            Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT,
+            $this->importProduct->getEmptyAttributeValueConstant()
+        );
+    }
+
+    public function testGetEmptyAttributeValueConstantFromParameters()
+    {
+        $expectedSeparator = '__EMPTY__VALUE__TEST__';
+        $this->setPropertyValue($this->importProduct, '_parameters', [
+            \Magento\ImportExport\Model\Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT => $expectedSeparator,
+        ]);
+
+        $this->assertEquals(
+            $expectedSeparator,
+            $this->importProduct->getEmptyAttributeValueConstant()
+        );
+    }
+
     public function testDeleteProductsForReplacement()
     {
         $importProduct = $this->getMockBuilder(\Magento\CatalogImportExport\Model\Import\Product::class)

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -175,6 +175,19 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 ]
             );
             $fieldsets[$behaviorCode]->addField(
+                $behaviorCode . \Magento\ImportExport\Model\Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT,
+                'text',
+                [
+                    'name' => \Magento\ImportExport\Model\Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT,
+                    'label' => __('Empty attribute value constant'),
+                    'title' => __('Empty attribute value constant'),
+                    'required' => true,
+                    'disabled' => true,
+                    'class' => $behaviorCode,
+                    'value' => Import::DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT,
+                ]
+            );
+            $fieldsets[$behaviorCode]->addField(
                 $behaviorCode . \Magento\ImportExport\Model\Import::FIELDS_ENCLOSURE,
                 'checkbox',
                 [

--- a/app/code/Magento/ImportExport/Model/Import.php
+++ b/app/code/Magento/ImportExport/Model/Import.php
@@ -78,6 +78,11 @@ class Import extends \Magento\ImportExport\Model\AbstractModel
     const FIELD_FIELD_MULTIPLE_VALUE_SEPARATOR = '_import_multiple_value_separator';
 
     /**
+     * Import empty attribute value constant.
+     */
+    const FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT = '_import_empty_attribute_value_constant';
+
+    /**
      * Allow multiple values wrapping in double quotes for additional attributes.
      */
     const FIELDS_ENCLOSURE = 'fields_enclosure';
@@ -88,6 +93,11 @@ class Import extends \Magento\ImportExport\Model\AbstractModel
      * default delimiter for several values in one cell as default for FIELD_FIELD_MULTIPLE_VALUE_SEPARATOR
      */
     const DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR = ',';
+
+    /**
+     * default empty attribute value constant
+     */
+    const DEFAULT_EMPTY_ATTRIBUTE_VALUE_CONSTANT = '__EMPTY__VALUE__';
 
     /**#@+
      * Import constants


### PR DESCRIPTION
Allow import of empty attributes in Magento2 import functionality. See internal number MAGETWO-61593.
### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/7468

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
