### PR TITLE
Fix load order of view.xml when loading Swatch config

### DIFF
--- a/app/code/Magento/Swatches/Helper/Media.php
+++ b/app/code/Magento/Swatches/Helper/Media.php
@@ -68,9 +68,9 @@ class Media extends \Magento\Framework\App\Helper\AbstractHelper
     protected $swatchImageTypes = ['swatch_image', 'swatch_thumb'];
 
     /**
-     * @var \Magento\Theme\Model\ResourceModel\Theme\Collection
+     * @var array
      */
-    private $registeredThemesCache;
+    private $imageConfig;
 
     /**
      * @param \Magento\Catalog\Model\Product\Media\Config $mediaConfig
@@ -256,18 +256,14 @@ class Media extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getImageConfig()
     {
-        $imageConfig = [];
-        foreach ($this->getRegisteredThemes() as $theme) {
-            $config = $this->viewConfig->getViewConfig([
-                'area' => Area::AREA_FRONTEND,
-                'themeModel' => $theme,
-            ]);
-            $imageConfig = array_merge(
-                $imageConfig,
-                $config->getMediaEntities('Magento_Catalog', Image::MEDIA_TYPE_CONFIG_NODE)
+        if (!$this->imageConfig) {
+            $this->imageConfig = $this->viewConfig->getViewConfig()->getMediaEntities(
+                'Magento_Catalog',
+                Image::MEDIA_TYPE_CONFIG_NODE
             );
         }
-        return $imageConfig;
+
+        return $this->imageConfig;
     }
 
     /**
@@ -337,17 +333,5 @@ class Media extends \Magento\Framework\App\Helper\AbstractHelper
     protected function prepareFile($file)
     {
         return ltrim(str_replace('\\', '/', $file), '/');
-    }
-
-    /**
-     * @return \Magento\Theme\Model\ResourceModel\Theme\Collection
-     */
-    private function getRegisteredThemes()
-    {
-        if ($this->registeredThemesCache === null) {
-            $this->registeredThemesCache = $this->themeCollection->loadRegisteredThemes();
-        }
-
-        return $this->registeredThemesCache;
     }
 }

--- a/app/code/Magento/Swatches/Test/Unit/Helper/MediaTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Helper/MediaTest.php
@@ -30,9 +30,6 @@ class MediaTest extends \PHPUnit\Framework\TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Image\Factory */
     protected $imageFactoryMock;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Theme\Model\ResourceModel\Theme\Collection */
-    protected $themeCollectionMock;
-
     /** @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\View\Config */
     protected $viewConfigMock;
 
@@ -59,10 +56,6 @@ class MediaTest extends \PHPUnit\Framework\TestCase
         $this->storeManagerMock = $this->createPartialMock(\Magento\Store\Model\StoreManager::class, ['getStore']);
 
         $this->imageFactoryMock = $this->createMock(\Magento\Framework\Image\Factory::class);
-        $this->themeCollectionMock = $this->createPartialMock(
-            \Magento\Theme\Model\ResourceModel\Theme\Collection::class,
-            ['loadRegisteredThemes']
-        );
 
         $this->viewConfigMock = $this->createMock(\Magento\Framework\View\Config::class);
 
@@ -83,7 +76,6 @@ class MediaTest extends \PHPUnit\Framework\TestCase
                 'fileStorageDb' => $this->fileStorageDbMock,
                 'storeManager' => $this->storeManagerMock,
                 'imageFactory' => $this->imageFactoryMock,
-                'themeCollection' => $this->themeCollectionMock,
                 'configInterface' => $this->viewConfigMock,
             ]
         );
@@ -248,10 +240,6 @@ class MediaTest extends \PHPUnit\Framework\TestCase
 
     protected function generateImageConfig()
     {
-        $themeMock = $this->createMock(\Magento\Theme\Model\Theme::class);
-        $themesArrayMock = [$themeMock];
-        $this->themeCollectionMock->expects($this->any())->method('loadRegisteredThemes')->willReturn($themesArrayMock);
-
         $configMock = $this->createMock(\Magento\Framework\Config\View::class);
 
         $this->viewConfigMock


### PR DESCRIPTION
### Description
Fix load/merge order of view.xml conifg in `\Magento\Swatches\Helper\Media` to match `\Magento\Catalog\Helper\Image`.

### Fixed Issues (if relevant)
1. magento/magento2#12647 

### Manual testing scenarios
1. Create new theme named to preceed 'Magento' alphabetically. ie 'Acme\default'
2. Add `view.xml` to theme's etc directory altering the swatch images sizes. Sample  
```xml
<?xml version="1.0"?>
<view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
    <media>
        <images module="Magento_Catalog">
            <image id="swatch_image" type="swatch_image">
                <width>48</width>
                <height>48</height>
            </image>
            <image id="swatch_thumb" type="swatch_thumb">
                <width>130</width>
                <height>130</height>
            </image>
            <image id="swatch_image_base" type="swatch_image">
                <width>48</width>
                <height>48</height>
            </image>
            <image id="swatch_thumb_base" type="swatch_thumb">
                <width>130</width>
                <height>130</height>
            </image>
        </images>
    </media>
</view>
```
3. Enable theme in admin panel.
5. Flush cache: `bin/magento cache:flush`
4. Deploy static content: `bin/magento setup:static-content:deploy`
5. Navigate to product list page containing visual swatch filters and validate swatch image dimensions match those specified in `view.xml`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
