### PR TITLE
[FIX] Add qty type check to the wishlist update action

### DIFF
--- a/app/code/Magento/Wishlist/Controller/Index/Update.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Update.php
@@ -12,7 +12,6 @@ use Magento\Wishlist\Model\LocaleQuantityProcessor;
 use Magento\Wishlist\Controller\WishlistProviderInterface;
 use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
-use Magento\Framework\App\ObjectManager;
 
 class Update extends \Magento\Wishlist\Controller\AbstractIndex
 {
@@ -54,8 +53,9 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
         $this->wishlistProvider = $wishlistProvider;
         $this->quantityProcessor = $quantityProcessor;
         parent::__construct($context);
-        $this->stockItemRepository = $stockItemRepository ?: ObjectManager::getInstance()
-            ->get(StockItemRepositoryInterface::class);
+        $this->stockItemRepository = $stockItemRepository ?: $this->_objectManager->get(
+            StockItemRepositoryInterface::class
+        );
     }
 
     /**
@@ -101,10 +101,10 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
 
                 $qty = null;
                 if (isset($post['qty'][$itemId])) {
-                    $stockItem = $this->stockItemRepository->get($itemId);
                     $qty = $this->quantityProcessor->process($post['qty'][$itemId]);
-                    if (is_double($qty) && !$stockItem->getIsQtyDecimal()) {
-                        $qty = floor($qty);
+                    if (is_double($qty)) {
+                        $stockItem = $this->stockItemRepository->get($itemId);
+                        $qty = !$stockItem->getIsQtyDecimal() ? floor($qty) : $qty;
                     }
                 }
                 if ($qty === null) {


### PR DESCRIPTION
### Description
In the wishlist page it is possible to set 0 for qty input if you try to add decimal less than 1 but greater than 0 for products having "Qty Uses Decimals" eq to "No".
From my point of view, it is not so logically because:
1. You can add the decimal value to product which should not have this type of qty
2. You can get 0 and will not be able to proceed with cart/checkout until changing qty to the right format.
3. Just unexpectable behaviour :)

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Add product which has "Qty Uses Decimals"="No" to the wishlist
2. Go to the wishlist page
3. Set qty to 0.5
4. Press "Update Wish List"
5. Check qty input value - it will have 0 value

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
