### PR TITLE
[Forwardport] Remove forced setting of cache_lifetime to false in constructor and set default cache_lifetime to 3600

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -57,7 +57,6 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     {
         $this->addData(
             [
-                'cache_lifetime' => false,
                 'cache_tags' => [\Magento\Store\Model\Store::CACHE_TAG, \Magento\Cms\Model\Block::CACHE_TAG],
             ]
         );
@@ -122,5 +121,15 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     public function getIdentities()
     {
         return [\Magento\Store\Model\Store::CACHE_TAG, \Magento\Cms\Model\Block::CACHE_TAG];
+    }
+
+    /**
+     * Get block cache life time
+     *
+     * @return int
+     */
+    protected function getCacheLifetime()
+    {
+        return parent::getCacheLifetime() ?: 3600;
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/FooterTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/FooterTest.php
@@ -30,4 +30,18 @@ class FooterTest extends \PHPUnit\Framework\TestCase
             $this->block->getIdentities()
         );
     }
+
+    /**
+     * Check Footer block has cache lifetime.
+     *
+     * @throws \ReflectionException
+     * @return void
+     */
+    public function testGetCacheLifetime()
+    {
+        $reflection = new \ReflectionClass($this->block);
+        $method = $reflection->getMethod('getCacheLifetime');
+        $method->setAccessible(true);
+        $this->assertEquals(3600, $method->invoke($this->block));
+    }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13762
<!--- Provide a general summary of the Pull Request in the Title above -->
As noted in issue https://github.com/magento/magento2/issues/13595 the Magento\Theme\Block\Html\Footer block is not saved to cache. This issue has been looked at as part of #MLAU18

### Description
<!--- Provide a description of the changes proposed in the pull request -->
In investigating the issue it was found that the footer block does not have a cache lifetime set and it also has code in its constructor to set the cache lifetime to false. This pull request removes the forcing of cache lifetime to false and sets the default value to 3600 as done so in the \Magento\Theme\Block\Html\Topmenu block.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13595

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Disable full page caching so that block level caching may be observed
2. View a page that contains the footer block. E.g. homepage
3. Debug \Magento\Framework\View\Element\AbstractBlock::_saveCache on the first time a given footer block is loaded, and see that is is successfully saved to cache.
4. Debug \Magento\Framework\View\Element\AbstractBlock::_loadCache on a following request and confirm that the observed footer block is loaded from cache.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
