### PR TITLE
Execute collection tasks only when a valid collection is passed to th…

### DIFF
--- a/app/code/Magento/Ui/Component/Form.php
+++ b/app/code/Magento/Ui/Component/Form.php
@@ -63,12 +63,12 @@ class Form extends AbstractComponent
         $filter = $this->filterBuilder->setField($this->getContext()->getDataProvider()->getPrimaryFieldName())
             ->setValue($id)
             ->create();
-        $dataProvider = $this->getContext()->getDataProvider();
-        if (isset($dataProvider->collection)) {
-            $dataProvider->addFilter($filter);
+        if ($this->getContext()->getDataProvider()->useCollection()) {
+            $this->getContext()->getDataProvider()
+                ->addFilter($filter);
         }
 
-        $data = $dataProvider->getData();
+        $data = $this->getContext()->getDataProvider()->getData();
 
         if (isset($data[$id])) {
             $dataSource = [

--- a/app/code/Magento/Ui/Component/Form.php
+++ b/app/code/Magento/Ui/Component/Form.php
@@ -59,27 +59,26 @@ class Form extends AbstractComponent
     {
         $dataSource = [];
 
-		$dataProvider = $this->getContext()->getDataProvider();
-
-        if ($dataProvider->getCollection()) {
-            $id = $this->getContext()->getRequestParam($this->getContext()->getDataProvider()->getRequestFieldName(), null);
-            $filter = $this->filterBuilder->setField($this->getContext()->getDataProvider()->getPrimaryFieldName())
-                ->setValue($id)
-                ->create();
+        $id = $this->getContext()->getRequestParam($this->getContext()->getDataProvider()->getRequestFieldName(), null);
+        $filter = $this->filterBuilder->setField($this->getContext()->getDataProvider()->getPrimaryFieldName())
+            ->setValue($id)
+            ->create();
+        $dataProvider = $this->getContext()->getDataProvider();
+        if (isset($dataProvider->collection)) {
             $this->getContext()->getDataProvider()
                 ->addFilter($filter);
+        }
 
-            $data = $this->getContext()->getDataProvider()->getData();
+        $data = $this->getContext()->getDataProvider()->getData();
 
-            if (isset($data[$id])) {
-                $dataSource = [
-                    'data' => $data[$id]
-                ];
-            } elseif (isset($data['items'])) {
-                foreach ($data['items'] as $item) {
-                    if ($item[$item['id_field_name']] == $id) {
-                        $dataSource = ['data' => ['general' => $item]];
-                    }
+        if (isset($data[$id])) {
+            $dataSource = [
+                'data' => $data[$id]
+            ];
+        } elseif (isset($data['items'])) {
+            foreach ($data['items'] as $item) {
+                if ($item[$item['id_field_name']] == $id) {
+                    $dataSource = ['data' => ['general' => $item]];
                 }
             }
         }

--- a/app/code/Magento/Ui/Component/Form.php
+++ b/app/code/Magento/Ui/Component/Form.php
@@ -59,23 +59,27 @@ class Form extends AbstractComponent
     {
         $dataSource = [];
 
-        $id = $this->getContext()->getRequestParam($this->getContext()->getDataProvider()->getRequestFieldName(), null);
-        $filter = $this->filterBuilder->setField($this->getContext()->getDataProvider()->getPrimaryFieldName())
-            ->setValue($id)
-            ->create();
-        $this->getContext()->getDataProvider()
-            ->addFilter($filter);
+		$dataProvider = $this->getContext()->getDataProvider();
 
-        $data = $this->getContext()->getDataProvider()->getData();
+        if ($dataProvider->getCollection()) {
+            $id = $this->getContext()->getRequestParam($this->getContext()->getDataProvider()->getRequestFieldName(), null);
+            $filter = $this->filterBuilder->setField($this->getContext()->getDataProvider()->getPrimaryFieldName())
+                ->setValue($id)
+                ->create();
+            $this->getContext()->getDataProvider()
+                ->addFilter($filter);
 
-        if (isset($data[$id])) {
-            $dataSource = [
-                'data' => $data[$id]
-            ];
-        } elseif (isset($data['items'])) {
-            foreach ($data['items'] as $item) {
-                if ($item[$item['id_field_name']] == $id) {
-                    $dataSource = ['data' => ['general' => $item]];
+            $data = $this->getContext()->getDataProvider()->getData();
+
+            if (isset($data[$id])) {
+                $dataSource = [
+                    'data' => $data[$id]
+                ];
+            } elseif (isset($data['items'])) {
+                foreach ($data['items'] as $item) {
+                    if ($item[$item['id_field_name']] == $id) {
+                        $dataSource = ['data' => ['general' => $item]];
+                    }
                 }
             }
         }

--- a/app/code/Magento/Ui/Component/Form.php
+++ b/app/code/Magento/Ui/Component/Form.php
@@ -65,11 +65,10 @@ class Form extends AbstractComponent
             ->create();
         $dataProvider = $this->getContext()->getDataProvider();
         if (isset($dataProvider->collection)) {
-            $this->getContext()->getDataProvider()
-                ->addFilter($filter);
+            $dataProvider->addFilter($filter);
         }
 
-        $data = $this->getContext()->getDataProvider()->getData();
+        $data = $dataProvider->getData();
 
         if (isset($data[$id])) {
             $dataSource = [

--- a/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
+++ b/app/code/Magento/Ui/DataProvider/AbstractDataProvider.php
@@ -294,4 +294,20 @@ abstract class AbstractDataProvider implements DataProviderInterface
     {
         return  $this->collection->getAllIds();
     }
+
+    /**
+     * Check configuration looking for a no-collection usage
+     *
+     * @return bool
+     */
+    public function useCollection()
+    {
+        $configData = $this->getConfigData();
+
+        if (isset($configData['noCollection']) && $configData['noCollection']) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/app/code/Magento/Ui/Test/Unit/Component/FormTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/FormTest.php
@@ -93,7 +93,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($filterMock);
 
-        if (isset($dataProviderMock->collection)) {
+        if ($dataProviderMock->useCollection()) {
             $dataProviderMock->expects($this->once())
                 ->method('addFilter')
                 ->with($filterMock);
@@ -149,7 +149,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($filterMock);
 
-        if (isset($dataProviderMock->collection)) {
+        if ($dataProviderMock->useCollection()) {
             $dataProviderMock->expects($this->once())
                 ->method('addFilter')
                 ->with($filterMock);
@@ -210,7 +210,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($filterMock);
 
-        if (isset($dataProviderMock->collection)) {
+        if ($dataProviderMock->useCollection()) {
             $dataProviderMock->expects($this->once())
                 ->method('addFilter')
                 ->with($filterMock);

--- a/app/code/Magento/Ui/Test/Unit/Component/FormTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/FormTest.php
@@ -93,9 +93,11 @@ class FormTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($filterMock);
 
-        $dataProviderMock->expects($this->once())
-            ->method('addFilter')
-            ->with($filterMock);
+        if (isset($dataProviderMock->collection)) {
+            $dataProviderMock->expects($this->once())
+                ->method('addFilter')
+                ->with($filterMock);
+        }
         $dataProviderMock->expects($this->once())
             ->method('getData')
             ->willReturn($data);
@@ -147,9 +149,11 @@ class FormTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($filterMock);
 
-        $dataProviderMock->expects($this->once())
-            ->method('addFilter')
-            ->with($filterMock);
+        if (isset($dataProviderMock->collection)) {
+            $dataProviderMock->expects($this->once())
+                ->method('addFilter')
+                ->with($filterMock);
+        }
         $dataProviderMock->expects($this->once())
             ->method('getData')
             ->willReturn($data);
@@ -206,9 +210,11 @@ class FormTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($filterMock);
 
-        $dataProviderMock->expects($this->once())
-            ->method('addFilter')
-            ->with($filterMock);
+        if (isset($dataProviderMock->collection)) {
+            $dataProviderMock->expects($this->once())
+                ->method('addFilter')
+                ->with($filterMock);
+        }
         $dataProviderMock->expects($this->once())
             ->method('getData')
             ->willReturn($data);


### PR DESCRIPTION
…e data source of a UI Component form. This prevents ui forms not attached to collections to crash on filtering

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
There should be some check in order to perform collection actions only if the data source of UI Componet forms contents and actual valid collection, and avoiding them if not. This keeps model-collections forms working as usual, and avoids crashes on stand-alone forms.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13573: UI Component forms not related with any model throw fatal error

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Starting from a vanilla Magento, download, install and enable your own sample Form UI Component, following the instructions given at: https://github.com/magento/magento2-samples/tree/master/sample-module-form-uicomponent
2. Go to the URL provided by the extension, which is [magento2-admin-url]/sampleform
3. You should now get the expected form: 
![sample_form](https://user-images.githubusercontent.com/11211929/35996437-d53d4450-0d16-11e8-8b31-13685ca1df2e.png)


### Contribution checklist
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [*] All new or changed code is covered with unit/integration tests (if applicable)
 - [*] All automated tests passed successfully (all builds on Travis CI are green)
