### PR TITLE
[Backport 2.1-develop] Change the store code in Swagger based on a param

### DIFF
--- a/app/code/Magento/Swagger/Block/Index.php
+++ b/app/code/Magento/Swagger/Block/Index.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Swagger\Block;
+
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Class Index
+ *
+ * @api
+ */
+class Index extends Template
+{
+    /**
+     * @return mixed|string
+     */
+    private function getParamStore()
+    {
+        return $this->getRequest()->getParam('store') ?: 'all';
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchemaUrl()
+    {
+        return rtrim($this->getBaseUrl(), '/') . '/rest/' . $this->getParamStore() . '/schema?services=all';
+    }
+}

--- a/app/code/Magento/Swagger/view/frontend/layout/swagger_index_index.xml
+++ b/app/code/Magento/Swagger/view/frontend/layout/swagger_index_index.xml
@@ -41,7 +41,7 @@
         <referenceContainer name="page.wrapper" remove="true"/>
         <referenceBlock name="requirejs-config" remove="true"/>
         <referenceContainer name="root">
-            <block name="swaggerUiContent" class="Magento\Framework\View\Element\Template" template="Magento_Swagger::swagger-ui/index.phtml"/>
+            <block name="swaggerUiContent" class="Magento\Swagger\Block\Index" template="Magento_Swagger::swagger-ui/index.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
+++ b/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
@@ -9,19 +9,19 @@
  *
  * The original name of this file, as part of the swagger-ui package, was dist/index.html.
  *
- * Modified by Magento, Modifications Copyright © Magento, Inc.
+ * Modified by Magento, Modifications Copyright © Magento, Inc. All rights reserved.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Magento\Swagger\Block\Index $block */
 
-$schemaUrl = rtrim($block->getBaseUrl(), '/') . '/rest/default/schema?services=all';
+$schemaUrl = $block->getSchemaUrl();
 ?>
 
 <div id='header'>
     <div class="swagger-ui-wrap">
         <a id="logo" href="http://swagger.io">swagger</a>
         <form id='api_selector'>
-            <input id="input_baseUrl" type="hidden" value="<?php /* @escapeNotVerified */ echo $schemaUrl ?>"/>
+            <input id="input_baseUrl" type="hidden" value="<?= /* @escapeNotVerified */ $schemaUrl ?>"/>
             <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
             <div class='input'><a id="explore" href="#" data-sw-translate>apply</a></div>
         </form>


### PR DESCRIPTION
Backport of https://github.com/magento-partners/magento2ce/pull/10

### Description
This feature makes it possible to easily switch between store codes in Swagger without changing the swagger-ui template but through adding a store param to the url. With this feature it is possible to test API calls in Swagger for different storeviews.

### Fixed Issues (if relevant)
1. magento/magento2#13474: Swagger not working for multistore installs?

### Manual testing scenarios
1. Go to Swagger `http://www.example.com/swagger`
2. By default the resources will be fetched for all storeviews with the following url `http://www.example.com/rest/all/schema?services=all`
3. Add store param to the url with a storecode `http://www.example.com/swagger?store=default`
4. The resources now will be fetched for the selected storeview for example default with the following url `http://www.example.com/rest/default/schema?services=all`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
