### PR TITLE
Issues 13769. Fix wrong info about sent email in order sender.

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender.php
@@ -84,6 +84,8 @@ abstract class Sender
             $sender->sendCopyTo();
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
+
+            return false;
         }
 
         return true;


### PR DESCRIPTION
### Description
Fixes wrong info about sent email in Order Sender. Order sender when send method got exception then checkAndSend should return false.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13769: Order Email Sender

### Manual testing scenarios
1. If we want check issue we should have wrong config sendmail in server.
2. We should place order.
3. We had wrong configuration in sendmail, so email not sent.
4. In database in sales_order we should have email_send and send_email as false.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
