### PR TITLE
[Forwardport] magento/magento2#:13040 Customer Login/Logout Issue

### DIFF
--- a/app/code/Magento/Customer/Model/Account/Redirect.php
+++ b/app/code/Magento/Customer/Model/Account/Redirect.php
@@ -75,6 +75,11 @@ class Redirect
     private $hostChecker;
 
     /**
+     * @var Session
+     */
+    private $session;
+
+    /**
      * @param RequestInterface $request
      * @param Session $customerSession
      * @param ScopeConfigInterface $scopeConfig
@@ -206,6 +211,10 @@ class Redirect
             $referer = $this->request->getParam(CustomerUrl::REFERER_QUERY_PARAM_NAME);
             if ($referer) {
                 $referer = $this->urlDecoder->decode($referer);
+                preg_match('/logoutSuccess\//', $referer, $matches, PREG_OFFSET_CAPTURE);
+                if (!empty($matches)) {
+                    $referer = str_replace('logoutSuccess/', '', $referer);
+                }
                 if ($this->hostChecker->isOwnOrigin($referer)) {
                     $this->applyRedirect($referer);
                 }

--- a/app/code/Magento/Customer/Test/Unit/Model/Account/RedirectTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Account/RedirectTest.php
@@ -147,15 +147,15 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
         $this->model = $objectManager->getObject(
             \Magento\Customer\Model\Account\Redirect::class,
             [
-                'request'               => $this->request,
-                'customerSession'       => $this->customerSession,
-                'scopeConfig'           => $this->scopeConfig,
-                'storeManager'          => $this->storeManager,
-                'url'                   => $this->url,
-                'urlDecoder'            => $this->urlDecoder,
-                'customerUrl'           => $this->customerUrl,
-                'resultFactory'         => $this->resultFactory,
-                'hostChecker' => $this->hostChecker
+                'request' => $this->request,
+                'customerSession' => $this->customerSession,
+                'scopeConfig' => $this->scopeConfig,
+                'storeManager' => $this->storeManager,
+                'url' => $this->url,
+                'urlDecoder' => $this->urlDecoder,
+                'customerUrl' => $this->customerUrl,
+                'resultFactory' => $this->resultFactory,
+                'hostChecker' => $this->hostChecker,
             ]
         );
     }
@@ -272,6 +272,10 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
             ->with(ResultFactory::TYPE_REDIRECT)
             ->willReturn($this->resultRedirect);
 
+        $this->hostChecker->expects($this->any())
+            ->method('isOwnOrigin')
+            ->willReturn(true);
+
         $this->model->getRedirect();
     }
 
@@ -296,16 +300,109 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
          */
         return [
             // Logged In, Redirect by Referer
-            [1, 2, 'referer', 'base', '', '', 'account', '', '', '', true, false],
-            [1, 2, 'http://referer.com/', 'http://base.com/', '', '', 'account', '', '', 'dashboard', true, false],
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'referer',
+                'base_url' => 'base',
+                'before_auth_url' => '',
+                'after_auth_url' => '',
+                'account_url' => 'account',
+                'login_url' => '',
+                'logout_url' => '',
+                'dashboard_url' => '',
+                'is_customer_logged_id_flag' => true,
+                'redirect_to_dashboard_flag' => false,
+            ],
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'http://referer.com/',
+                'base_url' => 'http://base.com/',
+                'before_auth_url' => '',
+                'after_auth_url' => '',
+                'account_url' => 'account',
+                'login_url' => '',
+                'logout_url' => '',
+                'dashboard_url' => 'dashboard',
+                'is_customer_logged_id_flag' => true,
+                'redirect_to_dashboard_flag' => false,
+            ],
             // Logged In, Redirect by AfterAuthUrl
-            [1, 2, 'referer', 'base', '', 'defined', 'account', '', '', '', true, true],
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'referer',
+                'base_url' => 'base',
+                'before_auth_url' => '',
+                'after_auth_url' => 'defined',
+                'account_url' => 'account',
+                'login_url' => '',
+                'logout_url' => '',
+                'dashboard_url' => '',
+                'is_customer_logged_id_flag' => true,
+                'redirect_to_dashboard_flag' => true,
+            ],
             // Not logged In, Redirect by LoginUrl
