### PR TITLE
Backport of MAGETWO-71545 for Magento 2.1: Added 'application/json' C…

### DIFF
--- a/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
@@ -9,12 +9,32 @@ use Magento\Backend\App\Action\Context;
 use Magento\Ui\Controller\Adminhtml\AbstractAction;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Framework\View\Element\UiComponentInterface;
+use Magento\Ui\Model\UiComponentTypeResolver;
 
 /**
  * Class Render
  */
 class Render extends AbstractAction
 {
+    /**
+     * @var \Magento\Ui\Model\UiComponentTypeResolver
+     */
+    private $contentTypeResolver;
+
+    /**
+     * @param Context $context
+     * @param UiComponentFactory $factory
+     * @param UiComponentTypeResolver $contentTypeResolver
+     */
+    public function __construct(
+        Context $context,
+        UiComponentFactory $factory,
+        UiComponentTypeResolver $contentTypeResolver
+    ) {
+        parent::__construct($context, $factory);
+        $this->contentTypeResolver = $contentTypeResolver;
+    }
+
     /**
      * Action for AJAX request
      *
@@ -27,7 +47,7 @@ class Render extends AbstractAction
             return;
         }
 
-        $component = $this->factory->create($this->_request->getParam('namespace'));
+        $component = $this->factory->create($this->getRequest()->getParam('namespace'));
 
         $aclResource = $component->getData('acl');
 
@@ -37,7 +57,10 @@ class Render extends AbstractAction
         }
 
         $this->prepareComponent($component);
-        $this->_response->appendBody((string) $component->render());
+        $this->getResponse()->appendBody((string) $component->render());
+
+        $contentType = $this->contentTypeResolver->resolve($component->getContext());
+        $this->getResponse()->setHeader('Content-Type', $contentType, true);
     }
 
     /**

--- a/app/code/Magento/Ui/Model/UiComponentTypeResolver.php
+++ b/app/code/Magento/Ui/Model/UiComponentTypeResolver.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Ui\Model;
+
+use Magento\Framework\View\Element\UiComponent\ContextInterface as UiComponentContext;
+
+/**
+ * Provides correct Content-Type header value for the Ui Component renderer based on the Accept Type of
+ * the Component Context. Additional types may be added to the type map via di.xml configuration for this resolver.
+ *
+ * This is a workaround for the lacking Content-Type processing in
+ * \Magento\Framework\View\Element\UiComponent\ContentType\ContentTypeInterface
+ */
+class UiComponentTypeResolver
+{
+    /**
+     * @var string
+     */
+    const DEFAULT_CONTENT_TYPE = 'text/html';
+
+    /**
+     * @var array
+     */
+    private $uiComponentTypeMap = [];
+
+    /**
+     * @param array $uiComponentTypeMap
+     */
+    public function __construct(array $uiComponentTypeMap)
+    {
+        $this->uiComponentTypeMap = $uiComponentTypeMap;
+    }
+
+    /**
+     * @param UiComponentContext $componentContext
+     * @return string
+     */
+    public function resolve(UiComponentContext $componentContext): string
+    {
+        $acceptType = $componentContext->getAcceptType();
+        return $this->uiComponentTypeMap[$acceptType] ?? static::DEFAULT_CONTENT_TYPE;
+    }
+}

--- a/app/code/Magento/Ui/Model/UiComponentTypeResolver.php
+++ b/app/code/Magento/Ui/Model/UiComponentTypeResolver.php
@@ -38,9 +38,11 @@ class UiComponentTypeResolver
      * @param UiComponentContext $componentContext
      * @return string
      */
-    public function resolve(UiComponentContext $componentContext): string
+    public function resolve(UiComponentContext $componentContext)
     {
         $acceptType = $componentContext->getAcceptType();
-        return $this->uiComponentTypeMap[$acceptType] ?? static::DEFAULT_CONTENT_TYPE;
+        return isset($this->uiComponentTypeMap[$acceptType])
+            ? $this->uiComponentTypeMap[$acceptType]
+            : static::DEFAULT_CONTENT_TYPE;
     }
 }

--- a/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
@@ -143,7 +143,7 @@ class RenderTest extends \PHPUnit_Framework_TestCase
             true,
             ['render']
         );
-        $contextMock = $this->createMock(ContextInterface::class);
+        $contextMock = $this->getMock(ContextInterface::class);
 
         $viewMock->expects($this->once())
             ->method('render')
