### PR TITLE
[REFACTORING] refactoring the wishlist module by replacing deprecated methods

### DIFF
--- a/app/code/Magento/Wishlist/Controller/Index/Add.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Add.php
@@ -11,6 +11,7 @@ use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Wishlist\Model\ResourceModel\Wishlist;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -38,24 +39,33 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
     protected $formKeyValidator;
 
     /**
+     * @var \Magento\Wishlist\Model\ResourceModel\Wishlist
+     */
+    protected $resourceModel;
+
+    /**
      * @param Action\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Wishlist\Controller\WishlistProviderInterface $wishlistProvider
      * @param ProductRepositoryInterface $productRepository
      * @param Validator $formKeyValidator
+     * @param \Magento\Wishlist\Model\ResourceModel\Wishlist $resourceModel
      */
     public function __construct(
         Action\Context $context,
         \Magento\Customer\Model\Session $customerSession,
         \Magento\Wishlist\Controller\WishlistProviderInterface $wishlistProvider,
         ProductRepositoryInterface $productRepository,
-        Validator $formKeyValidator
+        Validator $formKeyValidator,
+        Wishlist $resourceModel = null
     ) {
         $this->_customerSession = $customerSession;
         $this->wishlistProvider = $wishlistProvider;
         $this->productRepository = $productRepository;
         $this->formKeyValidator = $formKeyValidator;
         parent::__construct($context);
+        $this->resourceModel = $resourceModel ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(Wishlist::class);
     }
 
     /**
@@ -114,7 +124,7 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
             if (is_string($result)) {
                 throw new \Magento\Framework\Exception\LocalizedException(__($result));
             }
-            $wishlist->save();
+            $this->resourceModel->save($wishlist);
 
             $this->_eventManager->dispatch(
                 'wishlist_add_product',

--- a/app/code/Magento/Wishlist/Controller/Index/Configure.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Configure.php
@@ -101,11 +101,11 @@ class Configure extends \Magento\Wishlist\Controller\AbstractIndex
 
             return $resultPage;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('*');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t configure the product right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t configure the product right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             $resultRedirect->setPath('*');
             return $resultRedirect;

--- a/app/code/Magento/Wishlist/Controller/Index/Remove.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Remove.php
@@ -68,11 +68,11 @@ class Remove extends \Magento\Wishlist\Controller\AbstractIndex
             $item->delete();
             $wishlist->save();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('We can\'t delete the item from Wish List right now because of an error: %1.', $e->getMessage())
             );
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete the item from the Wish List right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete the item from the Wish List right now.'));
         }
 
         $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();

--- a/app/code/Magento/Wishlist/Controller/Index/Send.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Send.php
@@ -164,7 +164,7 @@ class Send extends \Magento\Wishlist\Controller\AbstractIndex
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->wishlistSession->setSharingForm($this->getRequest()->getPostValue());
             $resultRedirect->setPath('*/*/share');
             return $resultRedirect;
@@ -230,12 +230,12 @@ class Send extends \Magento\Wishlist\Controller\AbstractIndex
             $this->inlineTranslation->resume();
 
             $this->_eventManager->dispatch('wishlist_share', ['wishlist' => $wishlist]);
-            $this->messageManager->addSuccess(__('Your wish list has been shared.'));
+            $this->messageManager->addSuccessMessage(__('Your wish list has been shared.'));
             $resultRedirect->setPath('*/*', ['wishlist_id' => $wishlist->getId()]);
             return $resultRedirect;
         } catch (\Exception $e) {
             $this->inlineTranslation->resume();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->wishlistSession->setSharingForm($this->getRequest()->getPostValue());
             $resultRedirect->setPath('*/*/share');
             return $resultRedirect;

--- a/app/code/Magento/Wishlist/Controller/Index/UpdateItemOptions.php
+++ b/app/code/Magento/Wishlist/Controller/Index/UpdateItemOptions.php
@@ -85,7 +85,7 @@ class UpdateItemOptions extends \Magento\Wishlist\Controller\AbstractIndex
         }
 
         if (!$product || !$product->isVisibleInCatalog()) {
-            $this->messageManager->addError(__('We can\'t specify a product.'));
+            $this->messageManager->addErrorMessage(__('We can\'t specify a product.'));
             $resultRedirect->setPath('*/');
             return $resultRedirect;
         }
