### PR TITLE
fix for EAV ReadHandler

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -102,7 +102,7 @@ class ReadHandler implements AttributeInterface
 
         $attributeTables = [];
         $attributesMap = [];
-        $attributeValues = [];
+        $attributeValues = [[]];
 
         /** @var \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute */
         foreach ($this->getAttributes($entityType) as $attribute) {

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -102,7 +102,7 @@ class ReadHandler implements AttributeInterface
 
         $attributeTables = [];
         $attributesMap = [];
-        $attributeValues = [[]];
+        $attributeValues = [];
 
         /** @var \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute */
         foreach ($this->getAttributes($entityType) as $attribute) {
@@ -126,8 +126,8 @@ class ReadHandler implements AttributeInterface
                         $metadata->getEntityConnection()->quoteIdentifier($scope->getIdentifier()) . ' IN (?)',
                         $this->getContextVariables($scope)
                     )->order('t.' . $scope->getIdentifier() . ' ASC');
-                    $attributeValues[] = $connection->fetchAll($select);
                 }
+                $attributeValues[] = $connection->fetchAll($select);
             }
             $attributeValues = array_merge(...$attributeValues);
             foreach ($attributeValues as $attributeValue) {
@@ -136,7 +136,7 @@ class ReadHandler implements AttributeInterface
                 } else {
                     $this->logger->warning(
                         "Attempt to load value of nonexistent EAV attribute '{$attributeValue['attribute_id']}' 
-                    for entity type '$entityType'."
+                        for entity type '$entityType'."
                     );
                 }
             }

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -126,10 +126,10 @@ class ReadHandler implements AttributeInterface
                         $metadata->getEntityConnection()->quoteIdentifier($scope->getIdentifier()) . ' IN (?)',
                         $this->getContextVariables($scope)
                     )->order('t.' . $scope->getIdentifier() . ' ASC');
+                    $attributeValues[] = $connection->fetchAll($select);
                 }
-                $attrTablesValues = $connection->fetchAll($select);
-                $attributeValues = array_merge($attributeValues, $attrTablesValues);
             }
+            $attributeValues = array_merge(...$attributeValues);
             foreach ($attributeValues as $attributeValue) {
                 if (isset($attributesMap[$attributeValue['attribute_id']])) {
                     $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -125,22 +125,20 @@ class ReadHandler implements AttributeInterface
                     $select->where(
                         $metadata->getEntityConnection()->quoteIdentifier($scope->getIdentifier()) . ' IN (?)',
                         $this->getContextVariables($scope)
-                    )->order('t.' . $scope->getIdentifier() . ' DESC');
+                    )->order('t.' . $scope->getIdentifier() . ' ASC');
                 }
                 $selects[] = $select;
             }
-            $unionSelect = new \Magento\Framework\DB\Sql\UnionExpression(
-                $selects,
-                \Magento\Framework\DB\Select::SQL_UNION_ALL
-            );
-            foreach ($connection->fetchAll($unionSelect) as $attributeValue) {
-                if (isset($attributesMap[$attributeValue['attribute_id']])) {
-                    $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];
-                } else {
-                    $this->logger->warning(
-                        "Attempt to load value of nonexistent EAV attribute '{$attributeValue['attribute_id']}' 
+            foreach($selects as $select) {
+                foreach ($connection->fetchAll($select) as $attributeValue) {
+                    if (isset($attributesMap[$attributeValue['attribute_id']])) {
+                        $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];
+                    } else {
+                        $this->logger->warning(
+                            "Attempt to load value of nonexistent EAV attribute '{$attributeValue['attribute_id']}' 
                         for entity type '$entityType'."
-                    );
+                        );
+                    }
                 }
             }
         }

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -127,8 +127,8 @@ class ReadHandler implements AttributeInterface
                         $this->getContextVariables($scope)
                     )->order('t.' . $scope->getIdentifier() . ' ASC');
                 }
-                $attributeTablesValues = $connection->fetchAll($select);
-                $attributeValues = array_merge($attributeValues, $attributeTablesValues);
+                $attrTablesValues = $connection->fetchAll($select);
+                $attributeValues = array_merge($attributeValues, $attrTablesValues);
             }
             foreach ($attributeValues as $attributeValue) {
                 if (isset($attributesMap[$attributeValue['attribute_id']])) {

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -129,7 +129,7 @@ class ReadHandler implements AttributeInterface
                 }
                 $selects[] = $select;
             }
-            foreach($selects as $select) {
+            foreach ($selects as $select) {
                 foreach ($connection->fetchAll($select) as $attributeValue) {
                     if (isset($attributesMap[$attributeValue['attribute_id']])) {
                         $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -102,7 +102,7 @@ class ReadHandler implements AttributeInterface
 
         $attributeTables = [];
         $attributesMap = [];
-        $selects = [];
+        $attributeValues = [];
 
         /** @var \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute */
         foreach ($this->getAttributes($entityType) as $attribute) {
@@ -127,18 +127,17 @@ class ReadHandler implements AttributeInterface
                         $this->getContextVariables($scope)
                     )->order('t.' . $scope->getIdentifier() . ' ASC');
                 }
-                $selects[] = $select;
+                $attributeTablesValues = $connection->fetchAll($select);
+                $attributeValues = array_merge($attributeValues, $attributeTablesValues);
             }
-            foreach ($selects as $select) {
-                foreach ($connection->fetchAll($select) as $attributeValue) {
-                    if (isset($attributesMap[$attributeValue['attribute_id']])) {
-                        $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];
-                    } else {
-                        $this->logger->warning(
-                            "Attempt to load value of nonexistent EAV attribute '{$attributeValue['attribute_id']}' 
-                        for entity type '$entityType'."
-                        );
-                    }
+            foreach ($attributeValues as $attributeValue) {
+                if (isset($attributesMap[$attributeValue['attribute_id']])) {
+                    $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];
+                } else {
+                    $this->logger->warning(
+                        "Attempt to load value of nonexistent EAV attribute '{$attributeValue['attribute_id']}' 
+                    for entity type '$entityType'."
+                    );
                 }
             }
         }


### PR DESCRIPTION
Fix for issue #6958

https://github.com/magento/magento2/issues/14114
https://github.com/magento/magento2/issues/6958

### Description
Function of Magento\Eav\Model\ResourceModel\ReadHandler the attribute values were sort by store_id desc and then merged by a union query. In the following loop the store view values can be overwritten by default store value.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6958: Magento\Eav\Model\ResourceModel\ReadHandler wrong sort of entityData

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create an attribute value_id for a store_view lower than value_id of store_view 0 for attribute "name" of product 
2. Edit Product in backend and switch store_view from default to specific store_view

