### PR TITLE
[Backport 2.1] #9796 configurable product price options provider

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
@@ -63,7 +63,9 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
             );
 
             $this->productsMap[$product->getId()] = $this->collectionFactory->create()
-                ->addAttributeToSelect(['price', 'special_price'])
+                ->addAttributeToSelect(
+                    ['price', 'special_price', 'special_from_date', 'special_to_date', 'tax_class_id']
+                )
                 ->addIdFilter($productIds)
                 ->getItems();
         }


### PR DESCRIPTION
Backported pull request #9796

### Description
_LowestPriceOptionsProvider_ returns products without attributes which are used for price calculation (e.g. tax adjustment)

### Fixed Issues
1. magento/magento2#6729: Configurable product old price with taxes displayed wrong
2. magento/magento2#6457: Expired special_price is still shown for configurable products when no variant is selected
3. magento/magento2#7362: Special price vigency for configurable childs (simple products associated) doesn´t work

### Manual testing scenarios
As explained in #9796
