### PR TITLE
Backport of PR-11169 for Magento 2.1: Fixed issue #10738: Empty attribute label is displayed on product pag…

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -94,7 +94,7 @@
                         <argument name="at_call" xsi:type="string">getShortDescription</argument>
                         <argument name="at_code" xsi:type="string">short_description</argument>
                         <argument name="css_class" xsi:type="string">overview</argument>
-                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
+                        <argument name="at_label" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Overview</argument>
                         <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
                     </arguments>
@@ -109,7 +109,7 @@
                         <argument name="at_call" xsi:type="string">getDescription</argument>
                         <argument name="at_code" xsi:type="string">description</argument>
                         <argument name="css_class" xsi:type="string">description</argument>
-                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
+                        <argument name="at_label" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Details</argument>
                     </arguments>
                 </block>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -22,6 +22,12 @@ $_attributeLabel = $block->getAtLabel();
 $_attributeType = $block->getAtType();
 $_attributeAddAttribute = $block->getAddAttribute();
 
+$renderLabel = true;
+// if defined as 'none' in layout, do not render
+if ($_attributeLabel == 'none') {
+    $renderLabel = false;
+}
+
 if ($_attributeLabel && $_attributeLabel == 'default') {
     $_attributeLabel = $_product->getResource()->getAttribute($_code)->getFrontendLabel();
 }
@@ -34,7 +40,7 @@ if ($_attributeType && $_attributeType == 'text') {
 
 <?php if ($_attributeValue): ?>
 <div class="product attribute <?php /* @escapeNotVerified */ echo $_className?>">
-    <?php if ($_attributeLabel != __('none')): ?><strong class="type"><?php /* @escapeNotVerified */ echo $_attributeLabel?></strong><?php endif; ?>
+    <?php if ($renderLabel): ?><strong class="type"><?php /* @escapeNotVerified */ echo $_attributeLabel?></strong><?php endif; ?>
     <div class="value" <?php /* @escapeNotVerified */ echo $_attributeAddAttribute;?>><?php /* @escapeNotVerified */ echo $_attributeValue; ?></div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
…e when other language used

(cherry picked from commit f9562f1530a83560c4621ca77b8f78ad482080e5)

### Description
This is a backport of https://github.com/magento/magento2/pull/11169 for Magento 2.1

We saw the word `none` showing up on certain product detail pages in the frontend after upgrading from 2.1.9 to 2.1.11.
Also when you change the admin label of a certain attribute to `none`, it would not show up on the frontend, while it should show up.
This overrides the changes from https://github.com/magento/magento2/pull/10932 which were not good enough to fix the issue.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/10738: Empty attribute label is displayed on product page when other language used.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
