### PR TITLE
#12217 Add missing 6th element of theme file accumulation array that …

### DIFF
--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -898,6 +898,7 @@ class Files
                         null,
                         null,
                         null,
+                        null,
                     ];
                 }
             }


### PR DESCRIPTION
…is expected in \Magento\Deploy\Model\Deploy\LocaleDeploy::deployAppFiles

Fixes [Regression] Static content deploy is not possible when one of themes have no static assets #12217: https://github.com/magento/magento2/issues/12217

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Add missing 6th element of theme file accumulation array that is expected in \Magento\Deploy\Model\Deploy\LocaleDeploy::deployAppFiles

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12217: [Regression] Static content deploy is not possible when one of themes have no static assets

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
From the issue:

1. Create a theme without anything in web folder
2. Run bin/magento setup:static-content:deploy

Fail: Exception is thrown
Success: Exception is not thrown


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
