### PR TITLE
Allow changing head and body element through xml layout updates

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/page_layout.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/page_layout.xsd
@@ -7,6 +7,8 @@
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/elements.xsd"/>
+    <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/head.xsd"/>
+    <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/body.xsd"/>
 
     <xs:complexType name="pageLayoutType">
         <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -14,6 +16,8 @@
             <xs:element name="container" type="containerType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="update" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="move" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="head" type="headType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="body" type="bodyType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
### Description

The change allows updating the head and body parts of a page manually through xml layout updates.

One particular thing this changeset allows is:

```xml
<head>
  <meta name="robots" content="NOINDEX, NOFOLLOW"/>
</head>
```

This solution is curtesy of https://magento.stackexchange.com/questions/126646/magento2-how-to-add-different-custom-css-file-on-specific-cms-pages/166322#166322 and https://github.com/magento/magento2/issues/4454#issuecomment-289414473

### Fixed Issues

1. magento/magento2#4454: CMS Page with <head> in layout update xml

Closes: #4454