### PR TITLE
Backport PR-1895 for Magento 2.1 - Fix relative template references in individual Magento modules

### DIFF
--- a/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml
@@ -13,7 +13,7 @@
             <block class="Magento\AdminNotification\Block\Window" name="notification_window" as="notification_window" acl="Magento_AdminNotification::show_toolbar" template="notification/window.phtml"/>
         </referenceContainer>
         <referenceContainer name="header">
-            <block class="Magento\AdminNotification\Block\ToolbarEntry" name="notification.messages" before="user" template="toolbar_entry.phtml"/>
+            <block class="Magento\AdminNotification\Block\ToolbarEntry" name="notification.messages" before="user" template="Magento_AdminNotification::toolbar_entry.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml
@@ -10,7 +10,7 @@
         <referenceContainer name="notifications">
             <block class="Magento\AdminNotification\Block\System\Messages" name="system_messages" as="system_messages" before="-" template="Magento_AdminNotification::system/messages.phtml"/>
             <block class="Magento\AdminNotification\Block\System\Messages\UnreadMessagePopup" name="unread_system_messages" as="unread_system_messages" after="system_messages" template="Magento_AdminNotification::system/messages/popup.phtml"/>
-            <block class="Magento\AdminNotification\Block\Window" name="notification_window" as="notification_window" acl="Magento_AdminNotification::show_toolbar" template="notification/window.phtml"/>
+            <block class="Magento\AdminNotification\Block\Window" name="notification_window" as="notification_window" acl="Magento_AdminNotification::show_toolbar" template="Magento_AdminNotification::notification/window.phtml"/>
         </referenceContainer>
         <referenceContainer name="header">
             <block class="Magento\AdminNotification\Block\ToolbarEntry" name="notification.messages" before="user" template="Magento_AdminNotification::toolbar_entry.phtml"/>

--- a/app/code/Magento/Backend/composer.json
+++ b/app/code/Magento/Backend/composer.json
@@ -7,7 +7,6 @@
         "magento/module-directory": "100.1.*",
         "magento/module-developer": "100.1.*",
         "magento/module-eav": "100.1.*",
-        "magento/module-theme": "100.1.*",
         "magento/module-reports": "100.1.*",
         "magento/module-sales": "100.1.*",
         "magento/module-quote": "100.1.*",
@@ -20,6 +19,9 @@
         "magento/module-require-js": "100.1.*",
         "magento/module-config": "100.1.*",
         "magento/framework": "100.1.*"
+    },
+    "suggest": {
+        "magento/module-theme": "100.1.*"
     },
     "type": "magento2-module",
     "version": "100.1.9",

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_auth_login.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_auth_login.xml
@@ -9,10 +9,10 @@
     <update handle="admin_login" />
     <body>
         <referenceContainer name="login.content">
-            <block class="Magento\Backend\Block\Template" name="admin.login" template="admin/login.phtml">
+            <block class="Magento\Backend\Block\Template" name="admin.login" template="Magento_Backend::admin/login.phtml">
                 <container name="form.additional.info" label="Form Additional Info"/>
                 <container name="form.buttons" label="Form Buttons">
-                    <block class="Magento\Backend\Block\Template" name="adminhtml_auth_login_buttons" template="admin/login_buttons.phtml"/>
+                    <block class="Magento\Backend\Block\Template" name="adminhtml_auth_login_buttons" template="Magento_Backend::admin/login_buttons.phtml"/>
                 </container>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_denied.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_denied.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Backend\Block\Denied" name="content.denied" template="admin/access_denied.phtml"/>
+            <block class="Magento\Backend\Block\Denied" name="content.denied" template="Magento_Backend::admin/access_denied.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Backend/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/default.xml
@@ -17,7 +17,7 @@
         <attribute name="id" value="html-body"/>
         <block name="require.js" class="Magento\Backend\Block\Page\RequireJs" template="Magento_Backend::page/js/require_js.phtml"/>
         <referenceContainer name="global.notices">
-            <block class="Magento\Backend\Block\Page\Notices" name="global_notices" as="global_notices" template="page/notices.phtml"/>
+            <block class="Magento\Backend\Block\Page\Notices" name="global_notices" as="global_notices" template="Magento_Backend::page/notices.phtml"/>
         </referenceContainer>
         <referenceContainer name="header">
             <block class="Magento\Backend\Block\Page\Header" name="logo" before="-">
@@ -44,7 +44,7 @@
             <block class="Magento\Backend\Block\Admin\Formkey" name="formkey" as="formkey" template="Magento_Backend::admin/formkey.phtml"/>
         </referenceContainer>
         <referenceContainer name="main.top">
-            <block class="Magento\Theme\Block\Html\Title" name="page.title" template="title.phtml"/>
+            <block class="Magento\Theme\Block\Html\Title" name="page.title" template="Magento_Theme::title.phtml"/>
         </referenceContainer>
         <referenceContainer name="page.messages">
             <block class="Magento\Framework\View\Element\Messages" name="messages" as="messages"/>

--- a/app/code/Magento/Braintree/view/frontend/layout/braintree_paypal_review.xml
+++ b/app/code/Magento/Braintree/view/frontend/layout/braintree_paypal_review.xml
@@ -20,11 +20,11 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Braintree\Block\Paypal\Checkout\Review" name="braintree.paypal.review" template="Magento_Paypal::express/review.phtml">
-                <block class="Magento\Paypal\Block\Express\Review" name="express.review.shipping.method" as="shipping_method" template="express/review/shipping/method.phtml"/>
+                <block class="Magento\Paypal\Block\Express\Review" name="express.review.shipping.method" as="shipping_method" template="Magento_Paypal::express/review/shipping/method.phtml"/>
                 <block class="Magento\Framework\View\Element\Text\ListText" name="paypal.additional.actions">
                     <block class="Magento\Checkout\Block\Cart\Coupon" name="paypal.cart.coupon" as="coupon" template="Magento_Checkout::cart/coupon.phtml"/>
                 </block>
-                <block class="Magento\Paypal\Block\Express\Review\Details" name="paypal.express.review.details" as="details" template="express/review/details.phtml">
+                <block class="Magento\Paypal\Block\Express\Review\Details" name="paypal.express.review.details" as="details" template="Magento_Paypal::express/review/details.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="checkout.onepage.review.item.renderers" as="renderer.list"/>
                     <block class="Magento\Checkout\Block\Cart\Totals" name="paypal.express.review.details.totals" as="totals" template="Magento_Paypal::checkout/onepage/review/totals.phtml"/>
                 </block>

--- a/app/code/Magento/Braintree/view/frontend/layout/vault_cards_listaction.xml
+++ b/app/code/Magento/Braintree/view/frontend/layout/vault_cards_listaction.xml
@@ -12,7 +12,7 @@
                 <block class="Magento\Braintree\Block\Customer\CardRenderer" name="braintree.card.renderer" template="Magento_Vault::customer_account/credit_card.phtml"/>
             </referenceBlock>
             <referenceBlock name="vault.token.list">
-                <block class="Magento\Braintree\Block\Customer\PayPal\VaultTokenRenderer" name="braintree_paypal.token.renderer" template="paypal/vault_token.phtml"/>
+                <block class="Magento\Braintree\Block\Customer\PayPal\VaultTokenRenderer" name="braintree_paypal.token.renderer" template="Magento_Braintree::paypal/vault_token.phtml"/>
             </referenceBlock>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_order_shipment_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_order_shipment_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/shipment/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/shipment/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_order_shipment_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_order_shipment_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="shipment_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/shipment/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/shipment/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/catalog_product_view_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/catalog_product_view_type_bundle.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.composite.fieldset">
-            <block class="Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Bundle" before="product.composite.fieldset.options" name="product.composite.fieldset.bundle" template="product/composite/fieldset/options/bundle.phtml">
+            <block class="Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Bundle" before="product.composite.fieldset.options" name="product.composite.fieldset.bundle" template="Magento_Bundle::product/composite/fieldset/options/bundle.phtml">
                 <block class="Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Select" name="product.info.bundle.options.select" as="select"/>
                 <block class="Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Multi" name="product.info.bundle.options.multi" as="multi"/>
                 <block class="Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Radio" name="product.info.bundle.options.radio" as="radio"/>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/creditmemo/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/creditmemo/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/creditmemo/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/creditmemo/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/creditmemo/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/creditmemo/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/invoice/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/invoice/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/invoice/create/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/invoice/create/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="invoice_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="sales/invoice/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/invoice/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/sales_order_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer" as="bundle" template="sales/order/view/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/view/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
@@ -17,15 +17,15 @@
                         <argument name="zone" xsi:type="string">item_view</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart.bundle" as="addtocart" template="product/view/addtocart.phtml">
+                <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart.bundle" as="addtocart" template="Magento_Catalog::product/view/addtocart.phtml">
                     <block class="Magento\Catalog\Block\ShortcutButtons\InCatalog" name="addtocart.shortcut.buttons"/>
                 </block>
-                <block class="Magento\Catalog\Block\Product\View" name="product.info.addto.bundle" as="addto" template="product/view/addto.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View" name="product.info.addto.bundle" as="addto" template="Magento_Catalog::product/view/addto.phtml"/>
             </block>
         </referenceBlock>
         <referenceBlock name="product.info.options.wrapper">
             <block class="Magento\Catalog\Block\Product\View" name="bundle.product.view.options.notice" template="Magento_Bundle::catalog/product/view/options/notice.phtml"/>
-            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle.options" as="type_bundle_options" template="catalog/product/view/type/bundle/options.phtml" before="-">
+            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle.options" as="type_bundle_options" template="Magento_Bundle::catalog/product/view/type/bundle/options.phtml" before="-">
                 <container name="product.info.bundle.options.top" as="product_info_bundle_options_top">
                     <block class="Magento\Catalog\Block\Product\View" name="bundle.back.button" as="backButton" before="-" template="Magento_Bundle::catalog/product/view/backbutton.phtml"/>
                 </container>
@@ -42,7 +42,7 @@
         <move element="product.info.options.wrapper.bottom" destination="bundle.product.options.wrapper" after="product.info.options.wrapper" />
         <move element="product.price.tier" destination="product.info.options.wrapper.bottom" before="-" />
         <referenceBlock name="product.info.options.wrapper.bottom">
-            <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.qtyincrements" before="-" template="qtyincrements.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.qtyincrements" before="-" template="Magento_CatalogInventory::qtyincrements.phtml"/>
             <action method="unsetChild">
                 <argument name="block" xsi:type="string">product.info.addtocart</argument>
             </action>
@@ -57,7 +57,7 @@
             <container name="bundle.options.container" htmlTag="div" htmlClass="bundle-options-container" after="product.info.media"/>
         </referenceContainer>
         <referenceContainer name="product.info.type">
-            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle" as="product_type_data" template="catalog/product/view/type/bundle.phtml"/>
+            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle" as="product_type_data" template="Magento_Bundle::catalog/product/view/type/bundle.phtml"/>
             <container name="product.info.bundle.extra" after="product.info.bundle" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
         <referenceContainer name="product.info.main">

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="email/order/items/creditmemo/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/creditmemo/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="email/order/items/invoice/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/invoice/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="email/order/items/order/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/order/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_shipment_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.shipment.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="email/order/items/shipment/default.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::email/order/items/shipment/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/creditmemo/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/creditmemo/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/invoice/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/invoice/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/creditmemo/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/creditmemo/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.invoice.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/invoice/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/invoice/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_shipment_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_print_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.shipment.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/shipment/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/shipment/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_shipment_renderers.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.shipment.renderers">
-            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="sales/order/shipment/items/renderer.phtml"/>
+            <block class="Magento\Bundle\Block\Sales\Order\Items\Renderer" as="bundle" template="Magento_Bundle::sales/order/shipment/items/renderer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
@@ -8,7 +8,7 @@
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
         <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset" name="product.composite.fieldset">
-            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options" template="catalog/product/composite/fieldset/options.phtml">
+            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options" template="Magento_Catalog::catalog/product/composite/fieldset/options.phtml">
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\DefaultType" as="default" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/default.phtml"/>
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\Text" as="text" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/text.phtml"/>
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\File" as="file" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/file.phtml"/>
@@ -16,7 +16,7 @@
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\Date" as="date" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/date.phtml"/>
                 <block class="Magento\Framework\View\Element\Template" name="product.composite.fieldset.options.js" as="options_js" template="Magento_Catalog::catalog/product/composite/fieldset/options/js.phtml"/>
             </block>
-            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty" name="product.composite.fieldset.qty" template="catalog/product/composite/fieldset/qty.phtml"/>
+            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty" name="product.composite.fieldset.qty" template="Magento_Catalog::catalog/product/composite/fieldset/qty.phtml"/>
         </block>
         <block class="Magento\Framework\Pricing\Render" name="product.price.render.default">
             <arguments>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_category_add.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_category_add.xml
@@ -15,7 +15,7 @@
     <body>
         <referenceContainer name="left" htmlTag="div" />
         <referenceContainer name="left">
-            <block class="Magento\Catalog\Block\Adminhtml\Category\Tree" name="category.tree" template="catalog/category/tree.phtml"/>
+            <block class="Magento\Catalog\Block\Adminhtml\Category\Tree" name="category.tree" template="Magento_Catalog::catalog/category/tree.phtml"/>
         </referenceContainer>
         <referenceContainer name="content">
             <uiComponent name="category_form"/>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_category_edit.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_category_edit.xml
@@ -18,7 +18,7 @@
             <block class="Magento\Backend\Block\Store\Switcher" name="category.store.switcher" template="Magento_Backend::store/switcher.phtml"/>
         </referenceContainer>
         <referenceContainer name="left">
-            <block class="Magento\Catalog\Block\Adminhtml\Category\Tree" name="category.tree" template="catalog/category/tree.phtml"/>
+            <block class="Magento\Catalog\Block\Adminhtml\Category\Tree" name="category.tree" template="Magento_Catalog::catalog/category/tree.phtml"/>
         </referenceContainer>
         <referenceContainer name="content">
             <uiComponent name="category_form"/>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_action_attribute_edit.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_action_attribute_edit.xml
@@ -13,8 +13,8 @@
         <referenceContainer name="left">
             <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tabs" name="attributes_tabs">
                 <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Attributes" name="tab_attributes"/>
-                <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Inventory" name="tab_inventory" template="catalog/product/edit/action/inventory.phtml"/>
-                <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Websites" name="tab_websites" template="catalog/product/edit/action/websites.phtml"/>
+                <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Inventory" name="tab_inventory" template="Magento_Catalog::catalog/product/edit/action/inventory.phtml"/>
+                <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Websites" name="tab_websites" template="Magento_Catalog::catalog/product/edit/action/websites.phtml"/>
                 <action method="addTab">
                     <argument name="name" xsi:type="string">attributes</argument>
                     <argument name="block" xsi:type="string">tab_attributes</argument>
@@ -30,7 +30,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute" name="attribute" template="catalog/product/edit/action/attribute.phtml"/>
+            <block class="Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute" name="attribute" template="Magento_Catalog::catalog/product/edit/action/attribute.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_set_edit.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/catalog_product_set_edit.xml
@@ -9,7 +9,7 @@
     <body>
         <referenceContainer name="content">
             <container name="adminhtml.catalog.product.set.edit.wrapper" htmlTag="div" htmlClass="admin__scope-old"><!-- @todo ui: remove arguments within .admin__scope-old -->
-                <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Set\Main" name="adminhtml.catalog.product.set.edit" template="catalog/product/attribute/set/main.phtml"/>
+                <block class="Magento\Catalog\Block\Adminhtml\Product\Attribute\Set\Main" name="adminhtml.catalog.product.set.edit" template="Magento_Catalog::catalog/product/attribute/set/main.phtml"/>
             </container>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_default.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_default.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="sidebar.main">
-            <block class="Magento\Catalog\Block\Navigation" name="catalog.leftnav" before="-" template="navigation/left.phtml"/>
+            <block class="Magento\Catalog\Block\Navigation" name="catalog.leftnav" before="-" template="Magento_Catalog::navigation/left.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_compare_index.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_compare_index.xml
@@ -13,7 +13,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Catalog\Block\Product\Compare\ListCompare" name="catalog.compare.list" template="product/compare/list.phtml" cacheable="false"/>
+            <block class="Magento\Catalog\Block\Product\Compare\ListCompare" name="catalog.compare.list" template="Magento_Catalog::product/compare/list.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_gallery.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_gallery.xml
@@ -13,7 +13,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Catalog\Block\Product\Gallery" name="catalog_product_gallery" template="product/gallery.phtml"/>
+            <block class="Magento\Catalog\Block\Product\Gallery" name="catalog_product_gallery" template="Magento_Catalog::product/gallery.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -33,7 +33,7 @@
                 <container name="product.info.price" label="Product info auxiliary container" htmlTag="div" htmlClass="product-info-price" after="product.info.review">
                     <container name="product.info.stock.sku" label="Product auxiliary info" htmlTag="div" htmlClass="product-info-stock-sku">
                         <container name="product.info.type" before="-"/>
-                        <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.sku" template="product/view/attribute.phtml" after="product.info.type">
+                        <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.sku" template="Magento_Catalog::product/view/attribute.phtml" after="product.info.type">
                             <arguments>
                                 <argument name="at_call" xsi:type="string">getSku</argument>
                                 <argument name="at_code" xsi:type="string">sku</argument>
@@ -43,7 +43,7 @@
                             </arguments>
                         </block>
                     </container>
-                    <block class="Magento\Catalog\Block\Product\View" name="product.info.review" template="product/view/review.phtml" after="product.info.stock.sku" />
+                    <block class="Magento\Catalog\Block\Product\View" name="product.info.review" template="Magento_Catalog::product/view/review.phtml" after="product.info.stock.sku" />
                     <block class="Magento\Catalog\Pricing\Render" name="product.price.final" after="product.info.sku">
                         <arguments>
                             <argument name="price_render" xsi:type="string">product.price.render.default</argument>
@@ -60,36 +60,36 @@
                     </arguments>
                 </block>
                 <container name="alert.urls" as="alert_urls" label="Alert Urls" after="product.price.tier"/>
-                <block class="Magento\Catalog\Block\Product\View" name="product.info" template="product/view/form.phtml" after="alert.urls">
+                <block class="Magento\Catalog\Block\Product\View" name="product.info" template="Magento_Catalog::product/view/form.phtml" after="alert.urls">
                     <container name="product.info.form.content" as="product_info_form_content">
-                        <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart" as="addtocart" template="product/view/addtocart.phtml"/>
+                        <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart" as="addtocart" template="Magento_Catalog::product/view/addtocart.phtml"/>
                     </container>
                     <block class="Magento\Framework\View\Element\Template" name="product.info.form.options" as="options_container">
-                        <block class="Magento\Catalog\Block\Product\View" name="product.info.options.wrapper" as="product_options_wrapper" template="product/view/options/wrapper.phtml">
-                            <block class="Magento\Catalog\Block\Product\View\Options" name="product.info.options" as="product_options" template="product/view/options.phtml">
-                                <block class="Magento\Catalog\Block\Product\View\Options\Type\DefaultType" as="default" template="product/view/options/type/default.phtml"/>
-                                <block class="Magento\Catalog\Block\Product\View\Options\Type\Text" as="text" template="product/view/options/type/text.phtml"/>
-                                <block class="Magento\Catalog\Block\Product\View\Options\Type\File" as="file" template="product/view/options/type/file.phtml"/>
-                                <block class="Magento\Catalog\Block\Product\View\Options\Type\Select" as="select" template="product/view/options/type/select.phtml"/>
-                                <block class="Magento\Catalog\Block\Product\View\Options\Type\Date" as="date" template="product/view/options/type/date.phtml"/>
+                        <block class="Magento\Catalog\Block\Product\View" name="product.info.options.wrapper" as="product_options_wrapper" template="Magento_Catalog::product/view/options/wrapper.phtml">
+                            <block class="Magento\Catalog\Block\Product\View\Options" name="product.info.options" as="product_options" template="Magento_Catalog::product/view/options.phtml">
+                                <block class="Magento\Catalog\Block\Product\View\Options\Type\DefaultType" as="default" template="Magento_Catalog::product/view/options/type/default.phtml"/>
+                                <block class="Magento\Catalog\Block\Product\View\Options\Type\Text" as="text" template="Magento_Catalog::product/view/options/type/text.phtml"/>
+                                <block class="Magento\Catalog\Block\Product\View\Options\Type\File" as="file" template="Magento_Catalog::product/view/options/type/file.phtml"/>
+                                <block class="Magento\Catalog\Block\Product\View\Options\Type\Select" as="select" template="Magento_Catalog::product/view/options/type/select.phtml"/>
+                                <block class="Magento\Catalog\Block\Product\View\Options\Type\Date" as="date" template="Magento_Catalog::product/view/options/type/date.phtml"/>
                             </block>
                             <block class="Magento\Framework\View\Element\Html\Calendar" name="html_calendar" as="html_calendar" template="Magento_Theme::js/calendar.phtml"/>
                         </block>
-                        <block class="Magento\Catalog\Block\Product\View" name="product.info.options.wrapper.bottom" as="product_options_wrapper_bottom" template="product/view/options/wrapper/bottom.phtml">
-                            <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart.additional" as="product.info.addtocart" template="product/view/addtocart.phtml"/>
+                        <block class="Magento\Catalog\Block\Product\View" name="product.info.options.wrapper.bottom" as="product_options_wrapper_bottom" template="Magento_Catalog::product/view/options/wrapper/bottom.phtml">
+                            <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart.additional" as="product.info.addtocart" template="Magento_Catalog::product/view/addtocart.phtml"/>
                         </block>
                     </block>
                 </block>
                 <container name="product.info.extrahint" as="extrahint" label="Product View Extra Hint">
                     <container name="product.info.social" label="Product social links container" htmlTag="div" htmlClass="product-social-links" after="product.info.overview">
-                        <block class="Magento\Catalog\Block\Product\View" name="product.info.addto" as="addto" template="product/view/addto.phtml">
+                        <block class="Magento\Catalog\Block\Product\View" name="product.info.addto" as="addto" template="Magento_Catalog::product/view/addto.phtml">
                             <block class="Magento\Catalog\Block\Product\View\AddTo\Compare" name="view.addto.compare" after="view.addto.wishlist"
                                    template="Magento_Catalog::product/view/addto/compare.phtml" />
                         </block>
-                        <block class="Magento\Catalog\Block\Product\View" name="product.info.mailto" template="product/view/mailto.phtml"/>
+                        <block class="Magento\Catalog\Block\Product\View" name="product.info.mailto" template="Magento_Catalog::product/view/mailto.phtml"/>
                     </container>
                 </container>
