### PR TITLE
Stop cast of item_qty to int

### DIFF
--- a/app/code/Magento/Checkout/Controller/Sidebar/UpdateItemQty.php
+++ b/app/code/Magento/Checkout/Controller/Sidebar/UpdateItemQty.php
@@ -55,7 +55,7 @@ class UpdateItemQty extends Action
     public function execute()
     {
         $itemId = (int)$this->getRequest()->getParam('item_id');
-        $itemQty = (int)$this->getRequest()->getParam('item_qty');
+        $itemQty = $this->getRequest()->getParam('item_qty') * 1;
 
         try {
             $this->sidebar->checkQuoteItem($itemId);


### PR DESCRIPTION
### Description
Casting the `item_qty` param as an `int` prevented qty increments from
being allowed when updating the qty via the minicart.

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios
1. Create product with "Qty Uses Decimal" set to "Yes"
2. Add product to cart with qty of 1.
3. Using the minicart, change the item qty to 1.5 and click update.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