-            [1, 2, 'referer', 'base', '', '', 'account', 'login', '', '', false, true],
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'referer',
+                'base_url' => 'base',
+                'before_auth_url' => '',
+                'after_auth_url' => '',
+                'account_url' => 'account',
+                'login_url' => 'login',
+                'logout_url' => '',
+                'dashboard_url' => '',
+                'is_customer_logged_id_flag' => false,
+                'redirect_to_dashboard_flag' => true,
+            ],
             // Logout, Redirect to Dashboard
-            [1, 2, 'referer', 'base', 'logout', '', 'account', 'login', 'logout', 'dashboard', false, true],
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'referer',
+                'base_url' => 'base',
+                'before_auth_url' => 'logout',
+                'after_auth_url' => '',
+                'account_url' => 'account',
+                'login_url' => 'login',
+                'logout_url' => 'logout',
+                'dashboard_url' => 'dashboard',
+                'is_customer_logged_id_flag' => false,
+                'redirect_to_dashboard_flag' => true,
+            ],
+            // Logout, Without Redirect to Dashboard
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'http://base.com/customer/account/logoutSuccess/',
+                'base_url' => 'http://base.com/',
+                'before_auth_url' => 'http://base.com/',
+                'after_auth_url' => 'http://base.com/customer/account/',
+                'account_url' => 'account',
+                'login_url' => 'login',
+                'logout_url' => 'logout',
+                'dashboard_url' => 'dashboard',
+                'is_customer_logged_id_flag' => true,
+                'redirect_to_dashboard_flag' => false,
+            ],
             // Default redirect
-            [1, 2, 'referer', 'base', 'defined', '', 'account', 'login', 'logout', 'dashboard', true, true],
+            [
+                'customer_id' => 1,
+                'last_customer_id' => 2,
+                'referer' => 'referer',
+                'base_url' => 'base',
+                'before_auth_url' => 'defined',
+                'after_auth_url' => '',
+                'account_url' => 'account',
+                'login_url' => 'login',
+                'logout_url' => 'logout',
+                'dashboard_url' => 'dashboard',
+                'is_customer_logged_id_flag' => true,
+                'redirect_to_dashboard_flag' => true,
+            ],
         ];
     }
 