-                <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.overview" template="product/view/attribute.phtml" group="detailed_info" after="product.info.extrahint">
+                <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.overview" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info" after="product.info.extrahint">
                     <arguments>
                         <argument name="at_call" xsi:type="string">getShortDescription</argument>
                         <argument name="at_code" xsi:type="string">short_description</argument>
@@ -101,10 +101,10 @@
                 </block>
             </container>
             <container name="product.info.media" htmlTag="div" htmlClass="product media" after="product.info.main">
-                <block class="Magento\Catalog\Block\Product\View\Gallery" name="product.info.media.image" template="product/view/gallery.phtml"/>
+                <block class="Magento\Catalog\Block\Product\View\Gallery" name="product.info.media.image" template="Magento_Catalog::product/view/gallery.phtml"/>
             </container>
-            <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.details" template="product/view/details.phtml" after="product.info.media">
-                <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" template="product/view/attribute.phtml" group="detailed_info">
+            <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.details" template="Magento_Catalog::product/view/details.phtml" after="product.info.media">
+                <block class="Magento\Catalog\Block\Product\View\Description" name="product.info.description" template="Magento_Catalog::product/view/attribute.phtml" group="detailed_info">
                     <arguments>
                         <argument name="at_call" xsi:type="string">getDescription</argument>
                         <argument name="at_code" xsi:type="string">description</argument>
@@ -113,7 +113,7 @@
                         <argument name="title" translate="true" xsi:type="string">Details</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Catalog\Block\Product\View\Attributes" name="product.attributes" as="additional" template="product/view/attributes.phtml" group="detailed_info">
+                <block class="Magento\Catalog\Block\Product\View\Attributes" name="product.attributes" as="additional" template="Magento_Catalog::product/view/attributes.phtml" group="detailed_info">
                     <arguments>
                         <argument translate="true" name="title" xsi:type="string">More Information</argument>
                     </arguments>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.type">
-            <block class="Magento\Catalog\Block\Product\View\Type\Simple" name="product.info.simple" as="product_type_data" template="product/view/type/default.phtml"/>
+            <block class="Magento\Catalog\Block\Product\View\Type\Simple" name="product.info.simple" as="product_type_data" template="Magento_Catalog::product/view/type/default.phtml"/>
             <container name="product.info.simple.extra" after="product.info.simple" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_virtual.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_virtual.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.type">
-            <block class="Magento\Catalog\Block\Product\View\Type\Virtual" name="product.info.virtual" as="product_type_data" template="product/view/type/default.phtml"/>
+            <block class="Magento\Catalog\Block\Product\View\Type\Virtual" name="product.info.virtual" as="product_type_data" template="Magento_Catalog::product/view/type/default.phtml"/>
             <container name="product.info.virtual.extra" after="product.info.virtual" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Catalog/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="virtual" template="cart/item/default.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="virtual" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.virtual.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.virtual.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.virtual.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.extrahint">
-            <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.extrahint.qtyincrements" template="qtyincrements.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.extrahint.qtyincrements" template="Magento_CatalogInventory::qtyincrements.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.simple.extra">
-            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" template="stockqty/default.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" template="Magento_CatalogInventory::stockqty/default.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_virtual.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_virtual.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.virtual.extra">
-            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" template="stockqty/default.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" template="Magento_CatalogInventory::stockqty/default.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_index.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_index.xml
@@ -12,7 +12,7 @@
     <update handle="page_calendar"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\CatalogSearch\Block\Advanced\Form" name="catalogsearch_advanced_form" template="advanced/form.phtml"/>
+            <block class="Magento\CatalogSearch\Block\Advanced\Form" name="catalogsearch_advanced_form" template="Magento_CatalogSearch::advanced/form.phtml"/>
             <block class="Magento\Framework\View\Element\Html\Calendar" name="html_calendar" as="html_calendar" template="Magento_Theme::js/calendar.phtml"/>
         </referenceContainer>
     </body>

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -14,9 +14,9 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\CatalogSearch\Block\Advanced\Result" name="catalogsearch_advanced_result" template="advanced/result.phtml">
-                <block class="Magento\CatalogSearch\Block\SearchResult\ListProduct" name="search_result_list" template="product/list.phtml">
-                    <block class="Magento\Catalog\Block\Product\ProductList\Toolbar" name="product_list_toolbar" template="product/list/toolbar.phtml">
+            <block class="Magento\CatalogSearch\Block\Advanced\Result" name="catalogsearch_advanced_result" template="Magento_CatalogSearch::advanced/result.phtml">
+                <block class="Magento\CatalogSearch\Block\SearchResult\ListProduct" name="search_result_list" template="Magento_Catalog::product/list.phtml">
+                    <block class="Magento\Catalog\Block\Product\ProductList\Toolbar" name="product_list_toolbar" template="Magento_Catalog::product/list/toolbar.phtml">
                         <block class="Magento\Theme\Block\Html\Pager" name="product_list_toolbar_pager"/>
                     </block>
                     <action method="setToolbarBlockName">

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
@@ -9,15 +9,15 @@
     <body>
         <attribute name="class" value="page-products"/>
         <referenceContainer name="content">
-            <block class="Magento\CatalogSearch\Block\Result" name="search.result" template="result.phtml" cacheable="false">
-                <block class="Magento\CatalogSearch\Block\SearchResult\ListProduct" name="search_result_list" template="product/list.phtml" cacheable="false">
+            <block class="Magento\CatalogSearch\Block\Result" name="search.result" template="Magento_CatalogSearch::result.phtml" cacheable="false">
+                <block class="Magento\CatalogSearch\Block\SearchResult\ListProduct" name="search_result_list" template="Magento_Catalog::product/list.phtml" cacheable="false">
                     <arguments>
                         <!-- If argument's position depends on image size changeable in VDE:
                         positions:list-secondary,grid-secondary,list-actions,grid-actions,list-primary,grid-primary
                     -->
                         <argument name="positioned" xsi:type="string">positions:list-secondary</argument>
                     </arguments>
-                    <block class="Magento\Catalog\Block\Product\ProductList\Toolbar" name="product_list_toolbar" template="product/list/toolbar.phtml" cacheable="false">
+                    <block class="Magento\Catalog\Block\Product\ProductList\Toolbar" name="product_list_toolbar" template="Magento_Catalog::product/list/toolbar.phtml" cacheable="false">
                         <block class="Magento\Theme\Block\Html\Pager" name="product_list_toolbar_pager" cacheable="false"/>
                     </block>
                     <action method="setToolbarBlockName">

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
@@ -12,7 +12,7 @@
             <block class="Magento\Checkout\Block\Cart\ValidationMessages" name="checkout.cart.validationmessages"/>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Checkout\Block\Cart" name="checkout.cart" template="cart.phtml" cacheable="false">
+            <block class="Magento\Checkout\Block\Cart" name="checkout.cart" template="Magento_Checkout::cart.phtml" cacheable="false">
                 <container name="checkout.cart.items" as="with-items">
                     <container name="checkout.cart.container" htmlTag="div" htmlClass="cart-container" before="-">
                         <container name="checkout.cart.form.before" as="form_before" label="Shopping Cart Items Before" htmlTag="div" htmlClass="rewards"/>
@@ -24,7 +24,7 @@
                                     <argument name="css_class" xsi:type="string">summary title</argument>
                                 </arguments>
                             </block>
-                            <block class="Magento\Checkout\Block\Cart\Shipping" name="checkout.cart.shipping" as="shipping" template="cart/shipping.phtml" after="checkout.cart.summary.title">
+                            <block class="Magento\Checkout\Block\Cart\Shipping" name="checkout.cart.shipping" as="shipping" template="Magento_Checkout::cart/shipping.phtml" after="checkout.cart.summary.title">
                                 <arguments>
                                     <argument name="jsLayout" xsi:type="array">
                                         <item name="types" xsi:type="array">
@@ -131,7 +131,7 @@
                                 </arguments>
                             </block>
                             <container name="checkout.cart.totals.container" as="totals" label="Shopping Cart Totals">
-                                <block class="Magento\Checkout\Block\Cart\Totals" name="checkout.cart.totals" template="cart/totals.phtml">
+                                <block class="Magento\Checkout\Block\Cart\Totals" name="checkout.cart.totals" template="Magento_Checkout::cart/totals.phtml">
                                     <arguments>
                                         <argument name="jsLayout" xsi:type="array">
                                             <item name="components" xsi:type="array">
@@ -172,15 +172,15 @@
                                     </arguments>
                                 </block>
                             </container>
-                            <block class="Magento\Checkout\Block\Cart\Coupon" name="checkout.cart.coupon" as="coupon" template="cart/coupon.phtml"/>
-                            <block class="Magento\Checkout\Block\Cart" name="checkout.cart.methods.bottom" template="cart/methods.phtml">
+                            <block class="Magento\Checkout\Block\Cart\Coupon" name="checkout.cart.coupon" as="coupon" template="Magento_Checkout::cart/coupon.phtml"/>
+                            <block class="Magento\Checkout\Block\Cart" name="checkout.cart.methods.bottom" template="Magento_Checkout::cart/methods.phtml">
                                 <container name="checkout.cart.methods" as="methods" label="Payment Methods After Checkout Button">
-                                    <block class="Magento\Checkout\Block\Onepage\Link" name="checkout.cart.methods.onepage.bottom" template="onepage/link.phtml" />
+                                    <block class="Magento\Checkout\Block\Onepage\Link" name="checkout.cart.methods.onepage.bottom" template="Magento_Checkout::onepage/link.phtml" />
                                     <block class="Magento\Checkout\Block\QuoteShortcutButtons" name="checkout.cart.shortcut.buttons" />
                                 </container>
                             </block>
                         </container>
-                        <block class="Magento\Checkout\Block\Cart\Grid" name="checkout.cart.form" as="cart-items" template="cart/form.phtml" after="cart.summary">
+                        <block class="Magento\Checkout\Block\Cart\Grid" name="checkout.cart.form" as="cart-items" template="Magento_Checkout::cart/form.phtml" after="cart.summary">
                             <block class="Magento\Framework\View\Element\RendererList" name="checkout.cart.item.renderers" as="renderer.list"/>
                             <block class="Magento\Framework\View\Element\Text\ListText" name="checkout.cart.order.actions"/>
                         </block>
@@ -198,12 +198,12 @@
                     </block>
                 </container>
                 <container name="checkout.cart.noitems" as="no-items">
-                    <block class="Magento\Checkout\Block\Cart" name="checkout.cart.empty" before="-" template="cart/noItems.phtml">
+                    <block class="Magento\Checkout\Block\Cart" name="checkout.cart.empty" before="-" template="Magento_Checkout::cart/noItems.phtml">
                         <container name="checkout.cart.empty.widget" as="checkout_cart_empty_widget" label="Empty Shopping Cart Content Before"/>
                     </block>
                 </container>
             </block>
         </referenceContainer>
-        <block class="Magento\Checkout\Block\Cart\Additional\Info" name="additional.product.info" template="cart/additional/info.phtml"/>
+        <block class="Magento\Checkout\Block\Cart\Additional\Info" name="additional.product.info" template="Magento_Checkout::cart/additional/info.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -9,13 +9,13 @@
     <update handle="checkout_item_price_renderers"/>
     <body>
         <referenceBlock name="checkout.cart.item.renderers">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="cart/item/default.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.default.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.default.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.default.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>
                 </block>
             </block>
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="simple" template="cart/item/default.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="simple" template="Magento_Checkout::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions" name="checkout.cart.item.renderers.simple.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit" name="checkout.cart.item.renderers.simple.actions.edit" template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove" name="checkout.cart.item.renderers.simple.actions.remove" template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_sidebar_item_price_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_sidebar_item_price_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="minicart">
-            <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.cart.item.price.sidebar" template="cart/item/price/sidebar.phtml"/>
+            <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.cart.item.price.sidebar" template="Magento_Checkout::cart/item/price/sidebar.phtml"/>
             <arguments>
                 <argument name="jsLayout" xsi:type="array">
                     <item name="components" xsi:type="array">

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Checkout\Block\Onepage" name="checkout.root" template="onepage.phtml" cacheable="false">
+            <block class="Magento\Checkout\Block\Onepage" name="checkout.root" template="Magento_Checkout::onepage.phtml" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array">

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_item_price_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_item_price_renderers.xml
@@ -7,11 +7,11 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.item.price.unit" template="item/price/unit.phtml"/>
-        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.item.price.row" template="item/price/row.phtml"/>
-        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.excl" template="onepage/review/item/price/unit_excl_tax.phtml"/>
-        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.incl" template="onepage/review/item/price/unit_incl_tax.phtml"/>
-        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.excl" template="onepage/review/item/price/row_excl_tax.phtml"/>
-        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.incl" template="onepage/review/item/price/row_incl_tax.phtml"/>
+        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.item.price.unit" template="Magento_Checkout::item/price/unit.phtml"/>
+        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.item.price.row" template="Magento_Checkout::item/price/row.phtml"/>
+        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.excl" template="Magento_Checkout::onepage/review/item/price/unit_excl_tax.phtml"/>
+        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.incl" template="Magento_Checkout::onepage/review/item/price/unit_incl_tax.phtml"/>
+        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.excl" template="Magento_Checkout::onepage/review/item/price/row_excl_tax.phtml"/>
+        <block class="Magento\Checkout\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.incl" template="Magento_Checkout::onepage/review/item/price/row_incl_tax.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_failure.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_failure.xml
@@ -13,7 +13,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Checkout\Block\Onepage\Failure" name="checkout.failure" template="onepage/failure.phtml"/>
+            <block class="Magento\Checkout\Block\Onepage\Failure" name="checkout.failure" template="Magento_Checkout::onepage/failure.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_review_item_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_review_item_renderers.xml
@@ -9,7 +9,7 @@
     <update handle="checkout_item_price_renderers"/>
     <body>
         <referenceBlock name="checkout.onepage.review.item.renderers">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="onepage/review/item.phtml"/>
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer" as="default" template="Magento_Checkout::onepage/review/item.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_success.xml
@@ -11,14 +11,14 @@
     </head>
     <body>
         <referenceBlock name="page.main.title">
-            <block class="Magento\Checkout\Block\Onepage\Success" name="checkout.success.print.button" template="button.phtml"/>
+            <block class="Magento\Checkout\Block\Onepage\Success" name="checkout.success.print.button" template="Magento_Checkout::button.phtml"/>
             <action method="setPageTitle">
                 <argument translate="true" name="title" xsi:type="string">Thank you for your purchase!</argument>
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Checkout\Block\Onepage\Success" name="checkout.success" template="success.phtml" cacheable="false"/>
-            <block class="Magento\Checkout\Block\Registration" name="checkout.registration" template="registration.phtml" cacheable="false"/>
+            <block class="Magento\Checkout\Block\Onepage\Success" name="checkout.success" template="Magento_Checkout::success.phtml" cacheable="false"/>
+            <block class="Magento\Checkout\Block\Registration" name="checkout.registration" template="Magento_Checkout::registration.phtml" cacheable="false"/>
         </referenceContainer>
         <container name="order.success.additional.info" label="Order Success Additional Info"/>
     </body>

--- a/app/code/Magento/Checkout/view/frontend/layout/default.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/default.xml
@@ -14,7 +14,7 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="checkout_page_head_components" template="Magento_Checkout::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="header-wrapper">
-            <block class="Magento\Checkout\Block\Cart\Sidebar" name="minicart" as="minicart" after="logo" template="cart/minicart.phtml">
+            <block class="Magento\Checkout\Block\Cart\Sidebar" name="minicart" as="minicart" after="logo" template="Magento_Checkout::cart/minicart.phtml">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>

--- a/app/code/Magento/CheckoutAgreements/view/frontend/layout/multishipping_checkout_overview.xml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/layout/multishipping_checkout_overview.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout_overview">
-            <block class="Magento\CheckoutAgreements\Block\Agreements" name="checkout.multishipping.agreements" as="agreements" template="multishipping_agreements.phtml"/>
+            <block class="Magento\CheckoutAgreements\Block\Agreements" name="checkout.multishipping.agreements" as="agreements" template="Magento_CheckoutAgreements::multishipping_agreements.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Cms/view/adminhtml/layout/cms_wysiwyg_images_contents.xml
+++ b/app/code/Magento/Cms/view/adminhtml/layout/cms_wysiwyg_images_contents.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files" name="wysiwyg_images.files" template="browser/content/files.phtml"/>
+        <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files" name="wysiwyg_images.files" template="Magento_Cms::browser/content/files.phtml"/>
     </container>
 </layout>

--- a/app/code/Magento/Cms/view/adminhtml/layout/cms_wysiwyg_images_index.xml
+++ b/app/code/Magento/Cms/view/adminhtml/layout/cms_wysiwyg_images_index.xml
@@ -7,8 +7,8 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content" name="wysiwyg_images.content" template="browser/content.phtml">
-            <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree" name="wysiwyg_images.tree" template="browser/tree.phtml"/>
+        <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content" name="wysiwyg_images.content" template="Magento_Cms::browser/content.phtml">
+            <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree" name="wysiwyg_images.tree" template="Magento_Cms::browser/tree.phtml"/>
             <block class="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader" name="wysiwyg_images.uploader" template="Magento_Cms::browser/content/uploader.phtml"/>
         </block>
     </container>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_new.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_new.xml
@@ -11,7 +11,7 @@
     </head>
     <body>
         <referenceContainer name="js">
-            <block class="Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector" template="product/configurable/affected-attribute-set-selector/js.phtml"/>
+            <block class="Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector" template="Magento_ConfigurableProduct::product/configurable/affected-attribute-set-selector/js.phtml"/>
             <block class="Magento\Framework\View\Element\Template" template="Magento_ConfigurableProduct::product/configurable/stock/disabler.phtml"/>
         </referenceContainer>
         <referenceContainer name="content">

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_view_type_configurable.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/layout/catalog_product_view_type_configurable.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.composite.fieldset">
-            <block class="Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable" name="product.composite.fieldset.configurable" before="product.composite.fieldset.options" template="catalog/product/composite/fieldset/configurable.phtml"/>
+            <block class="Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable" name="product.composite.fieldset.configurable" before="product.composite.fieldset.options" template="Magento_ConfigurableProduct::catalog/product/composite/fieldset/configurable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/ConfigurableProduct/view/frontend/layout/catalog_product_view_type_configurable.xml
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/layout/catalog_product_view_type_configurable.xml
@@ -18,7 +18,7 @@
             </container>
         </referenceContainer>
         <referenceBlock name="product.info.options.wrapper">
-            <block class="Magento\ConfigurableProduct\Block\Product\View\Type\Configurable" name="product.info.options.configurable" as="options_configurable" before="-" template="product/view/type/options/configurable.phtml"/>
+            <block class="Magento\ConfigurableProduct\Block\Product\View\Type\Configurable" name="product.info.options.configurable" as="options_configurable" before="-" template="Magento_ConfigurableProduct::product/view/type/options/configurable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Cookie/view/frontend/layout/default.xml
+++ b/app/code/Magento/Cookie/view/frontend/layout/default.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="after.body.start">
-            <block class="Magento\Cookie\Block\Html\Notices" name="cookie_notices" template="html/notices.phtml" after="global_notices" />
+            <block class="Magento\Cookie\Block\Html\Notices" name="cookie_notices" template="Magento_Cookie::html/notices.phtml" after="global_notices" />
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/layout/adminhtml_system_currencysymbol_index.xml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/layout/adminhtml_system_currencysymbol_index.xml
@@ -9,7 +9,7 @@
     <update handle="styles" />
     <body>
         <referenceContainer name="content">
-            <block class="Magento\CurrencySymbol\Block\Adminhtml\System\Currencysymbol" name="mage.system.currencysymbol" template="grid.phtml"/>
+            <block class="Magento\CurrencySymbol\Block\Adminhtml\System\Currencysymbol" name="mage.system.currencysymbol" template="Magento_CurrencySymbol::grid.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Customer/view/adminhtml/layout/customer_index_edit.xml
+++ b/app/code/Magento/Customer/view/adminhtml/layout/customer_index_edit.xml
@@ -14,12 +14,12 @@
         <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
         <referenceContainer name="content">
             <referenceBlock name="customer_form">
-                <block class="Magento\Customer\Block\Adminhtml\Edit\Tab\View" name="customer_edit_tab_view" template="tab/view.phtml">
+                <block class="Magento\Customer\Block\Adminhtml\Edit\Tab\View" name="customer_edit_tab_view" template="Magento_Customer::tab/view.phtml">
                     <arguments>
                         <argument name="tab_label" xsi:type="string" translate="true">Customer View</argument>
                         <argument name="sort_order" xsi:type="number">10</argument>
                     </arguments>
-                    <block class="Magento\Customer\Block\Adminhtml\Edit\Tab\View\PersonalInfo" name="personal_info" template="tab/view/personal_info.phtml"/>
+                    <block class="Magento\Customer\Block\Adminhtml\Edit\Tab\View\PersonalInfo" name="personal_info" template="Magento_Customer::tab/view/personal_info.phtml"/>
                 </block>
             </referenceBlock>
             <uiComponent name="customer_form"/>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
@@ -11,7 +11,7 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="customer_account_create_head_components" template="Magento_Customer::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Form\Register" name="customer_form_register" template="form/register.phtml">
+            <block class="Magento\Customer\Block\Form\Register" name="customer_form_register" template="Magento_Customer::form/register.phtml">
                 <container name="form.additional.info" as="form_additional_info"/>
                 <container name="customer.form.register.fields.before" as="form_fields_before" label="Form Fields Before" htmlTag="div" htmlClass="customer-form-before"/>
             </block>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_createpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_createpassword.xml
@@ -16,7 +16,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Account\Resetpassword" name="resetPassword" template="form/resetforgottenpassword.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Account\Resetpassword" name="resetPassword" template="Magento_Customer::form/resetforgottenpassword.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_edit.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_edit.xml
@@ -17,7 +17,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Form\Edit" name="customer_edit" template="form/edit.phtml" cacheable="false">
+            <block class="Magento\Customer\Block\Form\Edit" name="customer_edit" template="Magento_Customer::form/edit.phtml" cacheable="false">
                 <container name="form.additional.info" as="form_additional_info"/>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
@@ -16,7 +16,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Account\Forgotpassword" name="forgotPassword" template="form/forgotpassword.phtml">
+            <block class="Magento\Customer\Block\Account\Forgotpassword" name="forgotPassword" template="Magento_Customer::form/forgotpassword.phtml">
                 <container name="form.additional.info" as="form_additional_info"/>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_index.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_index.xml
