### PR TITLE
Changes static content deploy log levels verbosity

### DIFF
--- a/app/code/Magento/Deploy/Console/ConsoleLogger.php
+++ b/app/code/Magento/Deploy/Console/ConsoleLogger.php
@@ -82,8 +82,8 @@ class ConsoleLogger extends AbstractLogger
         LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::NOTICE => OutputInterface::VERBOSITY_VERBOSE,
-        LogLevel::INFO => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::INFO => OutputInterface::VERBOSITY_VERBOSE,
         LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG
     ];
 

--- a/app/code/Magento/Deploy/Process/Queue.php
+++ b/app/code/Magento/Deploy/Process/Queue.php
@@ -161,7 +161,7 @@ class Queue
             foreach ($packages as $name => $packageJob) {
                 $this->assertAndExecute($name, $packages, $packageJob);
             }
-            $this->logger->notice('.');
+            $this->logger->info('.');
             sleep(3);
             foreach ($this->inProgress as $name => $package) {
                 if ($this->isDeployed($package)) {
@@ -214,7 +214,7 @@ class Queue
                     unset($this->inProgress[$name]);
                 }
             }
-            $this->logger->notice('.');
+            $this->logger->info('.');
             sleep(5);
         }
         if ($this->isCanBeParalleled()) {

--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -271,7 +271,7 @@ class DeployPackage
         $this->deployStaticFile->writeTmpFile('info.json', $package->getPath(), json_encode($info));
 
         if (!$skipLogging) {
-            $this->logger->notice($logMessage);
+            $this->logger->info($logMessage);
         }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
@@ -127,7 +127,7 @@ class DeployStaticContentCommand extends Command
 
         $logger = $this->consoleLoggerFactory->getLogger($output, $verbose);
         if (!$refreshOnly) {
-            $logger->alert(PHP_EOL . "Deploy using {$options[Options::STRATEGY]} strategy");
+            $logger->notice(PHP_EOL . "Deploy using {$options[Options::STRATEGY]} strategy");
         }
 
         $this->mockCache();
@@ -140,7 +140,7 @@ class DeployStaticContentCommand extends Command
         $deployService->deploy($options);
 
         if (!$refreshOnly) {
-            $logger->alert(PHP_EOL . "Execution time: " . (microtime(true) - $time));
+            $logger->notice(PHP_EOL . "Execution time: " . (microtime(true) - $time));
         }
 
         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DeployStaticContentCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DeployStaticContentCommandTest.php
@@ -102,7 +102,7 @@ class DeployStaticContentCommandTest extends \PHPUnit\Framework\TestCase
 
         $this->consoleLoggerFactory->expects($this->once())
             ->method('getLogger')->willReturn($this->logger);
-        $this->logger->expects($this->exactly(2))->method('alert');
+        $this->logger->expects($this->exactly(2))->method('notice');
 
         $this->objectManager->expects($this->once())->method('create')->willReturn($this->deployService);
         $this->deployService->expects($this->once())->method('deploy');


### PR DESCRIPTION
### Description
This is suggested change to how the log levels of the static content deploy is mapped to the verbosity of the output.

When deploying the static content, currently Magento outputs two messages using the log level 'alert':
- `Deploy using {some-strategy} strategy`
- `Execution time: {time-it-took-to-run-the-command}`

In my opinion, this is incorrect, 'alert' means that something is not quite right, PSR-3 describes the alert log level as 'Action must be taken immediately.' which is very incorrect in this case.
And this also results in outputting the messages with a red background in the terminal, which looks very scary.

This PR proposes to change the log level to 'notice' for these two messages.
But when doing this, the messages are no longer outputted, because they are mapped to the output's verbosity level of 'verbose', so they only show up when providing the `-v` flag.
I propose to increase the verbosity of the 'notice' log level to 'normal' so those messages get displayed, without providing the `-v` flag.

I've also increased the verbosity level of the 'info' log level to 'verbose', and changed the output of a bunch of other messages from 'notice' to 'info' to keep them behaving the same as how they behave currently (= only outputted when providing `-v` flag). Examples of these messages:
- `Processing file 'app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less'  for area 'frontend', theme 'Magento/luma', locale 'default'module 'Magento_Checkout'`
- `Processing file 'app/design/frontend/Magento/luma/web/images/select-bg.svg'  for area 'frontend', theme 'Magento/luma', locale 'default'`
- `Processing file 'app/design/frontend/Magento/luma/web/fonts/Luma-Icons.woff'  for area 'frontend', theme 'Magento/luma', locale 'default'`
- ...

If we want to follow the PSR-3 log levels strictly, we probably should even do more drastic changes:
- Instead of 'notice', we should use 'info' for those first two messages, and should still be outputted without providing verbosity flags on the cli
- Instead of 'info', we should use 'debug' for all those other messages, and they should only show up when the `-vvv` is used
- This means that we have to also increase the verbosity level from 'verbose' to 'normal' for the 'info' log level

I'm a bit hesitant to already do this, as it leaves very little moving space for some in-between verbosity level mapping, since all but one log level would all be mapped to verbosity 'normal', only 'debug' log level would be mapped to the 'debug' verbosity output, which is maybe not flexible enough for future additions.

Does this makes sense? What do you guys think?

#### Results

Before:
<img width="859" alt="screen shot 2018-02-17 at 18 29 06" src="https://user-images.githubusercontent.com/85479/36343789-d321904e-1410-11e8-986f-e6f0a0fe29cc.png">

After:
<img width="863" alt="screen shot 2018-02-17 at 18 29 38" src="https://user-images.githubusercontent.com/85479/36343799-d8b5ca8e-1410-11e8-88dd-806d6116f6f4.png">

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/12404: Output of setup:static-content:deploy contains red color, should be a friendlier color
2. https://github.com/magento/community-features/issues/15: Output of setup:static-content:deploy contains red color, should be a friendlier color

### Manual testing scenarios
1. Run the command: `bin/magento setup:static-content:deploy -f` with different verbosity flags: `-v`, `-vv` or `-vvv`
2. Watch the output

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
