### PR TITLE
[Forwardport] Add option to add IP address to existing list + add test

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
@@ -24,6 +24,7 @@ class MaintenanceAllowIpsCommand extends AbstractSetupCommand
      */
     const INPUT_KEY_IP = 'ip';
     const INPUT_KEY_NONE = 'none';
+    const INPUT_KEY_ADD = 'add';
 
     /**
      * @var MaintenanceMode
@@ -69,6 +70,12 @@ class MaintenanceAllowIpsCommand extends AbstractSetupCommand
                 InputOption::VALUE_NONE,
                 'Clear allowed IP addresses'
             ),
+            new InputOption(
+                self::INPUT_KEY_ADD,
+                null,
+                InputOption::VALUE_NONE,
+                'Add the IP address to existing list'
+            ),
         ];
         $this->setName('maintenance:allow-ips')
             ->setDescription('Sets maintenance mode exempt IPs')
@@ -91,6 +98,9 @@ class MaintenanceAllowIpsCommand extends AbstractSetupCommand
             }
 
             if (!empty($addresses)) {
+                if ($input->getOption(self::INPUT_KEY_ADD)) {
+                    $addresses = array_unique(array_merge($this->maintenanceMode->getAddressInfo(), $addresses));
+                }
                 $this->maintenanceMode->setAddresses(implode(',', $addresses));
                 $output->writeln(
                     '<info>Set exempt IP-addresses: ' . implode(' ', $this->maintenanceMode->getAddressInfo()) .

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/MaintenanceAllowIpsCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/MaintenanceAllowIpsCommandTest.php
@@ -67,6 +67,33 @@ class MaintenanceAllowIpsCommandTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @param array $addressInfo
+     * @param array $input
+     * @param array $validatorMessages
+     * @param string $expectedMessage
+     * @dataProvider executeWithAddDataProvider
+     */
+    public function testExecuteWithAdd(array $addressInfo, array $input, array $validatorMessages, $expectedMessage)
+    {
+        $newAddressInfo = array_unique(array_merge($addressInfo, $input['ip']));
+
+        $this->ipValidator->expects($this->once())->method('validateIps')->willReturn($validatorMessages);
+        $this->maintenanceMode
+            ->expects($this->once())
+            ->method('setAddresses')
+            ->with(implode(',', $newAddressInfo));
+
+        $this->maintenanceMode
+            ->expects($this->exactly(2))
+            ->method('getAddressInfo')
+            ->willReturnOnConsecutiveCalls($addressInfo, $newAddressInfo);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute($input);
+        $this->assertEquals($expectedMessage, $tester->getDisplay());
+    }
+
+    /**
      * return array
      */
     public function executeDataProvider()
@@ -97,6 +124,33 @@ class MaintenanceAllowIpsCommandTest extends \PHPUnit\Framework\TestCase
                 [],
                 ''
             ]
+        ];
+    }
+
+    /**
+     * return array
+     */
+    public function executeWithAddDataProvider()
+    {
+        return [
+            [
+                [],
+                ['ip' => ['127.0.0.1'], '--add' => true],
+                [],
+                'Set exempt IP-addresses: 127.0.0.1' . PHP_EOL,
+            ],
+            [
+                ['127.0.0.1'],
+                ['ip' => ['127.0.0.1'], '--add' => true],
+                [],
+                'Set exempt IP-addresses: 127.0.0.1' . PHP_EOL,
+            ],
+            [
+                ['127.0.0.1'],
+                ['ip' => ['127.0.0.2'], '--add' => true],
+                [],
+                'Set exempt IP-addresses: 127.0.0.1 127.0.0.2' . PHP_EOL,
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Original pull request
https://github.com/magento/magento2/pull/13586

### Description
When adding a new IP-address, you have to copy the existing ones. This adds a `--add` flag to just append the addresses, instead of replacing


### Manual testing scenarios
1. Set the IP address
2. Add new ones with --add
3. See the existing one still on the list

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)