### PR TITLE
Catalog price rule save is too slow #13378, ignore on demand reindex …

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -517,9 +517,11 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     public function afterSave()
     {
         if ($this->isObjectNew()) {
-            $this->getMatchingProductIds();
-            if (!empty($this->_productIds) && is_array($this->_productIds)) {
-                $this->_getResource()->addCommitCallback([$this, 'reindex']);
+            if (!$this->_ruleProductProcessor->isIndexerScheduled()) {
+                $this->getMatchingProductIds();
+                if (!empty($this->_productIds) && is_array($this->_productIds)) {
+                    $this->_getResource()->addCommitCallback([$this, 'reindex']);
+                }
             }
         } else {
             $this->_ruleProductProcessor->getIndexer()->invalidate();

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -516,12 +516,10 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      */
     public function afterSave()
     {
-        if ($this->isObjectNew()) {
-            if (!$this->_ruleProductProcessor->isIndexerScheduled()) {
-                $this->getMatchingProductIds();
-                if (!empty($this->_productIds) && is_array($this->_productIds)) {
-                    $this->_getResource()->addCommitCallback([$this, 'reindex']);
-                }
+        if ($this->isObjectNew() && !$this->_ruleProductProcessor->isIndexerScheduled()) {
+            $productIds = $this->getMatchingProductIds();
+            if (!empty($productIds) && is_array($productIds)) {
+                $this->_getResource()->addCommitCallback([$this, 'reindex']);
             }
         } else {
             $this->_ruleProductProcessor->getIndexer()->invalidate();


### PR DESCRIPTION
Fixes the performance issue occurs when creating a new catalog rule with a large catalog. the catalog rule indexer mode is set to "Update on Schedule"

### Description
When creating a catalog rule, Magento tries to retrieve matching products ids and pass the collected product ids to the indexer. However, the Magento\CatalogRule\Model\Rule:afterSave() method doesn't consider the indexer mode, and even when the catalogrule indexer is set to "Update on Schedule", Magento unnecessarily calls the "getMatchingProductIds" method and tries to collect the product ids.  Calling to "getMatchingProductIds" is unnecessary when the indexer mode is set to "Update on Schedule". When there is larger catalog this creates a performance issue that might then throws timeout errors.

This fix was done as part of the #MLAU18 contribution day.

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/13378, (1st issue)

### Manual testing scenarios
1 Setup a Magento environment with a large catalog, ex: 20,000 products 
2 Create a catalog rule
3 Set rule condition, ex: category is 3
4 try to save the new Catalog Rule
5 Catalog rule saving is too slow, sometime it might give a timeout

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
