### PR TITLE
[Forwardport] Display a more meaningful error message in case of misspelt module name

### DIFF
--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -45,8 +45,9 @@ class Dir
     {
         $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
 
-        if (! isset($path)) {
-            throw new \LogicException("Component '$moduleName' of type '$type' is not correctly registered.");
+        if (!isset($path)) {
+            // (Do not throw \LogicException, as it would break backwards-compatibility.)
+            throw new \InvalidArgumentException("Component '$moduleName' of type '$type' is not correctly registered.");
         }
 
         if ($type) {

--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -45,8 +45,9 @@ class Dir
     {
         $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
 
-        if (!isset($path)) {
-            // (Do not throw \LogicException, as it would break backwards-compatibility.)
+        // An empty $type means it's gettind the directory of the module itself.
+        if (empty($type) && !isset($path)) {
+            // Note: do not throw \LogicException, as it would break backwards-compatibility.
             throw new \InvalidArgumentException("Component '$moduleName' of type '$type' is not correctly registered.");
         }
 

--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -45,7 +45,7 @@ class Dir
     {
         $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
 
-        // An empty $type means it's gettind the directory of the module itself.
+        // An empty $type means it's getting the directory of the module itself.
         if (empty($type) && !isset($path)) {
             // Note: do not throw \LogicException, as it would break backwards-compatibility.
             throw new \InvalidArgumentException("Component '$moduleName' of type '$type' is not correctly registered.");

--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -45,6 +45,10 @@ class Dir
     {
         $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
 
+        if (! isset($path)) {
+            throw new \LogicException("Component '$moduleName' of type '$type' is not correctly registered.");
+        }
+
         if ($type) {
             if (!in_array($type, [
                 self::MODULE_ETC_DIR,

--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -48,7 +48,7 @@ class Dir
         // An empty $type means it's getting the directory of the module itself.
         if (empty($type) && !isset($path)) {
             // Note: do not throw \LogicException, as it would break backwards-compatibility.
-            throw new \InvalidArgumentException("Component '$moduleName' of type '$type' is not correctly registered.");
+            throw new \InvalidArgumentException("Module '$moduleName' is not correctly registered.");
         }
 
         if ($type) {

--- a/lib/internal/Magento/Framework/Module/Test/Unit/DirTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/DirTest.php
@@ -59,4 +59,17 @@ class DirTest extends \PHPUnit\Framework\TestCase
 
         $this->_model->getDir('Test_Module', 'unknown');
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Module 'Test Module' is not correctly registered.
+     */
+    public function testGetDirModuleIncorrectlyRegistered()
+    {
+        $this->moduleRegistryMock->expects($this->once())
+            ->method('getPath')
+            ->with($this->identicalTo(ComponentRegistrar::MODULE), $this->identicalTo('Test Module'))
+            ->willReturn(null);
+        $this->_model->getDir('Test Module');
+    }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/12843
### Description

Displays a more meaningful error message in case of misspelt module name.

`[LogicException] Component 'VendorA_ModuleB' of type '' is not correctly registered.`
instead of
`[Magento\Framework\Exception\FileSystemException] The file "/composer.json" doesn't exist`

### Manual testing scenarios

1. Create a new module and misspell its name in "registration.php" (e.g., 'Vendora_Popup' while the directory is named 'Vendora/Popups').
2. Run `bin/magento module:disable Magento_Bundle` (or `bin/magento module:enable Magento_Bundle`, if it is disabled); yes, it does not have to be the same incorrectly configured module, any will do.
3. You'll get the mentioned error.