### PR TITLE
Backport of MAGETWO-69379 for Magento 2.1: use payment method name to…

### DIFF
--- a/app/code/Magento/CheckoutAgreements/view/frontend/web/js/view/checkout-agreements.js
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/web/js/view/checkout-agreements.js
@@ -46,6 +46,26 @@ define(
             },
 
             /**
+             * build a unique id for the term checkbox
+             *
+             * @param {Object} context - the ko context
+             * @param {Number} agreementId
+             */
+            getCheckboxId: function (context, agreementId) {
+                var paymentMethodName = '',
+                    paymentMethodRenderer = context.$parents[1];
+
+                // corresponding payment method fetched from parent context
+                if (paymentMethodRenderer) {
+                    // item looks like this: {title: "Check / Money order", method: "checkmo"}
+                    paymentMethodName = paymentMethodRenderer.item ?
+                      paymentMethodRenderer.item.method : '';
+                }
+
+                return 'agreement_' + paymentMethodName + '_' + agreementId;
+            },
+
+            /**
              * Init modal window for rendered element
              *
              * @param element

--- a/app/code/Magento/CheckoutAgreements/view/frontend/web/template/checkout/checkout-agreements.html
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/web/template/checkout/checkout-agreements.html
@@ -11,11 +11,11 @@
             <div class="checkout-agreement required">
                 <input type="checkbox" class="required-entry"
                        data-bind="attr: {
-                                    'id': 'agreement_' + agreementId,
+                                    'id': $parent.getCheckboxId($parentContext, agreementId),
                                     'name': 'agreement[' + agreementId + ']',
                                     'value': agreementId
                                     }"/>
-                <label data-bind="attr: {'for': 'agreement_' + agreementId}">
+                <label data-bind="attr: {'for': $parent.getCheckboxId($parentContext, agreementId)}">
                     <button type="button"
                             class="action action-show"
                             data-bind="click: function(data, event) { return $parent.showContent(data, event) }"


### PR DESCRIPTION
… make checkbox of agreements more unique #6207 #9717

(cherry picked from commit 14b9b9813c9a16c0c45505885503cfb71bc4eb8d)

### Description
This is a backport of MAGETWO-69379 for Magento 2.1 (see https://github.com/magento/magento2/pull/9717)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6207: Checkbox IDs for Terms and Conditions should be unique in Checkout

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
