### PR TITLE
Increase the size of the flag_data field

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -741,7 +741,7 @@ class Installer
             )->addColumn(
                 'flag_data',
                 \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                '64k',
+                '16m',
                 [],
                 'Flag Data'
             )->addColumn(


### PR DESCRIPTION
The `flag_data` field in the `flag` table is too small to reimport a config generated by `bin/magento app:config:dump` with more than 64KB size.
Increasing this field should be considered, as exporting the config and reimporting it is the suggested way for pipeline deployment.

### Description
If a `bin/magento app:config:dump` produces a config.php with more than 64KB of size, the `bin/magento app:config:import` or `bin/magento setup:upgrade` will fail because of the `TEXT` field limitation from `flag_data` in the `flag` table.

This PR increases the `flag_data` field to `MEDIUMTEXT` accepting 16MB.

### Fixed Issues (if relevant)
1. magento/magento2#11657: app:config:import fails - flag column 'flag_data' is too short ?

### Manual testing scenarios
1. Run `bin/magento setup:install`
2. Before applying the PR, the `flag_data` field is a `TEXT` field accepting 64KB
3. After applying the PR, the `flag_data` field is a `MEDIUMTEXT` field accepting 16MB


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
