### PR TITLE
Fix possible undefined index when caching config data

### DIFF
--- a/app/code/Magento/Config/App/Config/Type/System.php
+++ b/app/code/Magento/Config/App/Config/Type/System.php
@@ -245,7 +245,7 @@ class System implements ConfigTypeInterface
         );
         $scopes = [];
         foreach (['websites', 'stores'] as $curScopeType) {
-            foreach ($data[$curScopeType] as $curScopeId => $curScopeData) {
+            foreach ($data[$curScopeType] ?? [] as $curScopeId => $curScopeData) {
                 $scopes[$curScopeType][$curScopeId] = 1;
                 $this->cache->save(
                     $this->serializer->serialize($curScopeData),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Fix possible undefined index when caching config data.

This replicates as per below steps to replicate.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install clean Magento 2.2 with the following commands:
```
cd /var/www/temp
git clone git@github.com:magento/magento2.git --branch 2.2-develop
cd magento2
composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader --no-dev
```
2. In order to replicate the issue, we will need to add some action which connects to config data during build command. We will add a logger processor which does add `request_uri` value for every log message, if the configuration flag `dev/log/request_uri` is enabled. The following sub-steps add a new logger processor in `Magento_Developer` module:
* Add in file `/var/www/temp/magento2/app/code/Magento/Developer/etc/di.xml` the following content under `<config>` tag:

```
    <type name="\Magento\Framework\Logger\Monolog">
        <arguments>
            <argument name="processors" xsi:type="array">
                <item name="Magento_Developer" xsi:type="object">\Magento\Developer\Logger\Processor</item>
            </argument>
        </arguments>
    </type>
```

* Add new file in 
`/var/www/temp/magento2/app/code/Magento/Developer/Logger/Processor.php` with the following content:

```
<?php
namespace Magento\Developer\Logger;

class Processor
{
    /** @var \Magento\Framework\App\Config\ScopeConfigInterface */
    private $scopeConfig;

    public function __construct(
        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
    ) {
        $this->scopeConfig = $scopeConfig;
    }

    public function __invoke($record)
    {
        if ($this->scopeConfig->isSetFlag('dev/log/request_uri') && is_array($record)) {
            if (!isset($record['extra'])) {
                $record['extra'] = [];
            }
            $record['extra']['request_uri'] = $_SERVER['REQUEST_URI'] ?? null;
        }

        return $record;
    }
}
```

3. Run the following two commands which are part of usual build procedure:
```
php bin/magento module:enable --all
php bin/magento setup:di:compile -v
```

**Expected**
Command `setup:di:compile` is successful.

**Actual**
Command `setup:di:compile` is **not** successful.
The following error occurs:
```
  [Exception]
  Notice: Undefined index: websites in /private/var/www/temp/magento2/app/code/Magento/Config/App/Config/Type/System.php on line 248


Exception trace:
 () at /private/var/www/temp/magento2/lib/internal/Magento/Framework/App/ErrorHandler.php:61
 Magento\Framework\App\ErrorHandler->handler() at /private/var/www/temp/magento2/app/code/Magento/Config/App/Config/Type/System.php:248
 Magento\Config\App\Config\Type\System->cacheData() at /private/var/www/temp/magento2/app/code/Magento/Config/App/Config/Type/System.php:192
 Magento\Config\App\Config\Type\System->loadDefaultScopeData() at /private/var/www/temp/magento2/app/code/Magento/Config/App/Config/Type/System.php:152
 Magento\Config\App\Config\Type\System->get() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/App/Config.php:131
 Magento\Framework\App\Config->get() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/App/Config.php:80
 Magento\Framework\App\Config->getValue() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/App/Config.php:93
 Magento\Framework\App\Config->isSetFlag() at /private/var/www/temp/magento2/app/code/Magento/Developer/Logger/Processor.php:23
 Magento\Developer\Logger\Processor->__invoke() at n/a:n/a
 call_user_func() at /private/var/www/temp/magento2/vendor/monolog/monolog/src/Monolog/Logger.php:333
 Monolog\Logger->addRecord() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/Logger/Monolog.php:48
 Magento\Framework\Logger\Monolog->addRecord() at /private/var/www/temp/magento2/vendor/monolog/monolog/src/Monolog/Logger.php:532
 Monolog\Logger->debug() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/Cache/InvalidateLogger.php:42
 Magento\Framework\Cache\InvalidateLogger->execute() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/Cache/Frontend/Decorator/Logger.php:58
 Magento\Framework\Cache\Frontend\Decorator\Logger->log() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/Cache/Frontend/Decorator/Logger.php:48
 Magento\Framework\Cache\Frontend\Decorator\Logger->clean() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/App/Cache.php:102
 Magento\Framework\App\Cache->clean() at /private/var/www/temp/magento2/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php:152
 Magento\Setup\Console\Command\DiCompileCommand->execute() at /private/var/www/temp/magento2/vendor/symfony/console/Command/Command.php:242
 Symfony\Component\Console\Command\Command->run() at /private/var/www/temp/magento2/vendor/symfony/console/Application.php:842
 Symfony\Component\Console\Application->doRunCommand() at /private/var/www/temp/magento2/vendor/symfony/console/Application.php:193
 Symfony\Component\Console\Application->doRun() at /private/var/www/temp/magento2/lib/internal/Magento/Framework/Console/Cli.php:104
 Magento\Framework\Console\Cli->doRun() at /private/var/www/temp/magento2/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at /private/var/www/temp/magento2/bin/magento:23

setup:di:compile
```

Note that valid code added in the previous steps does trigger the above error. The exception trace contains line:
```
/private/var/www/temp/magento2/app/code/Magento/Developer/Logger/Processor.php:23
```

**Explanation**
The error occurs because at this step of loading config data, there are no stores and no websites since Magento is not installed. As a consequence, config data does not contain any store-specific or website-specific configurations.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
