### PR TITLE
[Forwardport] Remove not-allowed currencies from the currencies dropdown in Setup

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -22,11 +22,19 @@ class Lists
     protected $allowedLocales;
 
     /**
+     * List of allowed currencies
+     *
+     * @var array
+     */
+    protected $allowedCurrencies;
+
+    /**
      * @param ConfigInterface $localeConfig
      */
     public function __construct(ConfigInterface $localeConfig)
     {
         $this->allowedLocales = $localeConfig->getAllowedLocales();
+        $this->allowedCurrencies = $localeConfig->getAllowedCurrencies();
     }
 
     /**
@@ -64,6 +72,10 @@ class Lists
         $currencies = (new CurrencyBundle())->get(Resolver::DEFAULT_LOCALE)['Currencies'];
         $list = [];
         foreach ($currencies as $code => $data) {
+            $isAllowedCurrency = array_search($code, $this->allowedCurrencies) !== false;
+            if (!$isAllowedCurrency) {
+                continue;
+            }
             $list[$code] = $data[1] . ' (' . $code . ')';
         }
         asort($list);

--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -26,7 +26,7 @@ class Lists
      *
      * @var array
      */
-    protected $allowedCurrencies;
+    private $allowedCurrencies;
 
     /**
      * @param ConfigInterface $localeConfig

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/ListsTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/ListsTest.php
@@ -58,6 +58,9 @@ class ListsTest extends \PHPUnit\Framework\TestCase
         $this->mockConfig->expects($this->any())
             ->method('getAllowedLocales')
             ->willReturn($this->expectedLocales);
+        $this->mockConfig->expects($this->any())
+            ->method('getAllowedCurrencies')
+            ->willReturn($this->expectedCurrencies);
 
         $this->lists = new Lists($this->mockConfig);
     }
@@ -72,5 +75,14 @@ class ListsTest extends \PHPUnit\Framework\TestCase
     {
         $locales = array_intersect($this->expectedLocales, array_keys($this->lists->getLocaleList()));
         $this->assertEquals($this->expectedLocales, $locales);
+    }
+
+    /**
+     * Test Lists:getCurrencyList() considering allowed currencies config values.
+     */
+    public function testGetCurrencyList()
+    {
+        $currencies = array_intersect($this->expectedCurrencies, array_keys($this->lists->getCurrencyList()));
+        $this->assertEquals($this->expectedCurrencies, $currencies);
     }
 }


### PR DESCRIPTION
### Original Pull Requests
 https://github.com/magento/magento2/pull/13770
 https://github.com/magento/magento2/pull/13966
### Description
As reported on #13760 some deprecated currencies were being displayed in the setup process.
This PR removes these and other not-allowed currencies from the setup step 4 (customize your store).

### Fixed Issues (if relevant)
1. Fixes #13760 by not displaying old and deprecated Brazilian currencies
2. Remove not-allowed currencies for being displayed


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