@@ -114,11 +114,11 @@ class UpdateItemOptions extends \Magento\Wishlist\Controller\AbstractIndex
             $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
 
             $message = __('%1 has been updated in your Wish List.', $product->getName());
-            $this->messageManager->addSuccess($message);
+            $this->messageManager->addSuccessMessage($message);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update your Wish List right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update your Wish List right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $resultRedirect->setPath('*/*', ['wishlist_id' => $wishlist->getId()]);

--- a/app/code/Magento/Wishlist/Controller/Shared/Cart.php
+++ b/app/code/Magento/Wishlist/Controller/Shared/Cart.php
@@ -103,19 +103,19 @@ class Cart extends \Magento\Framework\App\Action\Action
                     'You added %1 to your shopping cart.',
                     $this->escaper->escapeHtml($item->getProduct()->getName())
                 );
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             }
 
             if ($this->cartHelper->getShouldRedirectToCart()) {
                 $redirectUrl = $this->cartHelper->getCartUrl();
             }
         } catch (ProductException $e) {
-            $this->messageManager->addError(__('This product(s) is out of stock.'));
+            $this->messageManager->addErrorMessage(__('This product(s) is out of stock.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addNotice($e->getMessage());
+            $this->messageManager->addNoticeMessage($e->getMessage());
             $redirectUrl = $item->getProductUrl();
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t add the item to the cart right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t add the item to the cart right now.'));
         }
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Wishlist/Controller/WishlistProvider.php
+++ b/app/code/Magento/Wishlist/Controller/WishlistProvider.php
@@ -85,10 +85,10 @@ class WishlistProvider implements WishlistProviderInterface
                 );
             }
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return false;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t create the Wish List right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t create the Wish List right now.'));
             return false;
         }
         $this->wishlist = $wishlist;

