### PR TITLE
[Port 2.3-develop] Load CMS Page using repository in save action

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Save.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Save.php
@@ -46,7 +46,6 @@ class Save extends \Magento\Backend\App\Action
      * @param DataPersistorInterface $dataPersistor
      * @param \Magento\Cms\Model\PageFactory $pageFactory
      * @param \Magento\Cms\Api\PageRepositoryInterface $pageRepository
-     *
      */
     public function __construct(
         Action\Context $context,
@@ -90,11 +89,10 @@ class Save extends \Magento\Backend\App\Action
 
             $id = $this->getRequest()->getParam('page_id');
             if ($id) {
-                $model->load($id);
-                if (!$model->getId()) {
+                try {
+                    $model = $this->pageRepository->getById($id);
+                } catch (LocalizedException $e) {
                     $this->messageManager->addErrorMessage(__('This page no longer exists.'));
-                    /** \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
-                    $resultRedirect = $this->resultRedirectFactory->create();
                     return $resultRedirect->setPath('*/*/');
                 }
             }

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/SaveTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/SaveTest.php
@@ -153,12 +153,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($page);
 
-        $page->expects($this->any())
-            ->method('load')
-            ->willReturnSelf();
-        $page->expects($this->any())
-            ->method('getId')
-            ->willReturn(true);
+        $this->pageRepository->expects($this->once())->method('getById')->with($this->pageId)->willReturn($page);
         $page->expects($this->once())->method('setData');
         $this->pageRepository->expects($this->once())->method('save')->with($page);
 
@@ -178,6 +173,36 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     public function testSaveActionWithoutData()
     {
         $this->requestMock->expects($this->any())->method('getPostValue')->willReturn(false);
+        $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/') ->willReturnSelf();
+        $this->assertSame($this->resultRedirect, $this->saveController->execute());
+    }
+
+    public function testSaveActionNoId()
+    {
+        $this->requestMock->expects($this->any())->method('getPostValue')->willReturn(['page_id' => 1]);
+        $this->requestMock->expects($this->atLeastOnce())
+            ->method('getParam')
+            ->willReturnMap(
+                [
+                    ['page_id', null, 1],
+                    ['back', null, false],
+                ]
+            );
+
+        $page = $this->getMockBuilder(\Magento\Cms\Model\Page::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->pageFactory->expects($this->atLeastOnce())
+            ->method('create')
+            ->willReturn($page);
+        $this->pageRepository->expects($this->once())
+            ->method('getById')
+            ->with($this->pageId)
+            ->willThrowException(new \Magento\Framework\Exception\NoSuchEntityException(__('Error message')));
+        $this->messageManagerMock->expects($this->once())
+            ->method('addErrorMessage')
+            ->with(__('This page no longer exists.'));
         $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/') ->willReturnSelf();
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
@@ -204,12 +229,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($page);
 
-        $page->expects($this->any())
-            ->method('load')
-            ->willReturnSelf();
-        $page->expects($this->any())
-            ->method('getId')
-            ->willReturn(true);
+        $this->pageRepository->expects($this->once())->method('getById')->with($this->pageId)->willReturn($page);
         $page->expects($this->once())->method('setData');
         $this->pageRepository->expects($this->once())->method('save')->with($page);
 
@@ -251,12 +271,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($page);
 
-        $page->expects($this->any())
-            ->method('load')
-            ->willReturnSelf();
-        $page->expects($this->any())
-            ->method('getId')
-            ->willReturn(true);
+        $this->pageRepository->expects($this->once())->method('getById')->with($this->pageId)->willReturn($page);
         $page->expects($this->once())->method('setData');
         $this->pageRepository->expects($this->once())->method('save')->with($page)
             ->willThrowException(new \Exception('Error message.'));


### PR DESCRIPTION
Port of https://github.com/magento/magento2/pull/13814

### Description
Update Save action of CMS Page to load via repository. Also added `testSaveActionNoId()` to be consistent with CMS Bock tests

### Fixed Issues (if relevant)
1. None.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
