### PR TITLE
update the store app response redirect to also check for the backendu…

### DIFF
--- a/app/code/Magento/Backend/App/Area/FrontNameResolver.php
+++ b/app/code/Magento/Backend/App/Area/FrontNameResolver.php
@@ -134,9 +134,13 @@ class FrontNameResolver implements \Magento\Framework\App\Area\FrontNameResolver
     public function getBackEndUrl()
     {
         if ($this->scopeConfig->getValue(self::XML_PATH_USE_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE)) {
-            $this->backendUrl = $this->scopeConfig->getValue(self::XML_PATH_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE);
+            $this->backendUrl = $this->scopeConfig->getValue(
+                self::XML_PATH_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE
+            );
         } else {
-            $this->backendUrl = $this->scopeConfig->getValue(Store::XML_PATH_UNSECURE_BASE_URL, ScopeInterface::SCOPE_STORE);
+            $this->backendUrl = $this->scopeConfig->getValue(
+                Store::XML_PATH_UNSECURE_BASE_URL, ScopeInterface::SCOPE_STORE
+            );
         }
         return $this->backendUrl;
     }

--- a/app/code/Magento/Backend/App/Area/FrontNameResolver.php
+++ b/app/code/Magento/Backend/App/Area/FrontNameResolver.php
@@ -43,6 +43,11 @@ class FrontNameResolver implements \Magento\Framework\App\Area\FrontNameResolver
     protected $defaultFrontName;
 
     /**
+     * @var string
+     */
+    protected $backendUrl;
+
+    /**
      * @var \Magento\Backend\App\ConfigInterface
      */
     protected $config;
@@ -99,11 +104,7 @@ class FrontNameResolver implements \Magento\Framework\App\Area\FrontNameResolver
      */
     public function isHostBackend()
     {
-        if ($this->scopeConfig->getValue(self::XML_PATH_USE_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE)) {
-            $backendUrl = $this->scopeConfig->getValue(self::XML_PATH_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE);
-        } else {
-            $backendUrl = $this->scopeConfig->getValue(Store::XML_PATH_UNSECURE_BASE_URL, ScopeInterface::SCOPE_STORE);
-        }
+        $backendUrl = $this->getBackEndUrl();
         $host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
         return stripos($this->getHostWithPort($backendUrl), $host) !== false;
     }
@@ -124,4 +125,20 @@ class FrontNameResolver implements \Magento\Framework\App\Area\FrontNameResolver
         }
         return isset($port) ? $host . ':' . $port : $host;
     }
+
+    /**
+     * Set and return the backendUrl
+     *
+     * @return string
+     */
+    public function getBackEndUrl()
+    {
+        if ($this->scopeConfig->getValue(self::XML_PATH_USE_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE)) {
+            $this->backendUrl = $this->scopeConfig->getValue(self::XML_PATH_CUSTOM_ADMIN_URL, ScopeInterface::SCOPE_STORE);
+        } else {
+            $this->backendUrl = $this->scopeConfig->getValue(Store::XML_PATH_UNSECURE_BASE_URL, ScopeInterface::SCOPE_STORE);
+        }
+        return $this->backendUrl;
+    }
+
 }

--- a/app/code/Magento/Store/App/Response/Redirect.php
+++ b/app/code/Magento/Store/App/Response/Redirect.php
@@ -8,6 +8,7 @@
 namespace Magento\Store\App\Response;
 
 use Magento\Store\Api\StoreResolverInterface;
+use Magento\Backend\App\Area;
 
 class Redirect implements \Magento\Framework\App\Response\RedirectInterface
 {
@@ -47,6 +48,11 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
     protected $_urlBuilder;
 
     /**
+     * @var \Magento\Backend\App\Area\FrontNameResolver
+     */
+    protected $_backendFrontNameResolver;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\App\RequestInterface $request
@@ -55,6 +61,7 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
      * @param \Magento\Framework\Session\SessionManagerInterface $session
      * @param \Magento\Framework\Session\SidResolverInterface $sidResolver
      * @param \Magento\Framework\UrlInterface $urlBuilder
+     * @param \Magento\Backend\App\Area\FrontNameResolver $backendFrontNameResolver
      * @param bool $canUseSessionIdInParam
      */
     public function __construct(
@@ -63,6 +70,7 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
         \Magento\Framework\Encryption\UrlCoder $urlCoder,
         \Magento\Framework\Session\SessionManagerInterface $session,
         \Magento\Framework\Session\SidResolverInterface $sidResolver,
+        \Magento\Backend\App\Area\FrontNameResolver $backendFrontNameResolver,
         \Magento\Framework\UrlInterface $urlBuilder,
         $canUseSessionIdInParam = true
     ) {
@@ -72,6 +80,7 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
         $this->_urlCoder = $urlCoder;
         $this->_session = $session;
         $this->_sidResolver = $sidResolver;
+        $this->_backendFrontNameResolver = $backendFrontNameResolver;
         $this->_urlBuilder = $urlBuilder;
     }
 
@@ -210,7 +219,8 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
             $directLinkType = \Magento\Framework\UrlInterface::URL_TYPE_DIRECT_LINK;
             $unsecureBaseUrl = $this->_storeManager->getStore()->getBaseUrl($directLinkType, false);
             $secureBaseUrl = $this->_storeManager->getStore()->getBaseUrl($directLinkType, true);
-            return (strpos($url, $unsecureBaseUrl) === 0) || (strpos($url, $secureBaseUrl) === 0);
+            $backendUrl= $this->_backendFrontNameResolver->getBackEndUrl();
+            return (strpos($url, $unsecureBaseUrl) === 0) || (strpos($url, $secureBaseUrl) === 0 || strpos($url, $backendUrl) === 0);
         }
         return false;
     }

