### PR TITLE
Fix adding values to system variable collection

### DIFF
--- a/app/code/Magento/Variable/Model/ResourceModel/Variable/Collection.php
+++ b/app/code/Magento/Variable/Model/ResourceModel/Variable/Collection.php
@@ -62,7 +62,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $this->getSelect()->join(
             ['value_table' => $this->getTable('variable_value')],
             'value_table.variable_id = main_table.variable_id',
-            ['value_table.value']
+            ['value_table.plain_value', 'value_table.html_value']
         );
         $this->addFieldToFilter('value_table.store_id', ['eq' => $this->getStoreId()]);
         return $this;


### PR DESCRIPTION
Changed select fields in joined variable value table in `Magento\Variable\Model\ResourceModel\Variable\Collection#addValuesToResult()` method to match DB schema

### Description
Method mentioned above tried to select field `value` from joined `variable_value` table (which doesn't exist). I've replaced incorrect field with two proper ones: `plain_value` and `html_value`.

### Fixed Issues
Calling `Magento\Variable\Model\ResourceModel\Variable\Collection#addValuesToResult()` method results with `Zend_Db_Statement_Exception` thrown. Exception message:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'value_table.value' in 'field list', query was: SELECT `main_table`.*, `value_table`.`value` FROM `variable` AS `main_table`  
   INNER JOIN `variable_value` AS `value_table` ON value_table.variable_id = main_table.variable_id WHERE (`value_table`.`store_id` = 0)
```
### Manual testing scenarios
As the method is not used anywhere in the magento core there is no way to reproduce error with just clicking.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
