### PR TITLE
Fix json encoded attribute backend type to not encode attribute value multiple times

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/JsonEncoded.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/JsonEncoded.php
@@ -41,7 +41,7 @@ class JsonEncoded extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBa
     {
         // parent::beforeSave() is not called intentionally
         $attrCode = $this->getAttribute()->getAttributeCode();
-        if ($object->hasData($attrCode)) {
+        if ($object->hasData($attrCode) && !is_string($object->getData($attrCode))) {
             $object->setData($attrCode, $this->jsonSerializer->serialize($object->getData($attrCode)));
         }
         return $this;

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Backend/JsonEncodedTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Backend/JsonEncodedTest.php
@@ -83,6 +83,25 @@ class JsonEncodedTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test before save handler with already encoded attribute value
+     */
+    public function testBeforeSaveWithAlreadyEncodedValue()
+    {
+        $product = new \Magento\Framework\DataObject(
+            [
+                'json_encoded' => [1, 2, 3]
+            ]
+        );
+
+        // save twice
+        $this->model->beforeSave($product);
+        $this->model->beforeSave($product);
+        
+        // check it is encoded only once
+        $this->assertEquals(json_encode([1, 2, 3]), $product->getData('json_encoded'));
+    }
+
+    /**
      * Test after load handler
      */
     public function testAfterLoad()


### PR DESCRIPTION
With the last fix (https://github.com/magento/magento2/pull/11947) the json encoded attribute value loaded back correctly, but if you save a product muliple times then the attribute value will also be encoded muliple times which will cause issue during the next load.

This PR fixes the `beforeSave` method to only encode the attribute value when it is not encoded already.
