### PR TITLE
Removing deprecated dependencies from Braintree module

### DIFF
--- a/app/code/Magento/Braintree/Gateway/Response/PayPal/VaultDetailsHandler.php
+++ b/app/code/Magento/Braintree/Gateway/Response/PayPal/VaultDetailsHandler.php
@@ -12,8 +12,8 @@ use Magento\Payment\Gateway\Response\HandlerInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
-use Magento\Vault\Api\Data\PaymentTokenInterfaceFactory;
 
 /**
  * Vault Details Handler
@@ -21,7 +21,7 @@ use Magento\Vault\Api\Data\PaymentTokenInterfaceFactory;
 class VaultDetailsHandler implements HandlerInterface
 {
     /**
-     * @var PaymentTokenInterfaceFactory
+     * @var PaymentTokenFactoryInterface
      */
     private $paymentTokenFactory;
 
@@ -41,15 +41,13 @@ class VaultDetailsHandler implements HandlerInterface
     private $dateTimeFactory;
 
     /**
-     * Constructor
-     *
-     * @param PaymentTokenInterfaceFactory $paymentTokenFactory
+     * @param PaymentTokenFactoryInterface $paymentTokenFactory
      * @param OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory
      * @param SubjectReader $subjectReader
      * @param DateTimeFactory $dateTimeFactory
      */
     public function __construct(
-        PaymentTokenInterfaceFactory $paymentTokenFactory,
+        PaymentTokenFactoryInterface $paymentTokenFactory,
         OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
         SubjectReader $subjectReader,
         DateTimeFactory $dateTimeFactory
@@ -92,7 +90,7 @@ class VaultDetailsHandler implements HandlerInterface
         }
 
         /** @var PaymentTokenInterface $paymentToken */