@@ -15,8 +15,8 @@
         </referenceBlock>
         <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\Template" name="customer_account_dashboard_top" as="top"/>
-            <block class="Magento\Customer\Block\Account\Dashboard\Info" name="customer_account_dashboard_info" as="info" template="account/dashboard/info.phtml" cacheable="false"/>
-            <block class="Magento\Customer\Block\Account\Dashboard\Address" name="customer_account_dashboard_address" as="address" template="account/dashboard/address.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Account\Dashboard\Info" name="customer_account_dashboard_info" as="info" template="Magento_Customer::account/dashboard/info.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Account\Dashboard\Address" name="customer_account_dashboard_address" as="address" template="Magento_Customer::account/dashboard/address.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
@@ -10,10 +10,10 @@
         <referenceContainer name="content">
             <!-- customer.form.login.extra -->
             <container name="customer.login.container" label="Customer Login Container" htmlTag="div" htmlClass="login-container">
-                <block class="Magento\Customer\Block\Form\Login" name="customer_form_login" template="form/login.phtml">
+                <block class="Magento\Customer\Block\Form\Login" name="customer_form_login" template="Magento_Customer::form/login.phtml">
                     <container name="form.additional.info" as="form_additional_info"/>
                 </block>
-                <block class="Magento\Customer\Block\Form\Login\Info" name="customer.new" template="newcustomer.phtml"/>
+                <block class="Magento\Customer\Block\Form\Login\Info" name="customer.new" template="Magento_Customer::newcustomer.phtml"/>
             </container>
             <block class="Magento\Cookie\Block\RequireCookie" name="require-cookie" template="Magento_Cookie::require_cookie.phtml">
                 <arguments>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_address_form.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_address_form.xml
@@ -17,7 +17,7 @@
             </arguments>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Address\Edit" name="customer_address_edit" template="address/edit.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Address\Edit" name="customer_address_edit" template="Magento_Customer::address/edit.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_address_index.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_address_index.xml
@@ -12,7 +12,7 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="customer_address_head_components" template="Magento_Customer::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Address\Book" name="address_book" template="address/book.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Address\Book" name="address_book" template="Magento_Customer::address/book.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Directory/view/frontend/layout/default.xml
+++ b/app/code/Magento/Directory/view/frontend/layout/default.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="header.panel">
-            <block class="Magento\Directory\Block\Currency" name="currency" before="store_language" template="currency.phtml"/>
+            <block class="Magento\Directory\Block\Currency" name="currency" before="store_language" template="Magento_Directory::currency.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_view_type_downloadable.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.composite.fieldset">
-            <block class="Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Downloadable" name="product.composite.fieldset.downloadable" before="product.composite.fieldset.options" template="product/composite/fieldset/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Downloadable" name="product.composite.fieldset.downloadable" before="product.composite.fieldset.options" template="Magento_Downloadable::product/composite/fieldset/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/creditmemo/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/creditmemo/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/creditmemo/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/creditmemo/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/creditmemo/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/creditmemo/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/invoice/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/invoice/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/invoice/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/invoice/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="invoice_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/invoice/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/invoice/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/sales_order_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="sales/items/column/downloadable/name.phtml" group="column"/>
+            <block class="Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name" name="column_name_downloadable" template="Magento_Downloadable::sales/items/column/downloadable/name.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
@@ -9,15 +9,15 @@
     <body>
         <attribute name="class" value="page-product-downloadable"/>
         <referenceContainer name="product.info.main">
-            <block class="Magento\Downloadable\Block\Catalog\Product\Samples" name="product.info.downloadable.samples" as="samples" template="catalog/product/samples.phtml" after="product.price.tier" />
+            <block class="Magento\Downloadable\Block\Catalog\Product\Samples" name="product.info.downloadable.samples" as="samples" template="Magento_Downloadable::catalog/product/samples.phtml" after="product.price.tier" />
         </referenceContainer>
         <referenceContainer name="product.info.type">
-            <block class="Magento\Downloadable\Block\Catalog\Product\View\Type" name="product.info.downloadable" as="product_type_data" template="catalog/product/type.phtml">
-                <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" name="product.info.downloadable.extra" as="product_type_data_extra" template="stockqty/default.phtml"/>
+            <block class="Magento\Downloadable\Block\Catalog\Product\View\Type" name="product.info.downloadable" as="product_type_data" template="Magento_Downloadable::catalog/product/type.phtml">
+                <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" name="product.info.downloadable.extra" as="product_type_data_extra" template="Magento_CatalogInventory::stockqty/default.phtml"/>
             </block>
         </referenceContainer>
         <referenceBlock name="product.info.options.wrapper">
-            <block class="Magento\Downloadable\Block\Catalog\Product\Links" name="product.info.downloadable.options" as="type_downloadable_options" before="-" template="catalog/product/links.phtml">
+            <block class="Magento\Downloadable\Block\Catalog\Product\Links" name="product.info.downloadable.options" as="type_downloadable_options" before="-" template="Magento_Downloadable::catalog/product/links.phtml">
                 <block class="Magento\Catalog\Pricing\Render" name="product.price.link" after="product.info.downloadable.options">
                     <arguments>
                         <argument name="price_render" xsi:type="string">product.price.render.default</argument>

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_success.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.success">
-            <block class="Magento\Downloadable\Block\Checkout\Success" name="downloadable.checkout.success" template="checkout/success.phtml"/>
+            <block class="Magento\Downloadable\Block\Checkout\Success" name="downloadable.checkout.success" template="Magento_Downloadable::checkout/success.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/downloadable_customer_products.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/downloadable_customer_products.xml
@@ -9,7 +9,7 @@
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Downloadable\Block\Customer\Products\ListProducts" name="downloadable_customer_products_list" template="customer/products/list.phtml" cacheable="false"/>
+            <block class="Magento\Downloadable\Block\Customer\Products\ListProducts" name="downloadable_customer_products_list" template="Magento_Downloadable::customer/products/list.phtml" cacheable="false"/>
         </referenceContainer>
         <referenceBlock name="root">
             <action method="setHeaderTitle">

--- a/app/code/Magento/Downloadable/view/frontend/layout/multishipping_checkout_success.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/multishipping_checkout_success.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout_success">
-            <block class="Magento\Downloadable\Block\Checkout\Success" name="downloadable.checkout.success" template="checkout/success.phtml"/>
+            <block class="Magento\Downloadable\Block\Checkout\Success" name="downloadable.checkout.success" template="Magento_Downloadable::checkout/success.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" as="downloadable" template="email/order/items/creditmemo/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/creditmemo/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" as="downloadable" template="email/order/items/invoice/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/invoice/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.email.order.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable" as="downloadable" template="email/order/items/order/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable" as="downloadable" template="Magento_Downloadable::email/order/items/order/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="sales/order/creditmemo/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/creditmemo/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="sales/order/invoice/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/invoice/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="sales/order/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="sales/order/creditmemo/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/creditmemo/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.invoice.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="sales/order/invoice/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/invoice/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="sales/order/items/renderer/downloadable.phtml"/>
+            <block class="Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable" as="downloadable" template="Magento_Downloadable::sales/order/items/renderer/downloadable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_create_index.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_create_index.xml
@@ -8,13 +8,13 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_item_extra_info">
-            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Giftoptions" name="gift_options_link" template="sales/order/create/giftoptions.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Items" name="gift_options_item_data" template="sales/order/create/items.phtml"/>
+            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Giftoptions" name="gift_options_link" template="Magento_GiftMessage::sales/order/create/giftoptions.phtml">
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Items" name="gift_options_item_data" template="Magento_GiftMessage::sales/order/create/items.phtml"/>
             </block>
         </referenceBlock>
         <referenceBlock name="items_grid">
             <block class="Magento\Backend\Block\Template" name="popup_window" template="Magento_GiftMessage::popup.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Form" name="gift_options_form" template="giftoptionsform.phtml"/>
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Form" name="gift_options_form" template="Magento_GiftMessage::giftoptionsform.phtml"/>
             </block>
         </referenceBlock>
     </body>

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_create_load_block_data.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_create_load_block_data.xml
@@ -8,13 +8,13 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_item_extra_info">
-            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Giftoptions" name="gift_options_link" template="sales/order/create/giftoptions.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Items" name="gift_options_item_data" template="sales/order/create/items.phtml"/>
+            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Giftoptions" name="gift_options_link" template="Magento_GiftMessage::sales/order/create/giftoptions.phtml">
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Items" name="gift_options_item_data" template="Magento_GiftMessage::sales/order/create/items.phtml"/>
             </block>
         </referenceBlock>
         <referenceBlock name="items_grid">
             <block class="Magento\Backend\Block\Template" name="popup_window" template="Magento_GiftMessage::popup.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Form" name="gift_options_form" template="giftoptionsform.phtml"/>
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Form" name="gift_options_form" template="Magento_GiftMessage::giftoptionsform.phtml"/>
             </block>
         </referenceBlock>
     </body>

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_create_load_block_items.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_create_load_block_items.xml
@@ -8,13 +8,13 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_item_extra_info">
-            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Giftoptions" name="gift_options_link" template="sales/order/create/giftoptions.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Items" name="gift_options_item_data" template="sales/order/create/items.phtml"/>
+            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Giftoptions" name="gift_options_link" template="Magento_GiftMessage::sales/order/create/giftoptions.phtml">
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Items" name="gift_options_item_data" template="Magento_GiftMessage::sales/order/create/items.phtml"/>
             </block>
         </referenceBlock>
         <referenceBlock name="items_grid">
             <block class="Magento\Backend\Block\Template" name="popup_window" template="Magento_GiftMessage::popup.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Form" name="gift_options_form" template="giftoptionsform.phtml"/>
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create\Form" name="gift_options_form" template="Magento_GiftMessage::giftoptionsform.phtml"/>
             </block>
         </referenceBlock>
     </body>

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/sales_order_view.xml
@@ -8,13 +8,13 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_item_extra_info">
-            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\View\Giftoptions" name="gift_options_link" template="sales/order/view/giftoptions.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\View\Items" name="gift_options_item_data" template="sales/order/view/items.phtml"/>
+            <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\View\Giftoptions" name="gift_options_link" template="Magento_GiftMessage::sales/order/view/giftoptions.phtml">
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\View\Items" name="gift_options_item_data" template="Magento_GiftMessage::sales/order/view/items.phtml"/>
             </block>
         </referenceBlock>
         <referenceBlock name="order_tab_info">
             <block class="Magento\Backend\Block\Template" name="popup_window" template="Magento_GiftMessage::popup.phtml">
-                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\View\Form" name="gift_options_form" template="giftoptionsform.phtml"/>
+                <block class="Magento\GiftMessage\Block\Adminhtml\Sales\Order\View\Form" name="gift_options_form" template="Magento_GiftMessage::giftoptionsform.phtml"/>
             </block>
         </referenceBlock>
     </body>

--- a/app/code/Magento/GiftMessage/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/GiftMessage/view/frontend/layout/checkout_cart_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.order.actions">
-            <block class="Magento\GiftMessage\Block\Cart\GiftOptions" name="checkout.cart.order.actions.gift_options" template="cart/gift_options.phtml" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\GiftOptions" name="checkout.cart.order.actions.gift_options" template="Magento_GiftMessage::cart/gift_options.phtml" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>

--- a/app/code/Magento/GiftMessage/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/GiftMessage/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers.default.actions">
-            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.default.actions.gift_options" template="cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.default.actions.gift_options" template="Magento_GiftMessage::cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>
@@ -26,7 +26,7 @@
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.simple.actions">
-            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.simple.actions.gift_options" template="cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.simple.actions.gift_options" template="Magento_GiftMessage::cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>
@@ -44,7 +44,7 @@
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.bundle.actions">
-            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.bundle.actions.gift_options" template="cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.bundle.actions.gift_options" template="Magento_GiftMessage::cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>
@@ -62,7 +62,7 @@
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.grouped.actions">
-            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.grouped.actions.gift_options" template="cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.grouped.actions.gift_options" template="Magento_GiftMessage::cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>
@@ -80,7 +80,7 @@
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.configurable.actions">
-            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.configurable.actions.gift_options" template="cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.configurable.actions.gift_options" template="Magento_GiftMessage::cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>
@@ -98,7 +98,7 @@
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.gift-card.actions">
-            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.gift-card.actions.gift_options" template="cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
+            <block class="Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions" name="checkout.cart.item.renderers.gift-card.actions.gift_options" template="Magento_GiftMessage::cart/item/renderer/actions/gift_options.phtml" before="-" cacheable="false">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="types" xsi:type="array"/>

--- a/app/code/Magento/GoogleAdwords/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/layout/checkout_onepage_success.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\GoogleAdwords\Block\Code" name="google.adwords.code" template="code.phtml"/>
+            <block class="Magento\GoogleAdwords\Block\Code" name="google.adwords.code" template="Magento_GoogleAdwords::code.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="after.body.start">
-            <block class="Magento\GoogleAnalytics\Block\Ga" name="google_analytics" as="google_analytics" template="ga.phtml"/>
+            <block class="Magento\GoogleAnalytics\Block\Ga" name="google_analytics" as="google_analytics" template="Magento_GoogleAnalytics::ga.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/GroupedProduct/view/adminhtml/layout/catalog_product_grouped.xml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/layout/catalog_product_grouped.xml
@@ -13,7 +13,7 @@
     <body>
         <referenceBlock name="product_tabs">
             <block class="Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts" name="catalog.product.edit.tab.grouped.container" template="Magento_GroupedProduct::product/grouped/grouped.phtml">
-                <block class="Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts\ListAssociatedProducts" name="catalog.product.edit.tab.super.list" as="list" template="product/grouped/list.phtml"/>
+                <block class="Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts\ListAssociatedProducts" name="catalog.product.edit.tab.super.list" as="list" template="Magento_GroupedProduct::product/grouped/list.phtml"/>
                 <block class="Magento\Framework\View\Element\Template" name="catalog.product.edit.tab.super.grid.popup.container" as="catalog.product.group.grid.popup.container"/>
             </block>
             <action method="addTab">

--- a/app/code/Magento/GroupedProduct/view/adminhtml/layout/catalog_product_view_type_grouped.xml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/layout/catalog_product_view_type_grouped.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.composite.fieldset">
-            <block class="Magento\GroupedProduct\Block\Adminhtml\Product\Composite\Fieldset\Grouped" name="product.composite.fieldset.grouped" before="product.composite.fieldset.options" template="catalog/product/composite/fieldset/grouped.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Adminhtml\Product\Composite\Fieldset\Grouped" name="product.composite.fieldset.grouped" before="product.composite.fieldset.options" template="Magento_GroupedProduct::catalog/product/composite/fieldset/grouped.phtml"/>
         </referenceBlock>
         <referenceBlock name="product.composite.fieldset.qty" remove="true"/>
     </body>

--- a/app/code/Magento/GroupedProduct/view/frontend/layout/catalog_product_view_type_grouped.xml
+++ b/app/code/Magento/GroupedProduct/view/frontend/layout/catalog_product_view_type_grouped.xml
@@ -9,14 +9,14 @@
     <body>
         <attribute name="class" value="page-product-grouped"/>
         <referenceContainer name="product.info.form.content">
-            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" name="product.info.grouped" before="product.info.addtocart" template="product/view/type/grouped.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" name="product.info.grouped" before="product.info.addtocart" template="Magento_GroupedProduct::product/view/type/grouped.phtml"/>
             <container name="product.info.grouped.extra" after="product.info.grouped" before="product.info.grouped" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
         <referenceContainer name="product.info.grouped.extra">
             <block class="Magento\GroupedProduct\Block\Stockqty\Type\Grouped" template="Magento_CatalogInventory::stockqty/composite.phtml"/>
         </referenceContainer>
         <referenceContainer name="product.info.type">
-            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" as="product.info.grouped" template="product/view/type/default.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" as="product.info.grouped" template="Magento_GroupedProduct::product/view/type/default.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_start.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_start.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\ImportExport\Block\Adminhtml\Import\Frame\Result" template="import/frame/result.phtml" name="import.frame.result" as="import_frame_result"/>
+        <block class="Magento\ImportExport\Block\Adminhtml\Import\Frame\Result" template="Magento_ImportExport::import/frame/result.phtml" name="import.frame.result" as="import_frame_result"/>
     </container>
 </layout>

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_validate.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_validate.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\ImportExport\Block\Adminhtml\Import\Frame\Result" template="import/frame/result.phtml" name="import.frame.result" as="import_frame_result"/>
+        <block class="Magento\ImportExport\Block\Adminhtml\Import\Frame\Result" template="Magento_ImportExport::import/frame/result.phtml" name="import.frame.result" as="import_frame_result"/>
     </container>
 </layout>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/catalog_category_view_type_layered.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/catalog_category_view_type_layered.xml
@@ -9,9 +9,9 @@
     <body>
         <attribute name="class" value="page-with-filter"/>
         <referenceContainer name="sidebar.main">
-            <block class="Magento\LayeredNavigation\Block\Navigation\Category" name="catalog.leftnav" before="-" template="layer/view.phtml">
+            <block class="Magento\LayeredNavigation\Block\Navigation\Category" name="catalog.leftnav" before="-" template="Magento_LayeredNavigation::layer/view.phtml">
                 <block class="Magento\LayeredNavigation\Block\Navigation\State" name="catalog.navigation.state" as="state" />
-                <block class="Magento\LayeredNavigation\Block\Navigation\FilterRenderer" name="catalog.navigation.renderer" as="renderer" template="layer/filter.phtml"/>
+                <block class="Magento\LayeredNavigation\Block\Navigation\FilterRenderer" name="catalog.navigation.renderer" as="renderer" template="Magento_LayeredNavigation::layer/filter.phtml"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/catalogsearch_result_index.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="sidebar.main">
-            <block class="Magento\LayeredNavigation\Block\Navigation\Search" name="catalogsearch.leftnav" before="-" template="layer/view.phtml">
+            <block class="Magento\LayeredNavigation\Block\Navigation\Search" name="catalogsearch.leftnav" before="-" template="Magento_LayeredNavigation::layer/view.phtml">
                 <block class="Magento\LayeredNavigation\Block\Navigation\State" name="catalogsearch.navigation.state" as="state" />
-                <block class="Magento\LayeredNavigation\Block\Navigation\FilterRenderer" name="catalogsearch.navigation.renderer" as="renderer" template="layer/filter.phtml"/>
+                <block class="Magento\LayeredNavigation\Block\Navigation\FilterRenderer" name="catalogsearch.navigation.renderer" as="renderer" template="Magento_LayeredNavigation::layer/filter.phtml"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Msrp/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Msrp/view/frontend/layout/checkout_cart_index.xml
@@ -9,7 +9,7 @@
     <update handle="msrp_popup"/>
     <body>
         <referenceContainer name="checkout.cart.totals.container">
-            <block name="checkout.cart.totals.msrp" before="checkout.cart.totals" class="Magento\Msrp\Block\Total" template="cart/totals.phtml">
+            <block name="checkout.cart.totals.msrp" before="checkout.cart.totals" class="Magento\Msrp\Block\Total" template="Magento_Msrp::cart/totals.phtml">
                 <arguments>
                     <argument name="original_block_name" xsi:type="string">checkout.cart.totals</argument>
                 </arguments>

--- a/app/code/Magento/Multishipping/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/checkout_cart_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="checkout.cart.methods">
-            <block class="Magento\Multishipping\Block\Checkout\Link" name="checkout.cart.methods.multishipping" template="checkout/link.phtml"/>
+            <block class="Magento\Multishipping\Block\Checkout\Link" name="checkout.cart.methods.multishipping" template="Magento_Multishipping::checkout/link.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout.xml
@@ -26,7 +26,7 @@
             </arguments>
         </referenceBlock>
         <referenceContainer name="sidebar.main">
-            <block class="Magento\Multishipping\Block\Checkout\State" name="checkout_state" template="checkout/state.phtml" cacheable="false"/>
+            <block class="Magento\Multishipping\Block\Checkout\State" name="checkout_state" template="Magento_Multishipping::checkout/state.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_address_select.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_address_select.xml
@@ -9,7 +9,7 @@
     <update handle="multishipping_checkout"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Address\Select" name="checkout_address_select" template="checkout/address/select.phtml" cacheable="false"/>
+            <block class="Magento\Multishipping\Block\Checkout\Address\Select" name="checkout_address_select" template="Magento_Multishipping::checkout/address/select.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_address_selectbilling.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_address_selectbilling.xml
@@ -14,7 +14,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Address\Select" name="checkout_address_select" template="checkout/address/select.phtml" cacheable="false"/>
+            <block class="Magento\Multishipping\Block\Checkout\Address\Select" name="checkout_address_select" template="Magento_Multishipping::checkout/address/select.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_addresses.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_addresses.xml
@@ -15,7 +15,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Addresses" name="checkout_addresses" template="checkout/addresses.phtml" cacheable="false">
+            <block class="Magento\Multishipping\Block\Checkout\Addresses" name="checkout_addresses" template="Magento_Multishipping::checkout/addresses.phtml" cacheable="false">
                 <arguments>
                     <argument name="renderer_template" xsi:type="string">Magento_Multishipping::checkout/item/default.phtml</argument>
                 </arguments>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_billing.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_billing.xml
@@ -14,7 +14,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Billing" name="checkout_billing" template="checkout/billing.phtml" cacheable="false">
+            <block class="Magento\Multishipping\Block\Checkout\Billing" name="checkout_billing" template="Magento_Multishipping::checkout/billing.phtml" cacheable="false">
                 <container name="payment_methods_before" label="Payment Methods Before"/>
                 <container name="payment_methods_after" label="Payment Methods After"/>
             </block>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_customer_address.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_customer_address.xml
@@ -9,7 +9,7 @@
     <update handle="customer_form_template_handle"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Customer\Block\Address\Edit" name="customer_address_edit" template="address/edit.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Address\Edit" name="customer_address_edit" template="Magento_Customer::address/edit.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_overview.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_overview.xml
@@ -15,7 +15,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Overview" name="checkout_overview" template="checkout/overview.phtml" cacheable="false">
+            <block class="Magento\Multishipping\Block\Checkout\Overview" name="checkout_overview" template="Magento_Multishipping::checkout/overview.phtml" cacheable="false">
                 <arguments>
                     <argument name="renderer_template" xsi:type="string">Magento_Multishipping::checkout/item/default.phtml</argument>
                     <argument name="row_renderer_template" xsi:type="string">Magento_Multishipping::checkout/overview/item.phtml</argument>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_shipping.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_shipping.xml
