### PR TITLE
Change the way the minify_exclude configurations can be used.

### DIFF
--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -21,13 +21,13 @@
                 <merge_files>0</merge_files>
                 <minify_files>0</minify_files>
                 <minify_exclude>
-                    /tiny_mce/
+                    <tiny_mce>/tiny_mce/</tiny_mce>
                 </minify_exclude>
             </js>
             <css>
                 <minify_files>0</minify_files>
                 <minify_exclude>
-                    /tiny_mce/
+                    <tiny_mce>/tiny_mce/</tiny_mce>
                 </minify_exclude>
             </css>
             <image>

--- a/lib/internal/Magento/Framework/View/Asset/Minification.php
+++ b/lib/internal/Magento/Framework/View/Asset/Minification.php
@@ -143,12 +143,26 @@ class Minification
         if (!isset($this->configCache[self::XML_PATH_MINIFICATION_EXCLUDES][$contentType])) {
             $this->configCache[self::XML_PATH_MINIFICATION_EXCLUDES][$contentType] = [];
             $key = sprintf(self::XML_PATH_MINIFICATION_EXCLUDES, $contentType);
-            foreach (explode("\n", $this->scopeConfig->getValue($key, $this->scope)) as $exclude) {
+            $excludeValues = $this->getMinificationExcludeValues($key);
+            foreach ($excludeValues as $exclude) {
                 if (trim($exclude) != '') {
                     $this->configCache[self::XML_PATH_MINIFICATION_EXCLUDES][$contentType][] = trim($exclude);
                 }
             }
         }
         return $this->configCache[self::XML_PATH_MINIFICATION_EXCLUDES][$contentType];
+    }
+
+    /**
+     * Get minification exclude values from configuration
+     *
+     * @param string $key
+     * @return string[]
+     */
+    private function getMinificationExcludeValues($key)
+    {
+        $configValues = $this->scopeConfig->getValue($key, $this->scope) ?? [];
+
+        return array_values($configValues);
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MinificationTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MinificationTest.php
@@ -203,10 +203,10 @@ class MinificationTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('getValue')
             ->with('dev/js/minify_exclude')
-            ->willReturn(
-                "    /tiny_mce/  \n" .
-                "  /tiny_mce2/  "
-            );
+            ->willReturn([
+                'tiny_mce' => '/tiny_mce/',
+                'some_other_unique_name' => '/tiny_mce2/'
+            ]);
 
         $expected = ['/tiny_mce/', '/tiny_mce2/'];
         $this->assertEquals($expected, $this->minification->getExcludes('js'));


### PR DESCRIPTION
### Description
This is a first proposition at changing how the configuration value `minify_exclude` can be used.
I have the feeling Magento's purpose of this configuration value was to be able to be used in multiple modules. But currently this is not possible, since it is a simple value in the xml config. Which means that when multiple modules define this configuration, the value of the last module in the sequence wil be used. I think Magento's purpose was to make this configuration mergeable, which it currently isn't.

Concrete example, module A defines:
```
<config>
    <default>
        <dev>
            <js>
                <minify_exclude>
                    /regex1/
                </minify_exclude>
            </js>
            <css>
                <minify_exclude>
                    /regex1/
                </minify_exclude>
            </css>
        </dev>
    </default>
</config>
```

and module B defines:
```
<config>
    <default>
        <dev>
            <js>
                <minify_exclude>
                    /regex2/
                </minify_exclude>
            </js>
            <css>
                <minify_exclude>
                    /regex2/
                </minify_exclude>
            </css>
        </dev>
    </default>
</config>
```

Then the result of this should be that these values get merged, but now they are overwritten by one of the two modules and only `/regex1/` or `/regex2/` is used depending on which module is loaded as last.

In practice, I've encountered modules which add a single line to this configuration, which then removes the default `/tiny_mce/` regex which in turn causes the wysiwyg fields in the backend to no longer work.

This happens because the values of xml nodes are overwritten and not merged when identical nodes are encountered.
The proposition here, is to add a bit more structure to the xml, and to define a node per value, where each node name should be unique as to allow them to be merged.

The current solution to this problem which is circulating is a workaround and not very "user friendly" for developers to implement: https://magento.stackexchange.com/a/198480/2911

Some other remarks:
- I created this PR against the `2.3-develop` branch as this introduces a backwards incompatible change and this PR should *not* be backported to an older version of Magento.
- Is it somehow possible that these configuration values are stored in the database? If yes: then we should add an upgrade script as well, to change those database values to the new format.
- If this gets accepted, this should be clearly noted in the release notes, so that developers are aware of this change
- I'm pretty sure some tests will fail, and I'll do my best to fix them, but some help might be needed, and maybe some extra tests should be added to verify that the merging of this configuration actually works

I'm open to remarks or other ideas to improve this! :)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/11577: TinyMCE (WYSIWYG) doesn't work in admin when JS minify is enabled

### 3rd party modules which run against this problem:
- https://github.com/Adyen/adyen-magento2/pull/213
- https://github.com/magespecialist/m2-MSP_ReCaptcha/issues/21
- https://github.com/Magenerds/PageDesigner/issues/17
- ...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
