### PR TITLE
Point widget xml classes to the correct block classes

### DIFF
--- a/app/code/Magento/Catalog/etc/widget.xml
+++ b/app/code/Magento/Catalog/etc/widget.xml
@@ -85,7 +85,7 @@
         </containers>
     </widget>
     <widget id="catalog_product_link"
-            class="Magento\Catalog\Block\Product\Widget\Link"
+            class="Magento\Catalog\Block\Widget\Link"
             is_email_compatible="true"
             placeholder_image="Magento_Catalog::images/product_widget_link.png">
         <label translate="true">Catalog Product Link</label>
@@ -124,7 +124,7 @@
         </parameters>
     </widget>
     <widget id="catalog_category_link"
-            class="Magento\Catalog\Block\Category\Widget\Link"
+            class="Magento\Catalog\Block\Widget\Link"
             is_email_compatible="true"
             placeholder_image="Magento_Catalog::images/category_widget_link.png">
         <label translate="true">Catalog Category Link</label>


### PR DESCRIPTION
Points widget classes for product and category links to the correct block class

### Description
Discovered a bug today and looked to see if a fix was in develop 2.2/2.3 and seen that it wasn't. Figured this was worth opening

### Fixed Issues (if relevant)
1. Catalog category widget link broken
2. Catalog product widget link broken

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a cms page with a category widget link and save
2. Navigate to the cms page on the frontend
3. Observe the link does not appear

1. Create a cms page with a product widget link and save
2. Navigate to the cms page on the frontend
3. Observe the link does not appear

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
