### PR TITLE
Show redirect_to_base config in store scope

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -419,7 +419,7 @@
                         <![CDATA[<strong style="color:red">Warning!</strong> When using Store Code in URLs, in some cases system may not work properly if URLs without Store Codes are specified in the third party services (e.g. PayPal etc.).]]>
                     </comment>
                 </field>
-                <field id="redirect_to_base" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="redirect_to_base" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Auto-redirect to Base URL</label>
                     <source_model>Magento\Config\Model\Config\Source\Web\Redirect</source_model>
                     <comment>I.e. redirect from http://example.com/store/ to http://www.example.com/store/</comment>


### PR DESCRIPTION
### Description
Add `web/unsecure/base_url` config to website and store scope. Setting is used that way in the code, see:
https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php#L80-L83
https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Store/Model/BaseUrlChecker.php#L63-L66

The tests also use store scope.

### Fixed Issues (if relevant)
1. None I could find.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