@@ -15,7 +15,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Shipping" name="checkout_shipping" template="checkout/shipping.phtml" cacheable="false">
+            <block class="Magento\Multishipping\Block\Checkout\Shipping" name="checkout_shipping" template="Magento_Multishipping::checkout/shipping.phtml" cacheable="false">
                 <arguments>
                     <argument name="renderer_template" xsi:type="string">Magento_Multishipping::checkout/item/default.phtml</argument>
                 </arguments>

--- a/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_success.xml
+++ b/app/code/Magento/Multishipping/view/frontend/layout/multishipping_checkout_success.xml
@@ -16,7 +16,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Multishipping\Block\Checkout\Success" name="checkout_success" template="checkout/success.phtml" cacheable="false"/>
+            <block class="Magento\Multishipping\Block\Checkout\Success" name="checkout_success" template="Magento_Multishipping::checkout/success.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_queue_edit.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_queue_edit.xml
@@ -12,7 +12,7 @@
     <update handle="editor"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Newsletter\Block\Adminhtml\Queue\Edit" name="queue_edit" template="queue/edit.phtml"/>
+            <block class="Magento\Newsletter\Block\Adminhtml\Queue\Edit" name="queue_edit" template="Magento_Newsletter::queue/edit.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_template_edit.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_template_edit.xml
@@ -12,7 +12,7 @@
     <update handle="editor"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Newsletter\Block\Adminhtml\Template\Edit" name="template_edit" template="template/edit.phtml"/>
+            <block class="Magento\Newsletter\Block\Adminhtml\Template\Edit" name="template_edit" template="Magento_Newsletter::template/edit.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Newsletter/view/frontend/layout/default.xml
+++ b/app/code/Magento/Newsletter/view/frontend/layout/default.xml
@@ -11,7 +11,7 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="newsletter_head_components" template="Magento_Newsletter::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="footer">
-            <block class="Magento\Newsletter\Block\Subscribe" name="form.subscribe" as="subscribe" before="-" template="subscribe.phtml"/>
+            <block class="Magento\Newsletter\Block\Subscribe" name="form.subscribe" as="subscribe" before="-" template="Magento_Newsletter::subscribe.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Paypal/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalog_category_view.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="sidebar.additional">
-            <block class="Magento\Paypal\Block\Logo" name="paypal.partner.right.logo" template="partner/logo.phtml"/>
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Logo" name="paypal.partner.right.logo" template="Magento_Paypal::partner/logo.phtml"/>
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">categorypage</argument>
                     <argument name="position" xsi:type="number">1</argument>
@@ -17,7 +17,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="top.container">
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">categorypage</argument>
                     <argument name="position" xsi:type="number">0</argument>

--- a/app/code/Magento/Paypal/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalog_product_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="top.container">
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">productpage</argument>
                     <argument name="position" xsi:type="number">0</argument>
@@ -16,7 +16,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="product.info.addtocart">
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" after="product.info.addtocart.paypal" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" after="product.info.addtocart.paypal" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">productpage</argument>
                     <argument name="position" xsi:type="number">1</argument>

--- a/app/code/Magento/Paypal/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/checkout_cart_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="top.container">
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">checkout</argument>
                     <argument name="position" xsi:type="number">0</argument>
@@ -16,7 +16,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="checkout.cart.methods">
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" after="checkout.cart.methods.onepage.bottom" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" after="checkout.cart.methods.onepage.bottom" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">checkout</argument>
                     <argument name="position" xsi:type="number">1</argument>

--- a/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_success.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="order.success.additional.info">
-            <block class="Magento\Paypal\Block\Checkout\Onepage\Success\BillingAgreement" name="onepage.success.billing_agreement" template="checkout/onepage/success/billing_agreement.phtml"/>
+            <block class="Magento\Paypal\Block\Checkout\Onepage\Success\BillingAgreement" name="onepage.success.billing_agreement" template="Magento_Paypal::checkout/onepage/success/billing_agreement.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Paypal/view/frontend/layout/cms_index_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/cms_index_index.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="sidebar.additional">
-            <block class="Magento\Paypal\Block\Logo" name="paypal.partner.right.logo" template="partner/logo.phtml"/>
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Logo" name="paypal.partner.right.logo" template="Magento_Paypal::partner/logo.phtml"/>
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.right.logo" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">homepage</argument>
                     <argument name="position" xsi:type="number">1</argument>
@@ -17,7 +17,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="top.container">
-            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="bml.phtml">
+            <block class="Magento\Paypal\Block\Bml\Banners" name="bml.center.logo" template="Magento_Paypal::bml.phtml">
                 <arguments>
                     <argument name="section" xsi:type="string">homepage</argument>
                     <argument name="position" xsi:type="number">0</argument>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_billing_agreement_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_billing_agreement_index.xml
@@ -9,7 +9,7 @@
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Paypal\Block\Billing\Agreements" name="customer.account.billing.agreement" template="billing/agreements.phtml" cacheable="false"/>
+            <block class="Magento\Paypal\Block\Billing\Agreements" name="customer.account.billing.agreement" template="Magento_Paypal::billing/agreements.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_billing_agreement_view.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_billing_agreement_view.xml
@@ -9,7 +9,7 @@
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Paypal\Block\Billing\Agreement\View" name="customer.account.billing.agreement" template="billing/agreement/view.phtml" cacheable="false"/>
+            <block class="Magento\Paypal\Block\Billing\Agreement\View" name="customer.account.billing.agreement" template="Magento_Paypal::billing/agreement/view.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review.xml
@@ -19,12 +19,12 @@
             <block class="Magento\Paypal\Block\Cart\ValidationMessages" name="paypal.validation.messages"/>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Paypal\Block\Express\Review" name="paypal.express.review" template="express/review.phtml">
-                <block class="Magento\Paypal\Block\Express\Review" name="express.review.shipping.method" as="shipping_method" template="express/review/shipping/method.phtml"/>
+            <block class="Magento\Paypal\Block\Express\Review" name="paypal.express.review" template="Magento_Paypal::express/review.phtml">
+                <block class="Magento\Paypal\Block\Express\Review" name="express.review.shipping.method" as="shipping_method" template="Magento_Paypal::express/review/shipping/method.phtml"/>
                 <block class="Magento\Framework\View\Element\Text\ListText" name="paypal.additional.actions">
                     <block class="Magento\Checkout\Block\Cart\Coupon" name="paypal.cart.coupon" as="coupon" template="Magento_Checkout::cart/coupon.phtml"/>
                 </block>
-                <block class="Magento\Paypal\Block\Express\Review\Details" name="paypal.express.review.details" as="details" template="express/review/details.phtml">
+                <block class="Magento\Paypal\Block\Express\Review\Details" name="paypal.express.review.details" as="details" template="Magento_Paypal::express/review/details.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="checkout.onepage.review.item.renderers" as="renderer.list"/>
                     <block class="Magento\Checkout\Block\Cart\Totals" name="paypal.express.review.details.totals" as="totals" template="Magento_Paypal::checkout/onepage/review/totals.phtml"/>
                 </block>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review_details.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review_details.xml
@@ -8,7 +8,7 @@
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <update handle="checkout_onepage_review_item_renderers"/>
     <container name="root">
-        <block class="Magento\Paypal\Block\Express\Review\Details" name="page.block" template="express/review/details.phtml">
+        <block class="Magento\Paypal\Block\Express\Review\Details" name="page.block" template="Magento_Paypal::express/review/details.phtml">
             <block class="Magento\Framework\View\Element\RendererList" name="checkout.onepage.review.item.renderers" as="renderer.list"/>
             <block class="Magento\Checkout\Block\Cart\Totals" name="paypal.express.review.details.totals" as="totals" template="Magento_Paypal::checkout/onepage/review/totals.phtml"/>
         </block>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_cancelpayment.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_cancelpayment.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Paypal\Block\Payflow\Link\Iframe" name="payflow.link.iframe" template="payflowlink/redirect.phtml" cacheable="false"/>
+        <block class="Magento\Paypal\Block\Payflow\Link\Iframe" name="payflow.link.iframe" template="Magento_Paypal::payflowlink/redirect.phtml" cacheable="false"/>
     </container>
 </layout>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_form.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_form.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Paypal\Block\Payflow\Link\Iframe" name="payflow.link.iframe" template="payflowlink/form.phtml" cacheable="false"/>
+        <block class="Magento\Paypal\Block\Payflow\Link\Iframe" name="payflow.link.iframe" template="Magento_Paypal::payflowlink/form.phtml" cacheable="false"/>
     </container>
 </layout>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_returnurl.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_returnurl.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Paypal\Block\Payflow\Link\Iframe" name="payflow.link.iframe" template="payflowlink/redirect.phtml" cacheable="false"/>
+        <block class="Magento\Paypal\Block\Payflow\Link\Iframe" name="payflow.link.iframe" template="Magento_Paypal::payflowlink/redirect.phtml" cacheable="false"/>
     </container>
 </layout>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_cancelpayment.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_cancelpayment.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Paypal\Block\Payflow\Advanced\Iframe" name="payflow.advanced.iframe" template="payflowlink/redirect.phtml" cacheable="false"/>
+        <block class="Magento\Paypal\Block\Payflow\Advanced\Iframe" name="payflow.advanced.iframe" template="Magento_Paypal::payflowlink/redirect.phtml" cacheable="false"/>
     </container>
 </layout>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_form.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_form.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Paypal\Block\Payflow\Advanced\Iframe" name="payflow.advanced.iframe" template="payflowadvanced/form.phtml" cacheable="false"/>
+        <block class="Magento\Paypal\Block\Payflow\Advanced\Iframe" name="payflow.advanced.iframe" template="Magento_Paypal::payflowadvanced/form.phtml" cacheable="false"/>
     </container>
 </layout>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_returnurl.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_returnurl.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Paypal\Block\Payflow\Advanced\Iframe" name="payflow.advanced.iframe" template="payflowlink/redirect.phtml" cacheable="false"/>
+        <block class="Magento\Paypal\Block\Payflow\Advanced\Iframe" name="payflow.advanced.iframe" template="Magento_Paypal::payflowlink/redirect.phtml" cacheable="false"/>
     </container>
 </layout>

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowexpress_review.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowexpress_review.xml
@@ -19,15 +19,15 @@
             <block class="Magento\Paypal\Block\Cart\ValidationMessages" name="paypal.validation.messages"/>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Paypal\Block\Express\Review" name="paypal.express.review" template="express/review.phtml">
+            <block class="Magento\Paypal\Block\Express\Review" name="paypal.express.review" template="Magento_Paypal::express/review.phtml">
                 <action method="setControllerPath">
                     <argument name="prefix" xsi:type="string">paypal/payflowexpress</argument>
                 </action>
-                <block class="Magento\Paypal\Block\Express\Review" name="express.review.shipping.method" as="shipping_method" template="express/review/shipping/method.phtml"/>
+                <block class="Magento\Paypal\Block\Express\Review" name="express.review.shipping.method" as="shipping_method" template="Magento_Paypal::express/review/shipping/method.phtml"/>
                 <block class="Magento\Framework\View\Element\Text\ListText" name="paypal.additional.actions">
                     <block class="Magento\Checkout\Block\Cart\Coupon" name="paypal.cart.coupon" as="coupon" template="Magento_Checkout::cart/coupon.phtml"/>
                 </block>
-                <block class="Magento\Paypal\Block\Express\Review\Details" name="paypal.express.review.details" as="details" template="express/review/details.phtml">
+                <block class="Magento\Paypal\Block\Express\Review\Details" name="paypal.express.review.details" as="details" template="Magento_Paypal::express/review/details.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="checkout.onepage.review.item.renderers" as="renderer.list"/>
                     <block class="Magento\Checkout\Block\Cart\Totals" name="paypal.express.review.details.totals" as="totals" template="Magento_Paypal::checkout/onepage/review/totals.phtml"/>
                 </block>

--- a/app/code/Magento/Persistent/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Persistent/view/frontend/layout/customer_account_create.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="form.additional.info">
-            <block class="Magento\Persistent\Block\Form\Remember" name="persistent.remember.me" template="remember_me.phtml" before="-"/>
+            <block class="Magento\Persistent\Block\Form\Remember" name="persistent.remember.me" template="Magento_Persistent::remember_me.phtml" before="-"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Persistent/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Persistent/view/frontend/layout/customer_account_login.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="form.additional.info">
-            <block class="Magento\Persistent\Block\Form\Remember" name="persistent.remember.me" template="remember_me.phtml" before="-"/>
+            <block class="Magento\Persistent\Block\Form\Remember" name="persistent.remember.me" template="Magento_Persistent::remember_me.phtml" before="-"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/ProductAlert/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/ProductAlert/view/frontend/layout/catalog_product_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="alert.urls">
-            <block class="Magento\ProductAlert\Block\Product\View\Price" name="productalert.price" as="productalert_price" template="product/view.phtml">
+            <block class="Magento\ProductAlert\Block\Product\View\Price" name="productalert.price" as="productalert_price" template="Magento_ProductAlert::product/view.phtml">
                 <action method="setHtmlClass">
                     <argument name="value" xsi:type="string">price</argument>
                 </action>
@@ -16,7 +16,7 @@
                     <argument translate="true" name="value" xsi:type="string">Notify me when the price drops</argument>
                 </action>
             </block>
-            <block class="Magento\ProductAlert\Block\Product\View\Stock" name="productalert.stock" as="productalert_stock" template="product/view.phtml">
+            <block class="Magento\ProductAlert\Block\Product\View\Stock" name="productalert.stock" as="productalert_stock" template="Magento_ProductAlert::product/view.phtml">
                 <action method="setHtmlClass">
                     <argument name="value" xsi:type="string">stock</argument>
                 </action>

--- a/app/code/Magento/ProductVideo/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/ProductVideo/view/frontend/layout/catalog_product_view.xml
@@ -8,7 +8,7 @@
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.media">
-            <block class="Magento\ProductVideo\Block\Product\View\Gallery" name="product.info.media.video" after="product.info.media.image" template="product/view/gallery.phtml"/>
+            <block class="Magento\ProductVideo\Block\Product\View\Gallery" name="product.info.media.video" after="product.info.media.image" template="Magento_ProductVideo::product/view/gallery.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_viewed.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_viewed.xml
@@ -29,7 +29,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Product\Viewed" template="report/grid/container.phtml" name="product.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Product\Viewed" template="Magento_Reports::report/grid/container.phtml" name="product.report.grid.container">
                 <block class="Magento\Reports\Block\Adminhtml\Filter\Form" name="grid.filter.form">
                     <action method="setFieldVisibility">
                         <argument name="field" xsi:type="string">report_type</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_bestsellers.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_bestsellers.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Bestsellers" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Bestsellers" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form" name="grid.filter.form">
                     <action method="setFieldVisibility">
                         <argument name="field" xsi:type="string">report_type</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_coupons.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_coupons.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Coupons" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Coupons" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form\Coupon" name="grid.filter.form">
                     <action method="addReportTypeOption">
                         <argument name="key" xsi:type="string">created_at_order</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_invoiced.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_invoiced.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Invoiced" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Invoiced" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form" name="grid.filter.form">
                     <action method="addReportTypeOption">
                         <argument name="key" xsi:type="string">created_at_order</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_refunded.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_refunded.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Refunded" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Refunded" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form" name="grid.filter.form">
                     <action method="addReportTypeOption">
                         <argument name="key" xsi:type="string">created_at_order</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_sales.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_sales.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Sales" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Sales" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form\Order" name="grid.filter.form">
                     <action method="addReportTypeOption">
                         <argument name="key" xsi:type="string">created_at_order</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_shipping.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_shipping.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Shipping" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Shipping" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form" name="grid.filter.form">
                     <action method="addReportTypeOption">
                         <argument name="key" xsi:type="string">created_at_order</argument>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_tax.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_tax.xml
@@ -22,7 +22,7 @@
             </block>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Reports\Block\Adminhtml\Sales\Tax" template="report/grid/container.phtml" name="sales.report.grid.container">
+            <block class="Magento\Reports\Block\Adminhtml\Sales\Tax" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
                 <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form" name="grid.filter.form">
                     <action method="addReportTypeOption">
                         <argument name="key" xsi:type="string">created_at_order</argument>

--- a/app/code/Magento/Review/view/frontend/layout/customer_account_index.xml
+++ b/app/code/Magento/Review/view/frontend/layout/customer_account_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Review\Block\Customer\Recent" name="customer_account_dashboard_info1" template="customer/recent.phtml" after="customer_account_dashboard_address" cacheable="false"/>
+            <block class="Magento\Review\Block\Customer\Recent" name="customer_account_dashboard_info1" template="Magento_Review::customer/recent.phtml" after="customer_account_dashboard_address" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Review/view/frontend/layout/review_customer_index.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_customer_index.xml
@@ -9,7 +9,7 @@
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Review\Block\Customer\ListCustomer" name="review_customer_list" template="customer/list.phtml" cacheable="false"/>
+            <block class="Magento\Review\Block\Customer\ListCustomer" name="review_customer_list" template="Magento_Review::customer/list.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Review/view/frontend/layout/review_product_list.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_product_list.xml
@@ -16,7 +16,7 @@
                 <block class="Magento\Review\Block\Form" name="product.review.form" as="review_form">
                     <container name="product.review.form.fields.before" as="form_fields_before" label="Review Form Fields Before" htmlTag="div" htmlClass="rewards"/>
                 </block>
-                <block class="Magento\Review\Block\Product\View\ListView" name="product.info.product_additional_data" as="product_additional_data" template="product/view/list.phtml"/>
+                <block class="Magento\Review\Block\Product\View\ListView" name="product.info.product_additional_data" as="product_additional_data" template="Magento_Review::product/view/list.phtml"/>
                 <block class="Magento\Theme\Block\Html\Pager" name="product_review_list.toolbar"/>
             </container>
         </referenceContainer>

--- a/app/code/Magento/Review/view/frontend/layout/review_product_listajax.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_product_listajax.xml
@@ -7,7 +7,7 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Review\Block\Product\View\ListView" name="product.info.product_additional_data" as="product_additional_data" template="product/view/list.phtml" />
+        <block class="Magento\Review\Block\Product\View\ListView" name="product.info.product_additional_data" as="product_additional_data" template="Magento_Review::product/view/list.phtml" />
         <block class="Magento\Theme\Block\Html\Pager" name="product_review_list.toolbar">
             <arguments>
                 <argument name="show_per_page" xsi:type="boolean">false</argument>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_creditmemo_item_price.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_creditmemo_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_items">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_price" template="Magento_Sales::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_subtotal" template="Magento_Sales::items/price/row.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_total" template="Magento_Sales::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_invoice_item_price.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_invoice_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="invoice_items">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_price" template="Magento_Sales::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_subtotal" template="Magento_Sales::items/price/row.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_total" template="Magento_Sales::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_addcomment.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_addcomment.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Sales\Block\Adminhtml\Order\View\History" name="order_history" template="order/view/history.phtml"/>
+        <block class="Magento\Sales\Block\Adminhtml\Order\View\History" name="order_history" template="Magento_Sales::order/view/history.phtml"/>
     </container>
 </layout>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_index.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_index.xml
@@ -28,48 +28,48 @@
         </referenceContainer>
         <referenceBlock name="content">
             <block class="Magento\Sales\Block\Adminhtml\Order\Create" name="order_content">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form" template="order/create/form.phtml" name="order_create_form" as="form">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form" template="Magento_Sales::order/create/form.phtml" name="order_create_form" as="form">
                     <block class="Magento\Sales\Block\Adminhtml\Order\Create\Messages" name="message"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Customer" template="order/create/abstract.phtml" name="customer.grid.container"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Store" template="order/create/abstract.phtml" name="store">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Store\Select" template="order/create/store/select.phtml" name="select"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Customer" template="Magento_Sales::order/create/abstract.phtml" name="customer.grid.container"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Store" template="Magento_Sales::order/create/abstract.phtml" name="store">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Store\Select" template="Magento_Sales::order/create/store/select.phtml" name="select"/>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Data" template="order/create/data.phtml" name="data">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar" template="order/create/sidebar.phtml" name="sidebar">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="order/create/sidebar/items.phtml" name="cart"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="order/create/sidebar/items.phtml" name="wishlist"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="order/create/sidebar/items.phtml" name="reorder"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="order/create/sidebar/items.phtml" name="viewed"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="order/create/sidebar/items.phtml" name="compared"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="order/create/sidebar/items.phtml" name="pcompared"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="order/create/sidebar/items.phtml" name="pviewed"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Data" template="Magento_Sales::order/create/data.phtml" name="data">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar" template="Magento_Sales::order/create/sidebar.phtml" name="sidebar">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="Magento_Sales::order/create/sidebar/items.phtml" name="cart"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="Magento_Sales::order/create/sidebar/items.phtml" name="wishlist"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="Magento_Sales::order/create/sidebar/items.phtml" name="reorder"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="viewed"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="Magento_Sales::order/create/sidebar/items.phtml" name="compared"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="Magento_Sales::order/create/sidebar/items.phtml" name="pcompared"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="pviewed"/>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form\Account" template="order/create/form/account.phtml" name="form_account"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Address" template="order/create/form/address.phtml" name="shipping_address"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Address" template="order/create/form/address.phtml" name="billing_address"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="order/create/abstract.phtml" name="shipping_method">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="order/create/shipping/method/form.phtml" name="order_create_shipping_form" as="form"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form\Account" template="Magento_Sales::order/create/form/account.phtml" name="form_account"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Address" template="Magento_Sales::order/create/form/address.phtml" name="shipping_address"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Address" template="Magento_Sales::order/create/form/address.phtml" name="billing_address"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="Magento_Sales::order/create/abstract.phtml" name="shipping_method">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="Magento_Sales::order/create/shipping/method/form.phtml" name="order_create_shipping_form" as="form"/>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method" template="order/create/abstract.phtml" name="billing_method">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method\Form" template="order/create/billing/method/form.phtml" name="order_create_billing_form" as="form"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method" template="Magento_Sales::order/create/abstract.phtml" name="billing_method">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method\Form" template="Magento_Sales::order/create/billing/method/form.phtml" name="order_create_billing_form" as="form"/>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter" template="order/create/abstract.phtml" name="newsletter">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter\Form" template="order/create/newsletter/form.phtml" name="order_create_newsletter_form" as="form"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter" template="Magento_Sales::order/create/abstract.phtml" name="newsletter">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter\Form" template="Magento_Sales::order/create/newsletter/form.phtml" name="order_create_newsletter_form" as="form"/>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search" template="order/create/abstract.phtml" name="search">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search" template="Magento_Sales::order/create/abstract.phtml" name="search">
                             <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid" name="search_grid" as="grid"/>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items" template="order/create/items.phtml" name="items">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" template="order/create/items/grid.phtml" name="items_grid">
