### PR TITLE
[Forwardport] Add option "lock-config" for shell command "config:set"

### DIFF
--- a/app/code/Magento/Config/Console/Command/ConfigSet/ConfigSetProcessorFactory.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/ConfigSetProcessorFactory.php
@@ -28,7 +28,14 @@ class ConfigSetProcessorFactory
      * lock - save and lock configuration
      */
     const TYPE_DEFAULT = 'default';
+    
+    /**
+     * @deprecated
+     * @see TYPE_LOCK_ENV or TYPE_LOCK_CONFIG
+     */
     const TYPE_LOCK = 'lock';
+    const TYPE_LOCK_ENV = 'lock-env';
+    const TYPE_LOCK_CONFIG = 'lock-config';
     /**#@-*/
 
     /**#@-*/

--- a/app/code/Magento/Config/Console/Command/ConfigSet/DefaultProcessor.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/DefaultProcessor.php
@@ -72,7 +72,7 @@ class DefaultProcessor implements ConfigSetProcessorInterface
             throw new CouldNotSaveException(
                 __(
                     'The value you set has already been locked. To change the value, use the --%1 option.',
-                    ConfigSetCommand::OPTION_LOCK
+                    ConfigSetCommand::OPTION_LOCK_ENV
                 )
             );
         }

--- a/app/code/Magento/Config/Console/Command/ConfigSet/LockProcessor.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/LockProcessor.php
@@ -16,7 +16,8 @@ use Magento\Framework\Stdlib\ArrayManager;
 
 /**
  * Processes file lock flow of config:set command.
- * This processor saves the value of configuration and lock it for editing in Admin interface.
+ * This processor saves the value of configuration into app/etc/env.php
+ * and locks it for editing in Admin interface.
  *
  * {@inheritdoc}
  */
@@ -49,23 +50,30 @@ class LockProcessor implements ConfigSetProcessorInterface
      * @var ConfigPathResolver
      */
     private $configPathResolver;
+    /**
+     * @var string
+     */
+    private $target;
 
     /**
      * @param PreparedValueFactory $preparedValueFactory The factory for prepared value
      * @param DeploymentConfig\Writer $writer The deployment configuration writer
      * @param ArrayManager $arrayManager An array manager for different manipulations with arrays
      * @param ConfigPathResolver $configPathResolver The resolver for configuration paths according to source type
+     * @param string $target
      */
     public function __construct(
         PreparedValueFactory $preparedValueFactory,
         DeploymentConfig\Writer $writer,
         ArrayManager $arrayManager,
-        ConfigPathResolver $configPathResolver
+        ConfigPathResolver $configPathResolver,
+        $target = ConfigFilePool::APP_ENV
     ) {
         $this->preparedValueFactory = $preparedValueFactory;
         $this->deploymentConfigWriter = $writer;
         $this->arrayManager = $arrayManager;
         $this->configPathResolver = $configPathResolver;
+        $this->target = $target;
     }
 
     /**
@@ -97,7 +105,7 @@ class LockProcessor implements ConfigSetProcessorInterface
                  * we'll write value just after all validations are triggered.
                  */
                 $this->deploymentConfigWriter->saveConfig(
-                    [ConfigFilePool::APP_ENV => $this->arrayManager->set($configPath, [], $value)],
+                    [$this->target => $this->arrayManager->set($configPath, [], $value)],
                     false
                 );
             }

--- a/app/code/Magento/Config/Console/Command/ConfigSet/ProcessorFacade.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/ProcessorFacade.php
@@ -9,6 +9,7 @@ use Magento\Config\Console\Command\ConfigSetCommand;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Scope\ValidatorInterface;
 use Magento\Config\Model\Config\PathValidator;
+use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\ConfigurationMismatchException;
 use Magento\Framework\Exception\CouldNotSaveException;
@@ -98,12 +99,35 @@ class ProcessorFacade
      * @param boolean $lock The lock flag
      * @return string Processor response message
      * @throws ValidatorException If some validation is wrong
-     * @throws CouldNotSaveException If cannot save config value
-     * @throws ConfigurationMismatchException If processor can not be instantiated
      * @since 100.2.0