--- a/app/code/Magento/Wishlist/Model/ResourceModel/Item/Collection.php
+++ b/app/code/Magento/Wishlist/Model/ResourceModel/Item/Collection.php
@@ -220,7 +220,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      */
     protected function getMetadataPool()
     {
-        if ($this->metadataPool == null) {
+        if ($this->metadataPool === null) {
             $this->metadataPool = \Magento\Framework\App\ObjectManager::getInstance()
                 ->get(\Magento\Framework\EntityManager\MetadataPool::class);
         }

--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -128,6 +128,11 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
     private $serializer;
 
     /**
+     * @var \Magento\Wishlist\Model\ResourceModel\Wishlist
+     */
+    protected $resourceModel;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\Model\Context $context
@@ -181,6 +186,7 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
         $this->productRepository = $productRepository;
+        $this->resourceModel = $resource;
     }
 
     /**
@@ -196,12 +202,12 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
             return $this;
         }
         $customerId = (int)$customerId;
-        $customerIdFieldName = $this->_getResource()->getCustomerIdFieldName();
-        $this->_getResource()->load($this, $customerId, $customerIdFieldName);
+        $customerIdFieldName = $this->resourceModel->getCustomerIdFieldName();
+        $this->resourceModel->load($this, $customerId, $customerIdFieldName);
         if (!$this->getId() && $create) {
             $this->setCustomerId($customerId);
             $this->setSharingCode($this->_getSharingRandomCode());
-            $this->save();
+            $this->resourceModel->save($this);
         }
 
         return $this;
@@ -240,7 +246,7 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
      */
     public function loadByCode($code)
     {
-        $this->_getResource()->load($this, $code, 'sharing_code');
+        $this->resourceModel->load($this, $code, 'sharing_code');
         if (!$this->getShared()) {
             $this->setId(null);
         }
@@ -486,7 +492,7 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
      */
     public function setCustomerId($customerId)
     {
-        return $this->setData($this->_getResource()->getCustomerIdFieldName(), $customerId);
+        return $this->setData($this->resourceModel->getCustomerIdFieldName(), $customerId);
     }
 
     /**
@@ -496,7 +502,7 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
      */
     public function getCustomerId()
     {
-        return $this->getData($this->_getResource()->getCustomerIdFieldName());
+        return $this->getData($this->resourceModel->getCustomerIdFieldName());
     }
 
     /**
@@ -507,7 +513,7 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
     public function getDataForSave()
     {
         $data = [];
-        $data[$this->_getResource()->getCustomerIdFieldName()] = $this->getCustomerId();
+        $data[$this->resourceModel->getCustomerIdFieldName()] = $this->getCustomerId();
         $data['shared'] = (int)$this->getShared();
         $data['sharing_code'] = $this->getSharingCode();
         return $data;

--- a/app/code/Magento/Wishlist/Observer/AddToCart.php
+++ b/app/code/Magento/Wishlist/Observer/AddToCart.php
@@ -105,7 +105,7 @@ class AddToCart implements ObserverInterface
             $this->checkoutSession->setWishlistPendingUrls($urls);
             $this->checkoutSession->setWishlistPendingMessages($messages);
 
-            $this->messageManager->addError($message);
+            $this->messageManager->addErrorMessage($message);
 
             $observer->getEvent()->getResponse()->setRedirect($url);
             $this->checkoutSession->setNoCartRedirect(true);

--- a/app/code/Magento/Wishlist/Observer/CartUpdateBefore.php
+++ b/app/code/Magento/Wishlist/Observer/CartUpdateBefore.php
@@ -11,6 +11,7 @@ use Magento\Framework\Event\ObserverInterface;
 use Magento\Wishlist\Helper\Data;
 use Magento\Wishlist\Model\Wishlist;
 use Magento\Wishlist\Model\WishlistFactory;
+use Magento\Wishlist\Model\ResourceModel\Wishlist as ResourceWishlist;
 
 /**
  * Class CartUpdateBefore
@@ -31,15 +32,24 @@ class CartUpdateBefore implements ObserverInterface
     protected $wishlistFactory;
 
     /**
+     * @var \Magento\Wishlist\Model\ResourceModel\Wishlist
+     */
+    protected $resourceModel;
+
+    /**
      * @param Data $wishlistData
      * @param WishlistFactory $wishlistFactory
+     * @param \Magento\Wishlist\Model\ResourceModel\Wishlist $resourceModel
      */
     public function __construct(
         Data $wishlistData,
-        WishlistFactory $wishlistFactory
+        WishlistFactory $wishlistFactory,
+        ResourceWishlist $resourceModel = null
     ) {
         $this->wishlistData = $wishlistData;
         $this->wishlistFactory = $wishlistFactory;
+        $this->resourceModel = $resourceModel ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(Wishlist::class);
     }
 
     /**
@@ -92,7 +102,7 @@ class CartUpdateBefore implements ObserverInterface
         }
 
         if (count($productIds)) {
-            $wishlist->save();
+            $this->resourceModel->save($wishlist);
             $this->wishlistData->calculate();
         }
         return $this;

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
@@ -605,9 +605,6 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $options = [5 => 'option'];
         $params = ['item' => $itemId, 'qty' => $qty];
 
-        $exceptionMessage = 'exception_message';
-        $exception = new \Exception($exceptionMessage);
-
         $this->formKeyValidator->expects($this->once())
             ->method('validate')
             ->with($this->requestMock)

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
@@ -116,6 +116,11 @@ class CartTest extends \PHPUnit\Framework\TestCase
     protected $formKeyValidator;
 
     /**
+     * @var \Magento\Wishlist\Model\ResourceModel\Wishlist|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resource;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp()
@@ -172,7 +177,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManagerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess'])
+            ->setMethods(['addSuccessMessage'])
             ->getMockForAbstractClass();
 
         $this->urlMock = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
@@ -189,6 +194,10 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->resultJsonMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\Json::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->resource = $this->getMockBuilder(\Magento\Wishlist\Model\ResourceModel\Wishlist::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -237,7 +246,8 @@ class CartTest extends \PHPUnit\Framework\TestCase
             $this->escaperMock,
             $this->helperMock,
             $this->cartHelperMock,
-            $this->formKeyValidator
+            $this->formKeyValidator,
+            $this->resource
         );
     }
 
@@ -540,10 +550,6 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->method('collectTotals')
             ->willReturnSelf();
 
-        $wishlistMock->expects($this->once())
-            ->method('save')
-            ->willReturnSelf();
-
         $quoteMock->expects($this->once())
             ->method('getHasError')
             ->willReturn(false);
@@ -566,7 +572,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productName);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You added '  . $productName . ' to your shopping cart.', null)
             ->willReturnSelf();
 
@@ -581,7 +587,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $this->helperMock->expects($this->once())
             ->method('calculate')
             ->willReturnSelf();
-        
+
         return $refererUrl;
     }
 
@@ -598,6 +604,9 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $configureUrl = 'configure_url';
         $options = [5 => 'option'];
         $params = ['item' => $itemId, 'qty' => $qty];
+
+        $exceptionMessage = 'exception_message';
+        $exception = new \Exception($exceptionMessage);
 
         $this->formKeyValidator->expects($this->once())
             ->method('validate')
@@ -735,8 +744,8 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new ProductException(__('Test Phrase')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
-            ->with('This product(s) is out of stock.', null)
+            ->method('addExceptionMessage')
+            ->with(self::isInstanceOf('\Magento\Catalog\Model\Product\Exception'), 'This product(s) is out of stock.')
             ->willReturnSelf();
 
         $this->helperMock->expects($this->once())
@@ -901,7 +910,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('message', null)
             ->willReturnSelf();
 
@@ -1073,7 +1082,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('message', null)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
@@ -270,7 +270,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t delete the item from Wish List right now because of an error: Message.')
             ->willReturn(true);
 
@@ -355,7 +355,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t delete the item from the Wish List right now.')
             ->willReturn(true);
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
@@ -343,7 +343,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn($postValue);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage)
             ->willReturnSelf();
 
@@ -501,7 +501,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception($exceptionMessage));
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($exceptionMessage)
             ->willReturnSelf();
 
@@ -685,7 +685,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('Your wish list has been shared.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
@@ -249,7 +249,7 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t specify a product.')
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())
@@ -294,7 +294,7 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->never())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t specify a product.')
             ->willReturn(true);
 
@@ -433,12 +433,12 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('Test name has been updated in your Wish List.', null)
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('error-message')));
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('error-message', null)
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())
@@ -572,12 +572,12 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('Test name has been updated in your Wish List.', null)
             ->willThrowException($exception);
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t update your Wish List right now.', null)
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Shared/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Shared/CartTest.php
@@ -266,7 +266,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
 
         $successMessage = __('You added %1 to your shopping cart.', $productName);
         $this->messageManager->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($successMessage)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
@@ -584,7 +584,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('critical')
             ->with($exception, []);
 
-        $this->managerMock->expects($this->at(0))
+        $this->managerMock->expects($this->once())
             ->method('addErrorMessage')
             ->with(__('We can\'t add this item to your shopping cart right now.'), null)
             ->willReturnSelf();
@@ -602,11 +602,6 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
         $this->redirectMock->expects($this->once())
             ->method('getRefererUrl')
             ->willReturn('');
-
-        $this->managerMock->expects($this->at(1))
-            ->method('addErrorMessage')
-            ->with(__('We can\'t update the Wish List right now.'), null)
-            ->willReturnSelf();
 
         $productOneMock->expects($this->any())
             ->method('getName')

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
@@ -42,6 +42,11 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
     /** @var \Magento\Framework\App\Response\RedirectInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $redirectMock;
 
+    /**
+     * @var \Magento\Wishlist\Model\ResourceModel\Wishlist|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resource;
+
     protected function setUp()
     {
         $this->sessionMock = $this->getMockBuilder(\Magento\Customer\Model\Session::class)
@@ -64,9 +69,12 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
         $this->urlBuilderMock = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
             ->getMockForAbstractClass();
         $this->managerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
-            ->getMockForAbstractClass();
+            ->getMock();
         $this->redirectMock = $this->getMockBuilder(\Magento\Framework\App\Response\RedirectInterface::class)
             ->getMockForAbstractClass();
+        $this->resource = $this->getMockBuilder(\Magento\Wishlist\Model\ResourceModel\Wishlist::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->model = new \Magento\Wishlist\Model\ItemCarrier(
             $this->sessionMock,
@@ -77,7 +85,8 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             $this->cartHelperMock,
             $this->urlBuilderMock,
             $this->managerMock,
-            $this->redirectMock
+            $this->redirectMock,
+            $this->resource
         );
     }
 
@@ -216,10 +225,6 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('getCartUrl')
             ->willReturn($redirectUrl);
 
-        $wishlistMock->expects($this->once())
-            ->method('save')
-            ->willReturnSelf();
-
         $productOneMock->expects($this->any())
             ->method('getName')
             ->willReturn($productOneName);
@@ -228,7 +233,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productTwoName);
 
         $this->managerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('%1 product(s) have been added to shopping cart: %2.', 1, '"' . $productTwoName . '"'), null)
             ->willReturnSelf();
 
@@ -431,12 +436,12 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productTwoName);
 
         $this->managerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('%1 for "%2".', 'Localized Exception', $productTwoName), null)
             ->willReturnSelf();
 
         $this->managerMock->expects($this->at(1))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(
                 __(
                     'We couldn\'t add the following product(s) to the shopping cart: %1.',
@@ -580,7 +585,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->with($exception, []);
 
         $this->managerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t add this item to your shopping cart right now.'), null)
             ->willReturnSelf();
 
@@ -598,12 +603,8 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->method('getRefererUrl')
             ->willReturn('');
 
-        $wishlistMock->expects($this->once())
-            ->method('save')
-            ->willThrowException(new \Exception());
-
         $this->managerMock->expects($this->at(1))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t update the Wish List right now.'), null)
             ->willReturnSelf();
 
@@ -615,7 +616,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productTwoName);
 
         $this->managerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('%1 product(s) have been added to shopping cart: %2.', 1, '"' . $productOneName . '"'), null)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Observer/AddToCartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Observer/AddToCartTest.php
@@ -167,7 +167,7 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
             ->with([])
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message)
             ->willReturnSelf();
         $event->expects($this->once())

--- a/app/code/Magento/Wishlist/Test/Unit/Observer/CartUpdateBeforeTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Observer/CartUpdateBeforeTest.php
@@ -48,6 +48,11 @@ class CartUpdateBeforeTest extends \PHPUnit\Framework\TestCase
      */
     protected $messageManager;
 
+    /**
+     * @var \Magento\Wishlist\Model\ResourceModel\Wishlist|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resource;
+
     protected function setUp()
     {
         $this->helper = $this->getMockBuilder(\Magento\Wishlist\Helper\Data::class)
@@ -63,10 +68,14 @@ class CartUpdateBeforeTest extends \PHPUnit\Framework\TestCase
         $this->wishlistFactory->expects($this->any())
             ->method('create')
             ->willReturn($this->wishlist);
+        $this->resource = $this->getMockBuilder(\Magento\Wishlist\Model\ResourceModel\Wishlist::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->observer = new Observer(
             $this->helper,
-            $this->wishlistFactory
+            $this->wishlistFactory,
+            $this->resource
         );
     }
 
@@ -164,9 +173,6 @@ class CartUpdateBeforeTest extends \PHPUnit\Framework\TestCase
         $this->wishlist->expects($this->once())
             ->method('addNewItem')
             ->with($this->logicalOr($productId, $buyRequest));
-
-        $this->wishlist->expects($this->once())
-            ->method('save');
 
         $this->helper->expects($this->once())
             ->method('calculate');


### PR DESCRIPTION
### Description
The main goal of this PR is to replace deprecated methods for messenger object and use resource models directly instead of using `_getResource()` and `save()` methods.
I used backwards compatible guide for refactoring and adopted tests for new changes.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
