### PR TITLE
Use constant time string comparison in FormKey validator

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/FormKey/Validator.php
+++ b/lib/internal/Magento/Framework/Data/Form/FormKey/Validator.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\Data\Form\FormKey;
 
+use Magento\Framework\Encryption\Helper\Security;
+
 /**
  * @api
  */
@@ -32,9 +34,11 @@ class Validator
     public function validate(\Magento\Framework\App\RequestInterface $request)
     {
         $formKey = $request->getParam('form_key', null);
-        if (!$formKey || $formKey !== $this->_formKey->getFormKey()) {
+
+        if (!$formKey) {
             return false;
         }
-        return true;
+
+        return Security::compareStrings($formKey, $this->_formKey->getFormKey());
     }
 }

--- a/lib/internal/Magento/Framework/Data/Form/FormKey/Validator.php
+++ b/lib/internal/Magento/Framework/Data/Form/FormKey/Validator.php
@@ -34,11 +34,7 @@ class Validator
     public function validate(\Magento\Framework\App\RequestInterface $request)
     {
         $formKey = $request->getParam('form_key', null);
-
-        if (!$formKey) {
-            return false;
-        }
-
-        return Security::compareStrings($formKey, $this->_formKey->getFormKey());
+        
+        return $formKey && Security::compareStrings($formKey, $this->_formKey->getFormKey());
     }
 }


### PR DESCRIPTION
### Description
CSRF tokens should be considered sensitive strings. While the risk of a malicious actor attempting gleam the form key via a timing attack is very low, we should still follow best practices in verifying this token.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