-                                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons" template="order/create/coupons/form.phtml" name="coupons">
-                                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons\Form" template="order/create/coupons/form.phtml" name="order_create_coupons_form" as="form"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items" template="Magento_Sales::order/create/items.phtml" name="items">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" template="Magento_Sales::order/create/items/grid.phtml" name="items_grid">
+                                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons" template="Magento_Sales::order/create/coupons/form.phtml" name="coupons">
+                                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons\Form" template="Magento_Sales::order/create/coupons/form.phtml" name="order_create_coupons_form" as="form"/>
                                 </block>
                             </block>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Comment" template="order/create/comment.phtml" name="comment"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Totals" template="order/create/totals.phtml" name="totals"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Comment" template="Magento_Sales::order/create/comment.phtml" name="comment"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Totals" template="Magento_Sales::order/create/totals.phtml" name="totals"/>
                         <block class="Magento\Backend\Block\Template" name="gift_options" template="Magento_Sales::order/giftoptions.phtml">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage" template="order/create/giftmessage.phtml" name="giftmessage"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage" template="Magento_Sales::order/create/giftmessage.phtml" name="giftmessage"/>
                         </block>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
                     </block>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_item_price.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_item_price.xml
@@ -7,8 +7,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" name="item_unit_price" template="order/create/items/price/unit.phtml"/>
-        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" name="item_row_total" template="order/create/items/price/row.phtml"/>
-        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" name="item_row_total_with_discount" template="order/create/items/price/total.phtml"/>
+        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" name="item_unit_price" template="Magento_Sales::order/create/items/price/unit.phtml"/>
+        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" name="item_row_total" template="Magento_Sales::order/create/items/price/row.phtml"/>
+        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" name="item_row_total_with_discount" template="Magento_Sales::order/create/items/price/total.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_billing_address.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_billing_address.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Address" template="order/create/form/address.phtml" name="billing_address"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Address" template="Magento_Sales::order/create/form/address.phtml" name="billing_address"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_billing_method.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_billing_method.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method" template="order/create/abstract.phtml" name="billing_method">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method\Form" template="order/create/billing/method/form.phtml" name="order.create.billing.method.form" as="form"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method" template="Magento_Sales::order/create/abstract.phtml" name="billing_method">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method\Form" template="Magento_Sales::order/create/billing/method/form.phtml" name="order.create.billing.method.form" as="form"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_comment.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_comment.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Comment" template="order/create/comment.phtml" name="comment"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Comment" template="Magento_Sales::order/create/comment.phtml" name="comment"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_data.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_data.xml
@@ -9,42 +9,42 @@
     <update handle="sales_order_create_item_price"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Data" template="order/create/data.phtml" name="data">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar" template="order/create/sidebar.phtml" name="sidebar">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="order/create/sidebar/items.phtml" name="cart"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="order/create/sidebar/items.phtml" name="wishlist"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="order/create/sidebar/items.phtml" name="reorder"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="order/create/sidebar/items.phtml" name="viewed"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="order/create/sidebar/items.phtml" name="compared"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="order/create/sidebar/items.phtml" name="pcompared"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="order/create/sidebar/items.phtml" name="pviewed"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Data" template="Magento_Sales::order/create/data.phtml" name="data">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar" template="Magento_Sales::order/create/sidebar.phtml" name="sidebar">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="Magento_Sales::order/create/sidebar/items.phtml" name="cart"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="Magento_Sales::order/create/sidebar/items.phtml" name="wishlist"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="Magento_Sales::order/create/sidebar/items.phtml" name="reorder"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="viewed"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="Magento_Sales::order/create/sidebar/items.phtml" name="compared"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="Magento_Sales::order/create/sidebar/items.phtml" name="pcompared"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="pviewed"/>
                 </block>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form\Account" template="order/create/form/account.phtml" name="form_account"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Address" template="order/create/form/address.phtml" name="shipping_address"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Address" template="order/create/form/address.phtml" name="billing_address"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="order/create/abstract.phtml" name="shipping_method">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="order/create/shipping/method/form.phtml" name="order.create.shipping.method.form" as="form"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form\Account" template="Magento_Sales::order/create/form/account.phtml" name="form_account"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Address" template="Magento_Sales::order/create/form/address.phtml" name="shipping_address"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Address" template="Magento_Sales::order/create/form/address.phtml" name="billing_address"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="Magento_Sales::order/create/abstract.phtml" name="shipping_method">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="Magento_Sales::order/create/shipping/method/form.phtml" name="order.create.shipping.method.form" as="form"/>
                 </block>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method" template="order/create/abstract.phtml" name="billing_method">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method\Form" template="order/create/billing/method/form.phtml" name="order.create.billing.method.form" as="form"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method" template="Magento_Sales::order/create/abstract.phtml" name="billing_method">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Billing\Method\Form" template="Magento_Sales::order/create/billing/method/form.phtml" name="order.create.billing.method.form" as="form"/>
                 </block>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter" template="order/create/abstract.phtml" name="newsletter">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter\Form" template="order/create/newsletter/form.phtml" name="order.create.newsletter.form" as="form"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter" template="Magento_Sales::order/create/abstract.phtml" name="newsletter">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter\Form" template="Magento_Sales::order/create/newsletter/form.phtml" name="order.create.newsletter.form" as="form"/>
                 </block>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search" template="order/create/abstract.phtml" name="search">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search" template="Magento_Sales::order/create/abstract.phtml" name="search">
                     <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid" name="search.grid" as="grid"/>
                 </block>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items" template="order/create/items.phtml" name="items">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" template="order/create/items/grid.phtml" name="items_grid">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons" template="order/create/coupons/form.phtml" name="coupons">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons\Form" template="order/create/coupons/form.phtml" name="order.create.coupons.form" as="form"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items" template="Magento_Sales::order/create/items.phtml" name="items">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" template="Magento_Sales::order/create/items/grid.phtml" name="items_grid">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons" template="Magento_Sales::order/create/coupons/form.phtml" name="coupons">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons\Form" template="Magento_Sales::order/create/coupons/form.phtml" name="order.create.coupons.form" as="form"/>
                         </block>
                     </block>
                 </block>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Comment" template="order/create/comment.phtml" name="comment"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Totals" template="order/create/totals.phtml" name="totals"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Comment" template="Magento_Sales::order/create/comment.phtml" name="comment"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Totals" template="Magento_Sales::order/create/totals.phtml" name="totals"/>
                 <block class="Magento\Backend\Block\Template" name="gift_options" template="Magento_Sales::order/giftoptions.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage" template="order/create/giftmessage.phtml" name="giftmessage"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage" template="Magento_Sales::order/create/giftmessage.phtml" name="giftmessage"/>
                 </block>
                 <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
             </block>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_form_account.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_form_account.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form\Account" template="order/create/form/account.phtml" name="form_account"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Form\Account" template="Magento_Sales::order/create/form/account.phtml" name="form_account"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_giftmessage.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_giftmessage.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage" template="order/create/giftmessage.phtml" name="giftmessage"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage" template="Magento_Sales::order/create/giftmessage.phtml" name="giftmessage"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_items.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_items.xml
@@ -9,10 +9,10 @@
     <update handle="sales_order_create_item_price"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items" template="order/create/items.phtml" name="items">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" template="order/create/items/grid.phtml" name="items_grid">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons" template="order/create/coupons/form.phtml" name="coupons">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons\Form" template="order/create/coupons/form.phtml" name="order.create.coupons.form" as="form"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items" template="Magento_Sales::order/create/items.phtml" name="items">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" template="Magento_Sales::order/create/items/grid.phtml" name="items_grid">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons" template="Magento_Sales::order/create/coupons/form.phtml" name="coupons">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Create\Coupons\Form" template="Magento_Sales::order/create/coupons/form.phtml" name="order.create.coupons.form" as="form"/>
                     </block>
                 </block>
             </block>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_newsletter.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_newsletter.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter" template="order/create/abstract.phtml" name="newsletter">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter\Form" template="order/create/newsletter/form.phtml" name="order.create.newsletter.form" as="form"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter" template="Magento_Sales::order/create/abstract.phtml" name="newsletter">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Newsletter\Form" template="Magento_Sales::order/create/newsletter/form.phtml" name="order.create.newsletter.form" as="form"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_search.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_search.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search" template="order/create/abstract.phtml" name="search">
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search" template="Magento_Sales::order/create/abstract.phtml" name="search">
                 <block class="Magento\Sales\Block\Adminhtml\Order\Create\Search\Grid" name="search.grid" as="grid"/>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_shipping_address.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_shipping_address.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Address" template="order/create/form/address.phtml" name="shipping_address"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Address" template="Magento_Sales::order/create/form/address.phtml" name="shipping_address"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_shipping_method.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_shipping_method.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="order/create/abstract.phtml" name="shipping_method">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="order/create/shipping/method/form.phtml" name="order.create.shipping.method.form" as="form"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="Magento_Sales::order/create/abstract.phtml" name="shipping_method">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="Magento_Sales::order/create/shipping/method/form.phtml" name="order.create.shipping.method.form" as="form"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar.xml
@@ -8,14 +8,14 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar" template="order/create/sidebar.phtml" name="sidebar">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="order/create/sidebar/items.phtml" name="cart"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="order/create/sidebar/items.phtml" name="wishlist"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="order/create/sidebar/items.phtml" name="reorder"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="order/create/sidebar/items.phtml" name="viewed"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="order/create/sidebar/items.phtml" name="compared"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="order/create/sidebar/items.phtml" name="pcompared"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="order/create/sidebar/items.phtml" name="pviewed"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar" template="Magento_Sales::order/create/sidebar.phtml" name="sidebar">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="Magento_Sales::order/create/sidebar/items.phtml" name="cart"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="Magento_Sales::order/create/sidebar/items.phtml" name="wishlist"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="Magento_Sales::order/create/sidebar/items.phtml" name="reorder"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="viewed"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="Magento_Sales::order/create/sidebar/items.phtml" name="compared"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="Magento_Sales::order/create/sidebar/items.phtml" name="pcompared"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="pviewed"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_cart.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_cart.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="order/create/sidebar/items.phtml" name="sidebar_cart"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Cart" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_cart"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_compared.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_compared.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="order/create/sidebar/items.phtml" name="sidebar_compared"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Compared" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_compared"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_pcompared.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_pcompared.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="order/create/sidebar/items.phtml" name="sidebar_pcompared"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pcompared" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_pcompared"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_pviewed.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_pviewed.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="order/create/sidebar/items.phtml" name="sidebar_pviewed"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Pviewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_pviewed"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_reorder.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_reorder.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="order/create/sidebar/items.phtml" name="sidebar_reorder"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Reorder" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_reorder"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_viewed.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_viewed.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="order/create/sidebar/items.phtml" name="sidebar_viewed"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Viewed" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_viewed"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_wishlist.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_sidebar_wishlist.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="order/create/sidebar/items.phtml" name="sidebar_wishlist"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Wishlist" template="Magento_Sales::order/create/sidebar/items.phtml" name="sidebar_wishlist"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_totals.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_load_block_totals.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Totals" template="order/create/totals.phtml" name="totals"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Totals" template="Magento_Sales::order/create/totals.phtml" name="totals"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_addcomment.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_addcomment.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Comments" name="creditmemo_comments">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="order/comments/view.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml"/>
         </block>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -12,17 +12,17 @@
 
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create" name="sales_creditmemo_create">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Form" name="form" template="order/creditmemo/create/form.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="order/view/info.phtml"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Form" name="form" template="Magento_Sales::order/creditmemo/create/form.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items" name="order_items" template="order/creditmemo/create/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="order/creditmemo/create/items/renderer/default.phtml"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items" name="order_items" template="Magento_Sales::order/creditmemo/create/items.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/create/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Adjustments" name="adjustments" template="order/creditmemo/create/totals/adjustments.phtml"/>
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Adjustments" name="adjustments" template="Magento_Sales::order/creditmemo/create/totals/adjustments.phtml"/>
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
                         </block>
                         <container name="submit_before" label="Submit Before"/>
                         <container name="submit_after" label="Submit After"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -8,14 +8,14 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="sales_order_item_price"/>
     <body>
-        <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items" name="order_items" template="order/creditmemo/create/items.phtml">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="order/creditmemo/create/items/renderer/default.phtml"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+        <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items" name="order_items" template="Magento_Sales::order/creditmemo/create/items.phtml">
+            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/create/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
             <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-            <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Adjustments" name="adjustments" template="order/creditmemo/create/totals/adjustments.phtml"/>
-                <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Adjustments" name="adjustments" template="Magento_Sales::order/creditmemo/create/totals/adjustments.phtml"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
             </block>
             <container name="submit_before" label="Submit Before"/>
             <container name="submit_after" label="Submit After"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_view.xml
@@ -11,22 +11,22 @@
         <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View" name="sales_creditmemo_view">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Form" name="form" template="order/creditmemo/view/form.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="order/view/info.phtml"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Form" name="form" template="Magento_Sales::order/creditmemo/view/form.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Items" name="creditmemo_items" template="order/creditmemo/view/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="order/creditmemo/view/items/renderer/default.phtml"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Items" name="creditmemo_items" template="Magento_Sales::order/creditmemo/view/items.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/view/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="order/comments/view.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml">
                         <action method="setParentType">
                             <argument name="type" xsi:type="string">creditmemo</argument>
                         </action>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
                     </block>
                 </block>
             </block>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_addcomment.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_addcomment.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View\Comments" name="invoice_comments">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="order/comments/view.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml"/>
         </block>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -15,16 +15,16 @@
 
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create" name="sales_invoice_create">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Form" name="form" template="order/invoice/create/form.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="order/view/info.phtml"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Form" name="form" template="Magento_Sales::order/invoice/create/form.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items" name="order_items" template="order/invoice/create/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="order/invoice/create/items/renderer/default.phtml"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items" name="order_items" template="Magento_Sales::order/invoice/create/items.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/create/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml">
-                            <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
+                            <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
                         </block>
                         <container name="submit_before" label="Submit Before"/>
                         <container name="submit_after" label="Submit After"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -8,13 +8,13 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="sales_order_item_price"/>
     <body>
-        <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items" name="order_items" template="order/invoice/create/items.phtml">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="order/invoice/create/items/renderer/default.phtml"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+        <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items" name="order_items" template="Magento_Sales::order/invoice/create/items.phtml">
+            <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/create/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
             <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-            <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
             </block>
         </block>
     </body>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_view.xml
@@ -12,22 +12,22 @@
 
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View" name="sales_invoice_view">
-                <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View\Form" name="form" template="order/invoice/view/form.phtml">
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="order/view/info.phtml"/>
+                <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View\Form" name="form" template="Magento_Sales::order/invoice/view/form.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View\Items" name="invoice_items" template="order/invoice/view/items.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="order/invoice/view/items/renderer/default.phtml"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\View\Items" name="invoice_items" template="Magento_Sales::order/invoice/view/items.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/view/items/renderer/default.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="order/comments/view.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml">
                         <action method="setParentType">
                             <argument name="type" xsi:type="string">invoice</argument>
                         </action>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
                     </block>
                 </block>
             </block>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_item_price.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_price" template="Magento_Sales::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_subtotal" template="Magento_Sales::items/price/row.phtml" group="column"/>
+            <block class="Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn" name="column_total" template="Magento_Sales::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
@@ -20,10 +20,10 @@
         </referenceContainer>
         <referenceContainer name="left">
             <block class="Magento\Sales\Block\Adminhtml\Order\View\Tabs" name="sales_order_tabs">
-                <block class="Magento\Sales\Block\Adminhtml\Order\View\Tab\Info" name="order_tab_info" template="order/view/tab/info.phtml">
+                <block class="Magento\Sales\Block\Adminhtml\Order\View\Tab\Info" name="order_tab_info" template="Magento_Sales::order/view/tab/info.phtml">
                     <block class="Magento\Sales\Block\Adminhtml\Order\View\Messages" name="order_messages"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="order/view/info.phtml"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Items" name="order_items" template="order/view/items.phtml">
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\Items" name="order_items" template="Magento_Sales::order/view/items.phtml">
                         <arguments>
                             <argument name="columns" xsi:type="array">
                                 <item name="product" xsi:type="string" translate="true">Product</item>
@@ -38,7 +38,7 @@
                                 <item name="total" xsi:type="string" translate="true">Row Total</item>
                             </argument>
                         </arguments>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer" as="default" template="order/view/items/renderer/default.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Items\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/view/items/renderer/default.phtml">
                         <arguments>
                             <argument name="columns" xsi:type="array">
                                 <item name="product" xsi:type="string" translate="false">col-product</item>
@@ -54,19 +54,19 @@
                             </argument>
                         </arguments>
                         </block>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="items/column/qty.phtml" group="column"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="items/column/name.phtml" group="column"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
                     </block>
 
                     <container name="payment_additional_info" htmlTag="div" htmlClass="order-payment-additional" />
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\History" name="order_history" template="order/view/history.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\History" name="order_history" template="Magento_Sales::order/view/history.phtml"/>
                     <block class="Magento\Backend\Block\Template" name="gift_options" template="Magento_Sales::order/giftoptions.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Giftmessage" name="order_giftmessage" template="order/view/giftmessage.phtml"/>
+                        <block class="Magento\Sales\Block\Adminhtml\Order\View\Giftmessage" name="order_giftmessage" template="Magento_Sales::order/view/giftmessage.phtml"/>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Totals" name="order_totals" template="order/totals.phtml">
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="order/totals/tax.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
+                        <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
                     </block>
                 </block>
                 <action method="addTab">

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_transactions_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_transactions_view.xml
@@ -11,7 +11,7 @@
         <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
 
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Adminhtml\Transactions\Detail" name="sales_transactions.detail" template="transactions/detail.phtml">
+            <block class="Magento\Sales\Block\Adminhtml\Transactions\Detail" name="sales_transactions.detail" template="Magento_Sales::transactions/detail.phtml">
                 <block class="Magento\Sales\Block\Adminhtml\Transactions\Detail\Grid" name="sales_transactions.detail.grid" as="detail_grid"/>
                 <block class="Magento\Sales\Block\Adminhtml\Transactions" name="sales_transactions.grid.container" as="child_grid"/>
             </block>

--- a/app/code/Magento/Sales/view/frontend/layout/customer_account_index.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/customer_account_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\Recent" name="customer_account_dashboard_top" after="customer_account_dashboard_hello" template="order/recent.phtml"/>
+            <block class="Magento\Sales\Block\Order\Recent" name="customer_account_dashboard_top" after="customer_account_dashboard_hello" template="Magento_Sales::order/recent.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/default.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/default.xml
@@ -11,7 +11,7 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="sales_page_head_components" template="Magento_Sales::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="sidebar.additional">
-            <block class="Magento\Sales\Block\Reorder\Sidebar" name="sale.reorder.sidebar" as="reorder" template="reorder/sidebar.phtml"/>
+            <block class="Magento\Sales\Block\Reorder\Sidebar" name="sale.reorder.sidebar" as="reorder" template="Magento_Sales::reorder/sidebar.phtml"/>
         </referenceContainer>
         <referenceBlock name="footer_links">
             <block class="Magento\Sales\Block\Guest\Link" name="sales-guest-form-link">

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_item_price.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_item_price.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="items">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" name="item_price" template="email/items/price/row.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" name="item_price" template="Magento_Sales::email/items/price/row.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_items.xml
@@ -9,13 +9,13 @@
     <update handle="sales_email_order_creditmemo_renderers"/>
     <update handle="sales_email_item_price"/>
     <body>
-        <block class="Magento\Sales\Block\Order\Email\Creditmemo\Items" name="items" template="email/creditmemo/items.phtml">
+        <block class="Magento\Sales\Block\Order\Email\Creditmemo\Items" name="items" template="Magento_Sales::email/creditmemo/items.phtml">
             <block class="Magento\Framework\View\Element\RendererList" name="sales.email.order.creditmemo.renderers" as="renderer.list"/>
-            <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml" cacheable="false">
+            <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml" cacheable="false">
                 <arguments>
                     <argument name="label_properties" xsi:type="string">colspan="2"</argument>
                 </arguments>
-                <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
             </block>
         </block>
         <block class="Magento\Framework\View\Element\Template" name="additional.product.info" template="Magento_Theme::template.phtml"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.creditmemo.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="email/items/creditmemo/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="Magento_Sales::email/items/creditmemo/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_items.xml
@@ -9,13 +9,13 @@
     <update handle="sales_email_order_invoice_renderers"/>
     <update handle="sales_email_item_price"/>
     <body>
-        <block class="Magento\Sales\Block\Order\Email\Invoice\Items" name="items" template="email/invoice/items.phtml">
+        <block class="Magento\Sales\Block\Order\Email\Invoice\Items" name="items" template="Magento_Sales::email/invoice/items.phtml">
             <block class="Magento\Framework\View\Element\RendererList" name="sales.email.order.invoice.renderers" as="renderer.list"/>
-            <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml" cacheable="false">
+            <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml" cacheable="false">
                 <arguments>
                     <argument name="label_properties" xsi:type="string">colspan="2"</argument>
                 </arguments>
-                <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
             </block>
         </block>
         <block class="Magento\Framework\View\Element\Template" name="additional.product.info" template="Magento_Theme::template.phtml"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.invoice.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="email/items/invoice/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="Magento_Sales::email/items/invoice/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_items.xml
@@ -9,13 +9,13 @@
     <update handle="sales_email_order_renderers"/>
     <update handle="sales_email_item_price"/>
     <body>
-        <block class="Magento\Sales\Block\Order\Email\Items" name="items" template="email/items.phtml" cacheable="false">
+        <block class="Magento\Sales\Block\Order\Email\Items" name="items" template="Magento_Sales::email/items.phtml" cacheable="false">
             <block class="Magento\Framework\View\Element\RendererList" name="sales.email.order.renderers" as="renderer.list"/>
-            <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="order/totals.phtml">
+            <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
                 <arguments>
                     <argument name="label_properties" xsi:type="string">colspan="2"</argument>
                 </arguments>
-                <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml">
+                <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml">
                     <action method="setIsPlaneMode">
                         <argument name="value" xsi:type="string">1</argument>
                     </action>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\Order\DefaultOrder" as="default" template="email/items/order/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\Order\DefaultOrder" as="default" template="Magento_Sales::email/items/order/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_items.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Shipment Items List" design_abstraction="custom">
     <update handle="sales_email_order_shipment_renderers"/>
     <body>
