### PR TITLE
Fix order_list.php fixture to use with OrderCustomerManagementInterface account creation

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
@@ -59,5 +59,6 @@ foreach ($orders as $orderData) {
         ->addItem($orderItem)
         ->setBillingAddress($billingAddress)
         ->setBillingAddress($shippingAddress)
+        ->setPayment($payment)
         ->save();
 }


### PR DESCRIPTION
Fix order_list.php fixture to use with ``OrderCustomerManagementInterface::create($orderId)``

### Description
Use order_list.php fixture with ``OrderCustomerManagementInterface::create($orderId)`` generates error: ``Call to a member function getMethodInstance() on null``

### Fixed Issues
Fix error: ``Call to a member function getMethodInstance() on null`` while performing integration test.

### Manual testing scenarios
``` 

    /**
     * @magentoDataFixture Magento/Sales/_files/order_list.php
     */
    public function testExecute()
    {
        $this->_objectManager         = Bootstrap::getObjectManager();
        /** @var OrderCustomerManagementInterface $orderCustomerManagement */
        $orderCustomerManagement = $this->_objectManager->create(OrderCustomerManagementInterface::class);
        /** @var OrderRepositoryInterface $orderRepo */
        $orderRepo = $this->_objectManager->create(OrderRepositoryInterface::class);
        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
        $searchCriteriaBuilder = $this->_objectManager->create(SearchCriteriaBuilder::class);
        $searchCriteria = $searchCriteriaBuilder->create();
        $orders = $orderRepo->getList($searchCriteria)->getItems();
        foreach($orders as $order)
        {
            $orderCustomerManagement->create($order->getId());
        }
    }
 ```