+     * @deprecated
+     * @see processWithLockTarget()
      */
     public function process($path, $value, $scope, $scopeCode, $lock)
     {
+        return $this->processWithLockTarget($path, $value, $scope, $scopeCode, $lock);
+    }
+
+    /**
+     * Processes config:set command with the option to set a target file.
+     *
+     * @param string $path The configuration path in format section/group/field_name
+     * @param string $value The configuration value
+     * @param string $scope The configuration scope (default, website, or store)
+     * @param string $scopeCode The scope code
+     * @param boolean $lock The lock flag
+     * @param string $lockTarget
+     * @return string Processor response message
+     * @throws ValidatorException If some validation is wrong
+     */
+    public function processWithLockTarget(
+        $path,
+        $value,
+        $scope,
+        $scopeCode,
+        $lock,
+        $lockTarget = ConfigFilePool::APP_ENV
+    ) {
         try {
             $this->scopeValidator->isValid($scope, $scopeCode);
             $this->pathValidator->validate($path);
@@ -111,14 +135,24 @@ class ProcessorFacade
             throw new ValidatorException(__($exception->getMessage()), $exception);
         }
 
-        $processor = $lock
-            ? $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_LOCK)
-            : $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_DEFAULT);
-        $message = $lock
-            ? 'Value was saved and locked.'
-            : 'Value was saved.';
+        $processor =
+            $lock
+                ? ( $lockTarget == ConfigFilePool::APP_ENV
+                    ? $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_LOCK_ENV)
+                    : $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_LOCK_CONFIG)
+                )
+                : $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_DEFAULT)
+            ;
 
-        // The processing flow depends on --lock option.
+        $message =
+            $lock
+                ? ( $lockTarget == ConfigFilePool::APP_ENV
+                    ? 'Value was saved in app/etc/env.php and locked.'
+                    : 'Value was saved in app/etc/config.php and locked.'
+                )
+                : 'Value was saved.';
+
+        // The processing flow depends on --lock and --share options.
         $processor->process($path, $value, $scope, $scopeCode);
 
         $this->hash->regenerate(System::CONFIG_TYPE);

--- a/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Config\Console\Command;
 
 use Magento\Config\App\Config\Type\System;
@@ -10,6 +11,7 @@ use Magento\Config\Console\Command\ConfigSet\ProcessorFacadeFactory;
 use Magento\Deploy\Model\DeploymentConfig\ChangeDetector;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -34,6 +36,8 @@ class ConfigSetCommand extends Command
     const OPTION_SCOPE = 'scope';
     const OPTION_SCOPE_CODE = 'scope-code';
     const OPTION_LOCK = 'lock';
+    const OPTION_LOCK_ENV = 'lock-env';
+    const OPTION_LOCK_CONFIG = 'lock-config';
     /**#@-*/
 
     /**#@-*/
@@ -109,10 +113,23 @@ class ConfigSetCommand extends Command
                     'Scope code (required only if scope is not \'default\')'
                 ),
                 new InputOption(
+                    static::OPTION_LOCK_ENV,
+                    'le',
+                    InputOption::VALUE_NONE,
+                    'Lock value which prevents modification in the Admin (will be saved in app/etc/env.php)'
+                ),
+                new InputOption(
+                    static::OPTION_LOCK_CONFIG,
+                    'lc',
+                    InputOption::VALUE_NONE,
+                    'Lock and share value with other installations, prevents modification in the Admin '
+                    . '(will be saved in app/etc/config.php)'
+                ),
+                new InputOption(
                     static::OPTION_LOCK,
                     'l',
                     InputOption::VALUE_NONE,
-                    'Lock value which prevents modification in the Admin'
+                    'Deprecated, use the --' . static::OPTION_LOCK_ENV . ' option instead.'
                 ),
             ]);
 
