### PR TITLE
Fix de_CH case of FormatTest::getPriceFormatDataProvider

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
@@ -82,7 +82,7 @@ class FormatTest extends \PHPUnit\Framework\TestCase
         return [
             ['en_US', ['decimalSymbol' => '.', 'groupSymbol' => ',']],
             ['de_DE', ['decimalSymbol' => ',', 'groupSymbol' => '.']],
-            ['de_CH', ['decimalSymbol' => '.', 'groupSymbol' => '\'']],
+            ['de_CH', ['decimalSymbol' => '.', 'groupSymbol' => '’']],
             ['uk_UA', ['decimalSymbol' => ',', 'groupSymbol' => ' ']]
         ];
     }


### PR DESCRIPTION
Fix unit test FormatTest::getPriceFormatDataProvider, 1 out 4 cases currently fail on my machine forked from 2.2.2.

```
➤ ./bin/magento dev:tests:run -c'--filter=testGetPriceFormat' unit

---- /home/peter/src/github.com/peteraba/magento2-tetobox/dev/tests/unit> /usr/bin/php /home/peter/src/github.com/peteraba/magento2-tetobox/./vendor/phpunit/phpunit/phpunit  --filter=testGetPriceFormat 

PHPUnit 6.2.4 by Sebastian Bergmann and contributors.

..F.                                                                4 / 4 (100%)

Time: 5.85 seconds, Memory: 302.00MB

There was 1 failure:

1) Magento\Framework\Locale\Test\Unit\FormatTest::testGetPriceFormat with data set #2 ('de_CH', array('.', '''))
Failed asserting that actual size 1 matches expected size 2.

/home/peter/src/github.com/peteraba/magento2-tetobox/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php:74

FAILURES!
Tests: 4, Assertions: 7, Failures: 1.

---- /home/peter/src/github.com/peteraba/magento2-tetobox/dev/tests/static/framework/tests/unit> /usr/bin/php /home/peter/src/github.com/peteraba/magento2-tetobox/./vendor/phpunit/phpunit/phpunit  --filter=testGetPriceFormat 

PHPUnit 6.2.4 by Sebastian Bergmann and contributors.



Time: 36 ms, Memory: 6.00MB

No tests executed!

---- /home/peter/src/github.com/peteraba/magento2-tetobox/dev/tests/integration/framework/tests/unit> /usr/bin/php /home/peter/src/github.com/peteraba/magento2-tetobox/./vendor/phpunit/phpunit/phpunit  --filter=testGetPriceFormat 

PHPUnit 6.2.4 by Sebastian Bergmann and contributors.



Time: 50 ms, Memory: 6.00MB

No tests executed!
----------------------------------------------------------------------
FAILED - 1 of 3:
 - /home/peter/src/github.com/peteraba/magento2-tetobox/dev/tests/unit> /usr/bin/php /home/peter/src/github.com/peteraba/magento2-tetobox/./vendor/phpunit/phpunit/phpunit  --filter=testGetPriceFormat

```