### PR TITLE
Update AbstractExtensibleModel

### DIFF
--- a/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
@@ -165,14 +165,38 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
     public function setCustomAttribute($attributeCode, $attributeValue)
     {
         $customAttributesCodes = $this->getCustomAttributesCodes();
+
         /* If key corresponds to custom attribute code, populate custom attributes */
         if (in_array($attributeCode, $customAttributesCodes)) {
             $attribute = $this->customAttributeFactory->create();
             $attribute->setAttributeCode($attributeCode)
                 ->setValue($attributeValue);
             $this->_data[self::CUSTOM_ATTRIBUTES][$attributeCode] = $attribute;
+            $this->customAttributesChanged = true;
         }
+
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Added custom attributes support.
+     */
+    protected function _getData($key)
+    {
+        $data = parent::_getData($key);
+
+        if (null === $data) {
+            if (isset($this->_data[self::CUSTOM_ATTRIBUTES][$key])) {
+                $data = $this->_data[self::CUSTOM_ATTRIBUTES][$key];
+                if ($data instanceof \Magento\Framework\Api\AttributeValue) {
+                    $data = $data->getValue();
+                }
+            }
+        }
+
+        return $data;
     }
 
     /**
@@ -184,12 +208,24 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
     {
         if (is_array($key)) {
             $key = $this->filterCustomAttributes($key);
-        } elseif ($key == self::CUSTOM_ATTRIBUTES) {
-            $filteredData = $this->filterCustomAttributes([self::CUSTOM_ATTRIBUTES => $value]);
-            $value = $filteredData[self::CUSTOM_ATTRIBUTES];
+            parent::setData($key, $value);
+            $this->customAttributesChanged = true;
         }
-        $this->customAttributesChanged = true;
-        parent::setData($key, $value);
+
+        if (!is_array($key)) {
+            if ($key == self::CUSTOM_ATTRIBUTES) {
+                $filteredData = $this->filterCustomAttributes([self::CUSTOM_ATTRIBUTES => $value]);
+                $value = $filteredData[self::CUSTOM_ATTRIBUTES];
+            }
+
+            $customAttributesCodes = $this->getCustomAttributesCodes();
+
+            /* If key corresponds to custom attribute code, set custom attribute properly */
+            in_array($key, $customAttributesCodes)
+                ? $this->setCustomAttribute($key, $value)
+                : parent::setData($key, $value);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
Update AbstractExtensibleModel to avoid recreate custom attributes from customAttributeFactory when it's not really needed.

### Description
Depending on the number of custom attributes, `\Magento\Framework\Model\AbstractExtensibleModel::initializeCustomAttributes` may be an expensive operation, as it creates a new attribute model for each custom attribute using customAttributeFactory. When you retrieve a custom attribute the first time, custom attributes are initialized. Then, if you set some attribute value like price, even if it is a module built-in attribute, customAttributesChanged flag is changed regardless if changed attribute is a custom attribute or not, what forces to recreate all custom attribute models when calling getCustomAttribute again when it is not needed.

For further information, check this Gist: https://gist.github.com/adrian-martinez-interactiv4/17fec6072063d36eb20396f9c32e4c9a

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. None AFAIK, improvement

### Manual testing scenarios
1. Execute provided Gist

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