@@ -146,12 +163,23 @@ class ConfigSetCommand extends Command
 
         try {
             $message = $this->emulatedAreaProcessor->process(function () use ($input) {
-                return $this->processorFacadeFactory->create()->process(
+
+                $lock = $input->getOption(static::OPTION_LOCK_ENV)
+                    || $input->getOption(static::OPTION_LOCK_CONFIG)
+                    || $input->getOption(static::OPTION_LOCK);
+
+                $lockTargetPath = ConfigFilePool::APP_ENV;
+                if ($input->getOption(static::OPTION_LOCK_CONFIG)) {
+                    $lockTargetPath = ConfigFilePool::APP_CONFIG;
+                }
+
+                return $this->processorFacadeFactory->create()->processWithLockTarget(
                     $input->getArgument(static::ARG_PATH),
                     $input->getArgument(static::ARG_VALUE),
                     $input->getOption(static::OPTION_SCOPE),
                     $input->getOption(static::OPTION_SCOPE_CODE),
-                    $input->getOption(static::OPTION_LOCK)
+                    $lock,
+                    $lockTargetPath
                 );
             });
 

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/ConfigSetProcessorFactoryTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/ConfigSetProcessorFactoryTest.php
@@ -41,7 +41,7 @@ class ConfigSetProcessorFactoryTest extends \PHPUnit\Framework\TestCase
         $this->model = new ConfigSetProcessorFactory(
             $this->objectManagerMock,
             [
-                ConfigSetProcessorFactory::TYPE_LOCK => LockProcessor::class,
+                ConfigSetProcessorFactory::TYPE_LOCK_ENV => LockProcessor::class,
                 ConfigSetProcessorFactory::TYPE_DEFAULT => DefaultProcessor::class,
                 'wrongType' => \stdClass::class,
             ]
@@ -59,7 +59,7 @@ class ConfigSetProcessorFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(
             ConfigSetProcessorInterface::class,
-            $this->model->create(ConfigSetProcessorFactory::TYPE_LOCK)
+            $this->model->create(ConfigSetProcessorFactory::TYPE_LOCK_ENV)
         );
     }
 

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/DefaultProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/DefaultProcessorTest.php
@@ -166,7 +166,9 @@ class DefaultProcessorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\LocalizedException
-     * @expectedExceptionMessage The value you set has already been locked. To change the value, use the --lock option.
+     * @codingStandardsIgnoreStart
+     * @expectedExceptionMessage The value you set has already been locked. To change the value, use the --lock-env option.
+     * @codingStandardsIgnoreEnd
      */
     public function testProcessLockedValue()
     {

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockConfigProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockConfigProcessorTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Config\Test\Unit\Console\Command\ConfigSet;
+
+use Magento\Config\Console\Command\ConfigSet\LockProcessor;
+use Magento\Config\Model\PreparedValueFactory;
+use Magento\Framework\App\Config\ConfigPathResolver;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Stdlib\ArrayManager;
+use Magento\Store\Model\ScopeInterface;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+
+/**
+ * Test for ShareProcessor.
+ *
+ * @see ShareProcessor
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class LockConfigProcessorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var LockProcessor
+     */
+    private $model;
+
+    /**
+     * @var PreparedValueFactory|Mock
+     */
+    private $preparedValueFactory;
+
+    /**
+     * @var DeploymentConfig\Writer|Mock
+     */
+    private $deploymentConfigWriterMock;
+
+    /**
+     * @var ArrayManager|Mock
+     */
+    private $arrayManagerMock;
+
+    /**
+     * @var ConfigPathResolver|Mock
+     */
+    private $configPathResolver;
+
+    /**
+     * @var Value|Mock
+     */
+    private $valueMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->preparedValueFactory = $this->getMockBuilder(PreparedValueFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->deploymentConfigWriterMock = $this->getMockBuilder(DeploymentConfig\Writer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->arrayManagerMock = $this->getMockBuilder(ArrayManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configPathResolver = $this->getMockBuilder(ConfigPathResolver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->valueMock = $this->getMockBuilder(Value::class)
+            ->setMethods(['validateBeforeSave', 'beforeSave', 'setValue', 'getValue', 'afterSave'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->model = new LockProcessor(
+            $this->preparedValueFactory,
+            $this->deploymentConfigWriterMock,
+            $this->arrayManagerMock,
+            $this->configPathResolver,
+            ConfigFilePool::APP_CONFIG
+        );
+    }
+
+    /**
+     * Tests process of share flow.
+     *
+     * @param string $path
+     * @param string $value
+     * @param string $scope
+     * @param string|null $scopeCode
+     * @dataProvider processDataProvider
+     */
+    public function testProcess($path, $value, $scope, $scopeCode)
+    {
+        $this->preparedValueFactory->expects($this->once())
+            ->method('create')
+            ->with($path, $value, $scope, $scopeCode)
+            ->willReturn($this->valueMock);
+        $this->configPathResolver->expects($this->once())
+            ->method('resolve')
+            ->willReturn('system/default/test/test/test');
+        $this->arrayManagerMock->expects($this->once())
+            ->method('set')
+            ->with('system/default/test/test/test', [], $value)
+            ->willReturn([
+                'system' => [
+                    'default' => [
+                        'test' => [
+                            'test' => [
+                                'test' => $value
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+        $this->valueMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn($value);
+        $this->deploymentConfigWriterMock->expects($this->once())
+            ->method('saveConfig')
+            ->with(
+                [
+                    ConfigFilePool::APP_CONFIG => [
+                        'system' => [
+                            'default' => [
+                                'test' => [
+                                    'test' => [
+                                        'test' => $value
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                false
+            );
+        $this->valueMock->expects($this->once())
+            ->method('validateBeforeSave');
+        $this->valueMock->expects($this->once())
+            ->method('beforeSave');
+        $this->valueMock->expects($this->once())
+            ->method('afterSave');
+
+        $this->model->process($path, $value, $scope, $scopeCode);
+    }
+
+    /**
+     * @return array
+     */
+    public function processDataProvider()
+    {
+        return [
+            ['test/test/test', 'value', ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null],
+            ['test/test/test', 'value', ScopeInterface::SCOPE_WEBSITE, 'base'],
+            ['test/test/test', 'value', ScopeInterface::SCOPE_STORE, 'test'],
+        ];
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage Filesystem is not writable.
+     */
+    public function testProcessNotReadableFs()
+    {
+        $path = 'test/test/test';
+        $value = 'value';
+
+        $this->preparedValueFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->valueMock);
+        $this->valueMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn($value);
+        $this->configPathResolver->expects($this->once())
+            ->method('resolve')
+            ->willReturn('system/default/test/test/test');
+        $this->arrayManagerMock->expects($this->once())
+            ->method('set')
+            ->with('system/default/test/test/test', [], $value)
+            ->willReturn(null);
+        $this->deploymentConfigWriterMock->expects($this->once())
+            ->method('saveConfig')
+            ->willThrowException(new FileSystemException(__('Filesystem is not writable.')));
+
+        $this->model->process($path, $value, ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid values
+     */
+    public function testCustomException()
+    {
+        $path = 'test/test/test';
+        $value = 'value';
+
+        $this->configPathResolver->expects($this->once())
+            ->method('resolve')
+            ->willReturn('system/default/test/test/test');
+        $this->preparedValueFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->valueMock);
+        $this->arrayManagerMock->expects($this->never())
+            ->method('set');
+        $this->valueMock->expects($this->once())
+            ->method('getValue');
+        $this->valueMock->expects($this->once())
+            ->method('afterSave')
+            ->willThrowException(new \Exception('Invalid values'));
+        $this->deploymentConfigWriterMock->expects($this->never())
+            ->method('saveConfig');
+
+        $this->model->process($path, $value, ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null);
+    }
+}

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockEnvProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockEnvProcessorTest.php
@@ -23,7 +23,7 @@ use PHPUnit_Framework_MockObject_MockObject as Mock;
  * @see LockProcessor
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class LockProcessorTest extends \PHPUnit\Framework\TestCase
+class LockEnvProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var LockProcessor
@@ -81,7 +81,8 @@ class LockProcessorTest extends \PHPUnit\Framework\TestCase
             $this->preparedValueFactory,
             $this->deploymentConfigWriterMock,
             $this->arrayManagerMock,
-            $this->configPathResolver
+            $this->configPathResolver,
+            ConfigFilePool::APP_ENV
         );
     }
 

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSetCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSetCommandTest.php
@@ -95,7 +95,7 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($this->processorFacadeMock);
         $this->processorFacadeMock->expects($this->once())
-            ->method('process')
+            ->method('processWithLockTarget')
             ->willReturn('Some message');
         $this->emulatedAreProcessorMock->expects($this->once())
             ->method('process')
@@ -171,9 +171,7 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
         $this->emulatedAreProcessorMock->expects($this->once())
             ->method('process')
-            ->willThrowException(
-                new ValidatorException(__('The "test/test/test" path doesn\'t exist. Verify and try again.'))
-            );
+            ->willThrowException(new ValidatorException(__('The "test/test/test" path does not exists')));
 
         $tester = new CommandTester($this->command);
         $tester->execute([
@@ -182,7 +180,7 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertContains(
-            __('The "test/test/test" path doesn\'t exist. Verify and try again.')->render(),
+            __('The "test/test/test" path does not exists')->render(),
             $tester->getDisplay()
         );
         $this->assertSame(Cli::RETURN_FAILURE, $tester->getStatusCode());

--- a/app/code/Magento/Config/etc/di.xml
+++ b/app/code/Magento/Config/etc/di.xml
@@ -296,10 +296,21 @@
         <arguments>
             <argument name="processors" xsi:type="array">
                 <item name="default" xsi:type="string">Magento\Config\Console\Command\ConfigSet\DefaultProcessor</item>
-                <item name="lock" xsi:type="string">Magento\Config\Console\Command\ConfigSet\LockProcessor</item>
+                <item name="lock-env" xsi:type="string">Magento\Config\Console\Command\ConfigSet\VirtualLockEnvProcessor</item>
+                <item name="lock-config" xsi:type="string">Magento\Config\Console\Command\ConfigSet\VirtualLockConfigProcessor</item>
             </argument>
         </arguments>
     </type>
+    <virtualType name="Magento\Config\Console\Command\ConfigSet\VirtualLockEnvProcessor" type="Magento\Config\Console\Command\ConfigSet\LockProcessor">
+        <arguments>
+            <argument name="target" xsi:type="string">app_env</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Magento\Config\Console\Command\ConfigSet\VirtualLockConfigProcessor" type="Magento\Config\Console\Command\ConfigSet\LockProcessor">
+        <arguments>
+            <argument name="target" xsi:type="string">app_config</argument>
+        </arguments>
+    </virtualType>
     <type name="Magento\Deploy\Model\DeploymentConfig\ImporterPool">
         <arguments>
             <argument name="importers" xsi:type="array">

--- a/app/code/Magento/Deploy/Model/Mode.php
+++ b/app/code/Magento/Deploy/Model/Mode.php
@@ -236,7 +236,7 @@ class Mode
         $configs = $this->configProvider->getConfigs($this->getMode(), $mode);
         foreach ($configs as $path => $item) {
             $this->emulatedAreaProcessor->process(function () use ($path, $item) {
-                $this->processorFacadeFactory->create()->process(
+                $this->processorFacadeFactory->create()->processWithLockTarget(
                     $path,
                     $item['value'],
                     ScopeConfigInterface::SCOPE_TYPE_DEFAULT,

--- a/app/code/Magento/Deploy/Test/Unit/Model/ModeTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/ModeTest.php
@@ -241,7 +241,7 @@ class ModeTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->processorFacade);
         $this->processorFacade
             ->expects($this->once())
-            ->method('process')
+            ->method('processWithLockTarget')
             ->with(
                 'dev/debug/debug_logging',
                 0,

--- a/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
@@ -142,7 +142,7 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
      * @magentoDbIsolation enabled
      * @dataProvider runLockDataProvider
      */
-    public function testRunLock($path, $value, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null)
+    public function testRunLockEnv($path, $value, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null)
     {
         $this->inputMock->expects($this->any())
             ->method('getArgument')
@@ -153,15 +153,15 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
         $this->inputMock->expects($this->any())
             ->method('getOption')
             ->willReturnMap([
-                [ConfigSetCommand::OPTION_LOCK, true],
+                [ConfigSetCommand::OPTION_LOCK_ENV, true],
                 [ConfigSetCommand::OPTION_SCOPE, $scope],
                 [ConfigSetCommand::OPTION_SCOPE_CODE, $scopeCode]
             ]);
         $this->outputMock->expects($this->exactly(2))
             ->method('writeln')
             ->withConsecutive(
-                ['<info>Value was saved and locked.</info>'],
-                ['<info>Value was saved and locked.</info>']
+                ['<info>Value was saved in app/etc/env.php and locked.</info>'],
+                ['<info>Value was saved in app/etc/env.php and locked.</info>']
             );
 
         /** @var ConfigSetCommand $command */
@@ -218,7 +218,7 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
             [ConfigSetCommand::OPTION_SCOPE, $scope],
             [ConfigSetCommand::OPTION_SCOPE_CODE, $scopeCode]
         ];
-        $optionsLock = array_merge($options, [[ConfigSetCommand::OPTION_LOCK, true]]);
+        $optionsLock = array_merge($options, [[ConfigSetCommand::OPTION_LOCK_ENV, true]]);
 
         /** @var ConfigPathResolver $resolver */
         $resolver = $this->objectManager->get(ConfigPathResolver::class);
@@ -234,8 +234,8 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertSame(null, $this->arrayManager->get($configPath, $this->loadConfig()));
 
-        $this->runCommand($arguments, $optionsLock, '<info>Value was saved and locked.</info>');
-        $this->runCommand($arguments, $optionsLock, '<info>Value was saved and locked.</info>');
+        $this->runCommand($arguments, $optionsLock, '<info>Value was saved in app/etc/env.php and locked.</info>');
+        $this->runCommand($arguments, $optionsLock, '<info>Value was saved in app/etc/env.php and locked.</info>');
 
         $this->assertSame($value, $this->arrayManager->get($configPath, $this->loadConfig()));
     }

--- a/dev/tests/integration/testsuite/Magento/Developer/Model/Logger/Handler/DebugTest.php
+++ b/dev/tests/integration/testsuite/Magento/Developer/Model/Logger/Handler/DebugTest.php
@@ -112,25 +112,27 @@ class DebugTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
         $this->outputMock = $this->getMockBuilder(OutputInterface::class)
             ->getMockForAbstractClass();
+        $this->inputMock->expects($this->exactly(4))
+            ->method('getOption')
+            ->withConsecutive(
+                [ConfigSetCommand::OPTION_LOCK_ENV],
+                [ConfigSetCommand::OPTION_LOCK_CONFIG],
+                [ConfigSetCommand::OPTION_SCOPE],
+                [ConfigSetCommand::OPTION_SCOPE_CODE]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false,
+                ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+                null
+            );
         $this->inputMock->expects($this->exactly(2))
             ->method('getArgument')
             ->withConsecutive([ConfigSetCommand::ARG_PATH], [ConfigSetCommand::ARG_VALUE])
             ->willReturnOnConsecutiveCalls('dev/debug/debug_logging', 1);
-        $this->inputMock->expects($this->exactly(3))
-            ->method('getOption')
-            ->withConsecutive(
-                [ConfigSetCommand::OPTION_SCOPE],
-                [ConfigSetCommand::OPTION_SCOPE_CODE],
-                [ConfigSetCommand::OPTION_LOCK]
-            )
-            ->willReturnOnConsecutiveCalls(
-                ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
-                null,
-                true
-            );
         $this->outputMock->expects($this->once())
             ->method('writeln')
-            ->with('<info>Value was saved and locked.</info>');
+            ->with('<info>Value was saved in app/etc/env.php and locked.</info>');
         $this->assertFalse((bool)$this->configSetCommand->run($this->inputMock, $this->outputMock));
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13280

Taken over from https://github.com/magento/magento2/pull/12178.

This is similar to the "lock" switch which writes configuration
values to app/etc/env.php. The "lock-config" switch writes it to
app/etc/config.php instead which can be shared between environments. 
For consistency, the "lock" switch has been renamed to "lock-env".

### Description

In most cases, configuration settings should be shared among all development, staging and live instances of a shop. To achieve this, you can use the same mechanism as with the `--lock` switch described in http://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-set.html.

The only difference is that the configuration values will be stored in app/etc/config.php instead of app/etc/env.php. This file should usually be included in the VCS and thus shared between instances.

To store a config setting in the file via command line, the command would be as follows:

```
bin/magento config:set --lock-config <path> <value>
```

i.e. 

```
bin/magento config:set --lock-config general/store_information/name "Sample Store"
```

### Manual testing scenarios
1. Call `bin/magento config:set --lock-config general/store_information/name "Sample Store"` from the command line
2. Verify that the app/etc/config.php file contains a section as follows:

```
[...]
  'cache_types' => 
  array (
    'config' => 1,
    [...]
  ),
  'install' => 
  array (
    'date' => 'Wed, 08 Nov 2017 11:52:21 +0000',
  ),
  'system' => 
  array (
    'default' => 
    array (
      'general' => 
      array (
        'store_information' => 
        array (
          'name' => 'Sample Store',
        ),
      ),
    ),
  ),
);
```
3. Verify that the configuration setting "Store Name" in the section "General", group "Store Information" is filled with "Sample Store" and greyed out:

![grafik](https://user-images.githubusercontent.com/662059/32662987-ac0bffee-c62c-11e7-8641-97d5d9d3ac43.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