-        <block class="Magento\Sales\Block\Order\Email\Shipment\Items" name="items" template="email/shipment/items.phtml">
+        <block class="Magento\Sales\Block\Order\Email\Shipment\Items" name="items" template="Magento_Sales::email/shipment/items.phtml">
             <block class="Magento\Framework\View\Element\RendererList" name="sales.email.order.shipment.renderers" as="renderer.list"/>
         </block>
         <block class="Magento\Framework\View\Element\Template" name="additional.product.info" template="Magento_Theme::template.phtml"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Email Creditmemo Items List" design_abstraction="custom">
     <body>
         <referenceBlock name="sales.email.order.shipment.renderers">
-            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="email/items/shipment/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Email\Items\DefaultItems" as="default" template="Magento_Sales::email/items/shipment/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_creditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_creditmemo.xml
@@ -11,8 +11,8 @@
     <update handle="sales_order_guest_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml" />
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false">
                     <block class="Magento\Sales\Block\Order\Info\Buttons\Rss" as="buttons.rss" name="sales.order.info.buttons.rss" cacheable="false"/>
@@ -21,16 +21,16 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\Creditmemo" name="sales.order.creditmemo" after="sales.order.info.links" cacheable="false">
-                <block class="Magento\Sales\Block\Order\Creditmemo\Items" name="creditmemo_items" template="order/creditmemo/items.phtml">
+                <block class="Magento\Sales\Block\Order\Creditmemo\Items" name="creditmemo_items" template="Magento_Sales::order/creditmemo/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.creditmemo.renderers" as="renderer.list"/>
-                    <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="6" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                     </block>
-                    <block class="Magento\Sales\Block\Order\Comments" name="creditmemo_comments" template="order/comments.phtml"/>
+                    <block class="Magento\Sales\Block\Order\Comments" name="creditmemo_comments" template="Magento_Sales::order/comments.phtml"/>
                 </block>
             </block>
             <block class="Magento\Sales\Block\Order\Info" as="info" name="sales.order.info" after="sales.order.creditmemo"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_form.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_form.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Widget\Guest\Form" name="guest.form" template="guest/form.phtml"/>
+            <block class="Magento\Sales\Block\Widget\Guest\Form" name="guest.form" template="Magento_Sales::guest/form.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_invoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_invoice.xml
@@ -11,8 +11,8 @@
     <update handle="sales_order_guest_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml" />
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false">
                     <block class="Magento\Sales\Block\Order\Info\Buttons\Rss" as="buttons.rss" name="sales.order.info.buttons.rss" cacheable="false"/>
@@ -21,16 +21,16 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\Invoice" name="sales.order.invoice" after="sales.order.info.links" cacheable="false">
-                <block class="Magento\Sales\Block\Order\Invoice\Items" name="invoice_items" template="order/invoice/items.phtml">
+                <block class="Magento\Sales\Block\Order\Invoice\Items" name="invoice_items" template="Magento_Sales::order/invoice/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.invoice.renderers" as="renderer.list"/>
-                    <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                     </block>
-                    <block class="Magento\Sales\Block\Order\Comments" name="invoice_comments" template="order/comments.phtml"/>
+                    <block class="Magento\Sales\Block\Order\Comments" name="invoice_comments" template="Magento_Sales::order/comments.phtml"/>
                 </block>
             </block>
             <block class="Magento\Sales\Block\Order\Info" as="info" name="sales.order.info" after="-"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_print.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_print.xml
@@ -12,19 +12,19 @@
     <body>
         <attribute name="class" value="sales-guest-view"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="sales.order.print" template="order/view.phtml">
-                <block class="Magento\Sales\Block\Order\PrintShipment" name="order_items" template="order/items.phtml">
+            <block class="Magento\Sales\Block\Order\PrintShipment" name="sales.order.print" template="Magento_Sales::order/view.phtml">
+                <block class="Magento\Sales\Block\Order\PrintShipment" name="order_items" template="Magento_Sales::order/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.renderers" as="renderer.list" />
-                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml">
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml">
                             <action method="setIsPlaneMode">
                                 <argument name="value" xsi:type="string">1</argument>
                             </action>
@@ -32,7 +32,7 @@
                     </block>
                 </block>
             </block>
-            <block class="Magento\Sales\Block\Order\PrintShipment" as="sales.order.print.info" name="sales.order.print.info" template="order/info.phtml"/>
+            <block class="Magento\Sales\Block\Order\PrintShipment" as="sales.order.print.info" name="sales.order.print.info" template="Magento_Sales::order/info.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printcreditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printcreditmemo.xml
@@ -12,18 +12,18 @@
     <body>
         <attribute name="class" value="sales-guest-view"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="sales.order.print.creditmemo" template="order/print/creditmemo.phtml">
+            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="sales.order.print.creditmemo" template="Magento_Sales::order/print/creditmemo.phtml">
                 <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.creditmemo.renderers" as="renderer.list"/>
-                <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml" cacheable="false">
+                <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml" cacheable="false">
                     <arguments>
                         <argument name="label_properties" xsi:type="string">colspan="6" class="mark"</argument>
                         <argument name="value_properties" xsi:type="string">class="amount"</argument>
                     </arguments>
-                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printinvoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printinvoice.xml
@@ -12,18 +12,18 @@
     <body>
         <attribute name="class" value="sales-guest-view"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="sales.order.print.invoice" template="order/print/invoice.phtml">
+            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="sales.order.print.invoice" template="Magento_Sales::order/print/invoice.phtml">
                 <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.invoice.renderers" as="renderer.list" />
-                <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml" cacheable="false">
+                <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml" cacheable="false">
                     <arguments>
                         <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                         <argument name="value_properties" xsi:type="string">class="amount"</argument>
                     </arguments>
-                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printshipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printshipment.xml
@@ -11,11 +11,11 @@
     <body>
         <attribute name="class" value="sales-guest-view"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="sales.order.print.shipment" template="order/print/shipment.phtml">
+            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="sales.order.print.shipment" template="Magento_Sales::order/print/shipment.phtml">
                 <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.shipment.renderers" as="renderer.list" />
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_shipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_shipment.xml
@@ -9,8 +9,8 @@
     <update handle="sales_order_guest_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml" />
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false">
                     <block class="Magento\Sales\Block\Order\Info\Buttons\Rss" as="buttons.rss" name="sales.order.info.buttons.rss" cacheable="false"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_view.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_view.xml
@@ -11,8 +11,8 @@
     <update handle="sales_order_guest_info_links"/>
     <body>
        <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml" />
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false">
                     <block class="Magento\Sales\Block\Order\Info\Buttons\Rss" as="buttons.rss" name="sales.order.info.buttons.rss" cacheable="false"/>
@@ -21,14 +21,14 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\View" name="sales.order.view" cacheable="false">
-                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="order/items.phtml">
+                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="Magento_Sales::order/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.items.renderers" as="renderer.list" />
-                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                     </block>
                 </block>
             </block>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo.xml
@@ -12,24 +12,24 @@
     <update handle="sales_order_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml"/>
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml"/>
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false"/>
             </container>
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\Creditmemo" name="sales.order.creditmemo" cacheable="false" after="sales.order.info.links">
-                <block class="Magento\Sales\Block\Order\Creditmemo\Items" name="creditmemo_items" template="order/creditmemo/items.phtml">
+                <block class="Magento\Sales\Block\Order\Creditmemo\Items" name="creditmemo_items" template="Magento_Sales::order/creditmemo/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.creditmemo.renderers" as="renderer.list"/>
-                    <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="6" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                     </block>
-                    <block class="Magento\Sales\Block\Order\Comments" name="creditmemo_comments" template="order/comments.phtml"/>
+                    <block class="Magento\Sales\Block\Order\Comments" name="creditmemo_comments" template="Magento_Sales::order/comments.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.creditmemo.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/creditmemo/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_history.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_history.xml
@@ -18,7 +18,7 @@
                         name="sales.order.history.extra.container.data" as="extra.container.data"/>
                 </block>
             </block>
-            <block class="Magento\Customer\Block\Account\Dashboard" name="customer.account.link.back" template="account/link/back.phtml" cacheable="false"/>
+            <block class="Magento\Customer\Block\Account\Dashboard" name="customer.account.link.back" template="Magento_Customer::account/link/back.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice.xml
@@ -12,24 +12,24 @@
     <update handle="sales_order_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml"/>
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml"/>
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false"/>
             </container>
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\Invoice" name="sales.order.invoice" cacheable="false" after="sales.order.info.links">
-                <block class="Magento\Sales\Block\Order\Invoice\Items" name="invoice_items" template="order/invoice/items.phtml">
+                <block class="Magento\Sales\Block\Order\Invoice\Items" name="invoice_items" template="Magento_Sales::order/invoice/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.invoice.renderers" as="renderer.list"/>
-                    <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                     </block>
-                    <block class="Magento\Sales\Block\Order\Comments" name="invoice_comments" template="order/comments.phtml"/>
+                    <block class="Magento\Sales\Block\Order\Comments" name="invoice_comments" template="Magento_Sales::order/comments.phtml"/>
                 </block>
             </block>
             <block class="Magento\Sales\Block\Order\Info" as="info" name="sales.order.info" after="-"/>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.invoice.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_item_price.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_item_price.xml
@@ -7,8 +7,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="item_unit_price" template="items/price/unit.phtml"/>
-        <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="item_row_total" template="items/price/row.phtml"/>
-        <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="item_row_total_after_discount" template="items/price/total_after_discount.phtml"/>
+        <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="item_unit_price" template="Magento_Sales::items/price/unit.phtml"/>
+        <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="item_row_total" template="Magento_Sales::items/price/row.phtml"/>
+        <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" name="item_row_total_after_discount" template="Magento_Sales::items/price/total_after_discount.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_item_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_item_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.items.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print.xml
@@ -12,19 +12,19 @@
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="sales.order.print" template="order/view.phtml">
-                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="order/items.phtml">
+            <block class="Magento\Sales\Block\Order\PrintShipment" name="sales.order.print" template="Magento_Sales::order/view.phtml">
+                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="Magento_Sales::order/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.renderers" as="renderer.list" />
-                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml">
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml">
                             <action method="setIsPlaneMode">
                                 <argument name="value" xsi:type="string">1</argument>
                             </action>
@@ -32,7 +32,7 @@
                     </block>
                 </block>
             </block>
-            <block class="Magento\Sales\Block\Order\Info" as="sales.order.print.info" name="sales.order.print.info" template="order/info.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" as="sales.order.print.info" name="sales.order.print.info" template="Magento_Sales::order/info.phtml"/>
         </referenceContainer>
         <block class="Magento\Framework\View\Element\Template" name="additional.product.info" template="Magento_Theme::template.phtml"/>
     </body>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_creditmemo_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.creditmemo.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/creditmemo/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/creditmemo/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_invoice_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_invoice_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.invoice.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/invoice/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/invoice/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print_shipment_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.print.shipment.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/shipment/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/shipment/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printcreditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printcreditmemo.xml
@@ -12,18 +12,18 @@
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="sales.order.print.creditmemo" template="order/print/creditmemo.phtml">
+            <block class="Magento\Sales\Block\Order\PrintOrder\Creditmemo" name="sales.order.print.creditmemo" template="Magento_Sales::order/print/creditmemo.phtml">
                 <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.creditmemo.renderers" as="renderer.list"/>
-                <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="order/totals.phtml" cacheable="false">
+                <block class="Magento\Sales\Block\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml" cacheable="false">
                     <arguments>
                         <argument name="label_properties" xsi:type="string">colspan="6" class="mark"</argument>
                         <argument name="value_properties" xsi:type="string">class="amount"</argument>
                     </arguments>
-                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printinvoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printinvoice.xml
@@ -12,18 +12,18 @@
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="sales.order.print.invoice" template="order/print/invoice.phtml">
+            <block class="Magento\Sales\Block\Order\PrintOrder\Invoice" name="sales.order.print.invoice" template="Magento_Sales::order/print/invoice.phtml">
                 <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.invoice.renderers" as="renderer.list" />
-                <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="order/totals.phtml" cacheable="false">
+                <block class="Magento\Sales\Block\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml" cacheable="false">
                     <arguments>
                         <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                         <argument name="value_properties" xsi:type="string">class="amount"</argument>
                     </arguments>
-                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                    <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printshipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printshipment.xml
@@ -11,11 +11,11 @@
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.status" template="order/order_status.phtml" />
-            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.date" template="order/order_date.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="sales.order.print.shipment" template="order/print/shipment.phtml">
+            <block class="Magento\Sales\Block\Order\PrintOrder\Shipment" name="sales.order.print.shipment" template="Magento_Sales::order/print/shipment.phtml">
                 <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.shipment.renderers" as="renderer.list"/>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment.xml
@@ -10,8 +10,8 @@
     <update handle="sales_order_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml"/>
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml"/>
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false"/>
             </container>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment_renderers.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment_renderers.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.shipment.renderers">
-            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="order/shipment/items/renderer/default.phtml"/>
+            <block class="Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer" as="default" template="Magento_Sales::order/shipment/items/renderer/default.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_view.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_view.xml
@@ -12,8 +12,8 @@
     <update handle="sales_order_info_links"/>
     <body>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="order/order_status.phtml"/>
-            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="order/order_date.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.status" template="Magento_Sales::order/order_status.phtml"/>
+            <block class="Magento\Sales\Block\Order\Info" name="order.date" template="Magento_Sales::order/order_date.phtml"/>
             <container name="order.actions.container" htmlTag="div" htmlClass="actions-toolbar order-actions-toolbar">
                 <block class="Magento\Sales\Block\Order\Info\Buttons" as="buttons" name="sales.order.info.buttons" cacheable="false"/>
             </container>
@@ -22,17 +22,17 @@
             <block class="Magento\Sales\Block\Order\Info\Buttons\Rss" as="buttons.rss" name="sales.order.info.buttons.rss" cacheable="false"/>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Sales\Block\Order\View" name="order.comments" template="order/order_comments.phtml" before="sales.order.info.links"/>
+            <block class="Magento\Sales\Block\Order\View" name="order.comments" template="Magento_Sales::order/order_comments.phtml" before="sales.order.info.links"/>
             <block class="Magento\Sales\Block\Order\View" name="sales.order.view" cacheable="false" after="sales.order.info.links">
-                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="order/items.phtml">
+                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="Magento_Sales::order/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.items.renderers" as="renderer.list"/>
                     <block class="Magento\Theme\Block\Html\Pager" name="sales_order_item_pager"/>
-                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="order/totals.phtml">
+                    <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>
                             <argument name="label_properties" xsi:type="string">colspan="4" class="mark"</argument>
                             <argument name="value_properties" xsi:type="string">class="amount"</argument>
                         </arguments>
-                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="order/tax.phtml"/>
+                        <block class="Magento\Tax\Block\Sales\Order\Tax" name="tax" template="Magento_Tax::order/tax.phtml"/>
                     </block>
                 </block>
             </block>

--- a/app/code/Magento/Search/view/frontend/layout/search_term_popular.xml
+++ b/app/code/Magento/Search/view/frontend/layout/search_term_popular.xml
@@ -11,7 +11,7 @@
     </head>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Search\Block\Term" name="seo.searchterm" template="term.phtml" cacheable="false"/>
+            <block class="Magento\Search\Block\Term" name="seo.searchterm" template="Magento_Search::term.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/SendFriend/view/frontend/layout/sendfriend_product_send.xml
+++ b/app/code/Magento/SendFriend/view/frontend/layout/sendfriend_product_send.xml
@@ -13,7 +13,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\SendFriend\Block\Send" name="sendfriend.send" template="send.phtml"/>
+            <block class="Magento\SendFriend\Block\Send" name="sendfriend.send" template="Magento_SendFriend::send.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_addcomment.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_addcomment.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <block class="Magento\Shipping\Block\Adminhtml\View\Comments" name="shipment_comments">
-            <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="order/comments/view.phtml"/>
+            <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml"/>
         </block>
     </body>
 </page>

--- a/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_addtrack.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_addtrack.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="order/tracking/view.phtml"/>
+        <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="Magento_Shipping::order/tracking/view.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_new.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_new.xml
@@ -10,10 +10,10 @@
         <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
         <referenceContainer name="content">
             <block class="Magento\Shipping\Block\Adminhtml\Create" name="sales_shipment_create">
-                <block class="Magento\Shipping\Block\Adminhtml\Create\Form" name="form" template="create/form.phtml">
+                <block class="Magento\Shipping\Block\Adminhtml\Create\Form" name="form" template="Magento_Shipping::create/form.phtml">
                     <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Create\Items" name="order_items" template="create/items.phtml">
+                    <block class="Magento\Shipping\Block\Adminhtml\Create\Items" name="order_items" template="Magento_Shipping::create/items.phtml">
                         <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Shipping::create/items/renderer/default.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
@@ -21,7 +21,7 @@
                         <container name="submit_before" label="Submit Before"/>
                         <container name="submit_after" label="Submit After"/>
                     </block>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking" name="shipment_tracking" template="order/tracking.phtml"/>
+                    <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking" name="shipment_tracking" template="Magento_Shipping::order/tracking.phtml"/>
                     <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="Magento_Shipping::order/packaging/popup.phtml"/>
                 </block>
             </block>

--- a/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_removetrack.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_removetrack.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="order/tracking/view.phtml"/>
+        <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="Magento_Shipping::order/tracking/view.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_view.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_view.xml
@@ -10,19 +10,19 @@
         <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
         <referenceContainer name="content">
             <block class="Magento\Shipping\Block\Adminhtml\View" name="sales_shipment_view">
-                <block class="Magento\Shipping\Block\Adminhtml\View\Form" name="form" template="view/form.phtml">
+                <block class="Magento\Shipping\Block\Adminhtml\View\Form" name="form" template="Magento_Shipping::view/form.phtml">
                     <block class="Magento\Sales\Block\Adminhtml\Order\View\Info" name="order_info" template="Magento_Sales::order/view/info.phtml"/>
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\View\Items" name="shipment_items" template="view/items.phtml">
+                    <block class="Magento\Shipping\Block\Adminhtml\View\Items" name="shipment_items" template="Magento_Shipping::view/items.phtml">
                         <block class="Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer" as="default" template="Magento_Shipping::view/items/renderer/default.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="order/comments/view.phtml"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="order/tracking/view.phtml"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="order/packaging/popup.phtml"/>
-                    <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packed" template="order/packaging/packed.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml"/>
+                    <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="Magento_Shipping::order/tracking/view.phtml"/>
+                    <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="Magento_Shipping::order/packaging/popup.phtml"/>
+                    <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packed" template="Magento_Shipping::order/packaging/packed.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Shipping/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="form">
-            <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\Invoice" name="tracking" template="order/tracking.phtml"/>
+            <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\Invoice" name="tracking" template="Magento_Shipping::order/tracking.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_guest_reorder.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_guest_reorder.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.view">
-            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
+            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="Magento_Shipping::tracking/link.phtml">
                 <arguments>
                     <argument name="label" xsi:type="string">Track your order</argument>
                 </arguments>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_guest_shipment.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_guest_shipment.xml
@@ -10,14 +10,14 @@
     <body>
         <referenceContainer name="content">
             <block class="Magento\Shipping\Block\Order\Shipment" name="sales.order.shipment" after="sales.order.info">
-                <block class="Magento\Shipping\Block\Items" name="shipment_items" template="items.phtml">
+                <block class="Magento\Shipping\Block\Items" name="shipment_items" template="Magento_Shipping::items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.shipment.renderers" as="renderer.list"/>
-                    <block class="Magento\Shipping\Block\Tracking\Link" name="track-all-link" template="tracking/link.phtml">
+                    <block class="Magento\Shipping\Block\Tracking\Link" name="track-all-link" template="Magento_Shipping::tracking/link.phtml">
                         <arguments>
                             <argument name="label" xsi:type="string">Track All Shipments</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Sales\Block\Order\Comments" name="shipment_comments" template="order/comments.phtml"/>
+                    <block class="Magento\Sales\Block\Order\Comments" name="shipment_comments" template="Magento_Sales::order/comments.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_guest_view.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_guest_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.view">
-            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
+            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="Magento_Shipping::tracking/link.phtml">
                 <arguments>
                     <argument name="label" xsi:type="string">Track your order</argument>
                 </arguments>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_order_reorder.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_order_reorder.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.view">
-            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
+            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="Magento_Shipping::tracking/link.phtml">
                 <arguments>
                     <argument name="label" xsi:type="string">Track your order</argument>
                 </arguments>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_order_shipment.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_order_shipment.xml
@@ -10,14 +10,14 @@
     <body>
         <referenceContainer name="content">
             <block class="Magento\Shipping\Block\Order\Shipment" name="sales.order.shipment" cacheable="false" after="sales.order.info.links">
-                <block class="Magento\Shipping\Block\Items" name="shipment_items" template="items.phtml">
+                <block class="Magento\Shipping\Block\Items" name="shipment_items" template="Magento_Shipping::items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.shipment.renderers" as="renderer.list"/>
-                    <block class="Magento\Shipping\Block\Tracking\Link" name="track-all-link" template="tracking/link.phtml">
+                    <block class="Magento\Shipping\Block\Tracking\Link" name="track-all-link" template="Magento_Shipping::tracking/link.phtml">
                         <arguments>
                             <argument name="label" xsi:type="string">Track All Shipments</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Sales\Block\Order\Comments" name="shipment_comments" template="order/comments.phtml"/>
+                    <block class="Magento\Sales\Block\Order\Comments" name="shipment_comments" template="Magento_Sales::order/comments.phtml"/>
                 </block>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_order_view.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_order_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="sales.order.view">
-            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
+            <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="Magento_Shipping::tracking/link.phtml">
                 <arguments>
                     <argument name="label" xsi:type="string">Track your order</argument>
                 </arguments>

--- a/app/code/Magento/Shipping/view/frontend/layout/shipping_tracking_popup.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/shipping_tracking_popup.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="empty" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Shipping\Block\Tracking\Popup" name="shipping.tracking.popup" template="tracking/popup.phtml"/>
+            <block class="Magento\Shipping\Block\Tracking\Popup" name="shipping.tracking.popup" template="Magento_Shipping::tracking/popup.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Tax/view/adminhtml/layout/sales_creditmemo_item_price.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/sales_creditmemo_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_items">
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="Magento_Tax::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="Magento_Tax::items/price/row.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="Magento_Tax::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Tax/view/adminhtml/layout/sales_invoice_item_price.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/sales_invoice_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="invoice_items">
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="Magento_Tax::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="Magento_Tax::items/price/row.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="Magento_Tax::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Tax/view/adminhtml/layout/sales_order_create_item_price.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/sales_order_create_item_price.xml
@@ -7,17 +7,17 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_unit_price" template="order/create/items/price/unit.phtml">
+        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_unit_price" template="Magento_Tax::order/create/items/price/unit.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total" template="order/create/items/price/row.phtml">
+        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total" template="Magento_Tax::order/create/items/price/row.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total_with_discount" template="order/create/items/price/total.phtml">
+        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total_with_discount" template="Magento_Tax::order/create/items/price/total.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>

