### PR TITLE
[Forwardport] Add RewriteBase directive template in .htaccess file into pub/static folder

### DIFF
--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -12,6 +12,9 @@ Options -MultiViews
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
+    ## you can put here your pub/static folder path relative to web root
+    #RewriteBase /magento/pub/static/
+
     # Remove signature of the static files that is used to overcome the browser cache
     RewriteRule ^version.+?/(.+)$ $1 [L]
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13678
This PR adds RewriteBase directive into .htaccess file into pub/static folder, in case the need is to install Magento code under a directory inside the web root. Setting this directive into .htaccess file in Magento root and without setting it into .htaccess under pub/static folder cause a file missing (js and css) by Apache Web Server