### PR TITLE
[TODO] Move getting order history logic from block to the separate model and divided it into methods

### DIFF
--- a/app/code/Magento/Sales/Api/OrderHistoryInterface.php
+++ b/app/code/Magento/Sales/Api/OrderHistoryInterface.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+
+namespace Magento\Sales\Api;
+
+/**
+ * Order status history interface.
+ *
+ * An order is a document that a web store issues to a customer. Magento generates a sales order
+ * that lists the product items, billing and shipping addresses, and shipping and payment methods.
+ * A corresponding external document, known as a purchase order, is emailed to the customer.
+ *
+ * @api
+ * @since 101.0.2
+ */
+interface OrderHistoryInterface
+{
+    /**
+     * Get all status history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getAllStatusHistory($order);
+
+    /**
+     * Get credit memo history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getCreditMemosHistory($order);
+
+    /**
+     * Get shipment history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getShipmentHistory($order);
+
+    /**
+     * Get invoice history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getInvoiceHistory($order);
+
+    /**
+     * Get tracking history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getTracksHistory($order);
+
+    /**
+     * Compose and get order full history.
+     * Consists of the status history comments as well as of invoices,
+     * shipments and creditmemos creations
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getFullHistory($order);
+}

--- a/app/code/Magento/Sales/Model/Order/OrderHistory.php
+++ b/app/code/Magento/Sales/Model/Order/OrderHistory.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Sales\Model\Order;
+
+use Magento\Sales\Api\OrderHistoryInterface;
+
+/**
+ * Class OrderHistory
+ * @package Magento\Sales\Model\Order
+ */
+class OrderHistory implements OrderHistoryInterface
+{
+    /**
+     * Map history items as array
+     *
+     * @param string $label
+     * @param bool $notified
+     * @param \DateTimeInterface $created
+     * @param string $comment
+     * @return array
+     */
+    protected function _prepareHistoryItem($label, $notified, $created, $comment = '')
+    {
+        return ['title' => $label, 'notified' => $notified, 'comment' => $comment, 'created_at' => $created];
+    }
+
+    /**
+     * Get all status history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getAllStatusHistory($order)
+    {
+        $history = [];
+        foreach ($order->getAllStatusHistory() as $orderComment) {
+            $history[] = $this->_prepareHistoryItem(
+                $orderComment->getStatusLabel(),
+                $orderComment->getIsCustomerNotified(),
+                $orderComment->getCreatedAt(),
+                $orderComment->getComment()
+            );
+        }
+
+        return $history;
+    }
+
+    /**
+     * Get credit memo history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getCreditMemosHistory($order)
+    {
+        $history = [];
+        foreach ($order->getCreditmemosCollection() as $_memo) {
+            $history[] = $this->_prepareHistoryItem(
+                __('Credit memo #%1 created', $_memo->getIncrementId()),
+                $_memo->getEmailSent(),
+                $_memo->getCreatedAt()
+            );
+
+            foreach ($_memo->getCommentsCollection() as $_comment) {
+                $history[] = $this->_prepareHistoryItem(
+                    __('Credit memo #%1 comment added', $_memo->getIncrementId()),
+                    $_comment->getIsCustomerNotified(),
+                    $_comment->getCreatedAt(),
+                    $_comment->getComment()
+                );
+            }
+        }
+
+        return $history;
+    }
+
+    /**
+     * Get shipment history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getShipmentHistory($order)
+    {
+        $history = [];
+        foreach ($order->getShipmentsCollection() as $_shipment) {
+            $history[] = $this->_prepareHistoryItem(
+                __('Shipment #%1 created', $_shipment->getIncrementId()),
+                $_shipment->getEmailSent(),
+                $_shipment->getCreatedAt()
+            );
+
+            foreach ($_shipment->getCommentsCollection() as $_comment) {
+                $history[] = $this->_prepareHistoryItem(
+                    __('Shipment #%1 comment added', $_shipment->getIncrementId()),
+                    $_comment->getIsCustomerNotified(),
+                    $_comment->getCreatedAt(),
+                    $_comment->getComment()
+                );
+            }
+        }
+
+        return $history;
+    }
+
+    /**
+     * Get invoice history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getInvoiceHistory($order)
+    {
+        $history = [];
+        foreach ($order->getInvoiceCollection() as $_invoice) {
+            $history[] = $this->_prepareHistoryItem(
+                __('Invoice #%1 created', $_invoice->getIncrementId()),
+                $_invoice->getEmailSent(),
+                $_invoice->getCreatedAt()
+            );
+
+            foreach ($_invoice->getCommentsCollection() as $_comment) {
+                $history[] = $this->_prepareHistoryItem(
+                    __('Invoice #%1 comment added', $_invoice->getIncrementId()),
+                    $_comment->getIsCustomerNotified(),
+                    $_comment->getCreatedAt(),
+                    $_comment->getComment()
+                );
+            }
+        }
+
+        return $history;
+    }
+
+    /**
+     * Get tracking history data for specific order
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getTracksHistory($order)
+    {
+        $history = [];
+        foreach ($order->getTracksCollection() as $_track) {
+            $history[] = $this->_prepareHistoryItem(
+                __('Tracking number %1 for %2 assigned', $_track->getNumber(), $_track->getTitle()),
+                false,
+                $_track->getCreatedAt()
+            );
+        }
+
+        return $history;
+    }
+
+    /**
+     * Compose and get order full history.
+     * Consists of the status history comments as well as of invoices, shipments and creditmemos creations
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    public function getFullHistory($order)
+    {
+        $history = [];
+        $history = array_merge($history, $this->getAllStatusHistory($order));
+        $history = array_merge($history, $this->getCreditMemosHistory($order));
+        $history = array_merge($history, $this->getShipmentHistory($order));
+        $history = array_merge($history, $this->getInvoiceHistory($order));
+        $history = array_merge($history, $this->getTracksHistory($order));
+
+        return $history;
+    }
+}

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -65,6 +65,7 @@
     <preference for="Magento\Sales\Api\OrderRepositoryInterface" type="Magento\Sales\Model\OrderRepository"/>
     <preference for="Magento\Sales\Api\OrderManagementInterface" type="Magento\Sales\Model\Service\OrderService"/>
     <preference for="Magento\Sales\Api\OrderStatusHistoryRepositoryInterface" type="Magento\Sales\Model\Order\Status\HistoryRepository"/>
+    <preference for="Magento\Sales\Api\OrderHistoryInterface" type="Magento\Sales\Model\Order\OrderHistory"/>
     <preference for="Magento\Sales\Api\ShipmentCommentRepositoryInterface" type="Magento\Sales\Model\Order\Shipment\CommentRepository"/>
     <preference for="Magento\Sales\Api\ShipmentItemRepositoryInterface" type="Magento\Sales\Model\Order\Shipment\ItemRepository"/>
     <preference for="Magento\Sales\Api\ShipmentRepositoryInterface" type="Magento\Sales\Model\Order\ShipmentRepository"/>


### PR DESCRIPTION
### Description
In the `Magento\Sales\Block\Adminhtml\Order\View\Tab\History` I found next TODO:
"TODO This method requires refactoring. Need to create separate model for comment history handling"
The simple model was made based on the code from the history block. Currently, it can return information about the shipments, invoices, trackings, credit memos and full history data which collect all of this info.

### Fixed Issues (if relevant)
Finish TODO

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