--- a/app/code/Magento/Customer/Test/Unit/Model/Account/RedirectTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Account/RedirectTest.php
@@ -11,9 +11,9 @@ namespace Magento\Customer\Test\Unit\Model\Account;
 use Magento\Customer\Model\Account\Redirect;
 use Magento\Customer\Model\Url as CustomerUrl;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Url\HostChecker;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -300,79 +300,16 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
          */
         return [
             // Logged In, Redirect by Referer
-            [
-                'customer_id' => 1,
-                'last_customer_id' => 2,
-                'referer' => 'referer',
-                'base_url' => 'base',
-                'before_auth_url' => '',
-                'after_auth_url' => '',
-                'account_url' => 'account',
-                'login_url' => '',
-                'logout_url' => '',
-                'dashboard_url' => '',
-                'is_customer_logged_id_flag' => true,
-                'redirect_to_dashboard_flag' => false,
-            ],
-            [
-                'customer_id' => 1,
-                'last_customer_id' => 2,
-                'referer' => 'http://referer.com/',
-                'base_url' => 'http://base.com/',
-                'before_auth_url' => '',
-                'after_auth_url' => '',
-                'account_url' => 'account',
-                'login_url' => '',
-                'logout_url' => '',
-                'dashboard_url' => 'dashboard',
-                'is_customer_logged_id_flag' => true,
-                'redirect_to_dashboard_flag' => false,
-            ],
+            [1, 2, 'referer', 'base', '', '', 'account', '', '', '', true, false],
+            [1, 2, 'http://referer.com/', 'http://base.com/', '', '', 'account', '', '', 'dashboard', true, false],
             // Logged In, Redirect by AfterAuthUrl
-            [
-                'customer_id' => 1,
-                'last_customer_id' => 2,
-                'referer' => 'referer',
-                'base_url' => 'base',
-                'before_auth_url' => '',
-                'after_auth_url' => 'defined',
-                'account_url' => 'account',
-                'login_url' => '',
-                'logout_url' => '',
-                'dashboard_url' => '',
-                'is_customer_logged_id_flag' => true,
-                'redirect_to_dashboard_flag' => true,
-            ],
+            [1, 2, 'referer', 'base', '', 'defined', 'account', '', '', '', true, true],
             // Not logged In, Redirect by LoginUrl
-            [
-                'customer_id' => 1,
-                'last_customer_id' => 2,
-                'referer' => 'referer',
-                'base_url' => 'base',
-                'before_auth_url' => '',
-                'after_auth_url' => '',
-                'account_url' => 'account',
-                'login_url' => 'login',
-                'logout_url' => '',
-                'dashboard_url' => '',
-                'is_customer_logged_id_flag' => false,
-                'redirect_to_dashboard_flag' => true,
-            ],
+            [1, 2, 'referer', 'base', '', '', 'account', 'login', '', '', false, true],
             // Logout, Redirect to Dashboard
-            [
-                'customer_id' => 1,
-                'last_customer_id' => 2,
-                'referer' => 'referer',
-                'base_url' => 'base',
-                'before_auth_url' => 'logout',
-                'after_auth_url' => '',
-                'account_url' => 'account',
-                'login_url' => 'login',
-                'logout_url' => 'logout',
-                'dashboard_url' => 'dashboard',
-                'is_customer_logged_id_flag' => false,
-                'redirect_to_dashboard_flag' => true,
-            ],
+            [1, 2, 'referer', 'base', 'logout', '', 'account', 'login', 'logout', 'dashboard', false, true],
+            // Default redirect
+            [1, 2, 'referer', 'base', 'defined', '', 'account', 'login', 'logout', 'dashboard', true, true],
             // Logout, Without Redirect to Dashboard
             [
                 'customer_id' => 1,
@@ -387,21 +324,6 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
                 'dashboard_url' => 'dashboard',
                 'is_customer_logged_id_flag' => true,
                 'redirect_to_dashboard_flag' => false,
-            ],
-            // Default redirect
-            [
-                'customer_id' => 1,
-                'last_customer_id' => 2,
-                'referer' => 'referer',
-                'base_url' => 'base',
-                'before_auth_url' => 'defined',
-                'after_auth_url' => '',
-                'account_url' => 'account',
-                'login_url' => 'login',
-                'logout_url' => 'logout',
-                'dashboard_url' => 'dashboard',
-                'is_customer_logged_id_flag' => true,
-                'redirect_to_dashboard_flag' => true,
             ],
         ];
     }

