### PR TITLE
[Forwardport] magento/magento2#11485 do the stock check on default level because the stock on website level isn't updated and should be ignored

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
@@ -56,7 +56,9 @@ class StockStatusBaseSelectProcessor implements BaseSelectProcessorInterface
                 ['stock' => $stockStatusTable],
                 sprintf('stock.product_id = %s.entity_id', BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS),
                 []
-            )->where('stock.stock_status = ?', Stock::STOCK_IN_STOCK);
+            )
+                ->where('stock.stock_status = ?', Stock::STOCK_IN_STOCK)
+                ->where('stock.website_id = ?', 0);
         }
 
         return $select;

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/ResourceModel/Product/StockStatusBaseSelectProcessorTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/ResourceModel/Product/StockStatusBaseSelectProcessorTest.php
@@ -56,9 +56,13 @@ class StockStatusBaseSelectProcessorTest extends \PHPUnit\Framework\TestCase
                 []
             )
             ->willReturnSelf();
-        $this->select->expects($this->once())
+
+        $this->select->expects($this->exactly(2))
             ->method('where')
-            ->with('stock.stock_status = ?', Stock::STOCK_IN_STOCK)
+            ->withConsecutive(
+                ['stock.stock_status = ?', Stock::STOCK_IN_STOCK, null],
+                ['stock.website_id = ?', 0, null]
+            )
             ->willReturnSelf();
 
         $this->stockStatusBaseSelectProcessor->process($this->select);


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/11485 (created by @joost-florijn-kega)

### Included Commits
1. b58bc135d12135242139fa5cb550f44a2a1652cf
2. 5206728775e3bdee11511acc4ccd1492e1e8b882

### General
Product's are linked to categories without notice of any website. The visual merchandiser shows to lowest price of in stock and active simples that are associated with the configurable. The stock check ignores the website scope so if a simple is in stock on the website level but out of stock on default level it should been ignored to determine the lowest price. This commit fixes that issue.

### Fixed Issues (if relevant)
1. magento/magento2#11484: Visual Merchandiser show prices of out of stock simple products for the associated configurable product

### Manual testing scenarios
1. Have a configurable product that is associated with a simple product which is out of stock on default website level (id: 0) and is in stock on website level.
2. Go to the visual merchandiser of the category where the configurable product is linked.
3. Look up the configurable product in the visual merchandiser Tile overview.

Before the fix:
* The price of the out of stock simple product was shown.

After the fix:
* The price '0,00' is shown.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
