### PR TITLE
#13592 Performance Fix for strlen and mb_strlen

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -54,7 +54,7 @@ if (
     && isset($_SERVER['HTTP_ACCEPT'])
     && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false
 ) {
-    $profilerFlag = isset($_SERVER['MAGE_PROFILER']) && strlen($_SERVER['MAGE_PROFILER'])
+    $profilerFlag = isset($_SERVER['MAGE_PROFILER']) && '' !== $_SERVER['MAGE_PROFILER']
         ? $_SERVER['MAGE_PROFILER']
         : trim(file_get_contents(BP . '/var/profiler.flag'));
 

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php
@@ -139,7 +139,7 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
     {
         $isValid = false;
         foreach ($this->_tierPriceColumns as $column) {
-            if (isset($value[$column]) && strlen($value[$column])) {
+            if (isset($value[$column]) && '' !== $value[$column]) {
                 $isValid = true;
             }
         }
@@ -156,7 +156,7 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
     {
         $hasEmptyValues = false;
         foreach ($this->_tierPriceColumns as $column) {
-            if (!strlen($value[$column])) {
+            if ('' === $value[$column]) {
                 $hasEmptyValues = true;
             }
         }

--- a/app/code/Magento/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Attributes.php
@@ -89,7 +89,7 @@ class Attributes extends \Magento\Framework\View\Element\Template
                     $value = $this->priceCurrency->convertAndFormat($value);
                 }
 
-                if (is_string($value) && strlen($value)) {
+                if (is_string($value) && '' !== $value) {
                     $data[$attribute->getAttributeCode()] = [
                         'label' => __($attribute->getStoreLabel()),
                         'value' => $value,

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -75,7 +75,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
         );
 
         if ($attribute->getId() && !$attributeId) {
-            $message = strlen($this->getRequest()->getParam('attribute_code'))
+            $message = '' !== $this->getRequest()->getParam('attribute_code')
                 ? __('An attribute with this code already exists.')
                 : __('An attribute with the same code (%1) already exists.', $attributeCode);
 

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Attribute.php
@@ -81,7 +81,7 @@ class Attribute extends \Magento\Catalog\Model\Layer\Filter\AbstractFilter
             return $this;
         }
         $text = $this->getOptionText($filter);
-        if ($filter && strlen($text)) {
+        if ($filter && '' !== $text) {
             $this->_getResource()->applyFilterToCollection($this, $filter);
             $this->getLayer()->getState()->addFilter($this->_createItem($text, $filter));
             $this->_items = [];

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -2127,7 +2127,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         $products = $this->_getResource()->getProductsSku($productIds);
         if (count($products)) {
             foreach ($products as $product) {
-                if (!strlen($product['sku'])) {
+                if ('' === $product['sku']) {
                     return false;
                 }
             }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -51,7 +51,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     {
         $attrCode = $this->getAttribute()->getAttributeCode();
         $value = $object->getData($attrCode);
-        if ($this->getAttribute()->getIsRequired() && strlen($value) === 0) {
+        if ($this->getAttribute()->getIsRequired() && '' === $value) {
             throw new \Magento\Framework\Exception\LocalizedException(__('The value of attribute "%1" must be set', $attrCode));
         }
 

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php
@@ -58,7 +58,7 @@ class Text extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         $value = trim($this->getUserValue());
 
         // Check requires option to have some value
-        if (strlen($value) == 0 && $option->getIsRequire() && !$this->getSkipCheckRequiredOption()) {
+        if ('' === $value && $option->getIsRequire() && !$this->getSkipCheckRequiredOption()) {
             $this->setIsValid(false);
             throw new LocalizedException(__('Please specify product\'s required option(s).'));
         }

--- a/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
@@ -632,7 +632,7 @@ abstract class AbstractType
             foreach ($options as $option) {
                 if ($option->getIsRequire()) {
                     $customOption = $product->getCustomOption(self::OPTION_PREFIX . $option->getId());
-                    if (!$customOption || strlen($customOption->getValue()) == 0) {
+                    if (!$customOption || '' === $customOption->getValue()) {
                         $product->setSkipCheckRequiredOption(true);
                         throw new \Magento\Framework\Exception\LocalizedException(
                             __('The product has required options.')

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -320,9 +320,7 @@ abstract class AbstractType
                     'is_static' => $attribute->isStatic(),
                     'apply_to' => $attribute->getApplyTo(),
                     'type' => \Magento\ImportExport\Model\Import::getAttributeType($attribute),
-                    'default_value' => strlen(
-                        $attribute->getDefaultValue()
-                    ) ? $attribute->getDefaultValue() : null,
+                    'default_value' => '' !== $attribute->getDefaultValue() ? $attribute->getDefaultValue() : null,
                     'options' => $this->_entityModel->getAttributeOptions(
                         $attribute,
                         $this->_indexValueAttributes
@@ -448,7 +446,7 @@ abstract class AbstractType
         ) {
             foreach ($this->_getProductAttributes($rowData) as $attrCode => $attrParams) {
                 // check value for non-empty in the case of required attribute?
-                if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
+                if (isset($rowData[$attrCode]) && '' !== $rowData[$attrCode]) {
                     $error |= !$this->_entityModel->isAttributeValid($attrCode, $attrParams, $rowData, $rowNum);
                 } elseif ($this->_isAttributeRequiredCheckNeeded($attrCode) && $attrParams['is_required']) {
                     // For the default scope - if this is a new product or
@@ -503,7 +501,7 @@ abstract class AbstractType
             if ($attrParams['is_static']) {
                 continue;
             }
-            if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
+            if (isset($rowData[$attrCode]) && '' !== $rowData[$attrCode]) {
                 if (in_array($attrParams['type'], ['select', 'boolean'])) {
                     $resultAttrs[$attrCode] = $attrParams['options'][strtolower($rowData[$attrCode])];
                 } elseif ('multiselect' == $attrParams['type']) {

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
@@ -150,7 +150,7 @@ class Validator extends AbstractValidator implements RowValidatorInterface
             $doCheck = true;
         }
 
-        return $doCheck ? isset($rowData[$attrCode]) && strlen(trim($rowData[$attrCode])) : true;
+        return $doCheck ? isset($rowData[$attrCode]) && '' !== trim($rowData[$attrCode]) : true;
     }
 
     /**
@@ -185,7 +185,7 @@ class Validator extends AbstractValidator implements RowValidatorInterface
             return $valid;
         }
 
-        if (!strlen(trim($rowData[$attrCode]))) {
+        if ('' === trim($rowData[$attrCode])) {
             return true;
         }
         switch ($attrParams['type']) {

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
@@ -88,7 +88,7 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
         $this->_clearMessages();
         $valid = true;
         foreach ($this->mediaAttributes as $attribute) {
-            if (isset($value[$attribute]) && strlen($value[$attribute])) {
+            if (isset($value[$attribute]) && '' !== $value[$attribute]) {
                 if (!$this->checkPath($value[$attribute]) && !$this->validator->isValid($value[$attribute])) {
                     $this->_addMessages(
                         [
@@ -102,7 +102,7 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
                 }
             }
         }
-        if (isset($value[self::ADDITIONAL_IMAGES]) && strlen($value[self::ADDITIONAL_IMAGES])) {
+        if (isset($value[self::ADDITIONAL_IMAGES]) && '' !== $value[self::ADDITIONAL_IMAGES]) {
             foreach (explode($this->context->getMultipleValueSeparator(), $value[self::ADDITIONAL_IMAGES]) as $image) {
                 if (!$this->checkPath($image) && !$this->validator->isValid($image)) {
                     $this->_addMessages(

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php
@@ -37,21 +37,13 @@ class TierPrice extends AbstractPrice implements RowValidatorInterface
         $this->_clearMessages();
         if (isset(
             $value['_tier_price_website']
-        ) && strlen(
-            $value['_tier_price_website']
-        ) || isset(
+        ) && '' !== $value['_tier_price_website'] || isset(
             $value['_tier_price_customer_group']
-        ) && strlen(
-            $value['_tier_price_customer_group']
-        ) || isset(
+        ) && '' !== $value['_tier_price_customer_group'] || isset(
             $value['_tier_price_qty']
-        ) && strlen(
-            $value['_tier_price_qty']
-        ) || isset(
+        ) && '' !== $value['_tier_price_qty'] || isset(
             $value['_tier_price_price']
-        ) && strlen(
-            $value['_tier_price_price']
-        )
+        ) && '' !== $value['_tier_price_price']
         ) {
             if (!isset(
                 $value['_tier_price_website']
@@ -61,15 +53,7 @@ class TierPrice extends AbstractPrice implements RowValidatorInterface
                 $value['_tier_price_qty']
             ) || !isset(
                 $value['_tier_price_price']
-            ) || !strlen(
-                $value['_tier_price_website']
-            ) || !strlen(
-                $value['_tier_price_customer_group']
-            ) || !strlen(
-                $value['_tier_price_qty']
-            ) || !strlen(
-                $value['_tier_price_price']
-            )
+            ) || '' === $value['_tier_price_website'] || '' === $value['_tier_price_customer_group'] || '' === $value['_tier_price_qty'] || '' === $value['_tier_price_price']
             ) {
                 $this->_addMessages([self::ERROR_TIER_DATA_INCOMPLETE]);
                 return false;

--- a/app/code/Magento/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Condition/Product.php
@@ -116,7 +116,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
     {
         $attribute = $model->getResource()->getAttribute($this->getAttribute());
         if ($attribute && $attribute->getFrontendInput() == 'multiselect') {
-            $value = strlen($value) ? explode(',', $value) : [];
+            $value = '' !== $value ? explode(',', $value) : [];
         }
 
         return $value;

--- a/app/code/Magento/Checkout/Controller/Cart/CouponPost.php
+++ b/app/code/Magento/Checkout/Controller/Cart/CouponPost.php
@@ -74,7 +74,7 @@ class CouponPost extends \Magento\Checkout\Controller\Cart
         $oldCouponCode = $cartQuote->getCouponCode();
 
         $codeLength = strlen($couponCode);
-        if (!$codeLength && !strlen($oldCouponCode)) {
+        if (!$codeLength && '' === $oldCouponCode) {
             return $this->_goBack();
         }
 

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
@@ -19,16 +19,16 @@
                                                "removeCouponSelector": "#remove-coupon",
                                                "applyButton": "button.action.apply",
                                                "cancelButton": "button.action.cancel"}}'>
-            <div class="fieldset coupon<?= strlen($block->getCouponCode()) ? ' applied' : '' ?>">
+            <div class="fieldset coupon<?= '' !== $block->getCouponCode() ? ' applied' : '' ?>">
                 <input type="hidden" name="remove" id="remove-coupon" value="0" />
                 <div class="field">
                     <label for="coupon_code" class="label"><span><?= /* @escapeNotVerified */ __('Enter discount code') ?></span></label>
                     <div class="control">
-                        <input type="text" class="input-text" id="coupon_code" name="coupon_code" value="<?= $block->escapeHtml($block->getCouponCode()) ?>" placeholder="<?= $block->escapeHtml(__('Enter discount code')) ?>" <?php if (strlen($block->getCouponCode())): ?> disabled="disabled" <?php endif; ?> />
+                        <input type="text" class="input-text" id="coupon_code" name="coupon_code" value="<?= $block->escapeHtml($block->getCouponCode()) ?>" placeholder="<?= $block->escapeHtml(__('Enter discount code')) ?>" <?php if ('' !== $block->getCouponCode()): ?> disabled="disabled" <?php endif; ?> />
                     </div>
                 </div>
                 <div class="actions-toolbar">
-                    <?php if (!strlen($block->getCouponCode())): ?>
+                    <?php if ('' === $block->getCouponCode()): ?>
                     <div class="primary">
                         <button class="action apply primary" type="button" value="<?= /* @escapeNotVerified */ __('Apply Discount') ?>">
                             <span><?= /* @escapeNotVerified */ __('Apply Discount') ?></span>

--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -302,7 +302,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
                 // check attribute superity
                 $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_IS_NOT_SUPER, $rowNum, $superAttrCode);
                 return false;
-            } elseif (isset($rowData['_super_attribute_option']) && strlen($rowData['_super_attribute_option'])) {
+            } elseif (isset($rowData['_super_attribute_option']) && '' !== $rowData['_super_attribute_option']) {
                 $optionKey = strtolower($rowData['_super_attribute_option']);
                 if (!isset($this->_superAttributes[$superAttrCode]['options'][$optionKey])) {
                     $this->_entityModel->addRowError(self::ERROR_INVALID_OPTION_VALUE, $rowNum, $superAttrCode);

--- a/app/code/Magento/CustomerImportExport/Model/Import/Address.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Address.php
@@ -592,13 +592,13 @@ class Address extends AbstractCustomer
             if (array_key_exists($attributeAlias, $rowData)) {
                 $attributeParams = $this->adjustAttributeDataForWebsite($attributeParams, $websiteId);
 
-                if (!strlen($rowData[$attributeAlias])) {
+                if ('' === $rowData[$attributeAlias]) {
                     if ($newAddress) {
                         $value = null;
                     } else {
                         continue;
                     }
-                } elseif ($newAddress && !strlen($rowData[$attributeAlias])) {
+                } elseif ($newAddress && '' === $rowData[$attributeAlias]) {
                 } elseif (in_array($attributeParams['type'], ['select', 'boolean'])) {
                     $value = $this->getSelectAttrIdByValue($attributeParams, mb_strtolower($rowData[$attributeAlias]));
                 } elseif ('datetime' == $attributeParams['type']) {
@@ -816,7 +816,7 @@ class Address extends AbstractCustomer
                         if (in_array($attributeCode, $this->_ignoredAttributes)) {
                             continue;
                         }
-                        if (isset($rowData[$attributeCode]) && strlen($rowData[$attributeCode])) {
+                        if (isset($rowData[$attributeCode]) && '' !== $rowData[$attributeCode]) {
                             $this->isAttributeValid(
                                 $attributeCode,
                                 $attributeParams,
@@ -882,7 +882,7 @@ class Address extends AbstractCustomer
             if ($customerId === false) {
                 $this->addRowError(self::ERROR_CUSTOMER_NOT_FOUND, $rowNumber);
             } else {
-                if (!strlen($addressId)) {
+                if ('' === $addressId) {
                     $this->addRowError(self::ERROR_ADDRESS_ID_IS_EMPTY, $rowNumber);
                 } elseif (!in_array($addressId, $this->_addresses[$customerId])) {
                     $this->addRowError(self::ERROR_ADDRESS_NOT_FOUND, $rowNumber);

--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -379,7 +379,7 @@ class Customer extends AbstractCustomer
         }
 
         // password change/set
-        if (isset($rowData['password']) && strlen($rowData['password'])) {
+        if (isset($rowData['password']) && '' !== $rowData['password']) {
             $rowData['password_hash'] = $this->_customerModel->hashPassword($rowData['password']);
         }
         $entityRow = ['entity_id' => $entityId];
@@ -544,9 +544,7 @@ class Customer extends AbstractCustomer
             // check password
             if (isset(
                 $rowData['password']
-            ) && strlen(
-                $rowData['password']
-            ) && $this->string->strlen(
+            ) && '' !== $rowData['password'] && $this->string->strlen(
                 $rowData['password']
             ) < self::MIN_PASSWORD_LENGTH
             ) {
@@ -557,7 +555,7 @@ class Customer extends AbstractCustomer
                 if (in_array($attributeCode, $this->_ignoredAttributes)) {
                     continue;
                 }
-                if (isset($rowData[$attributeCode]) && strlen($rowData[$attributeCode])) {
+                if (isset($rowData[$attributeCode]) && '' !== $rowData[$attributeCode]) {
                     $this->isAttributeValid(
                         $attributeCode,
                         $attributeParams,

--- a/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
@@ -401,9 +401,7 @@ class CustomerComposite extends \Magento\ImportExport\Model\Import\AbstractEntit
         if (!isset($rowData[Customer::COLUMN_EMAIL])) {
             return self::SCOPE_ADDRESS;
         }
-        return strlen(
-            trim($rowData[Customer::COLUMN_EMAIL])
-        ) ? self::SCOPE_DEFAULT : self::SCOPE_ADDRESS;
+        return '' !== trim($rowData[Customer::COLUMN_EMAIL]) ? self::SCOPE_DEFAULT : self::SCOPE_ADDRESS;
     }
 
     /**

--- a/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -66,7 +66,7 @@ class Configuration extends \Magento\Framework\App\Helper\AbstractHelper impleme
     public function getLinksTitle($product)
     {
         $title = $product->getLinksTitle();
-        if (strlen($title)) {
+        if ('' !== $title) {
             return $title;
         }
         return $this->scopeConfig->getValue(\Magento\Downloadable\Model\Link::XML_PATH_LINKS_TITLE, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);

--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute.php
@@ -251,7 +251,7 @@ class Attribute extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 $connection->delete($this->getTable('eav_attribute_label'), $condition);
             }
             foreach ($storeLabels as $storeId => $label) {
-                if ($storeId == 0 || !strlen($label)) {
+                if ($storeId == 0 || '' === $label) {
                     continue;
                 }
                 $bind = ['attribute_id' => $object->getId(), 'store_id' => $storeId, 'value' => $label];

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php
@@ -233,7 +233,7 @@ abstract class AbstractEav extends \Magento\ImportExport\Model\Export\AbstractEn
                 foreach ($attribute->getSource()->getAllOptions(false) as $option) {
                     $optionValues = is_array($option['value']) ? $option['value'] : [$option];
                     foreach ($optionValues as $innerOption) {
-                        if (strlen($innerOption['value'])) {
+                        if ('' !== $innerOption['value']) {
                             // skip ' -- Please Select -- ' option
                             $options[$innerOption['value']] = $innerOption[$index];
                         }

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
@@ -414,7 +414,7 @@ abstract class AbstractEntity
             try {
                 foreach ($attribute->getSource()->getAllOptions(false) as $option) {
                     foreach (is_array($option['value']) ? $option['value'] : [$option] as $innerOption) {
-                        if (strlen($innerOption['value'])) {
+                        if ('' !== $innerOption['value']) {
                             // skip ' -- Please Select -- ' option
                             $options[$innerOption['value']] = (string)$innerOption[$index];
                         }

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEav.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEav.php
@@ -227,7 +227,7 @@ abstract class AbstractEav extends \Magento\ImportExport\Model\Import\AbstractEn
                     $value = is_array($option['value']) ? $option['value'] : [$option];
                     foreach ($value as $innerOption) {
                         // skip ' -- Please Select -- ' option
-                        if (strlen($innerOption['value'])) {
+                        if ('' !== $innerOption['value']) {
                             $options[mb_strtolower($innerOption[$index])] = $innerOption['value'];
                         }
                     }

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -526,7 +526,7 @@ abstract class AbstractEntity
                 foreach ($attribute->getSource()->getAllOptions(false) as $option) {
                     $value = is_array($option['value']) ? $option['value'] : [$option];
                     foreach ($value as $innerOption) {
-                        if (strlen($innerOption['value'])) {
+                        if ('' !== $innerOption['value']) {
                             // skip ' -- Please Select -- ' option
                             $options[strtolower($innerOption[$index])] = $innerOption['value'];
                         }

--- a/app/code/Magento/Integration/Model/CredentialsValidator.php
+++ b/app/code/Magento/Integration/Model/CredentialsValidator.php
@@ -24,10 +24,10 @@ class CredentialsValidator
     public function validate($username, $password)
     {
         $exception = new InputException();
-        if (!is_string($username) || strlen($username) == 0) {
+        if (!is_string($username) || '' === $username) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => 'username']));
         }
-        if (!is_string($password) || strlen($password) == 0) {
+        if (!is_string($password) || '' === $password) {
             $exception->addError(__('%fieldName is a required field.', ['fieldName' => 'password']));
         }
         if ($exception->wasErrorAdded()) {

--- a/app/code/Magento/MediaStorage/Model/File/Storage/Database.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Database.php
@@ -227,7 +227,7 @@ class Database extends \Magento\MediaStorage\Model\File\Storage\Database\Abstrac
 
         $dateSingleton = $this->_date;
         foreach ($files as $file) {
-            if (!isset($file['filename']) || !strlen($file['filename']) || !isset($file['content'])) {
+            if (!isset($file['filename']) || '' === $file['filename'] || !isset($file['content'])) {
                 continue;
             }
 
@@ -235,9 +235,7 @@ class Database extends \Magento\MediaStorage\Model\File\Storage\Database\Abstrac
                 $file['update_time'] = $dateSingleton->date();
                 $file['directory_id'] = isset(
                     $file['directory']
-                ) && strlen(
-                    $file['directory']
-                ) ? $this->_directoryFactory->create(
+                ) && '' !== $file['directory'] ? $this->_directoryFactory->create(
                     ['connectionName' => $this->getConnectionName()]
                 )->loadByPath(
                     $file['directory']

--- a/app/code/Magento/MediaStorage/Model/File/Storage/Directory/Database.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Directory/Database.php
@@ -191,7 +191,7 @@ class Database extends \Magento\MediaStorage\Model\File\Storage\Database\Abstrac
 
         $dateSingleton = $this->_date;
         foreach ($dirs as $dir) {
-            if (!is_array($dir) || !isset($dir['name']) || !strlen($dir['name'])) {
+            if (!is_array($dir) || !isset($dir['name']) || '' === $dir['name']) {
                 continue;
             }
 

--- a/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/Database.php
+++ b/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/Database.php
@@ -337,7 +337,7 @@ class Database extends \Magento\MediaStorage\Model\ResourceModel\File\Storage\Ab
     public function deleteFolder($folderName = '')
     {
         $folderName = rtrim($folderName, '/');
-        if (!strlen($folderName)) {
+        if ('' === $folderName) {
             return;
         }
 

--- a/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/File.php
+++ b/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/File.php
@@ -90,11 +90,11 @@ class File
      */
     public function saveDir($dir)
     {
-        if (!isset($dir['name']) || !strlen($dir['name']) || !isset($dir['path'])) {
+        if (!isset($dir['name']) || '' === $dir['name'] || !isset($dir['path'])) {
             return false;
         }
 
-        $path = strlen($dir['path']) ? $dir['path'] . '/' . $dir['name'] : $dir['name'];
+        $path = '' !== $dir['path'] ? $dir['path'] . '/' . $dir['name'] : $dir['name'];
 
         try {
             $this->_filesystem->getDirectoryWrite(DirectoryList::MEDIA)->create($path);

--- a/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
+++ b/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
@@ -178,7 +178,7 @@ class TotalsCollector
     protected function _validateCouponCode(\Magento\Quote\Model\Quote $quote)
     {
         $code = $quote->getData('coupon_code');
-        if (strlen($code)) {
+        if ('' !== $code) {
             $addressHasCoupon = false;
             $addresses = $quote->getAllAddresses();
             if (count($addresses) > 0) {

--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Address/Attribute/Frontend/Discount.php
@@ -24,7 +24,7 @@ class Discount extends \Magento\Quote\Model\ResourceModel\Quote\Address\Attribut
         if ($amount != 0) {
             $title = __('Discount');
             $couponCode = $address->getQuote()->getCouponCode();
-            if (strlen($couponCode)) {
+            if ('' !== $couponCode) {
                 $title .= sprintf(' (%s)', $couponCode);
             }
             $address->addTotal(['code' => 'discount', 'title' => $title, 'value' => -$amount]);

--- a/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
+++ b/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
@@ -554,7 +554,7 @@ abstract class AbstractProduct extends \Magento\Rule\Model\Condition\AbstractCon
 
             if ($attr && $attr->getFrontendInput() == 'multiselect') {
                 $value = $model->getData($attrCode);
-                $value = strlen($value) ? explode(',', $value) : [];
+                $value = '' !== $value ? explode(',', $value) : [];
                 return $this->validateAttribute($value);
             }
 
@@ -570,7 +570,7 @@ abstract class AbstractProduct extends \Magento\Rule\Model\Condition\AbstractCon
                 if ($attr && $attr->getBackendType() == 'datetime') {
                     $value = strtotime($value);
                 } elseif ($attr && $attr->getFrontendInput() == 'multiselect') {
-                    $value = strlen($value) ? explode(',', $value) : [];
+                    $value = '' !== $value ? explode(',', $value) : [];
                 }
 
                 $model->setData($attrCode, $value);

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1145,7 +1145,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         $newAdditionalOptions = [];
 
         foreach (explode("\n", $additionalOptions) as $_additionalOption) {
-            if (strlen(trim($_additionalOption))) {
+            if ('' !== trim($_additionalOption)) {
                 try {
                     if (strpos($_additionalOption, ':') === false) {
                         throw new \Magento\Framework\Exception\LocalizedException(__('There is an error in one of the option rows.'));

--- a/app/code/Magento/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/Transaction.php
@@ -792,7 +792,7 @@ class Transaction extends AbstractModel implements TransactionInterface
      */
     protected function _verifyTxnId($txnId)
     {
-        if (null !== $txnId && 0 == strlen($txnId)) {
+        if (null !== $txnId && '' === $txnId) {
             throw new \Magento\Framework\Exception\LocalizedException(__('Please enter a Transaction ID.'));
         }
     }

--- a/app/code/Magento/SalesRule/Model/Quote/Discount.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Discount.php
@@ -214,7 +214,7 @@ class Discount extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
             $description = $total->getDiscountDescription();
             $result = [
                 'code' => $this->getCode(),
-                'title' => strlen($description) ? __('Discount (%1)', $description) : __('Discount'),
+                'title' => '' !== $description ? __('Discount (%1)', $description) : __('Discount'),
                 'value' => $amount
             ];
         }

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Collection.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Collection.php
@@ -156,7 +156,7 @@ class Collection extends \Magento\Rule\Model\ResourceModel\Rule\Collection\Abstr
             $select = $this->getSelect();
 
             $connection = $this->getConnection();
-            if (strlen($couponCode)) {
+            if ('' !== $couponCode) {
                 $select->joinLeft(
                     ['rule_coupons' => $this->getTable('salesrule_coupon')],
                     $connection->quoteInto(

--- a/app/code/Magento/SalesRule/Model/Rule.php
+++ b/app/code/Magento/SalesRule/Model/Rule.php
@@ -286,9 +286,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel
     public function afterSave()
     {
         $couponCode = trim($this->getCouponCode());
-        if (strlen(
-            $couponCode
-        ) && $this->getCouponType() == self::COUPON_TYPE_SPECIFIC && !$this->getUseAutoGeneration()
+        if ('' !== $couponCode && $this->getCouponType() == self::COUPON_TYPE_SPECIFIC && !$this->getUseAutoGeneration()
         ) {
             $this->getPrimaryCoupon()->setCode(
                 $couponCode

--- a/app/code/Magento/SalesRule/Model/RulesApplier.php
+++ b/app/code/Magento/SalesRule/Model/RulesApplier.php
@@ -101,12 +101,12 @@ class RulesApplier
         if ($ruleLabel) {
             $label = $ruleLabel;
         } else {
-            if (strlen($address->getCouponCode())) {
+            if ('' !== $address->getCouponCode()) {
                 $label = $address->getCouponCode();
             }
         }
 
-        if (strlen($label)) {
+        if ('' !== $label) {
             $description[$rule->getId()] = $label;
         }
 

--- a/app/code/Magento/SalesRule/Model/Utility.php
+++ b/app/code/Magento/SalesRule/Model/Utility.php
@@ -91,7 +91,7 @@ class Utility
          */
         if ($rule->getCouponType() != \Magento\SalesRule\Model\Rule::COUPON_TYPE_NO_COUPON) {
             $couponCode = $address->getQuote()->getCouponCode();
-            if (strlen($couponCode)) {
+            if ('' !== $couponCode) {
                 /** @var \Magento\SalesRule\Model\Coupon $coupon */
                 $coupon = $this->couponFactory->create();
                 $coupon->load($couponCode, 'code');

--- a/app/code/Magento/Theme/Model/Design/Backend/Exceptions.php
+++ b/app/code/Magento/Theme/Model/Design/Backend/Exceptions.php
@@ -79,7 +79,7 @@ class Exceptions extends ArraySerialized
             }
 
             // Empty string (match all) is not supported, because it means setting a default theme. Remove such entries.
-            if (!strlen($row['search'])) {
+            if ('' === $row['search']) {
                 unset($exceptions[$rowKey]);
                 continue;
             }

--- a/app/code/Magento/Variable/Model/Variable.php
+++ b/app/code/Magento/Variable/Model/Variable.php
@@ -111,7 +111,7 @@ class Variable extends \Magento\Framework\Model\AbstractModel
         if ($type === null) {
             $type = self::TYPE_HTML;
         }
-        if ($type == self::TYPE_TEXT || !strlen((string)$this->getData('html_value'))) {
+        if ($type == self::TYPE_TEXT || '' === (string)$this->getData('html_value')) {
             $value = $this->getData('plain_value');
             //escape html if type is html, but html value is not defined
             if ($type == self::TYPE_HTML) {

--- a/app/code/Magento/Webapi/Model/Soap/Server.php
+++ b/app/code/Magento/Webapi/Model/Soap/Server.php
@@ -197,7 +197,7 @@ class Server
     protected function _checkRequest($soapRequest)
     {
         $dom = new \DOMDocument();
-        if (strlen($soapRequest) == 0 || !$dom->loadXML($soapRequest)) {
+        if ('' === $soapRequest || !$dom->loadXML($soapRequest)) {
             throw new \Magento\Framework\Webapi\Exception(
                 __('Invalid XML'),
                 0,

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl.php
@@ -44,10 +44,8 @@ class Wsdl extends \Zend\Soap\Wsdl
                 $fault['message']
             ) && is_string(
                 $fault['message']
-            ) && strlen(
-                trim($fault['message'])
-            );
-            $isNameValid = isset($fault['name']) && is_string($fault['name']) && strlen(trim($fault['name']));
+            ) && '' !== trim($fault['message']);
+            $isNameValid = isset($fault['name']) && is_string($fault['name']) && '' !== trim($fault['name']);
 
             if ($isNameValid && $isMessageValid) {
                 $node = $this->toDomDocument()->createElement('fault');

--- a/app/code/Magento/Widget/Model/Config/Converter.php
+++ b/app/code/Magento/Widget/Model/Config/Converter.php
@@ -292,7 +292,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             if ($dataChild instanceof \DOMElement) {
                 $data[$dataChild->attributes->getNamedItem('name')->nodeValue] = $this->_convertData($dataChild);
             } else {
-                if (strlen(trim($dataChild->nodeValue))) {
+                if ('' !== trim($dataChild->nodeValue)) {
                     $data = $dataChild->nodeValue;
                 }
             }

--- a/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance.php
@@ -124,7 +124,7 @@ class Instance extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 $pageGroupData['template']
             );
             $insert = ['handle' => $handle, 'xml' => $xml];
-            if (strlen($widgetInstance->getSortOrder())) {
+            if ('' !== $widgetInstance->getSortOrder()) {
                 $insert['sort_order'] = $widgetInstance->getSortOrder();
             }
 

--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -597,7 +597,7 @@ class Instance extends \Magento\Framework\Model\AbstractModel
             } elseif (is_array($value)) {
                 $value = implode(',', $value);
             }
-            if ($name && strlen((string)$value)) {
+            if ($name && '' !== (string)$value) {
                 $value = html_entity_decode($value);
                 $xml .= '<action method="setData">' .
                     '<argument name="name" xsi:type="string">' .

--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -215,7 +215,7 @@ class Wishlist extends \Magento\Framework\Model\AbstractModel implements \Magent
     public function getName()
     {
         $name = $this->_getData('name');
-        if (!strlen($name)) {
+        if ('' === $name) {
             return $this->_wishlistData->getDefaultWishlistName();
         }
         return $name;

--- a/lib/internal/Magento/Framework/Backup/Filesystem/Iterator/File.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem/Iterator/File.php
@@ -39,7 +39,7 @@ class File extends \SplFileObject
         $this->_currentStatement = '';
         while (!$this->eof()) {
             $line = $this->fgets();
-            if (strlen(trim($line))) {
+            if ('' !== trim($line)) {
                 $this->_currentStatement .= $line;
                 if ($this->_isLineLastInCommand($line)) {
                     break;

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -1643,7 +1643,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             $options['unsigned'] = true;
         }
         if ($columnData['NULLABLE'] === false
-            && !($type == Table::TYPE_TEXT && strlen($columnData['DEFAULT']) != 0)
+            && !($type == Table::TYPE_TEXT && '' !== $columnData['DEFAULT'])
         ) {
             $options['nullable'] = false;
         }
@@ -2437,7 +2437,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
          *  where default value can be quoted already.
          *  We need to avoid "double-quoting" here
          */
-        if ($cDefault !== null && is_string($cDefault) && strlen($cDefault)) {
+        if ($cDefault !== null && is_string($cDefault) && '' !== $cDefault) {
             $cDefault = str_replace("'", '', $cDefault);
         }
 

--- a/lib/internal/Magento/Framework/Encryption/Crypt.php
+++ b/lib/internal/Magento/Framework/Encryption/Crypt.php
@@ -151,7 +151,7 @@ class Crypt
      */
     public function encrypt($data)
     {
-        if (strlen($data) == 0) {
+        if ('' === $data) {
             return $data;
         }
         // @codingStandardsIgnoreStart
@@ -167,7 +167,7 @@ class Crypt
      */
     public function decrypt($data)
     {
-        if (strlen($data) == 0) {
+        if ('' === $data) {
             return $data;
         }
         // @codingStandardsIgnoreStart

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -52,7 +52,7 @@ class Escaper
             foreach ($data as $item) {
                 $result[] = $this->escapeHtml($item, $allowedTags);
             }
-        } elseif (strlen($data)) {
+        } elseif ('' !== $data) {
             if (is_array($allowedTags) && !empty($allowedTags)) {
                 $notAllowedTags = array_intersect(
                     array_map('strtolower', $allowedTags),

--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -444,7 +444,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
                 $value = $out[1];
             }
 
-            if (strlen($name)) {
+            if ('' !== $name) {
                 if ("Set-Cookie" == $name) {
                     if (!isset($this->_responseHeaders[$name])) {
                         $this->_responseHeaders[$name] = [];

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -187,7 +187,7 @@ class Changelog implements ChangelogInterface
      */
     public function getName()
     {
-        if (strlen($this->viewId) == 0) {
+        if ('' === $this->viewId) {
             throw new \Exception("View's identifier is not set");
         }
         return $this->viewId . '_' . self::NAME_SUFFIX;

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -259,7 +259,7 @@ class Element extends \SimpleXMLElement
         if ($this->hasChildren()) {
             $out .= '>';
             $value = trim((string)$this);
-            if (strlen($value)) {
+            if ('' !== $value) {
                 $out .= $this->xmlentities($value);
             }
             $out .= $nl;
@@ -269,7 +269,7 @@ class Element extends \SimpleXMLElement
             $out .= $pad . '</' . $this->getName() . '>' . $nl;
         } else {
             $value = (string)$this;
-            if (strlen($value)) {
+            if ('' !== $value) {
                 $out .= '>' . $this->xmlentities($value) . '</' . $this->getName() . '>' . $nl;
             } else {
                 $out .= '/>' . $nl;


### PR DESCRIPTION
### Preconditions
1. Magento 2.2 

### Steps to reproduce
1.  Run Php Inspections  in PHPstorm 

### Expected result

1.  In this parts, we should the recommend stuff for better Performance remanded by 
Php Inspections (EA Ultimate) and Roave.

### Actual result
- we use a slower function like **strlen** or **mb_strlen**

### Report from Php Inspections (EA Ultimate)
```xml
<?xml version="1.0" encoding="UTF-8"?>
<problems>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute.php</file>
    <line>254</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $label' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php</file>
    <line>551</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php</file>
    <line>567</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Quote/Model/Quote/TotalsCollector.php</file>
    <line>181</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Quote/Model/Quote/TotalsCollector.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $code' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Quote/Model/ResourceModel/Quote/Address/Attribute/Frontend/Discount.php</file>
    <line>27</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Quote/Model/ResourceModel/Quote/Address/Attribute/Frontend/Discount.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $couponCode' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Sales/Model/Order/Payment/Transaction.php</file>
    <line>795</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Sales/Model/Order/Payment/Transaction.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $txnId' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Sales/Model/AdminOrder/Create.php</file>
    <line>1135</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Sales/Model/AdminOrder/Create.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($_additionalOption)' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Theme/Model/Design/Backend/Exceptions.php</file>
    <line>82</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Theme/Model/Design/Backend/Exceptions.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $row['search']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Webapi/Model/Soap/Server.php</file>
    <line>200</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Webapi/Model/Soap/Server.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $soapRequest' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Webapi/Model/Soap/Wsdl.php</file>
    <line>47</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Webapi/Model/Soap/Wsdl.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($fault['message'])' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Webapi/Model/Soap/Wsdl.php</file>
    <line>50</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Webapi/Model/Soap/Wsdl.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($fault['name'])' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Widget/Model/Config/Converter.php</file>
    <line>284</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Widget/Model/Config/Converter.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($dataChild-&gt;nodeValue)' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Widget/Model/Widget/Instance.php</file>
    <line>595</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Widget/Model/Widget/Instance.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== (string)$value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance.php</file>
    <line>127</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $widgetInstance-&gt;getSortOrder()' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Block/Product/View/Attributes.php</file>
    <line>92</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Block/Product/View/Attributes.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product.php</file>
    <line>2123</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $product['sku']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Layer/Filter/Attribute.php</file>
    <line>84</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Layer/Filter/Attribute.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $text' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php</file>
    <line>635</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $customOption-&gt;getValue()' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php</file>
    <line>61</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php</file>
    <line>54</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php</file>
    <line>78</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $this-&gt;getRequest()-&gt;getParam('attribute_code')' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Checkout/Controller/Cart/CouponPost.php</file>
    <line>77</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Checkout/Controller/Cart/CouponPost.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $oldCouponCode' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Variable/Model/Variable.php</file>
    <line>114</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Variable/Model/Variable.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === (string)$this-&gt;getData('html_value')' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Wishlist/Model/Wishlist.php</file>
    <line>218</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Wishlist/Model/Wishlist.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $name' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Wishlist/Controller/Index/Update.php</file>
    <line>86</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Wishlist/Controller/Index/Update.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $description' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/RulesApplier.php</file>
    <line>104</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/RulesApplier.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $address-&gt;getCouponCode()' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/RulesApplier.php</file>
    <line>109</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/RulesApplier.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $label' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/Rule.php</file>
    <line>289</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/Rule.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $couponCode' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/Utility.php</file>
    <line>94</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/Utility.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $couponCode' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/Quote/Discount.php</file>
    <line>217</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/Quote/Discount.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $description' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Collection.php</file>
    <line>159</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Collection.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $couponCode' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogRule/Model/Rule/Condition/Product.php</file>
    <line>119</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogRule/Model/Rule/Condition/Product.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Integration/Model/CredentialsValidator.php</file>
    <line>27</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Integration/Model/CredentialsValidator.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $username' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Integration/Model/CredentialsValidator.php</file>
    <line>30</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Integration/Model/CredentialsValidator.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $password' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php</file>
    <line>69</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $title' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php</file>
    <line>417</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $innerOption['value']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php</file>
    <line>236</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $innerOption['value']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php</file>
    <line>528</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $innerOption['value']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEav.php</file>
    <line>230</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEav.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $innerOption['value']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/File/Storage/Database.php</file>
    <line>230</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/File/Storage/Database.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $file['filename']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/File/Storage/Database.php</file>
    <line>238</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/File/Storage/Database.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $file['directory']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/File/Storage/Directory/Database.php</file>
    <line>194</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/File/Storage/Directory/Database.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $dir['name']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/File.php</file>
    <line>93</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/File.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $dir['name']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/File.php</file>
    <line>97</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/File.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $dir['path']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/Database.php</file>
    <line>340</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/Database.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $folderName' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php</file>
    <line>153</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($rowData[$attrCode])' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php</file>
    <line>188</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === trim($rowData[$attrCode])' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php</file>
    <line>323</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $attribute-&gt;getDefaultValue()' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php</file>
    <line>451</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData[$attrCode]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php</file>
    <line>506</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData[$attrCode]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>40</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value['_tier_price_website']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>44</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value['_tier_price_customer_group']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>48</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value['_tier_price_qty']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>52</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value['_tier_price_price']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>64</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value['_tier_price_website']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>66</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value['_tier_price_customer_group']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>68</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value['_tier_price_qty']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php</file>
    <line>70</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value['_tier_price_price']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php</file>
    <line>91</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value[$attribute]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php</file>
    <line>105</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value[self::ADDITIONAL_IMAGES]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php</file>
    <line>404</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($rowData[Customer::COLUMN_EMAIL])' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Customer.php</file>
    <line>374</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Customer.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData['password']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Customer.php</file>
    <line>530</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Customer.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData['password']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Customer.php</file>
    <line>543</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Customer.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData[$attributeCode]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php</file>
    <line>519</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $rowData[$attributeAlias]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php</file>
    <line>525</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $rowData[$attributeAlias]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php</file>
    <line>740</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData[$attributeCode]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php</file>
    <line>806</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/CustomerImportExport/Model/Import/Address.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $addressId' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php</file>
    <line>296</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $rowData['_super_attribute_option']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php</file>
    <line>142</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value[$column]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php</file>
    <line>159</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $value[$column]' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Escaper.php</file>
    <line>55</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Escaper.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $data' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php</file>
    <line>1646</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $columnData['DEFAULT']' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php</file>
    <line>2440</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $cDefault' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/HTTP/Client/Curl.php</file>
    <line>447</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/HTTP/Client/Curl.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $name' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Mview/View/Changelog.php</file>
    <line>190</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Mview/View/Changelog.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $this-&gt;viewId' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Backup/Filesystem/Iterator/File.php</file>
    <line>42</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Backup/Filesystem/Iterator/File.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($line)' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Filter/Template.php</file>
    <line>207</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Filter/Template.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== trim($construction[$field])' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Simplexml/Element.php</file>
    <line>262</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Simplexml/Element.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Simplexml/Element.php</file>
    <line>272</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Simplexml/Element.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' !== $value' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Encryption/Crypt.php</file>
    <line>154</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Encryption/Crypt.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $data' can be used instead.</description>
  </problem>
  <problem>
    <file>file://$PROJECT_DIR$/lib/internal/Magento/Framework/Encryption/Crypt.php</file>
    <line>170</line>
    <entry_point TYPE="file" FQNAME="file://$PROJECT_DIR$/lib/internal/Magento/Framework/Encryption/Crypt.php" />
    <problem_class severity="WARNING" attribute_key="WARNING_ATTRIBUTES">'(mb_)strlen(...)' misused</problem_class>
    <description>''' === $data' can be used instead.</description>
  </problem>
</problems>
```

