### PR TITLE
Issue-13768 Fixed error messages on admin user account page after redirect for force password change

### DIFF
--- a/app/code/Magento/User/Observer/Backend/ForceAdminPasswordChangeObserver.php
+++ b/app/code/Magento/User/Observer/Backend/ForceAdminPasswordChangeObserver.php
@@ -108,6 +108,7 @@ class ForceAdminPasswordChangeObserver implements ObserverInterface
             'adminhtml_system_account_index',
             'adminhtml_system_account_save',
             'adminhtml_auth_logout',
+            'mui_index_render'
         ];
         /** @var \Magento\Framework\App\Action\Action $controller */
         $controller = $observer->getEvent()->getControllerAction();


### PR DESCRIPTION
This PR fixing bug described in this issue: 
https://github.com/magento/magento2/issues/13768

<!--- Provide a general summary of the Pull Request in the Title above -->
### Problem.
After redirection admin user to user account page (when user password expires), on page pops-up message with text “Something went wrong”.

### Reason.
When user password expires, user object has an access only for 3 routes: 'adminhtml_system_account_index',
'adminhtml_system_account_save' and 'adminhtml_auth_logout'. 

Any other request (request which lead to other route) will be redirected to “adminhtml/system_account/”. When system loads admin account page (after force password change  redirection), fires ajax request (ui form component logic) which leads to route 'mui_index_render' and it redirects to “adminhtml/system_account/”. As result we get those error message and pop-up.

### Fix.
Modify “Magento\User\Observer\Backend\ForceAdminPasswordChangeObserver::execute” method by adding to $actionList array 'mui_index_render' route.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