@@ -197,6 +197,8 @@ class RenderTest extends \PHPUnit_Framework_TestCase
             true,
             ['render']
         );
+        $contextMock = $this->getMock(ContextInterface::class);
+
         $componentMock->expects($this->any())
             ->method('render')
             ->willReturn($renderedData);
@@ -207,6 +209,9 @@ class RenderTest extends \PHPUnit_Framework_TestCase
             ->method('getData')
             ->with('acl')
             ->willReturn($acl);
+        $componentMock->expects($this->any())
+            ->method('getContext')
+            ->willReturn($contextMock);
         $this->uiFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($componentMock);

--- a/app/code/Magento/Ui/Test/Unit/Model/UiComponentTypeResolverTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/UiComponentTypeResolverTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Ui\Test\Unit\Model;
+
+use Magento\Ui\Model\UiComponentTypeResolver;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+
+class UiComponentTypeResolverTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var UiComponentTypeResolver
+     */
+    private $model;
+
+    /**
+     * @var array
+     */
+    private $contentTypeMap = [];
+
+    protected function setUp()
+    {
+        $this->contentTypeMap = [
+            'xml' => 'application/xml',
+            'json' => 'application/json',
+            'html' => 'text/html'
+        ];
+        $this->model = new UiComponentTypeResolver($this->contentTypeMap);
+    }
+
+    /**
+     * @param string $acceptType
+     * @param string $contentType
+     * @dataProvider resolveDataProvider
+     */
+    public function testResolve(string $acceptType, string $contentType)
+    {
+        $uiComponentContextMock = $this->createMock(ContextInterface::class);
+        $uiComponentContextMock->expects($this->atLeastOnce())->method('getAcceptType')->willReturn($acceptType);
+
+        $this->assertEquals($contentType, $this->model->resolve($uiComponentContextMock));
+    }
+
+    /**
+     * @return array
+     */
+    public function resolveDataProvider(): array
+    {
+        return [
+            ['json', 'application/json'],
+            ['xml', 'application/xml'],
+            ['html', 'text/html'],
+            ['undefined', UiComponentTypeResolver::DEFAULT_CONTENT_TYPE]
+        ];
+    }
+}

--- a/app/code/Magento/Ui/Test/Unit/Model/UiComponentTypeResolverTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/UiComponentTypeResolverTest.php
@@ -8,7 +8,7 @@ namespace Magento\Ui\Test\Unit\Model;
 use Magento\Ui\Model\UiComponentTypeResolver;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 
-class UiComponentTypeResolverTest extends \PHPUnit\Framework\TestCase
+class UiComponentTypeResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var UiComponentTypeResolver
@@ -35,9 +35,9 @@ class UiComponentTypeResolverTest extends \PHPUnit\Framework\TestCase
      * @param string $contentType
      * @dataProvider resolveDataProvider
      */
-    public function testResolve(string $acceptType, string $contentType)
+    public function testResolve($acceptType, $contentType)
     {
-        $uiComponentContextMock = $this->createMock(ContextInterface::class);
+        $uiComponentContextMock = $this->getMock(ContextInterface::class);
         $uiComponentContextMock->expects($this->atLeastOnce())->method('getAcceptType')->willReturn($acceptType);
 
         $this->assertEquals($contentType, $this->model->resolve($uiComponentContextMock));
@@ -46,7 +46,7 @@ class UiComponentTypeResolverTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function resolveDataProvider(): array
+    public function resolveDataProvider()
     {
         return [
             ['json', 'application/json'],

--- a/app/code/Magento/Ui/etc/di.xml
+++ b/app/code/Magento/Ui/etc/di.xml
@@ -282,4 +282,13 @@
             <argument name="subject" xsi:type="object">uiComponentAggregatedSourceOverrideThemeFiltered</argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Ui\Model\UiComponentTypeResolver">
+        <arguments>
+            <argument name="uiComponentTypeMap" xsi:type="array">
+                <item name="html" xsi:type="string">text/html</item>
+                <item name="json" xsi:type="string">application/json</item>
+                <item name="xml" xsi:type="string">application/xml</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
…ontent-Type to Ajax responses in the Magento_UI module. #10521

(cherry picked from commit ddfc01e7ca9d2d6709acdd85aa9860543428172d)

### Description
This is a backport of https://github.com/magento/magento2/pull/10521 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/pull/10521: Set correct Content-Type header for ajax responses in the Magento_UI module.
2. https://github.com/magento/up-for-grabs/issues/1: Newrelic Ignore Transaction

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
