### PR TITLE
[Backport 2.1] #9247 fixed layout handle for cms page

### DIFF
--- a/app/code/Magento/Cms/Helper/Page.php
+++ b/app/code/Magento/Cms/Helper/Page.php
@@ -152,7 +152,7 @@ class Page extends \Magento\Framework\App\Helper\AbstractHelper
         $resultPage = $this->resultPageFactory->create();
         $this->setLayoutType($inRange, $resultPage);
         $resultPage->addHandle('cms_page_view');
-        $resultPage->addPageLayoutHandles(['id' => $this->_page->getIdentifier()]);
+        $resultPage->addPageLayoutHandles(['id' => str_replace('/', '_', $this->_page->getIdentifier())]);
 
         $this->_eventManager->dispatch(
             'cms_page_render',


### PR DESCRIPTION
Backported pull request #9247

### Description
Cms module adds additional layout update handle with identifier on page view. Following problems appear when user use slashes in page identifier (e.g. `cms/page`):
1. Impossible to use custom layout update file (e.g. `cms_page_view_id_cms_page`)
2. Menu missing when varnish full page cache enable (relevant only for 2.0 and 2.1 branches)
3. Wrong layout handle format

### Manual testing scenarios
1. Enable varnish full page cache under `Stores > Configuration > Advanced > System > Full Page Cache > Caching Application`
2. Create new cms page
3. Provide URL Key with slashes (e.g. cms/page)
4. Check result on frontend (menu will be missing)