--- a/app/code/Magento/Customer/Test/Unit/Model/Account/RedirectTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Account/RedirectTest.php
@@ -191,57 +191,31 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
         $redirectToDashboard
     ) {
         // Preparations for method updateLastCustomerId()
-        $this->customerSession->expects($this->once())
-            ->method('getLastCustomerId')
-            ->willReturn($customerId);
-        $this->customerSession->expects($this->any())
-            ->method('isLoggedIn')
-            ->willReturn($customerLoggedIn);
-        $this->customerSession->expects($this->any())
-            ->method('getId')
-            ->willReturn($lastCustomerId);
-        $this->customerSession->expects($this->any())
-            ->method('unsBeforeAuthUrl')
-            ->willReturnSelf();
+        $this->customerSession->expects($this->once())->method('getLastCustomerId')->willReturn($customerId);
+        $this->customerSession->expects($this->any())->method('isLoggedIn')->willReturn($customerLoggedIn);
+        $this->customerSession->expects($this->any())->method('getId')->willReturn($lastCustomerId);
+        $this->customerSession->expects($this->any())->method('unsBeforeAuthUrl')->willReturnSelf();
         $this->customerSession->expects($this->any())
             ->method('setLastCustomerId')
             ->with($lastCustomerId)
             ->willReturnSelf();
 
         // Preparations for method prepareRedirectUrl()
-        $this->store->expects($this->once())
-            ->method('getBaseUrl')
-            ->willReturn($baseUrl);
+        $this->store->expects($this->once())->method('getBaseUrl')->willReturn($baseUrl);
 
-        $this->customerSession->expects($this->any())
-            ->method('getBeforeAuthUrl')
-            ->willReturn($beforeAuthUrl);
-        $this->customerSession->expects($this->any())
-            ->method('setBeforeAuthUrl')
-            ->willReturnSelf();
-        $this->customerSession->expects($this->any())
-            ->method('getAfterAuthUrl')
-            ->willReturn($afterAuthUrl);
+        $this->customerSession->expects($this->any())->method('getBeforeAuthUrl')->willReturn($beforeAuthUrl);
+        $this->customerSession->expects($this->any())->method('setBeforeAuthUrl')->willReturnSelf();
+        $this->customerSession->expects($this->any())->method('getAfterAuthUrl')->willReturn($afterAuthUrl);
         $this->customerSession->expects($this->any())
             ->method('setAfterAuthUrl')
             ->with($beforeAuthUrl)
             ->willReturnSelf();
-        $this->customerSession->expects($this->any())
-            ->method('getBeforeRequestParams')
-            ->willReturn(false);
+        $this->customerSession->expects($this->any())->method('getBeforeRequestParams')->willReturn(false);
 
-        $this->customerUrl->expects($this->any())
-            ->method('getAccountUrl')
-            ->willReturn($accountUrl);
-        $this->customerUrl->expects($this->any())
-            ->method('getLoginUrl')
-            ->willReturn($loginUrl);
-        $this->customerUrl->expects($this->any())
-            ->method('getLogoutUrl')
-            ->willReturn($logoutUrl);
-        $this->customerUrl->expects($this->any())
-            ->method('getDashboardUrl')
-            ->willReturn($dashboardUrl);
+        $this->customerUrl->expects($this->any())->method('getAccountUrl')->willReturn($accountUrl);
+        $this->customerUrl->expects($this->any())->method('getLoginUrl')->willReturn($loginUrl);
+        $this->customerUrl->expects($this->any())->method('getLogoutUrl')->willReturn($logoutUrl);
+        $this->customerUrl->expects($this->any())->method('getDashboardUrl')->willReturn($dashboardUrl);
 
         $this->scopeConfig->expects($this->any())
             ->method('isSetFlag')
@@ -253,28 +227,18 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
             ->with(CustomerUrl::REFERER_QUERY_PARAM_NAME)
             ->willReturn($referer);
 
-        $this->urlDecoder->expects($this->any())
-            ->method('decode')
-            ->with($referer)
-            ->willReturn($referer);
+        $this->urlDecoder->expects($this->any())->method('decode')->with($referer)->willReturn($referer);
 
-        $this->url->expects($this->any())
-            ->method('isOwnOriginUrl')
-            ->willReturn(true);
+        $this->url->expects($this->any())->method('isOwnOriginUrl')->willReturn(true);
 
-        $this->resultRedirect->expects($this->once())
-            ->method('setUrl')
-            ->with($beforeAuthUrl)
-            ->willReturnSelf();
+        $this->resultRedirect->expects($this->once())->method('setUrl')->with($beforeAuthUrl)->willReturnSelf();
 
         $this->resultFactory->expects($this->once())
             ->method('create')
             ->with(ResultFactory::TYPE_REDIRECT)
             ->willReturn($this->resultRedirect);
 
-        $this->hostChecker->expects($this->any())
-            ->method('isOwnOrigin')
-            ->willReturn(true);
+        $this->hostChecker->expects($this->any())->method('isOwnOrigin')->willReturn(true);
 
         $this->model->getRedirect();
     }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/13040 (created by @vinayshah)

### Included Commits
1. fb66c07e3558c87b5e544ddfeddfd5b6507a8f5f
### General
- Solve issue: If customer logouts and login with out completing its timeout on logout success page, then customer get logout page displayed

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

If customer logouts and login with out completing its timeout on logout success page, then customer get logout page displayed

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1, Login to admin.
2. Navigate to Stores > Configuration > Customers > Customer Configuration > Login Options
3. Set "Redirect Customer to Account Dashboard after Logging in " = No
4. Navigate to storefront.
5. Login the customer with it's credentials
6. Then Logout the user.
7. Before the the logout session is expired click on login and login again.
8. The user is redirected to logout page first and then to it's my account page.

Please refer [video](https://drive.google.com/file/d/1GOMrAWBVteGrY7eFXvktSl7_kRa4RIos/view) 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
