### PR TITLE
Cart state (selected shipping method for estimation) is lost on coupon apply since 2.2.0

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/checkout-data.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/checkout-data.js
@@ -20,6 +20,7 @@ define([
          * @param {Object} data
          */
         saveData = function (data) {
+            data['data_persistence'] = true;
             storage.set(cacheKey, data);
         },
 

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -213,6 +213,11 @@ define([
                     $.cookieStorage.set(privateContentVersion, privateContent);
                 }
                 $.localStorage.set(privateContentVersion, privateContent);
+                _.each(dataProvider.getFromStorage(storage.keys()), function (sectionData, sectionName) {
+                    if (sectionData['data_persistence']) {
+                        buffer.notify(sectionName, sectionData);
+                    }
+                });
                 this.reload([], false);
             } else if (expiredSectionNames.length > 0) {
                 _.each(dataProvider.getFromStorage(storage.keys()), function (sectionData, sectionName) {


### PR DESCRIPTION
### Description
When you apply a coupon on the cart page, the selected shipping option is lost.

I'm aware this might not be the ideal fix. In general though it seems like the way to go. At the moment there are many sectionData objects in the frontend and most of them mirror some data on the server-side, so when private data version changes it is expected for them to be reloaded from the server. However, the checkout-data sectionData contains data that pertains to front-end state and has no mirror on the server. Thus it cannot be reloaded from the server. I figured the best fix is a way to flag a sectionData as being something that needs to persist across version changes, and I noticed there is already a `data_id` special property so added a `data_persistence` property.

Happy to discuss options to get the desired behaviour here.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Select a shipping method
2. Apply a coupon code (even an invalid one)
3. The selected shipping method is lost on page load

After fix, at 3, the selected shipping method is maintained as per Magento 2.1.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)