### PR TITLE
magento/magento2#11252: fix adminhtml file attribute edit form

### DIFF
--- a/app/code/Magento/Customer/Model/FileUploader.php
+++ b/app/code/Magento/Customer/Model/FileUploader.php
@@ -110,7 +110,7 @@ class FileUploader
         $result = $fileProcessor->saveTemporaryFile($this->scope . '[' . $this->getAttributeCode() . ']');
 
         // Update tmp_name param. Required for attribute validation!
-        $result['tmp_name'] = $result['path'] . '/' . ltrim($result['file'], '/');
+        $result['tmp_name'] = ltrim($result['file'], '/');
 
         $result['url'] = $fileProcessor->getViewUrl(
             FileProcessor::TMP_DIR . '/' . ltrim($result['name'], '/'),

--- a/app/code/Magento/Customer/Test/Unit/Model/FileUploaderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/FileUploaderTest.php
@@ -140,7 +140,7 @@ class FileUploaderTest extends \PHPUnit\Framework\TestCase
             'name' => $resultFileName,
             'file' => $resultFileName,
             'path' => $resultFilePath,
-            'tmp_name' => $resultFilePath . $resultFileName,
+            'tmp_name' => ltrim($resultFileName, '/'),
             'url' => $resultFileUrl,
         ];
 


### PR DESCRIPTION
Applying fix for issue 11252 to Magento2 version 2.2.2
Backport of https://github.com/magento/magento2/pull/11267
### Description
This fixes issue #11252 file not allowing uploads for custom customer attributes in the Admin environment.  FileUploaderTest passes with implemented change.

### Fixed Issues (if relevant)
1. magento/magento2#11252: Custom attribute - File not allowing uploads

### Manual testing scenarios
1. Create a Customer custom attribute of type file
2. Attempt to upload a file in the admin panel.
3. Run Unit test app/code/Magento/Customer/Test/Unit/Model/FileUploaderTest.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
