### PR TITLE
#5463 - Use specified hashing algo in \Magento\Framework\Encryption\Encryptor::getHash

### DIFF
--- a/lib/internal/Magento/Framework/Encryption/Encryptor.php
+++ b/lib/internal/Magento/Framework/Encryption/Encryptor.php
@@ -143,7 +143,7 @@ class Encryptor implements EncryptorInterface
     public function getHash($password, $salt = false, $version = self::HASH_VERSION_LATEST)
     {
         if ($salt === false) {
-            return $this->hash($password);
+            return $this->hash($password, $version);
         }
         if ($salt === true) {
             $salt = self::DEFAULT_SALT_LENGTH;
@@ -155,7 +155,7 @@ class Encryptor implements EncryptorInterface
         return implode(
             self::DELIMITER,
             [
-                $this->hash($salt . $password),
+                $this->hash($salt . $password, $version),
                 $salt,
                 $version
             ]

--- a/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
+++ b/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
@@ -207,4 +207,32 @@ class EncryptorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedEncryptedData, $actualEncryptedData);
         $this->assertEquals($crypt->decrypt($expectedEncryptedData), $actual->decrypt($actualEncryptedData));
     }
+
+    public function testUseSpecifiedHashingAlgoDataProvider()
+    {
+        return [
+            ['password', 'salt', Encryptor::HASH_VERSION_MD5,
+             '67a1e09bb1f83f5007dc119c14d663aa:salt:0'],
+            ['password', 'salt', Encryptor::HASH_VERSION_SHA256,
+             '13601bda4ea78e55a07b98866d2be6be0744e3866f13c00c811cab608a28f322:salt:1'],
+            ['password', false, Encryptor::HASH_VERSION_MD5,
+             '5f4dcc3b5aa765d61d8327deb882cf99'],
+            ['password', false, Encryptor::HASH_VERSION_SHA256,
+             '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8']
+        ];
+    }
+
+    /**
+     * @dataProvider testUseSpecifiedHashingAlgoDataProvider
+     *
+     * @param $password
+     * @param $salt
+     * @param $hashAlgo
+     * @param $expected
+     */
+    public function testGetHashMustUseSpecifiedHashingAlgo($password, $salt, $hashAlgo, $expected)
+    {
+        $hash = $this->_model->getHash($password, $salt, $hashAlgo);
+        $this->assertEquals($expected, $hash);
+    }
 }


### PR DESCRIPTION
### Description
\Magento\Framework\Encryption\Encryptor::getHash would previously ignore the specified hashing algorithm version that was supplied

### Fixed Issues (if relevant)
1. magento/magento2#5463: The ability to store passwords using different hashing algorithms is limited

### Manual testing scenarios
N/A, Magento currently has no support for specifying hashing algorithms by default.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
