### PR TITLE
SQL query is printed into browser in case of exception

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1114,7 +1114,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
             $query = $this->getSelect();
             $rows = $this->_fetchAll($query);
         } catch (\Exception $e) {
-            $this->printLogQuery(true, true, $query);
+            $this->printLogQuery(false, true, $query);
             throw $e;
         }
 


### PR DESCRIPTION
### Description
SQL query is printed into browser in case of exception

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13385: SQL query is printed into browser in case of exception


### Manual testing scenarios
Add an erroneous SQL statement to collection select object. I've added this code to \Magento\Catalog\Block\Product\ListProduct::initializeProductCollection():
$collection = $layer->getProductCollection();
$collection->getSelect()->columns('qwerty');
as an example
Open some category page in a browser.
SQL query is printed in a browser

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
