### PR TITLE
Fixed Duplicate entry '0-0-0-0' for key 'PRIMARY' during setup:upgrade for Magento_SalesRule Data

### DIFF
--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
@@ -349,7 +349,9 @@ class Rule extends AbstractResource
                     }
                 }
             }
-            $connection->insertMultiple($this->getTable('salesrule_product_attribute'), $data);
+            if ($data) {
+                $connection->insertMultiple($this->getTable('salesrule_product_attribute'), $data);
+            }
         }
 
         return $this;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
During the upgrade of sales rules data from Magento 2.1.7 -> 2.2.2 the setup:upgrade command fails with the following output:

```
Module 'Magento_SalesRule':
Upgrading data.. SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '0-0-0-0' for key 'PRIMARY', query was: INSERT INTO `salesrule_product_attribute` () VALUES ()
```

There appears to be an issue where `$data` is blank and passing this through to `insertMultiple()` results in the creation of an empty record with a key of `0-0-0-0`, however if multiple empty rows are passed you get duplicate primary keys, throwing an sql violation.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Upgrade from Magento 2.1.7 -> 2.2.2 with sales rules already defined.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
