### PR TITLE
Fix #13652. Mini cart - fix issue in product title with special chars.

### DIFF
--- a/app/code/Magento/Checkout/CustomerData/DefaultItem.php
+++ b/app/code/Magento/Checkout/CustomerData/DefaultItem.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Checkout\CustomerData;
 
+use Magento\Framework\App\ObjectManager;
+
 /**
  * Default item
  */
@@ -37,11 +39,19 @@ class DefaultItem extends AbstractItem
     protected $checkoutHelper;
 
     /**
+     * Escaper
+     *
+     * @var \Magento\Framework\Escaper
+     */
+    private $escaper;
+
+    /**
      * @param \Magento\Catalog\Helper\Image $imageHelper
      * @param \Magento\Msrp\Helper\Data $msrpHelper
      * @param \Magento\Framework\UrlInterface $urlBuilder
      * @param \Magento\Catalog\Helper\Product\ConfigurationPool $configurationPool
      * @param \Magento\Checkout\Helper\Data $checkoutHelper
+     * @param \Magento\Framework\Escaper|null $escaper
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -49,13 +59,15 @@ class DefaultItem extends AbstractItem
         \Magento\Msrp\Helper\Data $msrpHelper,
         \Magento\Framework\UrlInterface $urlBuilder,
         \Magento\Catalog\Helper\Product\ConfigurationPool $configurationPool,
-        \Magento\Checkout\Helper\Data $checkoutHelper
+        \Magento\Checkout\Helper\Data $checkoutHelper,
+        \Magento\Framework\Escaper $escaper = null
     ) {
         $this->configurationPool = $configurationPool;
         $this->imageHelper = $imageHelper;
         $this->msrpHelper = $msrpHelper;
         $this->urlBuilder = $urlBuilder;
         $this->checkoutHelper = $checkoutHelper;
+        $this->escaper = $escaper ?: ObjectManager::getInstance()->get(\Magento\Framework\Escaper::class);
     }
 
     /**
@@ -64,6 +76,8 @@ class DefaultItem extends AbstractItem
     protected function doGetItemData()
     {
         $imageHelper = $this->imageHelper->init($this->getProductForThumbnail(), 'mini_cart_product_thumbnail');
+        $productName = $this->escaper->escapeHtml($this->item->getProduct()->getName());
+
         return [
             'options' => $this->getOptionList(),
             'qty' => $this->item->getQty() * 1,
@@ -71,7 +85,7 @@ class DefaultItem extends AbstractItem
             'configure_url' => $this->getConfigureUrl(),
             'is_visible_in_site_visibility' => $this->item->getProduct()->isVisibleInSiteVisibility(),
             'product_id' => $this->item->getProduct()->getId(),
-            'product_name' => $this->item->getProduct()->getName(),
+            'product_name' => $productName,
             'product_sku' => $this->item->getProduct()->getSku(),
             'product_url' => $this->getProductUrl(),
             'product_has_url' => $this->hasProductUrl(),

--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
@@ -24,7 +24,7 @@
         <div class="product-item-details">
             <strong class="product-item-name">
                 <!-- ko if: product_has_url -->
-                <a data-bind="attr: {href: product_url}, text: product_name"></a>
+                <a data-bind="attr: {href: product_url}, html: product_name"></a>
                 <!-- /ko -->
                 <!-- ko ifnot: product_has_url -->
                     <!-- ko text: product_name --><!-- /ko -->

--- a/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
+++ b/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
@@ -26,6 +26,7 @@ class ConfigurableItem extends DefaultItem
      * @param \Magento\Catalog\Helper\Product\ConfigurationPool $configurationPool
      * @param \Magento\Checkout\Helper\Data $checkoutHelper
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\Escaper|null $escaper
      */
     public function __construct(
         \Magento\Catalog\Helper\Image $imageHelper,
@@ -33,14 +34,16 @@ class ConfigurableItem extends DefaultItem
         \Magento\Framework\UrlInterface $urlBuilder,
         \Magento\Catalog\Helper\Product\ConfigurationPool $configurationPool,
         \Magento\Checkout\Helper\Data $checkoutHelper,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Escaper $escaper = null
     ) {
         parent::__construct(
             $imageHelper,
             $msrpHelper,
             $urlBuilder,
             $configurationPool,
-            $checkoutHelper
+            $checkoutHelper,
+            $escaper
         );
         $this->_scopeConfig = $scopeConfig;
     }

--- a/app/code/Magento/GroupedProduct/CustomerData/GroupedItem.php
+++ b/app/code/Magento/GroupedProduct/CustomerData/GroupedItem.php
@@ -22,6 +22,7 @@ class GroupedItem extends DefaultItem
      * @param \Magento\Catalog\Helper\Product\ConfigurationPool $configurationPool
      * @param \Magento\Checkout\Helper\Data $checkoutHelper
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\Escaper|null $escaper
      */
     public function __construct(
         \Magento\Catalog\Helper\Image $imageHelper,
@@ -29,14 +30,16 @@ class GroupedItem extends DefaultItem
         \Magento\Framework\UrlInterface $urlBuilder,
         \Magento\Catalog\Helper\Product\ConfigurationPool $configurationPool,
         \Magento\Checkout\Helper\Data $checkoutHelper,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Escaper $escaper = null
     ) {
         parent::__construct(
             $imageHelper,
             $msrpHelper,
             $urlBuilder,
             $configurationPool,
-            $checkoutHelper
+            $checkoutHelper,
+            $escaper
         );
         $this->_scopeConfig = $scopeConfig;
     }


### PR DESCRIPTION
Fix showing product name with special chars in mini cart.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This code was used in html template to show product name  
```
<a data-bind="attr: {href: product_url}, text: product_name"></a>
```

I replaced it with:
```
<a data-bind="attr: {href: product_url}, html: product_name"></a>
```

### Fixed Issues (if relevant)
1. magento/magento2#13652: Issue in product title with special chars in mini cart

### Manual testing scenarios
<ol>
<li>Create a product titled Fusion Backpack &trade;</li>
<li>Go to frontend, the product title comes up correctly as Fusion Backpack ™ then add it to cart</li>
<li>Open the mini cart - product title should be display correctly as Fusion Backpack ™ </li>
</ol>

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
