### PR TITLE
Changing order of deleting old records in default Stock Indexer

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
@@ -292,6 +292,8 @@ class DefaultStock extends AbstractIndexer implements StockInterface
         $select = $this->_getStockStatusSelect($entityIds, true);
         $select = $this->getQueryProcessorComposite()->processQuery($select, $entityIds, true);
         $query = $connection->query($select);
+        
+        $this->deleteOldRecords($entityIds);
 
         $i = 0;
         $data = [];
@@ -310,7 +312,6 @@ class DefaultStock extends AbstractIndexer implements StockInterface
             }
         }
 
-        $this->deleteOldRecords($entityIds);
         $this->_updateIndexTable($data);
 
         return $this;


### PR DESCRIPTION
### Description
When updating product attributes en masse (clicking the checkboxes in the Catalog > Product screen and then going to Update Attributes), if the updated product count is > 1000, rows from the `cataloginventory_stock_status` table disappear.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. None. Found the issue today and am patching it.

### Manual testing scenarios
1. Go to Catalog > Product.
2. Select more than 1k products.
3. Update attributes on those products.
4. They should remain visible in the categories on the frontend. The edited products should continue to have rows visible in the `cataloginventory_stock_status` table.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
  - [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds on Travis CI are green)