--- a/app/code/Magento/Tax/view/adminhtml/layout/sales_order_item_price.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/sales_order_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="Magento_Tax::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="Magento_Tax::items/price/row.phtml" group="column"/>
+            <block class="Magento\Tax\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="Magento_Tax::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Tax/view/adminhtml/layout/tax_rule_edit.xml
+++ b/app/code/Magento/Tax/view/adminhtml/layout/tax_rule_edit.xml
@@ -13,8 +13,8 @@
     <body>
         <referenceContainer name="content">
             <block class="Magento\Tax\Block\Adminhtml\Rule\Edit"/>
-            <block class="Magento\Tax\Block\Adminhtml\Rule\Edit\Form" name="tax-rule-edit" template="rule/edit.phtml"/>
-            <block class="Magento\Tax\Block\Adminhtml\Rate\Form" name="tax-rate-form" template="rule/rate/form.phtml"/>
+            <block class="Magento\Tax\Block\Adminhtml\Rule\Edit\Form" name="tax-rule-edit" template="Magento_Tax::rule/edit.phtml"/>
+            <block class="Magento\Tax\Block\Adminhtml\Rate\Form" name="tax-rate-form" template="Magento_Tax::rule/rate/form.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Tax/view/frontend/layout/sales_email_item_price.xml
+++ b/app/code/Magento/Tax/view/frontend/layout/sales_email_item_price.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="items">
-            <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_price" template="email/items/price/row.phtml">
+            <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_price" template="Magento_Tax::email/items/price/row.phtml">
                 <arguments>
                     <argument name="zone" xsi:type="string">email</argument>
                 </arguments>

--- a/app/code/Magento/Tax/view/frontend/layout/sales_order_item_price.xml
+++ b/app/code/Magento/Tax/view/frontend/layout/sales_order_item_price.xml
@@ -7,16 +7,16 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_unit_price" template="item/price/unit.phtml">
+        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_unit_price" template="Magento_Tax::item/price/unit.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">sales</argument>
             </arguments>
         </block>
-        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total" template="item/price/row.phtml">
+        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total" template="Magento_Tax::item/price/row.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">sales</argument>
             </arguments>
         </block>
-        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total_after_discount" template="item/price/total_after_discount.phtml"/>
+        <block class="Magento\Tax\Block\Item\Price\Renderer" name="item_row_total_after_discount" template="Magento_Tax::item/price/total_after_discount.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/TaxImportExport/view/adminhtml/layout/tax_rule_edit.xml
+++ b/app/code/Magento/TaxImportExport/view/adminhtml/layout/tax_rule_edit.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="content">
-            <block class="Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport" name="tax-rate-importExport" template="importExport.phtml"/>
+            <block class="Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport" name="tax-rate-importExport" template="Magento_TaxImportExport::importExport.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Theme/composer.json
+++ b/app/code/Magento/Theme/composer.json
@@ -13,12 +13,12 @@
         "magento/module-media-storage": "100.1.*",
         "magento/module-ui": "100.1.*",
         "magento/framework": "100.1.*",
-        "magento/module-require-js": "100.1.*",
-        "magento/module-directory": "100.1.*"
+        "magento/module-require-js": "100.1.*"
     },
     "suggest": {
         "magento/module-translation": "100.1.*",
-        "magento/module-theme-sample-data": "Sample Data version:100.1.*"
+        "magento/module-theme-sample-data": "Sample Data version:100.1.*",
+        "magento/module-directory": "100.1.*"
     },
     "type": "magento2-module",
     "version": "100.1.11",

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_edit.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_edit.xml
@@ -18,8 +18,8 @@
         </referenceContainer>
         <referenceContainer name="left">
             <block class="Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tabs" name="theme_edit_tabs">
-                <block class="Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Css" template="tabs/css.phtml" name="theme_edit_tabs_tab_css_tab"/>
-                <block class="Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Js" template="tabs/js.phtml" name="theme_edit_tabs_tab_js_tab">
+                <block class="Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Css" template="Magento_Theme::tabs/css.phtml" name="theme_edit_tabs_tab_css_tab"/>
+                <block class="Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Js" template="Magento_Theme::tabs/js.phtml" name="theme_edit_tabs_tab_js_tab">
                     <block class="Magento\Backend\Block\Widget\Form\Renderer\Fieldset" template="Magento_Theme::tabs/fieldset/js.phtml" name="theme_edit_tabs_tab_js_tab_content"/>
                 </block>
                 <action method="addTab">

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_contents.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_contents.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
-        <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Files" name="wysiwyg_files.files" template="browser/content/files.phtml"/>
+        <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Files" name="wysiwyg_files.files" template="Magento_Theme::browser/content/files.phtml"/>
     </container>
 </layout>

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_index.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_index.xml
@@ -12,8 +12,8 @@
             <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Tree" name="wysiwyg_files.tree" template="Magento_Cms::browser/tree.phtml"/>
         </referenceContainer>
         <referenceContainer name="content">
-            <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content" name="wysiwyg_files.content" template="browser/content.phtml">
-                <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Uploader" name="wysiwyg_files.uploader" template="browser/content/uploader.phtml"/>
+            <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content" name="wysiwyg_files.content" template="Magento_Theme::browser/content.phtml">
+                <block class="Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Uploader" name="wysiwyg_files.uploader" template="Magento_Theme::browser/content/uploader.phtml"/>
             </block>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Theme/view/adminhtml/layout/theme_design_config_edit.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/theme_design_config_edit.xml
@@ -12,7 +12,7 @@
         <referenceContainer name="page.main.actions">
             <block class="Magento\Theme\Block\Adminhtml\Design\Config\Edit\Scope"
                    name="design.config.edit.scope"
-                   template="design/config/edit/scope.phtml"/>
+                   template="Magento_Theme::design/config/edit/scope.phtml"/>
         </referenceContainer>
         <referenceContainer name="content">
             <uiComponent name="design_config_form"/>

--- a/app/code/Magento/Theme/view/frontend/layout/default.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default.xml
@@ -14,7 +14,7 @@
             <block class="Magento\Translation\Block\Html\Head\Config" name="translate-config"/>
             <block class="Magento\Translation\Block\Js" name="translate" template="Magento_Translation::translate.phtml"/>
             <block class="Magento\Framework\View\Element\Js\Cookie" name="js_cookies" template="Magento_Theme::js/cookie.phtml"/>
-            <block class="Magento\Theme\Block\Html\Notices" name="global_notices" template="html/notices.phtml"/>
+            <block class="Magento\Theme\Block\Html\Notices" name="global_notices" template="Magento_Theme::html/notices.phtml"/>
         </referenceContainer>
         <referenceBlock name="top.links">
             <block class="Magento\Theme\Block\Html\Header" name="header" as="header" before="-">
@@ -39,7 +39,7 @@
                             <argument name="label" translate="true" xsi:type="string">Skip to Content</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Store\Block\Switcher" name="store_language" as="store_language" template="switch/languages.phtml"/>
+                    <block class="Magento\Store\Block\Switcher" name="store_language" as="store_language" template="Magento_Store::switch/languages.phtml"/>
                     <block class="Magento\Framework\View\Element\Html\Links" name="top.links">
                         <arguments>
                             <argument name="css_class" xsi:type="string">header links</argument>
@@ -66,7 +66,7 @@
                     <arguments>
                         <argument name="title" translate="true" xsi:type="string">Menu</argument>
                     </arguments>
-                    <block class="Magento\Theme\Block\Html\Topmenu" name="catalog.topnav" template="html/topmenu.phtml" ttl="3600" before="-"/>
+                    <block class="Magento\Theme\Block\Html\Topmenu" name="catalog.topnav" template="Magento_Theme::html/topmenu.phtml" ttl="3600" before="-"/>
                 </block>
                 <block class="Magento\Framework\View\Element\Text" name="store.links" group="navigation-sections">
                     <arguments>
@@ -79,12 +79,12 @@
                     <arguments>
                         <argument name="title" translate="true" xsi:type="string">Settings</argument>
                     </arguments>
-                    <block class="Magento\Store\Block\Switcher" name="store.settings.language" template="switch/languages.phtml">
+                    <block class="Magento\Store\Block\Switcher" name="store.settings.language" template="Magento_Store::switch/languages.phtml">
                         <arguments>
                             <argument name="id_modifier" xsi:type="string">nav</argument>
                         </arguments>
                     </block>
-                    <block class="Magento\Directory\Block\Currency" name="store.settings.currency" template="currency.phtml">
+                    <block class="Magento\Directory\Block\Currency" name="store.settings.currency" template="Magento_Directory::currency.phtml">
                         <arguments>
                             <argument name="id_modifier" xsi:type="string">nav</argument>
                         </arguments>
@@ -95,7 +95,7 @@
             <block class="Magento\Theme\Block\Html\Breadcrumbs" name="breadcrumbs" as="breadcrumbs"/>
         </referenceContainer>
         <referenceContainer name="columns.top">
-            <block class="Magento\Theme\Block\Html\Title" name="page.main.title" template="html/title.phtml"/>
+            <block class="Magento\Theme\Block\Html\Title" name="page.main.title" template="Magento_Theme::html/title.phtml"/>
             <container name="page.messages" htmlTag="div" htmlClass="page messages">
                 <block class="Magento\Framework\View\Element\Template" name="ajax.message.placeholder" template="Magento_Theme::html/messages.phtml"/>
                 <block class="Magento\Framework\View\Element\Messages" name="messages" as="messages" template="Magento_Theme::messages.phtml"/>
@@ -112,18 +112,18 @@
         </referenceContainer>
         <referenceContainer name="footer-container">
             <container name="footer" as="footer" label="Page Footer" htmlTag="div" htmlClass="footer content">
-                <block class="Magento\Store\Block\Switcher" name="store_switcher" as="store_switcher" template="switch/stores.phtml"/>
+                <block class="Magento\Store\Block\Switcher" name="store_switcher" as="store_switcher" template="Magento_Store::switch/stores.phtml"/>
                 <block class="Magento\Framework\View\Element\Html\Links" name="footer_links">
                     <arguments>
                         <argument name="css_class" xsi:type="string">footer links</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Theme\Block\Html\Footer" name="copyright" template="html/copyright.phtml"/>
+                <block class="Magento\Theme\Block\Html\Footer" name="copyright" template="Magento_Theme::html/copyright.phtml"/>
                 <block class="Magento\Framework\View\Element\Template" name="report.bugs" template="Magento_Theme::html/bugreport.phtml" />
             </container>
         </referenceContainer>
         <referenceContainer name="before.body.end">
-            <block class="Magento\Theme\Block\Html\Footer" name="absolute_footer" template="html/absolute_footer.phtml" />
+            <block class="Magento\Theme\Block\Html\Footer" name="absolute_footer" template="Magento_Theme::html/absolute_footer.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\FormKey" name="formkey"/>

--- a/app/code/Magento/Ups/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/Ups/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="js">
-            <block class="Magento\Ups\Block\Backend\System\CarrierConfig" template="system/shipping/carrier_config.phtml"/>
+            <block class="Magento\Ups\Block\Backend\System\CarrierConfig" template="Magento_Ups::system/shipping/carrier_config.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_editrole.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_editrole.xml
@@ -19,7 +19,7 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Backend\Block\Template" name="adminhtml.user.roles.users.grid.js" template="Magento_User::role/users_grid_js.phtml"/>
-            <block class="Magento\User\Block\Buttons" name="adminhtml.user.role.buttons" template="role/info.phtml"/>
+            <block class="Magento\User\Block\Buttons" name="adminhtml.user.role.buttons" template="Magento_User::role/info.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Vault/view/frontend/layout/vault_cards_listaction.xml
+++ b/app/code/Magento/Vault/view/frontend/layout/vault_cards_listaction.xml
@@ -9,8 +9,8 @@
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Vault\Block\Customer\CreditCards" name="vault.cards.list" cacheable="false" template="cards_list.phtml" />
-            <block class="Magento\Vault\Block\Customer\AccountTokens" name="vault.token.list" cacheable="false" template="token_list.phtml" />
+            <block class="Magento\Vault\Block\Customer\CreditCards" name="vault.cards.list" cacheable="false" template="Magento_Vault::cards_list.phtml" />
+            <block class="Magento\Vault\Block\Customer\AccountTokens" name="vault.token.list" cacheable="false" template="Magento_Vault::token_list.phtml" />
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Weee/view/adminhtml/layout/sales_creditmemo_item_price.xml
+++ b/app/code/Magento/Weee/view/adminhtml/layout/sales_creditmemo_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="creditmemo_items">
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="Magento_Weee::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="Magento_Weee::items/price/row.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="Magento_Weee::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Weee/view/adminhtml/layout/sales_invoice_item_price.xml
+++ b/app/code/Magento/Weee/view/adminhtml/layout/sales_invoice_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="invoice_items">
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="Magento_Weee::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="Magento_Weee::items/price/row.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="Magento_Weee::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Weee/view/adminhtml/layout/sales_order_create_item_price.xml
+++ b/app/code/Magento/Weee/view/adminhtml/layout/sales_order_create_item_price.xml
@@ -7,17 +7,17 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_unit_price" template="order/create/items/price/unit.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_unit_price" template="Magento_Weee::order/create/items/price/unit.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total" template="order/create/items/price/row.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total" template="Magento_Weee::order/create/items/price/row.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total_with_discount" template="order/create/items/price/total.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total_with_discount" template="Magento_Weee::order/create/items/price/total.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>

--- a/app/code/Magento/Weee/view/adminhtml/layout/sales_order_item_price.xml
+++ b/app/code/Magento/Weee/view/adminhtml/layout/sales_order_item_price.xml
@@ -8,9 +8,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="order_items">
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="items/price/unit.phtml" group="column"/>
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="items/price/row.phtml" group="column"/>
-            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="items/price/total.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_price" template="Magento_Weee::items/price/unit.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_subtotal" template="Magento_Weee::items/price/row.phtml" group="column"/>
+            <block class="Magento\Weee\Block\Adminhtml\Items\Price\Renderer" name="column_total" template="Magento_Weee::items/price/total.phtml" group="column"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Weee/view/frontend/layout/checkout_item_price_renderers.xml
+++ b/app/code/Magento/Weee/view/frontend/layout/checkout_item_price_renderers.xml
@@ -7,32 +7,32 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.excl" template="checkout/onepage/review/item/price/unit_excl_tax.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.excl" template="Magento_Weee::checkout/onepage/review/item/price/unit_excl_tax.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.incl" template="checkout/onepage/review/item/price/unit_incl_tax.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.unit.incl" template="Magento_Weee::checkout/onepage/review/item/price/unit_incl_tax.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.excl" template="checkout/onepage/review/item/price/row_excl_tax.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.excl" template="Magento_Weee::checkout/onepage/review/item/price/row_excl_tax.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.incl" template="checkout/onepage/review/item/price/row_incl_tax.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.onepage.review.item.price.rowtotal.incl" template="Magento_Weee::checkout/onepage/review/item/price/row_incl_tax.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.item.price.unit" template="item/price/unit.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.item.price.unit" template="Magento_Weee::item/price/unit.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.item.price.row" template="item/price/row.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="checkout.item.price.row" template="Magento_Weee::item/price/row.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">cart</argument>
             </arguments>

--- a/app/code/Magento/Weee/view/frontend/layout/sales_email_item_price.xml
+++ b/app/code/Magento/Weee/view/frontend/layout/sales_email_item_price.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="items">
-            <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_price" template="email/items/price/row.phtml">
+            <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_price" template="Magento_Weee::email/items/price/row.phtml">
                 <arguments>
                     <argument name="zone" xsi:type="string">email</argument>
                 </arguments>

--- a/app/code/Magento/Weee/view/frontend/layout/sales_order_item_price.xml
+++ b/app/code/Magento/Weee/view/frontend/layout/sales_order_item_price.xml
@@ -7,16 +7,16 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_unit_price" template="item/price/unit.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_unit_price" template="Magento_Weee::item/price/unit.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">sales</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total" template="item/price/row.phtml">
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total" template="Magento_Weee::item/price/row.phtml">
             <arguments>
                 <argument name="zone" xsi:type="string">sales</argument>
             </arguments>
         </block>
-        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total_after_discount" template="item/price/total_after_discount.phtml"/>
+        <block class="Magento\Weee\Block\Item\Price\Renderer" name="item_row_total_after_discount" template="Magento_Weee::item/price/total_after_discount.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Wishlist/composer.json
+++ b/app/code/Magento/Wishlist/composer.json
@@ -12,7 +12,6 @@
         "magento/module-rss": "100.1.*",
         "magento/module-backend": "100.1.*",
         "magento/module-sales": "100.1.*",
-        "magento/module-grouped-product": "100.1.*",
         "magento/framework": "100.1.*",
         "magento/module-ui": "100.1.*"
     },
@@ -21,6 +20,7 @@
         "magento/module-downloadable": "100.1.*",
         "magento/module-bundle": "100.1.*",
         "magento/module-cookie": "100.1.*",
+        "magento/module-grouped-product": "100.1.*",
         "magento/module-wishlist-sample-data": "Sample Data version:100.1.*"
     },
     "type": "magento2-module",

--- a/app/code/Magento/Wishlist/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -8,25 +8,25 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers.default.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.default.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.default.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.default.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.default.actions.edit"/>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.simple.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.simple.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.simple.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.simple.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.simple.actions.edit"/>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.bundle.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.bundle.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.bundle.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.bundle.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.bundle.actions.edit"/>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.downloadable.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.downloadable.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.downloadable.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.downloadable.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.downloadable.actions.edit"/>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.grouped.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.grouped.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.grouped.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.grouped.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.grouped.actions.edit"/>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.configurable.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.configurable.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.configurable.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.configurable.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.configurable.actions.edit"/>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.virtual.actions">
-            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.virtual.actions.move_to_wishlist" template="cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.virtual.actions.edit"/>
+            <block class="Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist" name="checkout.cart.item.renderers.virtual.actions.move_to_wishlist" template="Magento_Wishlist::cart/item/renderer/actions/move_to_wishlist.phtml" before="checkout.cart.item.renderers.virtual.actions.edit"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure.xml
@@ -10,7 +10,7 @@
     <body>
         <referenceBlock name="product.info.addto">
             <block class="Magento\Wishlist\Block\Item\Configure" name="view.addto.wishlist" after="view.addto.requisition"
-                template="item/configure/addto/wishlist.phtml" />
+                template="Magento_Wishlist::item/configure/addto/wishlist.phtml" />
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
@@ -17,11 +17,11 @@
                         <argument name="zone" xsi:type="string">item_view</argument>
                     </arguments>
                 </block>
-                <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart.bundle" as="addtocart" template="product/view/addtocart.phtml" />
+                <block class="Magento\Catalog\Block\Product\View" name="product.info.addtocart.bundle" as="addtocart" template="Magento_Catalog::product/view/addtocart.phtml" />
                 <block class="Magento\Catalog\Block\Product\View" name="product.info.addto.bundle" as="addto" after="product.info.addtocart.bundle"
                        template="Magento_Catalog::product/view/addto.phtml" cacheable="false">
                     <block class="Magento\Wishlist\Block\Item\Configure" name="view.addto.wishlist.bundle" after="view.addto.requisition"
-                           template="item/configure/addto/wishlist.phtml" />
+                           template="Magento_Wishlist::item/configure/addto/wishlist.phtml" />
                     <block class="Magento\Catalog\Block\Product\View\AddTo\Compare" name="view.addto.compare.bundle" after="view.addto.wishlist"
                            template="Magento_Catalog::product/view/addto/compare.phtml" />
                 </block>
@@ -29,7 +29,7 @@
         </referenceBlock>
         <referenceBlock name="product.info.options.wrapper">
             <block class="Magento\Catalog\Block\Product\View" name="bundle.product.view.options.notice" template="Magento_Bundle::catalog/product/view/options/notice.phtml"/>
-            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle.options" as="type_bundle_options" template="catalog/product/view/type/bundle/options.phtml" before="-">
+            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle.options" as="type_bundle_options" template="Magento_Bundle::catalog/product/view/type/bundle/options.phtml" before="-">
                 <container name="product.info.bundle.options.top" as="product_info_bundle_options_top">
                     <block class="Magento\Catalog\Block\Product\View" name="bundle.back.button" as="backButton" before="-" template="Magento_Bundle::catalog/product/view/backbutton.phtml"/>
                 </container>
@@ -41,7 +41,7 @@
         </referenceBlock>
         <move element="product.price.tier" destination="product.info.options.wrapper.bottom" before="-" />
         <referenceBlock name="product.info.options.wrapper.bottom">
-            <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.qtyincrements" before="-" template="qtyincrements.phtml"/>
+            <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.qtyincrements" before="-" template="Magento_CatalogInventory::qtyincrements.phtml"/>
             <action method="unsetChild">
                 <argument name="block" xsi:type="string">product.info.addtocart</argument>
             </action>
@@ -56,7 +56,7 @@
             <container name="bundle.options.container" htmlTag="div" htmlClass="bundle-options-container" after="product.info.media"/>
         </referenceContainer>
         <referenceContainer name="product.info.type">
-            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle" as="product_type_data" template="catalog/product/view/type/bundle.phtml"/>
+            <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle" as="product_type_data" template="Magento_Bundle::catalog/product/view/type/bundle.phtml"/>
             <container name="product.info.bundle.extra" after="product.info.bundle" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
         <referenceContainer name="product.info.main">

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_configurable.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_configurable.xml
@@ -17,7 +17,7 @@
             <container name="product.info.configurable.extra" after="product.info.configurable" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
         <referenceBlock name="product.info.options.wrapper">
-            <block class="Magento\ConfigurableProduct\Block\Product\View\Type\Configurable" name="product.info.options.configurable" as="options_configurable" before="-" template="product/view/type/options/configurable.phtml"/>
+            <block class="Magento\ConfigurableProduct\Block\Product\View\Type\Configurable" name="product.info.options.configurable" as="options_configurable" before="-" template="Magento_ConfigurableProduct::product/view/type/options/configurable.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_downloadable.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_downloadable.xml
@@ -13,15 +13,15 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="downloadable_page_head_components" template="Magento_Downloadable::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="product.info.main">
-            <block class="Magento\Downloadable\Block\Catalog\Product\Samples" name="product.info.downloadable.samples" as="samples" template="catalog/product/samples.phtml" after="product.price.tier" />
+            <block class="Magento\Downloadable\Block\Catalog\Product\Samples" name="product.info.downloadable.samples" as="samples" template="Magento_Downloadable::catalog/product/samples.phtml" after="product.price.tier" />
         </referenceContainer>
         <referenceContainer name="product.info.type">
