### PR TITLE
[Forwardport] magento/magento2#13498 issue #13497 - Method getUrl in Magento\Catalog\Model\Product\Attribute\Frontend\Image

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Frontend/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Frontend/Image.php
@@ -9,23 +9,28 @@
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
+
 namespace Magento\Catalog\Model\Product\Attribute\Frontend;
 
-class Image extends \Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend
+use Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Image extends AbstractFrontend
 {
     /**
      * Store manager
      *
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     protected $_storeManager;
 
     /**
      * Construct
      *
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param StoreManagerInterface $storeManager
      */
-    public function __construct(\Magento\Store\Model\StoreManagerInterface $storeManager)
+    public function __construct(StoreManagerInterface $storeManager)
     {
         $this->_storeManager = $storeManager;
     }
@@ -42,9 +47,9 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFronten
         $image = $product->getData($this->getAttribute()->getAttributeCode());
         $url = false;
         if (!empty($image)) {
-            $url = $this->_storeManager->getStore($product->getStore())
-                ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA)
-                . 'catalog/product/' . $image;
+            $url = $this->_storeManager
+                    ->getStore($product->getStore())
+                    ->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . 'catalog/product/' . ltrim($image, '/');
         }
         return $url;
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Frontend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Frontend/ImageTest.php
@@ -3,45 +3,71 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Test\Unit\Model\Product\Attribute\Frontend;
 
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Frontend\Image;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
 
-class ImageTest extends \PHPUnit\Framework\TestCase
+class ImageTest extends TestCase
 {
     /**
-     * @var \Magento\Catalog\Model\Product\Attribute\Frontend\Image
+     * @var Image
      */
     private $model;
 
-    public function testGetUrl()
+    /**
+     * @dataProvider getUrlDataProvider
+     * @param string $expectedImage
+     * @param string $productImage
+     */
+    public function testGetUrl(string $expectedImage, string $productImage)
     {
-        $this->assertEquals('catalog/product/img.jpg', $this->model->getUrl($this->getMockedProduct()));
+        $this->assertEquals($expectedImage, $this->model->getUrl($this->getMockedProduct($productImage)));
+    }
+
+    /**
+     * Data provider for testGetUrl
+     *
+     * @return array
+     */
+    public function getUrlDataProvider(): array
+    {
+        return [
+            ['catalog/product/img.jpg', 'img.jpg'],
+            ['catalog/product/img.jpg', '/img.jpg'],
+        ];
     }
 
     protected function setUp()
     {
         $helper = new ObjectManager($this);
         $this->model = $helper->getObject(
-            \Magento\Catalog\Model\Product\Attribute\Frontend\Image::class,
+            Image::class,
             ['storeManager' => $this->getMockedStoreManager()]
         );
         $this->model->setAttribute($this->getMockedAttribute());
     }
 
     /**
-     * @return \Magento\Catalog\Model\Product
+     * @param string $productImage
+     * @return Product
      */
-    private function getMockedProduct()
+    private function getMockedProduct(string $productImage): Product
     {
-        $mockBuilder = $this->getMockBuilder(\Magento\Catalog\Model\Product::class);
+        $mockBuilder = $this->getMockBuilder(Product::class);
         $mock = $mockBuilder->setMethods(['getData', 'getStore', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $mock->expects($this->any())
             ->method('getData')
-            ->will($this->returnValue('img.jpg'));
+            ->will($this->returnValue($productImage));
 
         $mock->expects($this->any())
             ->method('getStore');
@@ -50,13 +76,13 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Magento\Store\Model\StoreManagerInterface
+     * @return StoreManagerInterface
      */
-    private function getMockedStoreManager()
+    private function getMockedStoreManager(): StoreManagerInterface
     {
         $mockedStore = $this->getMockedStore();
 
-        $mockBuilder = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class);
+        $mockBuilder = $this->getMockBuilder(StoreManagerInterface::class);
         $mock = $mockBuilder->setMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -69,11 +95,11 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Magento\Store\Model\Store
+     * @return Store
      */
-    private function getMockedStore()
+    private function getMockedStore(): Store
     {
-        $mockBuilder = $this->getMockBuilder(\Magento\Store\Model\Store::class);
+        $mockBuilder = $this->getMockBuilder(Store::class);
         $mock = $mockBuilder->setMethods(['getBaseUrl', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -86,11 +112,11 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Magento\Eav\Model\Entity\Attribute\AbstractAttribute
+     * @return AbstractAttribute
      */
-    private function getMockedAttribute()
+    private function getMockedAttribute(): AbstractAttribute
     {
-        $mockBuilder = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute\AbstractAttribute::class);
+        $mockBuilder = $this->getMockBuilder(AbstractAttribute::class);
         $mockBuilder->setMethods(['getAttributeCode', '__wakeup']);
         $mockBuilder->disableOriginalConstructor();
         $mock = $mockBuilder->getMockForAbstractClass();


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/13498 (created by @igortregub)

### Included Commits
1. 220ad974a2f440c428a15c87a861483b83a23154
### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13497: Method getUrl in Magento\Catalog\Model\Product\Attribute\Frontend returns image url with double slash

### Manual testing scenarios
1. Try to get product image via method getUrl from class Magento\Catalog\Model\Product\Attribute\Frontend\Image. Example(console command):
```
protected function execute(InputInterface $input, OutputInterface $output)
    {
        ObjectManager::getInstance()->get(State::class)->setAreaCode(Area::AREA_ADMINHTML);
        //Be sure, you have simple product with sku = "s1", and with image.
        $product = ObjectManager::getInstance()->get(ProductRepositoryInterface::class)->get('s1');
        $attributeRepository = ObjectManager::getInstance()->get(AttributeRepositoryInterface::class);
        $imageAttribute = $attributeRepository->get(4, 'image');
        $image = ObjectManager::getInstance()->get(\Magento\Catalog\Model\Product\Attribute\Frontend\Image::class);
        $image->setAttribute($imageAttribute);
        $output->writeln($image->getUrl($product));
    }
```
2. Check, image url has only single slashes ex: "http://domain/pub/media/catalog/product/t/e/test.jpg".

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
