### PR TITLE
Backport of MAGETWO-84006 for Magento 2.1: Fix robots.txt content typ…

### DIFF
--- a/app/code/Magento/Robots/Controller/Index/Index.php
+++ b/app/code/Magento/Robots/Controller/Index/Index.php
@@ -43,6 +43,7 @@ class Index extends Action
         /** @var Page $resultPage */
         $resultPage = $this->resultPageFactory->create(true);
         $resultPage->addHandle('robots_index_index');
+        $resultPage->setHeader('Content-Type', 'text/plain');
         return $resultPage;
     }
 }

--- a/app/code/Magento/Robots/Test/Unit/Controller/Index/IndexTest.php
+++ b/app/code/Magento/Robots/Test/Unit/Controller/Index/IndexTest.php
@@ -51,6 +51,9 @@ class IndexTest extends \PHPUnit_Framework_TestCase
         $resultPageMock->expects($this->once())
             ->method('addHandle')
             ->with('robots_index_index');
+        $resultPageMock->expects($this->once())
+            ->method('setHeader')
+            ->with('Content-Type', 'text/plain');
 
         $this->resultPageFactory->expects($this->any())
             ->method('create')


### PR DESCRIPTION
…e to 'text/plain' #12310

(cherry picked from commit 2c3cd64b7b5aad670ca0eaac06112833a4a85437)

### Description
This is a backport of https://github.com/magento/magento2/pull/12310 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13214: Not a correct displaying for Robots.txt

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
