### PR TITLE
Add @api annotation to block argument marker interface

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Block/ArgumentInterface.php
+++ b/lib/internal/Magento/Framework/View/Element/Block/ArgumentInterface.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\View\Element\Block;
 /**
  * Block argument interface.
  * All objects that are injected to block arguments should implement this interface.
- * 
+ *
  * @api
  */
 interface ArgumentInterface

--- a/lib/internal/Magento/Framework/View/Element/Block/ArgumentInterface.php
+++ b/lib/internal/Magento/Framework/View/Element/Block/ArgumentInterface.php
@@ -8,6 +8,8 @@ namespace Magento\Framework\View\Element\Block;
 /**
  * Block argument interface.
  * All objects that are injected to block arguments should implement this interface.
+ * 
+ * @api
  */
 interface ArgumentInterface
 {


### PR DESCRIPTION
### Description
Without the `@api` annotation implementing this interface would require a patch level dependency on magento/framework.  
This PR changes that by adding an `@api` annotation so that only a minor version dependency is required according to http://devdocs.magento.com/guides/v2.2/extension-dev-guide/versioning/dependencies.html

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable) **NA**
 - [ ] All automated tests passed successfully (all builds on Travis CI are green) **NA**
