### PR TITLE
Remove not-allowed currencies from the currencies dropdown in Setup

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -22,11 +22,19 @@ class Lists
     protected $allowedLocales;
 
     /**
+     * List of allowed currencies
+     *
+     * @var array
+     */
+    protected $allowedCurrencies;
+
+    /**
      * @param ConfigInterface $localeConfig
      */
     public function __construct(ConfigInterface $localeConfig)
     {
         $this->allowedLocales = $localeConfig->getAllowedLocales();
+        $this->allowedCurrencies = $localeConfig->getAllowedCurrencies();
     }
 
     /**
@@ -64,6 +72,10 @@ class Lists
         $currencies = (new CurrencyBundle())->get(Resolver::DEFAULT_LOCALE)['Currencies'];
         $list = [];
         foreach ($currencies as $code => $data) {
+            $isAllowedCurrency = array_search($code, $this->allowedCurrencies) !== false;
+            if (!$isAllowedCurrency) {
+                continue;
+            }
             $list[$code] = $data[1] . ' (' . $code . ')';
         }
         asort($list);


### PR DESCRIPTION
### Description
As reported on #13760 some deprecated currencies were being displayed in the setup process.
This PR removes these and other not-allowed currencies from the setup step 4 (customize your store).

### Fixed Issues (if relevant)
1. Fixes #13760 by not displaying old and deprecated Brazilian currencies
2. Remove not-allowed currencies for being displayed


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