--- a/app/code/Magento/Store/App/Response/Redirect.php
+++ b/app/code/Magento/Store/App/Response/Redirect.php
@@ -8,7 +8,6 @@
 namespace Magento\Store\App\Response;
 
 use Magento\Store\Api\StoreResolverInterface;
-use Magento\Backend\App\Area;
 
 class Redirect implements \Magento\Framework\App\Response\RedirectInterface
 {
@@ -70,8 +69,8 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
         \Magento\Framework\Encryption\UrlCoder $urlCoder,
         \Magento\Framework\Session\SessionManagerInterface $session,
         \Magento\Framework\Session\SidResolverInterface $sidResolver,
-        \Magento\Backend\App\Area\FrontNameResolver $backendFrontNameResolver,
         \Magento\Framework\UrlInterface $urlBuilder,
+        \Magento\Backend\App\Area\FrontNameResolver $backendFrontNameResolver,
         $canUseSessionIdInParam = true
     ) {
         $this->_canUseSessionIdInParam = $canUseSessionIdInParam;
@@ -220,7 +219,8 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
             $unsecureBaseUrl = $this->_storeManager->getStore()->getBaseUrl($directLinkType, false);
             $secureBaseUrl = $this->_storeManager->getStore()->getBaseUrl($directLinkType, true);
             $backendUrl= $this->_backendFrontNameResolver->getBackEndUrl();
-            return (strpos($url, $unsecureBaseUrl) === 0) || (strpos($url, $secureBaseUrl) === 0 || strpos($url, $backendUrl) === 0);
+            return (strpos($url, $unsecureBaseUrl) === 0) ||
+                (strpos($url, $secureBaseUrl) === 0) || (strpos($url, $backendUrl) === 0);
         }
         return false;
     }

--- a/app/code/Magento/Store/Test/Unit/App/Response/RedirectTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Response/RedirectTest.php
@@ -44,6 +44,11 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
      */
     protected $_urlBuilderMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $_backendFrontNameResolverMock;
+
     protected function setUp()
     {
         $this->_requestMock = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
@@ -53,6 +58,7 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
         $this->_sessionMock = $this->createMock(\Magento\Framework\Session\SessionManagerInterface::class);
         $this->_sidResolverMock = $this->createMock(\Magento\Framework\Session\SidResolverInterface::class);
         $this->_urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->_backendFrontNameResolverMock = $this->createMock(\Magento\Backend\App\Area\FrontNameResolver::class);
 
         $this->_model = new \Magento\Store\App\Response\Redirect(
             $this->_requestMock,
@@ -60,7 +66,8 @@ class RedirectTest extends \PHPUnit\Framework\TestCase
             $this->_urlCoderMock,
             $this->_sessionMock,
             $this->_sidResolverMock,
-            $this->_urlBuilderMock
+            $this->_urlBuilderMock,
+            $this->_backendFrontNameResolverMock
         );
     }
 

--- a/app/code/Magento/Store/composer.json
+++ b/app/code/Magento/Store/composer.json
@@ -11,7 +11,8 @@
         "magento/module-config": "100.3.*",
         "magento/module-directory": "100.3.*",
         "magento/module-media-storage": "100.3.*",
-        "magento/module-ui": "100.3.*"
+        "magento/module-ui": "100.3.*",
+        "magento/module-backend": "100.3.*"
     },
     "suggest": {
         "magento/module-deploy": "100.3.*"


### PR DESCRIPTION
…rl when determining if the url isInternal

The goal of this was to create an additional check in the isUrlInternal method to take into account if there is a custom admin domain used. Because the default config returns the default store url, if you are using a custom admin domain without explicitly setting the store id to 0 it will return the wrong url for a test of the admin.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
1. Add a call to the backendFrontNameresolver to get the admin url and use it as an additional check
2. In the Magento\Backend\App\Area\FrontNameresolver add the backendUrl code to its own method to get set into a private variable which can be accessed by itself.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12354: When the Admin is on a different domain, redirect always fails and causes it to redirect to the front page

### Manual testing scenarios
1. Set a custom admin path in the admin
2. Create a test method which uses the admin host as a variable.
3. Pass the variable to the \Magento\Store\App\Response\Redirect::_isUrlInternal($url) method and verify that it returns true instead of false

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
