### PR TITLE
[Port 2.3-develop] Update Store getConfig() to respect valid false return value

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -535,8 +535,8 @@ class Store extends AbstractExtensibleModel implements
     public function getConfig($path)
     {
         $data = $this->_config->getValue($path, ScopeInterface::SCOPE_STORE, $this->getCode());
-        if (!$data) {
-            $data = $this->_config->getValue($path, ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+        if ($data === null) {
+            $data = $this->_config->getValue($path);
         }
         return $data === false ? null : $data;
     }


### PR DESCRIPTION
Port of https://github.com/magento/magento2/pull/13653, https://github.com/magento/magento2/pull/13654

### Description
Using a config setting Yes/No will return string '0' when No is saved. Method will therefore fetch default config value because '0' equals false. Removed the `ScopeConfigInterface::SCOPE_TYPE_DEFAULT` because it's the default value.

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios
1. Add config value to Store module in both default and store view scope.
2. Set config on store scope to `No`.
3. Value `'0'` is returned and value from default scope is fetched.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
