### PR TITLE
Add quoting for base path in DI compile command

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -239,7 +239,7 @@ class DiCompileCommand extends Command
                 $vendorPathsRegExps[] = $vendorDir
                     . '/(?:' . join('|', $vendorModules) . ')';
             }
-            $basePathsRegExps[] = $basePath
+            $basePathsRegExps[] = preg_quote($basePath, '#')
                 . '/(?:' . join('|', $vendorPathsRegExps) . ')';
         }
 
@@ -258,6 +258,10 @@ class DiCompileCommand extends Command
      */
     private function getExcludedLibraryPaths(array $libraryPaths)
     {
+        $libraryPaths = array_map(function ($libraryPath) {
+            return preg_quote($libraryPath, '#');
+        }, $libraryPaths);
+
         $excludedLibraryPaths = [
             '#^(?:' . join('|', $libraryPaths) . ')/([\\w]+/)?Test#',
             '#^(?:' . join('|', $libraryPaths) . ')/([\\w]+/)?tests#',
@@ -274,7 +278,7 @@ class DiCompileCommand extends Command
     private function getExcludedSetupPaths($setupPath)
     {
         return [
-            '#^(?:' . $setupPath . ')(/[\\w]+)*/Test#'
+            '#^(?:' . preg_quote($setupPath, '#') . ')(/[\\w]+)*/Test#'
         ];
     }
 

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DiCompileCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DiCompileCommandTest.php
@@ -7,6 +7,7 @@ namespace Magento\Setup\Test\Unit\Console\Command;
 
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Setup\Console\Command\DiCompileCommand;
+use Magento\Setup\Module\Di\App\Task\OperationFactory;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -61,6 +62,10 @@ class DiCompileCommandTest extends \PHPUnit\Framework\TestCase
         $this->managerMock = $this->createMock(\Magento\Setup\Module\Di\App\Task\Manager::class);
         $this->directoryListMock =
             $this->createMock(\Magento\Framework\App\Filesystem\DirectoryList::class);
+        $this->directoryListMock->expects($this->any())->method('getPath')->willReturnMap([
+            [\Magento\Framework\App\Filesystem\DirectoryList::SETUP, '/path (1)/to/setup/'],
+        ]);
+
         $this->filesystemMock = $this->getMockBuilder(\Magento\Framework\Filesystem::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -70,8 +75,8 @@ class DiCompileCommandTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $this->componentRegistrarMock = $this->createMock(\Magento\Framework\Component\ComponentRegistrar::class);
         $this->componentRegistrarMock->expects($this->any())->method('getPaths')->willReturnMap([
-            [ComponentRegistrar::MODULE, ['/path/to/module/one', '/path/to/module/two']],
-            [ComponentRegistrar::LIBRARY, ['/path/to/library/one', '/path/to/library/two']],
+            [ComponentRegistrar::MODULE, ['/path/to/module/one', '/path (1)/to/module/two']],
+            [ComponentRegistrar::LIBRARY, ['/path/to/library/one', '/path (1)/to/library/two']],
         ]);
 
         $this->command = new DiCompileCommand(
@@ -128,7 +133,28 @@ class DiCompileCommandTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->with(\Symfony\Component\Console\Helper\ProgressBar::class)
             ->willReturn($progressBar);
-        $this->managerMock->expects($this->exactly(7))->method('addOperation');
+
+        $this->managerMock->expects($this->exactly(7))->method('addOperation')
+            ->withConsecutive(
+                [OperationFactory::PROXY_GENERATOR, []],
+                [OperationFactory::REPOSITORY_GENERATOR, $this->anything()],
+                [OperationFactory::DATA_ATTRIBUTES_GENERATOR, []],
+                [OperationFactory::APPLICATION_CODE_GENERATOR, $this->callback(function ($subject) {
+                    $this->assertEmpty(array_diff($subject['excludePatterns'], [
+                        "#^(?:/path \(1\)/to/setup/)(/[\w]+)*/Test#",
+                        "#^(?:/path/to/library/one|/path \(1\)/to/library/two)/([\w]+/)?Test#",
+                        "#^(?:/path/to/library/one|/path \(1\)/to/library/two)/([\w]+/)?tests#",
+                        "#^(?:/path/to/(?:module/(?:one))|/path \(1\)/to/(?:module/(?:two)))/Test#",
+                        "#^(?:/path/to/(?:module/(?:one))|/path \(1\)/to/(?:module/(?:two)))/tests#"
+                    ]));
+                    return true;
+                })],
+                [OperationFactory::INTERCEPTION, $this->anything()],
+                [OperationFactory::AREA_CONFIG_GENERATOR, $this->anything()],
+                [OperationFactory::INTERCEPTION_CACHE, $this->anything()]
+            )
+        ;
+
         $this->managerMock->expects($this->once())->method('process');
         $tester = new CommandTester($this->command);
         $tester->execute([]);


### PR DESCRIPTION
Quoting magento path in DI compile command.

### Description
DI Compile command tries to exclude tests paths from compilation process via regex in `excludedPathsList` property. That property contains full path to magento without quoting, that's why for some paths (e.g. `/var/www/magento (1)/`) excluding doesn't work.

### Manual testing scenarios
1. Rename magento folder to 'magento.com (1)'
2. Run `bin/magento setup:di:compile` command
3. Find unit test classes in `generated\metadata\*.php` files

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
