### PR TITLE
[Backport 2.1-develop] Correctly save Product Custom Option values

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -191,27 +191,29 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
     public function saveValues()
     {
         foreach ($this->getValues() as $value) {
-            $this->isDeleted(false);
-            $this->setData(
+            $optionValue = clone $this;
+            $optionValue->isDeleted(false);
+
+            $optionValue->setData(
                 $value
             )->setData(
                 'option_id',
-                $this->getOption()->getId()
+                $optionValue->getOption()->getId()
             )->setData(
                 'store_id',
-                $this->getOption()->getStoreId()
+                $optionValue->getOption()->getStoreId()
             );
 
-            if ($this->getData('is_delete') == '1') {
-                if ($this->getId()) {
-                    $this->deleteValues($this->getId());
-                    $this->delete();
+            if ($optionValue->getData('is_delete') == '1') {
+                if ($optionValue->getId()) {
+                    $optionValue->deleteValues($optionValue->getId());
+                    $optionValue->delete();
                 }
             } else {
-                $this->save();
+                $optionValue->save();
             }
         }
-        //eof foreach()
+
         return $this;
     }
 


### PR DESCRIPTION
### Description
Backport of https://github.com/magento/magento2/pull/13569

This occurred because the same value object is used for saving all values. After the save `updateStoredData()` is called and is used in `prepareDataForUpdate()`.
https://github.com/magento/magento2/blob/3561b6614eeafb70cbcbf0dc0254359b857af3d4/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php#L718-L733

### Fixed Issues (if relevant)
1. magento/magento2#5067: Custom option values do not save correctly

### Manual testing scenarios
1. Install module [ReachDigital_CustomOption.zip](https://github.com/magento/magento2/files/1707887/ReachDigital_CustomOption.zip)
2. An extra column as added to the Product Custom Options (http://cloud.h-o.nl/pP3N).
3. Uncheck all `Changes Appearance` checkboxes and save product.
4. Only the first checkbox is saved.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
