### PR TITLE
Fix bug Magento 2.2.2 password reset strength meter #13429

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
@@ -31,6 +31,8 @@ define([
             this.options.cache.label = $(this.options.passwordStrengthMeterLabelSelector, this.element);
 
             // We need to look outside the module for backward compatibility, since someone can already use the module.
+            // @todo Narrow this selector in 2.3 so it doesn't accidentally finds the the email field from the newsletter
+            // email field or any other "email" field.
             this.options.cache.email = $(this.options.formSelector).find(this.options.emailSelector);
             this._bind();
         },
@@ -74,7 +76,9 @@ define([
                     'password-not-equal-to-user-name': this.options.cache.email.val()
                 });
 
-                if (password.toLowerCase() === this.options.cache.email.val().toLowerCase()) {
+                // We should only perform this check in case there is an email field on screen
+                if (this.options.cache.email.length &&
+                    password.toLowerCase() === this.options.cache.email.val().toLowerCase()) {
                     displayScore = 1;
                 } else {
                     isValid = $.validator.validateSingleElement(this.options.cache.input);

--- a/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
@@ -31,8 +31,8 @@ define([
             this.options.cache.label = $(this.options.passwordStrengthMeterLabelSelector, this.element);
 
             // We need to look outside the module for backward compatibility, since someone can already use the module.
-            // @todo Narrow this selector in 2.3 so it doesn't accidentally finds the the email field from the newsletter
-            // email field or any other "email" field.
+            // @todo Narrow this selector in 2.3 so it doesn't accidentally finds the the email field from the
+            // newsletter email field or any other "email" field.
             this.options.cache.email = $(this.options.formSelector).find(this.options.emailSelector);
             this._bind();
         },


### PR DESCRIPTION
Fix bug "Magento 2.2.2 password reset strength meter" #13429 by doing the email comparison only if an email field exists. 

The form email input field selector at the "password-strength-indicator.js" is generic enough to match any input field "email" in the frontend at that time. This causes the password strength indicator to work in the password reset email screen in the default theme, given that this selector ends up matching the email field of the newsletter subscription form.

However, if you are using a theme in which the newsletter subscription email form is removed, it then causes this password strength validation to break. Moreover, it doesn't make much sense to compare your password with any possible email that is written in the newsletter subscription form.

This was done as part of the #MLAU18 contribution day.

### Description
This PR simply causes the condition in which the password is compared to the email to be skipped in this situation, removing the Javascript error. Further review of this selector (that populates the this.options.cache.email variable) to narrow it so it only matches the email fields that are part of the same form as the password field should be done in the future.

### Fixed Issues
1. magento/magento2#13429

### Manual testing scenarios
1. Test reset password screen with the "newsletter subscription" email field in there (default Magento). The password strength indicator already works correctly in this situation.
2. Now remove such newsletter subscription field and test again. A js error will be thrown as per described in the issue. This PR fixes such js error and causes the password strength indicator to work again in this case.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
