### PR TITLE
cron_schedule forever increasing in size. Lots of pending jobs never cleared #11002

### DIFF
--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -61,7 +61,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @return bool
      * @since 100.2.0
      */
-     public function trySetJobUniqueStatusAtomic($scheduleId, $newStatus, $currentStatus)
+    public function trySetJobUniqueStatusAtomic($scheduleId, $newStatus, $currentStatus)
     {
         $connection = $this->getConnection();
 
@@ -78,7 +78,8 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             ->from(['schedule' => $this->getTable('cron_schedule')])
             ->where('schedule.job_code = ?', $jobcode)
             ->where('schedule.scheduled_at > UTC_TIMESTAMP() - INTERVAL 1 DAY')
-            ->where('schedule.status = ? ', $newStatus);
+            ->where('schedule.status = ? ', $newStatus)
+            ->where('schedule.status != ? ', $currentStatus);
 
         $result = count($connection->fetchAll($selectIfUnlocked));
 
@@ -86,7 +87,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $where = $connection->quoteInto('schedule_id =?', $scheduleId);
             $result = $connection->update(
                 $this->getTable('cron_schedule'),
-                ['status'=>$newStatus,'executed_at'=>date("Y-m-d H:i:s", time())],
+                ['status'=>$newStatus],
                 $where);
 
             if ($result == 1) {
@@ -96,5 +97,3 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         return false;
     }
 }
-
-

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -86,7 +86,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
         if ($result == 0) {
             $where = $connection->quoteInto('schedule_id =?', $scheduleId);
-            $result = $connection->update($this->getTable('cron_schedule'),['status'=>$newStatus],$where);
+            $result = $connection->update($this->getTable('cron_schedule'), ['status'=>$newStatus], $where);
 
             if ($result == 1) {
                 return true;

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -68,30 +68,28 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         // this condition added to avoid cron jobs locking after incorrect termination of running job
 
         $match = $connection->select()
-          ->from(['schedule' => $this->getTable('cron_schedule')])
-          ->where('schedule.schedule_id = ?', $scheduleId);
+            ->from(['schedule' => $this->getTable('cron_schedule')])
+            ->where('schedule.schedule_id = ?', $scheduleId);
 
         $result = $connection->fetchAll($match);
 
         $selectIfUnlocked = $connection->select()
-          ->from(['schedule' => $this->getTable('cron_schedule')])
-          ->where('schedule.job_code = ?', $result[0]["job_code"])
-          ->where('schedule.executed_at > UTC_TIMESTAMP() - INTERVAL 1 DAY')
-          ->where('schedule.status = ? ', $newStatus);
+            ->from(['schedule' => $this->getTable('cron_schedule')])
+            ->where('schedule.job_code = ?', $result[0]["job_code"])
+            ->where('schedule.executed_at > UTC_TIMESTAMP() - INTERVAL 1 DAY')
+            ->where('schedule.status = ? ', $newStatus);
         $result = $connection->query($selectIfUnlocked)->rowCount();
 
         if ($result == 0) {
-          $where = $connection->quoteInto('schedule_id =?', $scheduleId);
-          $result = $connection->update(
-            $this->getTable('cron_schedule'),
-            array('status'=>$newStatus),
-            $where);
+            $where = $connection->quoteInto('schedule_id =?', $scheduleId);
+            $result = $connection->update(
+                $this->getTable('cron_schedule'),
+                array('status'=>$newStatus),
+                $where);
 
-          if ($result == 1) {
-            return true;
-          } else {
-            return false;
-          }
+            if ($result == 1) {
+                return true;
+            }
         }
         return false;
     }

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -3,7 +3,7 @@
  * Copyright Â© Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magemojo\Cron\Model;
+namespace Magento\Cron\Model\ResourceModel;
 
 /**
  * Schedule resource

--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -18,7 +18,8 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      *
      * @return void
      */
-    public function _construct() {
+    public function _construct()
+    {
         $this->_init('cron_schedule', 'schedule_id');
     }
 
@@ -85,10 +86,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
         if ($result == 0) {
             $where = $connection->quoteInto('schedule_id =?', $scheduleId);
-            $result = $connection->update(
-                $this->getTable('cron_schedule'),
-                ['status'=>$newStatus],
-                $where);
+            $result = $connection->update($this->getTable('cron_schedule'),['status'=>$newStatus],$where);
 
             if ($result == 1) {
                 return true;


### PR DESCRIPTION
Reported in #11002 the cron_schedule table can lock up while running multiple update statements against the table. This is due to a high cost query, where a left join is included in the update to ensure uniqueness. Written this way the query forces a full table scan and lock as it is updating a row it must also select. As this table naturally grows in size the cost of the query will keep increasing. This was fixed by removing the left join from the update and doing a separate select query to still ensure that unique job codes will run.