### PR TITLE
Fixing of Problem with updating stock item qty and stock status

### DIFF
--- a/app/code/Magento/CatalogInventory/Observer/ProcessInventoryDataObserver.php
+++ b/app/code/Magento/CatalogInventory/Observer/ProcessInventoryDataObserver.php
@@ -97,7 +97,7 @@ class ProcessInventoryDataObserver implements ObserverInterface
             ) {
                 unset($quantityAndStockStatus['is_in_stock']);
             }
-            if (isset($quantityAndStockStatus['qty'])
+            if (array_key_exists('qty', $quantityAndStockStatus)
                 && $stockItem->getQty() == $quantityAndStockStatus['qty']
             ) {
                 unset($quantityAndStockStatus['qty']);


### PR DESCRIPTION
Problem happens during updating product stock item data  via REST Post/PUT request /V1/products when previously product was created via REST API call without specified “stock_item” in extension attributes of call Body.

### Steps to reproduce: 
1. Create new product via REST API request without “stock_item” in extension_attributes parameter of API Request body
2. Make another “products” API POST request for updating this product with data which includes “stock_item” inside of extension_attributes (set some qty, “is_in_stock”: true, some other parameters... ).
3. Result: some values of product “stock_item” parameters  left “default” - “qty”: null, “is_in_stock”: false.
(tested on Magento EE 2.22, Magento CE 2.3-develop).

### Description
* Problem with updating “stock_item”  starts in \Magento\CatalogInventory\Observer
\ProcessInventoryDataObserver which runs before saving product. 
* In method “prepareQuantityAndStockStatus” it checks product array value  “quantity_and_stock_status”: compare $quantityAndStockStatus['qty'] $quantityAndStockStatus['is_in_stock'] values with corresponding values from persisted “stock_item” and unset them if they equal. 
* If after running this method “quantity_and_stock_status” array not empty – it values will be set to product as “stock_data” array value, which will merging with stock item data before saving “stock_item”. So during updating product data with stock data  (after first save product without provided “stock_item” data) in  product  “quantity_and_stock_status” array  we have “qty” = null and “is _in_stock” = false  - same values as in currently  persisted “stock_item”, so they both must be unset from array. But “qty” will not be removed from $quantityAndStockStatus array in  “prepareQuantityAndStockStatus” method  when it has “null” value because of  condition:

`if (isset($quantityAndStockStatus['qty'])
    && $stockItem->getQty() == $quantityAndStockStatus['qty']
) {
    unset($quantityAndStockStatus['qty']);
}
`
As result will be set “stock_data” array to product with “qty” = null which will further update “stock_item” data before it saving. 

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create new product via REST API request without “stock_item” in extension_attributes parameter of API Request body
2. Make another “products” API POST request for updating this product with data which includes “stock_item” inside of extension_attributes (set some qty, “is_in_stock”: true, some other parameters... ).
3. Result: Product Stock information have to be updated

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
