### PR TITLE
Show maintenance IP-address without commas

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
@@ -93,7 +93,7 @@ class MaintenanceAllowIpsCommand extends AbstractSetupCommand
             if (!empty($addresses)) {
                 $this->maintenanceMode->setAddresses(implode(',', $addresses));
                 $output->writeln(
-                    '<info>Set exempt IP-addresses: ' . implode(', ', $this->maintenanceMode->getAddressInfo()) .
+                    '<info>Set exempt IP-addresses: ' . implode(' ', $this->maintenanceMode->getAddressInfo()) .
                     '</info>'
                 );
             }

--- a/setup/src/Magento/Setup/Console/Command/MaintenanceStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/MaintenanceStatusCommand.php
@@ -54,7 +54,7 @@ class MaintenanceStatusCommand extends AbstractSetupCommand
             ($this->maintenanceMode->isOn() ? 'active' : 'not active') . '</info>'
         );
         $addressInfo = $this->maintenanceMode->getAddressInfo();
-        $addresses = implode(', ', $addressInfo);
+        $addresses = implode(' ', $addressInfo);
         $output->writeln('<info>List of exempt IP-addresses: ' . ($addresses ? $addresses : 'none') . '</info>');
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/MaintenanceAllowIpsCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/MaintenanceAllowIpsCommandTest.php
@@ -75,7 +75,7 @@ class MaintenanceAllowIpsCommandTest extends \PHPUnit\Framework\TestCase
             [
                 ['ip' => ['127.0.0.1', '127.0.0.2'], '--none' => false],
                 [],
-                'Set exempt IP-addresses: 127.0.0.1, 127.0.0.2' . PHP_EOL
+                'Set exempt IP-addresses: 127.0.0.1 127.0.0.2' . PHP_EOL
             ],
             [
                 ['--none' => true],

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/MaintenanceStatusCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/MaintenanceStatusCommandTest.php
@@ -50,7 +50,7 @@ class MaintenanceStatusCommandTest extends \PHPUnit\Framework\TestCase
             [
                 [true, ['127.0.0.1', '127.0.0.2']],
                 'Status: maintenance mode is active' . PHP_EOL .
-                'List of exempt IP-addresses: 127.0.0.1, 127.0.0.2' . PHP_EOL
+                'List of exempt IP-addresses: 127.0.0.1 127.0.0.2' . PHP_EOL
             ],
             [
                 [true, []],
@@ -63,7 +63,7 @@ class MaintenanceStatusCommandTest extends \PHPUnit\Framework\TestCase
             [
                 [false, ['127.0.0.1', '127.0.0.2']],
                 'Status: maintenance mode is not active' . PHP_EOL .
-                'List of exempt IP-addresses: 127.0.0.1, 127.0.0.2' . PHP_EOL
+                'List of exempt IP-addresses: 127.0.0.1 127.0.0.2' . PHP_EOL
             ],
         ];
     }


### PR DESCRIPTION
### Description
When looking at existing IP-address for the maintenance status, they are shown with commas. But when setting them, commas are not accepted. This is a pretty trivial change, but makes it easier to copy, modify and paste the list of IP-addresses.