### PR TITLE
Add event to admin user edit form

### DIFF
--- a/app/code/Magento/Backend/Block/System/Account/Edit/Form.php
+++ b/app/code/Magento/Backend/Block/System/Account/Edit/Form.php
@@ -72,8 +72,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      */
     protected function _prepareForm()
     {
-        $userId = $this->_authSession->getUser()->getId();
-        $user = $this->_userFactory->create()->load($userId);
+        $user = $this->_userFactory->create()->load($this->_authSession->getUser()->getId());
         $user->unsetData('password');
 
         /** @var \Magento\Framework\Data\Form $form */
@@ -157,14 +156,15 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ]
         );
 
-        $data = $user->getData();
-        unset($data[self::IDENTITY_VERIFICATION_PASSWORD_FIELD]);
-        $form->setValues($data);
         $form->setAction($this->getUrl('adminhtml/system_account/save'));
         $form->setMethod('post');
         $form->setUseContainer(true);
         $form->setId('edit_form');
+        $this->_eventManager->dispatch('adminhtml_backend_user_edit_prepare_form', ['form' => $form, 'user' => $user]);
 
+        $data = $user->getData();
+        unset($data[self::IDENTITY_VERIFICATION_PASSWORD_FIELD]);
+        $form->setValues($data);
         $this->setForm($form);
 
         return parent::_prepareForm();


### PR DESCRIPTION
### Description
The event allows addition of form fields by extensions without needing
to override the block class. Structured similar to the event dispatched
in `Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Front`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Create module and observe `adminhtml_backend_user_edit_prepare_form` event.
2. Perform task on form object

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
