### PR TITLE
Fixed fatal error on "magento sampledata:deploy" when magento is not installed. 

### DIFF
--- a/app/code/Magento/SampleData/Model/Dependency.php
+++ b/app/code/Magento/SampleData/Model/Dependency.php
@@ -12,7 +12,7 @@ use Magento\Framework\Composer\ComposerInformation;
 use Magento\Framework\Config\Composer\Package;
 use Magento\Framework\Config\Composer\PackageFactory;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\ReadInterfaceFactory;
+use Magento\Framework\Filesystem\Directory\ReadFactory;
 
 /**
  * Sample Data dependency
@@ -40,7 +40,7 @@ class Dependency
     private $componentRegistrar;
 
     /**
-     * @var ReadInterfaceFactory
+     * @var ReadFactory
      */
     private $directoryReadFactory;
 
@@ -51,7 +51,7 @@ class Dependency
      * @param Filesystem $filesystem @deprecated 2.3.0 $directoryReadFactory is used instead
      * @param PackageFactory $packageFactory
      * @param ComponentRegistrarInterface $componentRegistrar
-     * @param Filesystem\Directory\ReadInterfaceFactory|null $directoryReadFactory
+     * @param Filesystem\Directory\ReadFactory|null $directoryReadFactory
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
@@ -59,13 +59,13 @@ class Dependency
         Filesystem $filesystem,
         PackageFactory $packageFactory,
         ComponentRegistrarInterface $componentRegistrar,
-        \Magento\Framework\Filesystem\Directory\ReadInterfaceFactory $directoryReadFactory = null
+        \Magento\Framework\Filesystem\Directory\ReadFactory $directoryReadFactory = null
     ) {
         $this->composerInformation = $composerInformation;
         $this->packageFactory = $packageFactory;
         $this->componentRegistrar = $componentRegistrar;
         $this->directoryReadFactory = $directoryReadFactory ?:
-            ObjectManager::getInstance()->get(ReadInterfaceFactory::class);
+            ObjectManager::getInstance()->get(ReadFactory::class);
     }
 
     /**
@@ -123,7 +123,7 @@ class Dependency
          */
         foreach ([$moduleDir, $moduleDir . DIRECTORY_SEPARATOR . '..'] as $dir) {
             /** @var Filesystem\Directory\ReadInterface $directory */
-            $directory = $this->directoryReadFactory->create(['path' => $dir]);
+            $directory = $this->directoryReadFactory->create($dir);
             if ($directory->isExist('composer.json') && $directory->isReadable('composer.json')) {
                 /** @var Package $package */
                 return $this->packageFactory->create(['json' => json_decode($directory->readFile('composer.json'))]);

--- a/app/code/Magento/SampleData/Test/Unit/Model/DependencyTest.php
+++ b/app/code/Magento/SampleData/Test/Unit/Model/DependencyTest.php
@@ -14,6 +14,7 @@ use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Phrase;
 use Magento\SampleData\Model\Dependency;
+use Magento\Framework\Filesystem\DriverPool;
 
 class DependencyTest extends \PHPUnit\Framework\TestCase
 {
@@ -59,7 +60,7 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
                 $moduleDirectories
             );
 
-        $directoryReadFactory = $this->getMockBuilder(Filesystem\Directory\ReadInterfaceFactory::class)
+        $directoryReadFactory = $this->getMockBuilder(Filesystem\Directory\ReadFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
@@ -88,7 +89,8 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
                 'composerJsonGenerator' => function (DependencyTest $test) {
                     return [
                         [
-                            ['path' => 'app/code/LocalModule'],
+                            'app/code/LocalModule',
+                            DriverPool::FILE,
                             $test->stubComposerJsonReader(
                                 [
                                     'name' => 'local/module',
@@ -99,11 +101,13 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
                             )
                         ],
                         [
-                            ['path' => 'app/code/LocalModuleWithoutComposerJson'],
+                            'app/code/LocalModuleWithoutComposerJson',
+                            DriverPool::FILE,
                             $test->stubFileNotFoundReader()
                         ],
                         [
-                            ['path' => 'vendor/company/module'],
+                            'vendor/company/module',
+                            DriverPool::FILE,
                             $test->stubComposerJsonReader(
                                 [
                                     'name' => 'company/module',
@@ -114,7 +118,8 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
                             )
                         ],
                         [
-                            ['path' => 'vendor/company2/module/src/..'],
+                            'vendor/company2/module/src/..',
+                            DriverPool::FILE,
                             $test->stubComposerJsonReader(
                                 [
                                     'name' => 'company2/module',
@@ -125,19 +130,23 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
                             )
                         ],
                         [
-                            ['path' => 'vendor/company2/module/src'],
+                            'vendor/company2/module/src',
+                            DriverPool::FILE,
                             $test->stubFileNotFoundReader()
                         ],
                         [
-                            ['path' => 'vendor/company/module/..'],
+                            'vendor/company/module/..',
+                            DriverPool::FILE,
                             $test->stubFileNotFoundReader()
                         ],
                         [
-                            ['path' => 'app/code/LocalModuleWithoutComposerJson/..'],
+                            'app/code/LocalModuleWithoutComposerJson/..',
+                            DriverPool::FILE,
                             $test->stubFileNotFoundReader()
                         ],
                         [
-                            ['path' => 'app/code/LocalModule/..'],
+                            'app/code/LocalModule/..',
+                            DriverPool::FILE,
                             $test->stubFileNotFoundReader()
                         ],
                     ];

--- a/app/code/Magento/SampleData/etc/di.xml
+++ b/app/code/Magento/SampleData/etc/di.xml
@@ -15,10 +15,4 @@
             </argument>
         </arguments>
     </type>
-    <virtualType name="Magento\SampleData\Filesystem\Directory\Read" type="Magento\Framework\Filesystem\Directory\Read">
-        <arguments>
-            <argument name="driver" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
-        </arguments>
-    </virtualType>
-    <preference for="Magento\Framework\Filesystem\Directory\ReadInterface" type="Magento\SampleData\Filesystem\Directory\Read" />
 </config>


### PR DESCRIPTION

### Description
Fixed fatal error on "magento sampledata:deploy" when magento is not installed. 
Original PR https://github.com/magento/magento2/pull/8990


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. checkout Magento from 2.3-develop branch
2. Run bin/magento sampledata:deploy (with no errors)

### Manual testing scenarios
1. checkout Magento from 2.3-develop branch
2. install magento
3. Run bin/magento sampledata:deploy (with no errors)

Additional test cases see https://github.com/magento/magento2/pull/8990

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
