### PR TITLE
Fix for #12081: missing translations in the js-translations.json

### DIFF
--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -67,6 +67,7 @@
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
                 <item name="mage_translation_widget" xsi:type="string"><![CDATA[~(?:\$|jQuery)\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
                 <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
+                <item name="translate_args" xsi:type="string"><![CDATA[~translate args\=("|'|"')([^\'].*?)('"|'|")~]]></item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR adds an additional pattern to the module responsible for generating the js-translations.json file. The translation routine doesn't translate strings in tags like`<translate args="This won't be translated"`.

This is related to (but doesn't fix) https://github.com/magento/magento2/pull/13471 where the Html parser of the phrase collection module is also missing a pattern matching the `<translate args=` tags.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12081: Magento 2.2.0: Translations for 'Item in Cart' missing in mini cart.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Clean Magento installation with a translation file translating the string "Item in Cart" from Magento_Checkout.
2. Run setup:static-content:deploy
3. Without the fix, the string isn't in the generated js-translations.json file. With the fix it will be.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
