### PR TITLE
#8333: Use Design to get theme, because theme is changed after constr…

### DIFF
--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -50,6 +50,11 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
     private $theme;
 
     /**
+     * @var \Magento\Framework\View\DesignInterface
+     */
+    private $design;
+
+    /**
      * @var \Magento\Framework\Url\ScopeInterface
      */
     private $scope;
@@ -193,6 +198,7 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
         $cacheSuffix = '',
         LayoutCacheKeyInterface $layoutCacheKey = null
     ) {
+        $this->design = $design;
         $this->theme = $theme ?: $design->getDesignTheme();
         $this->scope = $scopeResolver->getScope();
         $this->fileSource = $fileSource;
@@ -436,6 +442,7 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
         }
 
         $this->addHandle($handles);
+        $this->theme = $this->design->getDesignTheme();
 
         $cacheId = $this->getCacheId();
         $cacheIdPageLayout = $cacheId . '_' . self::PAGE_LAYOUT_CACHE_SUFFIX;


### PR DESCRIPTION
### Description
Functionality helps of custom theme per product allows to rollout new theme partially.
But it was broken for some reason.

Solution is applied in production as a patch for 2.2.2.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8333: Magento v2.1.2 - Choosing a child theme for product page
2. magento/magento2#7710: Custom theme doesn't apply XML layout updates when applied to a product
3. magento/magento2#7503: Category design / theme update not inheriting correctly on product pages
### Manual testing scenarios
1. Go to product in admin
2. Change theme, save.
3. Selected theme must apply in full

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