-        $paymentToken = $this->paymentTokenFactory->create();
+        $paymentToken = $this->paymentTokenFactory->create(PaymentTokenFactoryInterface::TOKEN_TYPE_ACCOUNT);
         $paymentToken->setGatewayToken($token);
         $paymentToken->setExpiresAt($this->getExpirationDate());
         $details = json_encode([

--- a/app/code/Magento/Braintree/Gateway/Response/VaultDetailsHandler.php
+++ b/app/code/Magento/Braintree/Gateway/Response/VaultDetailsHandler.php
@@ -8,12 +8,14 @@ namespace Magento\Braintree\Gateway\Response;
 use Braintree\Transaction;
 use Magento\Braintree\Gateway\Config\Config;
 use Magento\Braintree\Gateway\Helper\SubjectReader;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Payment\Gateway\Response\HandlerInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
-use Magento\Vault\Api\Data\PaymentTokenInterfaceFactory;
 
 /**
  * Vault Details Handler
@@ -22,7 +24,7 @@ use Magento\Vault\Api\Data\PaymentTokenInterfaceFactory;
 class VaultDetailsHandler implements HandlerInterface
 {
     /**
-     * @var PaymentTokenInterfaceFactory
+     * @var PaymentTokenFactoryInterface
      */
     protected $paymentTokenFactory;
 
@@ -49,26 +51,26 @@ class VaultDetailsHandler implements HandlerInterface
     /**
      * VaultDetailsHandler constructor.
      *
-     * @param PaymentTokenInterfaceFactory $paymentTokenFactory
+     * @param PaymentTokenFactoryInterface $paymentTokenFactory
      * @param OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory
      * @param Config $config
      * @param SubjectReader $subjectReader
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param Json|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
-        PaymentTokenInterfaceFactory $paymentTokenFactory,
+        PaymentTokenFactoryInterface $paymentTokenFactory,
         OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
         Config $config,
         SubjectReader $subjectReader,
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        Json $serializer = null
     ) {
         $this->paymentTokenFactory = $paymentTokenFactory;
         $this->paymentExtensionFactory = $paymentExtensionFactory;
         $this->config = $config;
         $this->subjectReader = $subjectReader;
-        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->serializer = $serializer ?: ObjectManager::getInstance()
+            ->get(Json::class);
     }
 
     /**
@@ -103,7 +105,7 @@ class VaultDetailsHandler implements HandlerInterface
         }
 
         /** @var PaymentTokenInterface $paymentToken */
-        $paymentToken = $this->paymentTokenFactory->create();
+        $paymentToken = $this->paymentTokenFactory->create(PaymentTokenFactoryInterface::TOKEN_TYPE_CREDIT_CARD);
         $paymentToken->setGatewayToken($token);
         $paymentToken->setExpiresAt($this->getExpirationDate($transaction));
 

--- a/app/code/Magento/Braintree/Model/Adminhtml/Source/PaymentAction.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/Source/PaymentAction.php
@@ -6,7 +6,7 @@
 namespace Magento\Braintree\Model\Adminhtml\Source;
 
 use Magento\Framework\Option\ArrayInterface;
-use Magento\Payment\Model\Method\AbstractMethod;
+use Magento\Payment\Model\MethodInterface;
 
 /**
  * Class PaymentAction
@@ -22,11 +22,11 @@ class PaymentAction implements ArrayInterface
     {
         return [
             [
-                'value' => AbstractMethod::ACTION_AUTHORIZE,
+                'value' => MethodInterface::ACTION_AUTHORIZE,
                 'label' => __('Authorize'),
             ],
             [
-                'value' => AbstractMethod::ACTION_AUTHORIZE_CAPTURE,
+                'value' => MethodInterface::ACTION_AUTHORIZE_CAPTURE,
                 'label' => __('Authorize and Capture'),
             ]
         ];

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PayPal/VaultDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PayPal/VaultDetailsHandlerTest.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Braintree\Test\Unit\Gateway\Response\PayPal;
 
+use Braintree\Result\Successful;
 use Braintree\Transaction;
 use Braintree\Transaction\PayPalDetails;
 use Magento\Braintree\Gateway\Helper\SubjectReader;
@@ -15,24 +16,23 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
 use Magento\Sales\Model\Order\Payment;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
-use Magento\Vault\Api\Data\PaymentTokenInterfaceFactory;
-use Magento\Vault\Model\AccountPaymentTokenFactory;
 use Magento\Vault\Model\PaymentToken;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class VaultDetailsHandlerTest
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
+class VaultDetailsHandlerTest extends TestCase
 {
     private static $transactionId = '1n2suy';
 
-    /**
-     * @var SubjectReader|MockObject
-     */
-    private $subjectReader;
+    private static $token = 'rc39al';
+
+    private static $payerEmail = 'john.doe@example.com';
 
     /**
      * @var PaymentDataObjectInterface|MockObject
@@ -45,7 +45,7 @@ class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
     private $paymentInfo;
 
     /**
-     * @var AccountPaymentTokenFactory|MockObject
+     * @var PaymentTokenFactoryInterface|MockObject
      */
     private $paymentTokenFactory;
 
@@ -92,7 +92,7 @@ class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->paymentToken = $objectManager->getObject(PaymentToken::class);
 
-        $this->paymentTokenFactory = $this->getMockBuilder(AccountPaymentTokenFactory::class)
+        $this->paymentTokenFactory = $this->getMockBuilder(PaymentTokenFactoryInterface::class)
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -109,14 +109,6 @@ class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
         $this->subject = [
             'payment' => $this->paymentDataObject,
         ];
-        $this->subjectReader = $this->getMockBuilder(SubjectReader::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['readPayment', 'readTransaction'])
-            ->getMock();
-        $this->subjectReader->expects(static::once())
-            ->method('readPayment')
-            ->with($this->subject)
-            ->willReturn($this->paymentDataObject);
 
         $this->dateTimeFactory = $this->getMockBuilder(DateTimeFactory::class)
             ->disableOriginalConstructor()
@@ -126,103 +118,80 @@ class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
         $this->handler = new VaultDetailsHandler(
             $this->paymentTokenFactory,
             $this->paymentExtensionFactory,
-            $this->subjectReader,
+            new SubjectReader(),
             $this->dateTimeFactory
         );
     }
 
-    /**
-     * @covers \Magento\Braintree\Gateway\Response\PayPal\VaultDetailsHandler::handle
-     */
     public function testHandle()
     {
-        /** @var Transaction $transaction */
         $transaction = $this->getTransaction();
         $response = [
             'object' => $transaction
         ];
 
-        $this->paymentExtension->expects(static::once())
-            ->method('setVaultPaymentToken')
+        $this->paymentExtension->method('setVaultPaymentToken')
             ->with($this->paymentToken);
-        $this->paymentExtension->expects(static::once())
-            ->method('getVaultPaymentToken')
+        $this->paymentExtension->method('getVaultPaymentToken')
             ->willReturn($this->paymentToken);
-
-        $this->subjectReader->expects(static::once())
-            ->method('readTransaction')
-            ->with($response)
-            ->willReturn($transaction);
         
-        $this->paymentDataObject->expects(static::once())
-            ->method('getPayment')
+        $this->paymentDataObject->method('getPayment')
             ->willReturn($this->paymentInfo);
 
-        $this->paymentTokenFactory->expects(static::once())
-            ->method('create')
+        $this->paymentTokenFactory->method('create')
+            ->with(PaymentTokenFactoryInterface::TOKEN_TYPE_ACCOUNT)
             ->willReturn($this->paymentToken);
 
-        $this->paymentExtensionFactory->expects(static::once())
-            ->method('create')
+        $this->paymentExtensionFactory->method('create')
             ->willReturn($this->paymentExtension);
 
         $dateTime = new \DateTime('2016-07-05 00:00:00', new \DateTimeZone('UTC'));
         $expirationDate = '2017-07-05 00:00:00';
-        $this->dateTimeFactory->expects(static::once())
-            ->method('create')
+        $this->dateTimeFactory->method('create')
             ->willReturn($dateTime);
         
         $this->handler->handle($this->subject, $response);
 
         $extensionAttributes = $this->paymentInfo->getExtensionAttributes();
-        /** @var PaymentTokenInterface $paymentToken */
         $paymentToken = $extensionAttributes->getVaultPaymentToken();
-        static::assertNotNull($paymentToken);
+        self::assertNotNull($paymentToken);
 
         $tokenDetails = json_decode($paymentToken->getTokenDetails(), true);
 
-        static::assertSame($this->paymentToken, $paymentToken);
-        static::assertEquals($transaction->paypalDetails->token, $paymentToken->getGatewayToken());
-        static::assertEquals($transaction->paypalDetails->payerEmail, $tokenDetails['payerEmail']);
-        static::assertEquals($expirationDate, $paymentToken->getExpiresAt());
+        self::assertSame($this->paymentToken, $paymentToken);
+        self::assertEquals(self::$token, $paymentToken->getGatewayToken());
+        self::assertEquals(self::$payerEmail, $tokenDetails['payerEmail']);
+        self::assertEquals($expirationDate, $paymentToken->getExpiresAt());
     }
 
-    /**
-     * @covers \Magento\Braintree\Gateway\Response\PayPal\VaultDetailsHandler::handle
-     */
     public function testHandleWithoutToken()
     {
         $transaction = $this->getTransaction();
-        $transaction->paypalDetails->token = null;
+        $transaction->transaction->paypalDetails->token = null;
 
         $response = [
             'object' => $transaction
         ];
 
-        $this->subjectReader->expects(static::once())
-            ->method('readTransaction')
-            ->with($response)
-            ->willReturn($transaction);
-
-        $this->paymentDataObject->expects(static::once())
-            ->method('getPayment')
+        $this->paymentDataObject->method('getPayment')
             ->willReturn($this->paymentInfo);
 
-        $this->paymentTokenFactory->expects(static::never())
+        $this->paymentTokenFactory->expects(self::never())
             ->method('create');
 
-        $this->dateTimeFactory->expects(static::never())
+        $this->dateTimeFactory->expects(self::never())
             ->method('create');
 
         $this->handler->handle($this->subject, $response);
-        static::assertNull($this->paymentInfo->getExtensionAttributes());
+        self::assertNull($this->paymentInfo->getExtensionAttributes());
     }
 
     /**
-     * Create Braintree transaction
-     * @return Transaction
+     * Creates Braintree transaction.
+     *
+     * @return Successful
      */
-    private function getTransaction()
+    private function getTransaction(): Successful
     {
         $attributes = [
             'id' => self::$transactionId,
@@ -230,19 +199,21 @@ class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
         ];
 
         $transaction = Transaction::factory($attributes);
+        $result = new Successful(['transaction' => $transaction]);
 
-        return $transaction;
+        return $result;
     }
 
     /**
-     * Get PayPal transaction details
+     * Gets PayPal transaction details.
+     *
      * @return PayPalDetails
      */
-    private function getPayPalDetails()
+    private function getPayPalDetails(): PayPalDetails
     {
         $attributes = [
-            'token' => 'rc39al',
-            'payerEmail' => 'john.doe@example.com'
+            'token' => self::$token,
+            'payerEmail' => self::$payerEmail
         ];
 
         $details = new PayPalDetails($attributes);

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
@@ -5,19 +5,23 @@
  */
 namespace Magento\Braintree\Test\Unit\Gateway\Response;
 
+use Braintree\Result\Successful;
 use Braintree\Transaction;
 use Braintree\Transaction\CreditCardDetails;
 use Magento\Braintree\Gateway\Config\Config;
 use Magento\Braintree\Gateway\Helper\SubjectReader;
+use Magento\Braintree\Gateway\Response\PaymentDetailsHandler;
 use Magento\Braintree\Gateway\Response\VaultDetailsHandler;
-use Magento\Framework\DataObject;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Sales\Api\Data\OrderPaymentExtension;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
-use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
-use Magento\Vault\Api\Data\PaymentTokenInterface;
-use Magento\Vault\Model\CreditCardTokenFactory;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
+use Magento\Vault\Model\PaymentToken;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -25,193 +29,141 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
+class VaultDetailsHandlerTest extends TestCase
 {
-    const TRANSACTION_ID = '432erwwe';
+    private static $transactionId = '432erwwe';
+
+    private static $token = 'rh3gd4';
 
     /**
-     * @var \Magento\Braintree\Gateway\Response\PaymentDetailsHandler
+     * @var PaymentDetailsHandler
      */
     private $paymentHandler;
 
     /**
-     * @var \Magento\Sales\Model\Order\Payment|MockObject
+     * @var Payment|MockObject
      */
     private $payment;
 
     /**
-     * @var CreditCardTokenFactory|MockObject
+     * @var PaymentTokenFactoryInterface|MockObject
      */
     private $paymentTokenFactory;
 
     /**
-     * @var PaymentTokenInterface|MockObject
-     */
-    protected $paymentToken;
-
-    /**
-     * @var \Magento\Sales\Api\Data\OrderPaymentExtension|MockObject
+     * @var OrderPaymentExtension|MockObject
      */
     private $paymentExtension;
 
     /**
-     * @var \Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory|MockObject
+     * @var OrderPaymentExtensionInterfaceFactory|MockObject
      */
     private $paymentExtensionFactory;
 
-    /**
-     * @var SubjectReader|MockObject
-     */
-    private $subjectReader;
-
-    /**
-     * @var Config|MockObject
-     */
-    private $config;
-
     protected function setUp()
     {
-        $this->paymentToken = $this->createMock(PaymentTokenInterface::class);
-        $this->paymentTokenFactory = $this->getMockBuilder(CreditCardTokenFactory::class)
+        $objectManager = new ObjectManager($this);
+        $paymentToken = $objectManager->getObject(PaymentToken::class);
+        $this->paymentTokenFactory = $this->getMockBuilder(PaymentTokenFactoryInterface::class)
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->paymentTokenFactory->expects(self::once())
-            ->method('create')
-            ->willReturn($this->paymentToken);
+        $this->paymentTokenFactory->method('create')
+            ->with(PaymentTokenFactoryInterface::TOKEN_TYPE_CREDIT_CARD)
+            ->willReturn($paymentToken);
 
-        $this->paymentExtension = $this->getMockBuilder(OrderPaymentExtensionInterface::class)
-            ->setMethods(['setVaultPaymentToken', 'getVaultPaymentToken'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->paymentExtensionFactory = $this->getMockBuilder(OrderPaymentExtensionInterfaceFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
-        $this->paymentExtensionFactory->expects(self::once())
-            ->method('create')
-            ->willReturn($this->paymentExtension);
+        $this->initPaymentExtensionAttributesMock();
+        $this->paymentExtension->method('setVaultPaymentToken')
+            ->with($paymentToken);
+        $this->paymentExtension->method('getVaultPaymentToken')
+            ->willReturn($paymentToken);
 
         $this->payment = $this->getMockBuilder(Payment::class)
             ->disableOriginalConstructor()
             ->setMethods(['__wakeup'])
             ->getMock();
 
-        $this->subjectReader = $this->getMockBuilder(SubjectReader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mapperArray = [
-            "american-express" => "AE",
-            "discover" => "DI",
-            "jcb" => "JCB",
-            "mastercard" => "MC",
-            "master-card" => "MC",
-            "visa" => "VI",
-            "maestro" => "MI",
-            "diners-club" => "DN",
-            "unionpay" => "CUP"
-        ];
-
-        $this->config = $this->getMockBuilder(Config::class)
-            ->setMethods(['getCctypesMapper'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->config->expects(self::once())
-            ->method('getCctypesMapper')
-            ->willReturn($mapperArray);
-
-        $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
+        $config = $this->getConfigMock();
 
         $this->paymentHandler = new VaultDetailsHandler(
             $this->paymentTokenFactory,
             $this->paymentExtensionFactory,
-            $this->config,
-            $this->subjectReader,
-            $this->serializer
+            $config,
+            new SubjectReader(),
+            new Json()
+        );
+    }
+
+    public function testHandle()
+    {
+        $paymentData = $this->getPaymentDataObjectMock();
+
+        $subject = ['payment' => $paymentData];
+        $response = ['object' => $this->getBraintreeTransaction()];
+
+        $this->paymentHandler->handle($subject, $response);
+        $paymentToken = $this->payment->getExtensionAttributes()
+            ->getVaultPaymentToken();
+
+        self::assertEquals(self::$token, $paymentToken->getGatewayToken());
+        self::assertEquals('2022-01-01 00:00:00', $paymentToken->getExpiresAt());
+
+        $details = json_decode($paymentToken->getTokenDetails(), true);
+        self::assertEquals(
+            [
+                'type' => 'AE',
+                'maskedCC' => 1231,
+                'expirationDate' => '12/2021'
+            ],
+            $details
         );
     }
 
     /**
-     * @covers \Magento\Braintree\Gateway\Response\VaultDetailsHandler::handle
+     * Creates mock for payment data object and order payment.
+     *
+     * @return PaymentDataObject|MockObject
      */
-    public function testHandle()
-    {
-        $this->paymentExtension->expects(self::once())
-            ->method('setVaultPaymentToken')
-            ->with($this->paymentToken);
-        $this->paymentExtension->expects(self::once())
-            ->method('getVaultPaymentToken')
-            ->willReturn($this->paymentToken);
-
-        $paymentData = $this->getPaymentDataObjectMock();
-        $transaction = $this->getBraintreeTransaction();
-
-        $subject = ['payment' => $paymentData];
-        $response = ['object' => $transaction];
-
-        $this->subjectReader->expects(self::once())
-            ->method('readPayment')
-            ->with($subject)
-            ->willReturn($paymentData);
-        $this->subjectReader->expects(self::once())
-            ->method('readTransaction')
-            ->with($response)
-            ->willReturn($transaction);
-        $this->paymentToken->expects(static::once())
-            ->method('setGatewayToken')
-            ->with('rh3gd4');
-        $this->paymentToken->expects(static::once())
-            ->method('setExpiresAt')
-            ->with('2022-01-01 00:00:00');
-
-        $this->paymentHandler->handle($subject, $response);
-        $this->assertSame($this->paymentToken, $this->payment->getExtensionAttributes()->getVaultPaymentToken());
-    }
-
-    /**
-     * Create mock for payment data object and order payment
-     * @return MockObject
-     */
-    private function getPaymentDataObjectMock()
+    private function getPaymentDataObjectMock(): PaymentDataObject
     {
         $mock = $this->getMockBuilder(PaymentDataObject::class)
             ->setMethods(['getPayment'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mock->expects($this->once())
-            ->method('getPayment')
+        $mock->method('getPayment')
             ->willReturn($this->payment);
 
         return $mock;
     }
 
     /**
-     * Create Braintree transaction
-     * @return MockObject
+     * Creates Braintree transaction.
+     *
+     * @return Successful
      */
     private function getBraintreeTransaction()
     {
         $attributes = [
-            'id' => self::TRANSACTION_ID,
+            'id' => self::$transactionId,
             'creditCardDetails' => $this->getCreditCardDetails()
         ];
 
         $transaction = Transaction::factory($attributes);
+        $result = new Successful(['transaction' => $transaction]);
 
-        return $transaction;
+        return $result;
     }
 
     /**
-     * Create Braintree transaction
-     * @return \Braintree\Transaction\CreditCardDetails
+     * Creates Braintree transaction.
+     *
+     * @return CreditCardDetails
      */
-    private function getCreditCardDetails()
+    private function getCreditCardDetails(): CreditCardDetails
     {
         $attributes = [
-            'token' => 'rh3gd4',
+            'token' => self::$token,
             'bin' => '5421',
             'cardType' => 'American Express',
             'expirationMonth' => 12,
@@ -222,5 +174,55 @@ class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
         $creditCardDetails = new CreditCardDetails($attributes);
 
         return $creditCardDetails;
+    }
+
+    /**
+     * Creates mock of config class.
+     *
+     * @return Config|MockObject
+     */
+    private function getConfigMock(): Config
+    {
+        $mapperArray = [
+            'american-express' => 'AE',
+            'discover' => 'DI',
+            'jcb' => 'JCB',
+            'mastercard' => 'MC',
+            'master-card' => 'MC',
+            'visa' => 'VI',
+            'maestro' => 'MI',
+            'diners-club' => 'DN',
+            'unionpay' => 'CUP'
+        ];
+
+        $config = $this->getMockBuilder(Config::class)
+            ->setMethods(['getCctypesMapper'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config->method('getCctypesMapper')
+            ->willReturn($mapperArray);
+
+        return $config;
+    }
+
+    /**
+     * Initializes payment extension attributes mocks.
+     *
+     * @return void
+     */
+    private function initPaymentExtensionAttributesMock()
+    {
+        $this->paymentExtension = $this->getMockBuilder(OrderPaymentExtensionInterface::class)
+            ->setMethods(['setVaultPaymentToken', 'getVaultPaymentToken'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->paymentExtensionFactory = $this->getMockBuilder(OrderPaymentExtensionInterfaceFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->paymentExtensionFactory->method('create')
+            ->willReturn($this->paymentExtension);
     }
 }

--- a/app/code/Magento/Payment/Model/Method/AbstractMethod.php
+++ b/app/code/Magento/Payment/Model/Method/AbstractMethod.php
@@ -29,12 +29,6 @@ abstract class AbstractMethod extends \Magento\Framework\Model\AbstractExtensibl
     MethodInterface,
     PaymentMethodInterface
 {
-    const ACTION_ORDER = 'order';
-
-    const ACTION_AUTHORIZE = 'authorize';
-
-    const ACTION_AUTHORIZE_CAPTURE = 'authorize_capture';
-
     const STATUS_UNKNOWN = 'UNKNOWN';
 
     const STATUS_APPROVED = 'APPROVED';
@@ -46,23 +40,6 @@ abstract class AbstractMethod extends \Magento\Framework\Model\AbstractExtensibl
     const STATUS_VOID = 'VOID';
 
     const STATUS_SUCCESS = 'SUCCESS';
-
-    /**
-     * Different payment method checks.
-     */
-    const CHECK_USE_FOR_COUNTRY = 'country';
-
-    const CHECK_USE_FOR_CURRENCY = 'currency';
-
-    const CHECK_USE_CHECKOUT = 'checkout';
-
-    const CHECK_USE_INTERNAL = 'internal';
-
-    const CHECK_ORDER_TOTAL_MIN_MAX = 'total';
-
-    const CHECK_ZERO_TOTAL = 'zero_total';
-
-    const GROUP_OFFLINE = 'offline';
 
     /**
      * @var string

--- a/app/code/Magento/Payment/Model/MethodInterface.php
+++ b/app/code/Magento/Payment/Model/MethodInterface.php
@@ -16,6 +16,32 @@ use Magento\Quote\Api\Data\CartInterface;
 interface MethodInterface
 {
     /**
+     * Different payment actions.
+     */
+    const ACTION_ORDER = 'order';
+
+    const ACTION_AUTHORIZE = 'authorize';
+
+    const ACTION_AUTHORIZE_CAPTURE = 'authorize_capture';
+
+    /**
+     * Different payment method checks.
+     */
+    const CHECK_USE_FOR_COUNTRY = 'country';
+
+    const CHECK_USE_FOR_CURRENCY = 'currency';
+
+    const CHECK_USE_CHECKOUT = 'checkout';
+
+    const CHECK_USE_INTERNAL = 'internal';
+
+    const CHECK_ORDER_TOTAL_MIN_MAX = 'total';
+
+    const CHECK_ZERO_TOTAL = 'zero_total';
+
+    const GROUP_OFFLINE = 'offline';
+
+    /**
      * Retrieve payment method code
      *
      * @return string


### PR DESCRIPTION
Braintree module has dependencies on deprecated `\Magento\Payment\Model\Method\AbstractMethod` and `\Magento\Vault\Api\Data\PaymentTokenInterfaceFactory`. Proposed changes remove or replace them.

### Description

- Removed dependency of AbstractMethod
- Replaced usage of deprecated Vault factories

Changes are covered by unit tests.

Code coverage **before** test refactoring (`\Magento\Braintree\Test\Unit\Gateway\Response\VaultDetailsHandlerTest`):
![code coverage 3](https://user-images.githubusercontent.com/2736528/36024074-3f43614c-0d97-11e8-81f5-444aaf15a124.png)
**After**:
![code coverage 1](https://user-images.githubusercontent.com/2736528/36024091-486fd3d6-0d97-11e8-90de-271c8feed54e.png)

Code coverage **before** test refactoring (`\Magento\Braintree\Test\Unit\Gateway\Response\PayPal\VaultDetailsHandlerTest`):
![code coverage 4](https://user-images.githubusercontent.com/2736528/36024128-6842a526-0d97-11e8-8c2c-d8cc9d770335.png)
**After**:
![code coverage 2](https://user-images.githubusercontent.com/2736528/36024144-762b893c-0d97-11e8-8596-d040f7a3987f.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