-            <block class="Magento\Downloadable\Block\Catalog\Product\View\Type" name="product.info.downloadable" as="product_type_data" template="catalog/product/type.phtml">
-                <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" name="product.info.downloadable.extra" as="product_type_data_extra" template="stockqty/default.phtml"/>
+            <block class="Magento\Downloadable\Block\Catalog\Product\View\Type" name="product.info.downloadable" as="product_type_data" template="Magento_Downloadable::catalog/product/type.phtml">
+                <block class="Magento\CatalogInventory\Block\Stockqty\DefaultStockqty" name="product.info.downloadable.extra" as="product_type_data_extra" template="Magento_CatalogInventory::stockqty/default.phtml"/>
             </block>
         </referenceContainer>
         <referenceBlock name="product.info.options.wrapper">
-            <block class="Magento\Downloadable\Block\Catalog\Product\Links" name="product.info.downloadable.options" as="type_downloadable_options" before="-" template="catalog/product/links.phtml">
+            <block class="Magento\Downloadable\Block\Catalog\Product\Links" name="product.info.downloadable.options" as="type_downloadable_options" before="-" template="Magento_Downloadable::catalog/product/links.phtml">
                 <block class="Magento\Catalog\Pricing\Render" name="product.price.link" after="product.info.downloadable.options">
                     <arguments>
                         <argument name="price_render" xsi:type="string">product.price.render.default</argument>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_grouped.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_grouped.xml
@@ -9,7 +9,7 @@
     <body>
         <attribute name="class" value="page-product-grouped"/>
         <referenceContainer name="product.info.form.content">
-            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" name="product.info.grouped" before="product.info.addtocart" template="product/view/type/grouped.phtml"/>
+            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" name="product.info.grouped" before="product.info.addtocart" template="Magento_GroupedProduct::product/view/type/grouped.phtml"/>
             <container name="product.info.grouped.extra" after="product.info.grouped" before="product.info.grouped" as="product_type_data_extra" label="Product Extra Info"/>
         </referenceContainer>
     </body>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_index.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_index.xml
@@ -12,12 +12,12 @@
             <block class="Magento\Framework\View\Element\Js\Components" name="wishlist_head_components" template="Magento_Wishlist::js/components.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Magento\Wishlist\Block\Customer\Wishlist" name="customer.wishlist" template="view.phtml" cacheable="false">
-                <block class="Magento\Wishlist\Block\Rss\Link" name="wishlist.rss.link" template="rss/wishlist.phtml"/>
-                <block class="Magento\Wishlist\Block\Customer\Wishlist\Items" name="customer.wishlist.items" as="items" template="item/list.phtml" cacheable="false">
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image" name="customer.wishlist.item.image" template="item/column/image.phtml" cacheable="false"/>
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Info" name="customer.wishlist.item.name" template="item/column/name.phtml" cacheable="false"/>
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart" name="customer.wishlist.item.price" template="item/column/price.phtml" cacheable="false">
+            <block class="Magento\Wishlist\Block\Customer\Wishlist" name="customer.wishlist" template="Magento_Wishlist::view.phtml" cacheable="false">
+                <block class="Magento\Wishlist\Block\Rss\Link" name="wishlist.rss.link" template="Magento_Wishlist::rss/wishlist.phtml"/>
+                <block class="Magento\Wishlist\Block\Customer\Wishlist\Items" name="customer.wishlist.items" as="items" template="Magento_Wishlist::item/list.phtml" cacheable="false">
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image" name="customer.wishlist.item.image" template="Magento_Wishlist::item/column/image.phtml" cacheable="false"/>
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Info" name="customer.wishlist.item.name" template="Magento_Wishlist::item/column/name.phtml" cacheable="false"/>
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart" name="customer.wishlist.item.price" template="Magento_Wishlist::item/column/price.phtml" cacheable="false">
                         <block class="Magento\Catalog\Pricing\Render" name="product.price.render.wishlist">
                             <arguments>
                                 <argument name="price_render" xsi:type="string">product.price.render.default</argument>
@@ -28,34 +28,34 @@
                         </block>
                         <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Options" name="customer.wishlist.item.options" cacheable="false"/>
                     </block>
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Actions" name="customer.wishlist.item.inner" template="item/column/actions.phtml" cacheable="false">
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Actions" name="customer.wishlist.item.inner" template="Magento_Wishlist::item/column/actions.phtml" cacheable="false">
                         <arguments>
                             <argument name="css_class" xsi:type="string">product-item-inner</argument>
                         </arguments>
-                        <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Comment" name="customer.wishlist.item.comment" template="item/column/comment.phtml" cacheable="false">
+                        <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Comment" name="customer.wishlist.item.comment" template="Magento_Wishlist::item/column/comment.phtml" cacheable="false">
                             <arguments>
                                 <argument name="title" translate="true" xsi:type="string">Product Details and Comment</argument>
                             </arguments>
                         </block>
-                        <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart" name="customer.wishlist.item.cart" template="item/column/cart.phtml" cacheable="false">
+                        <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart" name="customer.wishlist.item.cart" template="Magento_Wishlist::item/column/cart.phtml" cacheable="false">
                             <arguments>
                                 <argument name="title" translate="true" xsi:type="string">Add to Cart</argument>
                             </arguments>
                         </block>
 
-                        <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Actions" name="customer.wishlist.item.actions" template="item/column/actions.phtml" cacheable="false">
+                        <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Actions" name="customer.wishlist.item.actions" template="Magento_Wishlist::item/column/actions.phtml" cacheable="false">
                             <arguments>
                                 <argument name="css_class" xsi:type="string">product-item-actions</argument>
                             </arguments>
-                            <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Edit" name="customer.wishlist.item.edit" template="item/column/edit.phtml" before="-" cacheable="false"/>
-                            <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Remove" name="customer.wishlist.item.remove" template="item/column/remove.phtml" cacheable="false"/>
+                            <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Edit" name="customer.wishlist.item.edit" template="Magento_Wishlist::item/column/edit.phtml" before="-" cacheable="false"/>
+                            <block class="Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Remove" name="customer.wishlist.item.remove" template="Magento_Wishlist::item/column/remove.phtml" cacheable="false"/>
                         </block>
                     </block>
                 </block>
                 <container name="customer.wishlist.buttons" as="control_buttons" label="Wishlist Control Buttons">
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Button" name="customer.wishlist.button.update" template="button/update.phtml" cacheable="false"/>
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Button" name="customer.wishlist.button.share" template="button/share.phtml" cacheable="false"/>
-                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Button" name="customer.wishlist.button.toCart" template="button/tocart.phtml" cacheable="false"/>
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Button" name="customer.wishlist.button.update" template="Magento_Wishlist::button/update.phtml" cacheable="false"/>
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Button" name="customer.wishlist.button.share" template="Magento_Wishlist::button/share.phtml" cacheable="false"/>
+                    <block class="Magento\Wishlist\Block\Customer\Wishlist\Button" name="customer.wishlist.button.toCart" template="Magento_Wishlist::button/tocart.phtml" cacheable="false"/>
                 </container>
             </block>
         </referenceContainer>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_share.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_share.xml
@@ -9,7 +9,7 @@
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Wishlist\Block\Customer\Sharing" name="wishlist.sharing" template="sharing.phtml" cacheable="false"/>
+            <block class="Magento\Wishlist\Block\Customer\Sharing" name="wishlist.sharing" template="Magento_Wishlist::sharing.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_shared_index.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_shared_index.xml
@@ -8,7 +8,7 @@
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Wishlist\Block\Share\Wishlist" name="customer.wishlist" template="shared.phtml" cacheable="false"/>
+            <block class="Magento\Wishlist\Block\Share\Wishlist" name="customer.wishlist" template="Magento_Wishlist::shared.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
@@ -8,8 +8,8 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="header.links">
-            <block class="Magento\Customer\Block\Account\Customer" name="customer" template="account/customer.phtml" before="-"/>
-            <block class="Magento\Customer\Block\Account\AuthorizationLink" name="authorization-link-login" template="account/link/authorization.phtml"/>
+            <block class="Magento\Customer\Block\Account\Customer" name="customer" template="Magento_Customer::account/customer.phtml" before="-"/>
+            <block class="Magento\Customer\Block\Account\AuthorizationLink" name="authorization-link-login" template="Magento_Customer::account/link/authorization.phtml"/>
         </referenceBlock>
         <block class="Magento\Theme\Block\Html\Header" name="header" as="header">
             <arguments>

--- a/app/design/frontend/Magento/luma/Magento_Theme/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Theme/layout/default.xml
@@ -21,7 +21,7 @@
             </arguments>
         </referenceBlock>
         <referenceContainer name="footer">
-            <block class="Magento\Store\Block\Switcher" name="store_switcher" as="store_switcher" after="footer_links" template="switch/stores.phtml"/>
+            <block class="Magento\Store\Block\Switcher" name="store_switcher" as="store_switcher" after="footer_links" template="Magento_Store::switch/stores.phtml"/>
         </referenceContainer>
         <referenceBlock name="report.bugs" remove="true"/>
         <move element="copyright" destination="before.body.end"/>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
@@ -13,7 +13,7 @@ class MergeTest extends \PHPUnit_Framework_TestCase
      * Fixture XML instruction(s) to be used in tests
      */
     // @codingStandardsIgnoreStart
-    const FIXTURE_LAYOUT_XML = '<block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>';
+    const FIXTURE_LAYOUT_XML = '<block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>';
     // @codingStandardsIgnoreEnd
 
     /**
@@ -226,10 +226,12 @@ class MergeTest extends \PHPUnit_Framework_TestCase
         $expectedResult = '
             <root>
                 <body>
-                    <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+                    <block class="Magento\Framework\View\Element\Template" 
+                           template="Magento_Framework::fixture_template_one.phtml"/>
                 </body>
                 <body>
-                    <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+                    <block class="Magento\Framework\View\Element\Template" 
+                           template="Magento_Framework::fixture_template_two.phtml"/>
                 </body>
             </root>
         ';
@@ -245,7 +247,8 @@ class MergeTest extends \PHPUnit_Framework_TestCase
             <root>
                 <body>
                     <referenceContainer name="main.container">
-                        <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+                        <block class="Magento\Framework\View\Element\Template" 
+                               template="Magento_Framework::fixture_template_one.phtml"/>
                     </referenceContainer>
                 </body>
             </root>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_files/_layout_update.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_files/_layout_update.xml
@@ -12,7 +12,7 @@
         <script src="prototype/window.js"/>
         <script src="prototype/deprecation.js"/>
     </head>
-    <block class="Magento\Backend\Block\Page" name="root" output="1" template="page.phtml">
+    <block class="Magento\Backend\Block\Page" name="root" output="1" template="Magento_Backend::page.phtml">
         <block class="Magento\Backend\Block\Page" name="nodeForTesting">
             <action method="setSomething"/>
         </block>
@@ -38,6 +38,6 @@
         <action method="getSomething"/>
     </referenceBlock>
     <referenceBlock name="after.body.start">
-        <block class="Magento\Framework\View\Element\Html\Calendar" name="head.calendar" as="calendar" template="page/js/calendar.phtml"/>
+        <block class="Magento\Framework\View\Element\Html\Calendar" name="head.calendar" as="calendar" template="Magento_Framework::page/js/calendar.phtml"/>
     </referenceBlock>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/layout/fixture_handle_one.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/layout/fixture_handle_one.xml
@@ -7,6 +7,6 @@
 -->
 <page>
     <body>
-        <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+        <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>
     </body>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/layout/fixture_handle_two.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/layout/fixture_handle_two.xml
@@ -7,6 +7,6 @@
 -->
 <page>
     <body>
-        <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+        <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_two.phtml"/>
     </body>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/layout/fixture_handle_with_page_layout.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/layout/fixture_handle_with_page_layout.xml
@@ -8,7 +8,7 @@
 <page layout="fixture_handle_page_layout">
     <body>
         <referenceContainer name="main.container">
-            <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+            <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/merged.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/_mergeFiles/merged.xml
@@ -30,7 +30,7 @@
     </handle>
     <handle id="fixture_handle_one">
         <body>
-            <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+            <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>
         </body>
     </handle>
     <layout id="fixture_handle_page_layout">
@@ -38,13 +38,13 @@
     </layout>
     <handle id="fixture_handle_two">
         <body>
-            <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+            <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_two.phtml"/>
         </body>
     </handle>
     <handle id="fixture_handle_with_page_layout" layout="fixture_handle_page_layout">
         <body>
             <referenceContainer name="main.container">
-                <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+                <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>
             </referenceContainer>
         </body>
     </handle>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/MergeTest.php
@@ -31,12 +31,12 @@ class MergeTest extends \PHPUnit_Framework_TestCase
             'Magento\Widget\Model\Layout\Update'
         );
         $layoutUpdate1->setHandle('fixture_handle_one');
-        $layoutUpdate1->setXml('
-            <body>
+        $layoutUpdate1->setXml(
+            '<body>
                 <block class="Magento\Framework\View\Element\Template"
                        template="Magento_Framework::fixture_template_one.phtml"/>
-            </body>
-        ');
+            </body>'
+        );
         $layoutUpdate1->setHasDataChanges(true);
         $layoutUpdate1->save();
         $link1 = $objectManager->create('Magento\Widget\Model\Layout\Link');
@@ -49,12 +49,12 @@ class MergeTest extends \PHPUnit_Framework_TestCase
             'Magento\Widget\Model\Layout\Update'
         );
         $layoutUpdate2->setHandle('fixture_handle_two');
-        $layoutUpdate2->setXml('
-            <body>
+        $layoutUpdate2->setXml(
+            '<body>
                 <block class="Magento\Framework\View\Element\Template"
                        template="Magento_Framework::fixture_template_two.phtml"/>
-            </body>
-        ');
+            </body>'
+        );
         $layoutUpdate2->setHasDataChanges(true);
         $layoutUpdate2->save($layoutUpdate2);
         $link2 = $objectManager->create('Magento\Widget\Model\Layout\Link');
@@ -62,10 +62,10 @@ class MergeTest extends \PHPUnit_Framework_TestCase
         $link2->setLayoutUpdateId($layoutUpdate2->getId());
         $link2->save();
 
-        $this->model = $objectManager->create('Magento\Framework\View\Model\Layout\Merge',
-            [
-                'theme' => $theme
-            ]);
+        $this->model = $objectManager->create(
+            'Magento\Framework\View\Model\Layout\Merge',
+            ['theme' => $theme]
+        );
     }
 
     public function testLoadDbApp()

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/MergeTest.php
@@ -10,7 +10,8 @@ class MergeTest extends \PHPUnit_Framework_TestCase
     /**
      * Fixture XML instruction(s) to be used in tests
      */
-    const FIXTURE_LAYOUT_XML = '<block class="Magento\Framework\View\Element\Template" template="fixture.phtml"/>';
+    const FIXTURE_LAYOUT_XML
+        = '<block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture.phtml"/>';
 
     /**
      * @var \Magento\Framework\View\Model\Layout\Merge
@@ -32,7 +33,8 @@ class MergeTest extends \PHPUnit_Framework_TestCase
         $layoutUpdate1->setHandle('fixture_handle_one');
         $layoutUpdate1->setXml('
             <body>
-                <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+                <block class="Magento\Framework\View\Element\Template"
+                       template="Magento_Framework::fixture_template_one.phtml"/>
             </body>
         ');
         $layoutUpdate1->setHasDataChanges(true);
@@ -49,7 +51,8 @@ class MergeTest extends \PHPUnit_Framework_TestCase
         $layoutUpdate2->setHandle('fixture_handle_two');
         $layoutUpdate2->setXml('
             <body>
-                <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+                <block class="Magento\Framework\View\Element\Template"
+                       template="Magento_Framework::fixture_template_two.phtml"/>
             </body>
         ');
         $layoutUpdate2->setHasDataChanges(true);
@@ -74,10 +77,12 @@ class MergeTest extends \PHPUnit_Framework_TestCase
         $expectedResult = '
             <root>
                 <body>
-                    <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+                    <block class="Magento\Framework\View\Element\Template"
+                           template="Magento_Framework::fixture_template_one.phtml"/>
                 </body>
                 <body>
-                    <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+                    <block class="Magento\Framework\View\Element\Template"
+                           template="Magento_Framework::fixture_template_two.phtml"/>
                 </body>
             </root>
         ';

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/_files/layout/fixture_handle_one.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/_files/layout/fixture_handle_one.xml
@@ -7,6 +7,6 @@
 -->
 <page>
     <body>
-        <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+        <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>
     </body>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/_files/layout/fixture_handle_two.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Model/Layout/_files/layout/fixture_handle_two.xml
@@ -7,6 +7,6 @@
 -->
 <page>
     <body>
-        <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+        <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_two.phtml"/>
     </body>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/default/Magento_Core/layout_test_handle_sample.xml
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/default/Magento_Core/layout_test_handle_sample.xml
@@ -13,9 +13,9 @@
         <script src="prototype/deprecation.js"/>
     </head>
     <referenceBlock name="after.body.start">
-        <block class="Magento\Framework\View\Element\Html\Calendar" name="head.calendar" as="calendar" template="page/js/calendar.phtml"/>
+        <block class="Magento\Framework\View\Element\Html\Calendar" name="head.calendar" as="calendar" template="Magento_Framework::page/js/calendar.phtml"/>
     </referenceBlock>
-    <block class="Magento\Backend\Block\Page" name="root" output="1" template="page.phtml">
+    <block class="Magento\Backend\Block\Page" name="root" output="1" template="Magento_Backend::page.phtml">
         <block class="Magento\Backend\Block\Page\Header" name="header" as="header"/>
         <block class="Magento\Backend\Block\Menu" name="menu" as="menu"/>
         <block class="Magento\Framework\View\Element\Messages" name="messages" as="messages"/>

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/TemplatesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/TemplatesTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Test layout declaration and usage of block elements
+ *
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Test\Integrity\Layout;
+
+use Magento\Framework\App\Utility\Files;
+
+class TemplatesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var array
+     */
+    protected static $templates = [];
+
+    /**
+     * @var array
+     */
+    protected static $blockVirtualTypes = [];
+
+    /**
+     * Collect declarations of containers per layout file that have aliases
+     */
+    public static function setUpBeforeClass()
+    {
+        $count = 0;
+        self::getBlockVirtualTypesWithDifferentModule();
+        foreach (Files::init()->getLayoutFiles([], false) as $file) {
+            $xml = simplexml_load_file($file);
+            $blocks = $xml->xpath('//block[@template]') ?: [];
+            $fileTemplates = [];
+            foreach ($blocks as $block) {
+                $fileTemplates[] = ['class' => (string)$block['class'], 'file' => (string)$block['template']];
+            }
+            if (!empty($fileTemplates)) {
+                self::$templates[$file] = $fileTemplates;
+                $count += count($fileTemplates);
+            }
+        }
+    }
+
+    /**
+     * Test that references to template files follows canonical format.
+     *
+     * path/to/template.phtml Format is prohibited.
+     * @return void
+     */
+    public function testTemplateFollowsCanonicalName()
+    {
+        $errors = [];
+        $warnings = [];
+        foreach (self::$templates as $file => $templates) {
+            foreach ($templates as $templatePair) {
+                if (!preg_match('/[A-Za-z0-9]_[A-Za-z0-9]+\:\:[A-Za-z0-9\\_\-\.]+/', $templatePair['file'])) {
+                    if (!isset($errors[$file])) {
+                        $errors[$file] = [];
+                    }
+                    $errors[$file][] = $templatePair['file'];
+                } else {
+                    if (isset(self::$blockVirtualTypes[$templatePair['class']])) {
+                        $warnings[$file][] = $templatePair;
+                    }
+                }
+            }
+        }
+        if (count($errors) > 0) {
+            $message = 'Failed to assert that the template reference follows the canonical format '
+                     . 'Vendor' . '_' . 'Module::path/to/template.phtml. Following files haven\'t pass verification:'
+                     . PHP_EOL;
+            foreach ($errors as $file => $wrongTemplates) {
+                $message .= $file . ':' . PHP_EOL;
+                $message .= '- ' . implode(PHP_EOL . '- ', $wrongTemplates) . PHP_EOL;
+            }
+            $this->fail($message);
+        }
+    }
+
+    /**
+     * Initialize array with the Virtual types for blocks
+     *
+     * Contains just those occurrences where base type and virtual type are located in different modules
+     */
+    private static function getBlockVirtualTypesWithDifferentModule()
+    {
+        $virtual = \Magento\Framework\App\Utility\Classes::getVirtualClasses();
+        foreach ($virtual as $className => $resolvedName) {
+            if (strpos($resolvedName, 'Block') !== false) {
+                $matches = [];
+                preg_match('/([A-Za-z0-9]+\\\\[A-Za-z0-9]+).*/', $className, $matches);
+                if (count($matches) > 1) {
+                    $oldModule = $matches[1];
+                } else {
+                    $oldModule = $className;
+                }
+
+                $matches = [];
+                preg_match('/([A-Za-z0-9]+\\\\[A-Za-z0-9]+).*/', $resolvedName, $matches);
+                $newModule = $matches[1];
+                if ($oldModule != $newModule) {
+                    self::$blockVirtualTypes[$className] = $resolvedName;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This is a backport of https://github.com/magento/magento2/pull/1895 for Magento 2.1
I started with cherry picking this commit: https://github.com/magento/magento2/commit/a4341625abdf4321849b4c318abd20eece843856 (since it contains some extra fixes above the PR referenced above) and fixed a bunch of merge conflicts.
Then ran the new static test introduced in the above commit, which revealed two more files which needed fixing, and fixed those two in a separate commit (curiously enough they were fixed in the initial PR by @davidalger, but were not included in the merge commit from @vrann)

Please be very careful when reviewing this, a lot of files have changed!
I'm not exactly sure about the changes in the `composer.json` files, but since they were included in the commit from @vrann, I also included them.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/7273: Remember me template is not loaded from the original module
2. https://github.com/magento/magento2/issues/1287: setting target Module Name when generating a block
3. https://github.com/magento/magento2/pull/11004: fix for lost template when creating a preference for Magento\Checkout\Block\Cart\Item\Renderer
...


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
