### PR TITLE
[Improvement] Implement customer group form on ui component

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/BackButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/BackButton.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+/**
+ * Class BackButton
+ */
+class BackButton extends GenericButton implements ButtonProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getButtonData()
+    {
+        return [
+            'label' => __('Back'),
+            'on_click' => sprintf("location.href = '%s';", $this->getBackUrl()),
+            'class' => 'back',
+            'sort_order' => 10
+        ];
+    }
+
+    /**
+     * Get URL for back (reset) button
+     *
+     * @return string
+     */
+    public function getBackUrl()
+    {
+        return $this->getUrl('*/*/');
+    }
+}

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/DeleteButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/DeleteButton.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+/**
+ * Class DeleteButton
+ */
+class DeleteButton extends GenericButton implements ButtonProviderInterface
+{
+    /**
+     * @var \Magento\Customer\Api\GroupManagementInterface
+     */
+    protected $groupManagement;
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Backend\Block\Widget\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Customer\Api\GroupManagementInterface $groupManagement
+     */
+    public function __construct(
+        \Magento\Backend\Block\Widget\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Customer\Api\GroupManagementInterface $groupManagement
+    ) {
+        parent::__construct($context, $registry);
+        $this->groupManagement = $groupManagement;
+    }
+
+    /**
+     * @return array
+     */
+    public function getButtonData()
+    {
+        $groupId = $this->getGroupId();
+        $canModify = $groupId && !$this->groupManagement->isReadonly($this->getGroupId());
+        $data = [];
+        if ($canModify) {
+            $data = [
+                'label' => __('Delete Customer Group'),
+                'class' => 'delete',
+                'on_click' => 'deleteConfirm(\'' . __(
+                        'Are you sure you want to do this?'
+                    ) . '\', \'' . $this->getDeleteUrl() . '\')',
+                'sort_order' => 20,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDeleteUrl()
+    {
+        return $this->getUrl('*/*/delete', ['id' => $this->getGroupId()]);
+    }
+}

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/DeleteButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/DeleteButton.php
@@ -46,8 +46,8 @@ class DeleteButton extends GenericButton implements ButtonProviderInterface
                 'label' => __('Delete Customer Group'),
                 'class' => 'delete',
                 'on_click' => 'deleteConfirm(\'' . __(
-                        'Are you sure you want to do this?'
-                    ) . '\', \'' . $this->getDeleteUrl() . '\')',
+                    'Are you sure you want to do this?'
+                ) . '\', \'' . $this->getDeleteUrl() . '\')',
                 'sort_order' => 20,
             ];
         }

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/GenericButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/GenericButton.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Adminhtml\Group\Edit;
+
+use Magento\Customer\Controller\RegistryConstants;
+
+/**
+ * Class GenericButton
+ */
+class GenericButton
+{
+    /**
+     * Url Builder
+     *
+     * @var \Magento\Framework\UrlInterface
+     */
+    protected $urlBuilder;
+
+    /**
+     * Registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $registry;
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Backend\Block\Widget\Context $context
+     * @param \Magento\Framework\Registry $registry
+     */
+    public function __construct(
+        \Magento\Backend\Block\Widget\Context $context,
+        \Magento\Framework\Registry $registry
+    ) {
+        $this->urlBuilder = $context->getUrlBuilder();
+        $this->registry = $registry;
+    }
+
+    /**
+     * Return the group Id.
+     *
+     * @return int|null
+     */
+    public function getGroupId()
+    {
+        return $this->registry->registry(RegistryConstants::CURRENT_GROUP_ID);
+    }
+
+    /**
+     * Generate url by route and parameters
+     *
+     * @param   string $route
+     * @param   array $params
+     * @return  string
+     */
+    public function getUrl($route = '', $params = [])
+    {
+        return $this->urlBuilder->getUrl($route, $params);
+    }
+}

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/ResetButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/ResetButton.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+/**
+ * Class ResetButton
+ */
+class ResetButton extends GenericButton implements ButtonProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getButtonData()
+    {
+        return [
+            'label' => __('Reset'),
+            'class' => 'reset',
+            'on_click' => 'location.reload();',
+            'sort_order' => 30
+        ];
+    }
+}

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/SaveAndContinueButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/SaveAndContinueButton.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+/**
+ * Class SaveAndContinueButton
+ */
+class SaveAndContinueButton extends GenericButton implements ButtonProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getButtonData()
+    {
+        return [
+            'label' => __('Save and Continue Edit'),
+            'class' => 'save',
+            'data_attribute' => [
+                'mage-init' => [
+                    'button' => ['event' => 'saveAndContinueEdit'],
+                ],
+            ],
+            'sort_order' => 80,
+        ];
+    }
+}

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/SaveButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit/SaveButton.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+/**
+ * Class SaveButton
+ */
+class SaveButton extends GenericButton implements ButtonProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getButtonData()
+    {
+        return [
+            'label' => __('Save Customer Group'),
+            'class' => 'save primary',
+            'data_attribute' => [
+                'mage-init' => ['button' => ['event' => 'save']],
+                'form-role' => 'save',
+            ],
+            'sort_order' => 90,
+        ];
+    }
+}

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/NewAction.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/NewAction.php
@@ -49,9 +49,6 @@ class NewAction extends \Magento\Customer\Controller\Adminhtml\Group
             );
         }
 
-        $resultPage->getLayout()->addBlock(\Magento\Customer\Block\Adminhtml\Group\Edit::class, 'group', 'content')
-            ->setEditMode((bool)$groupId);
-
         return $resultPage;
     }
 }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
@@ -69,16 +69,17 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Group
      */
     public function execute()
     {
-        $taxClass = (int)$this->getRequest()->getParam('tax_class');
+        $taxClass = (int)$this->getRequest()->getParam('tax_class_id');
 
         /** @var \Magento\Customer\Api\Data\GroupInterface $customerGroup */
         $customerGroup = null;
         if ($taxClass) {
-            $id = $this->getRequest()->getParam('id');
+            $id = $this->getRequest()->getParam('customer_group_id');
+            /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             try {
-                $customerGroupCode = (string)$this->getRequest()->getParam('code');
-                if ($id !== null) {
+                $customerGroupCode = (string)$this->getRequest()->getParam('customer_group_code');
+                if ($id !== null && $id !== '') {
                     $customerGroup = $this->groupRepository->getById((int)$id);
                     $customerGroupCode = $customerGroupCode ?: $customerGroup->getCode();
                 } else {
@@ -87,10 +88,14 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Group
                 $customerGroup->setCode(!empty($customerGroupCode) ? $customerGroupCode : null);
                 $customerGroup->setTaxClassId($taxClass);
 
-                $this->groupRepository->save($customerGroup);
+                $customerGroup = $this->groupRepository->save($customerGroup);
 
                 $this->messageManager->addSuccess(__('You saved the customer group.'));
-                $resultRedirect->setPath('customer/group');
+                if ($this->getRequest()->getParam('back')) {
+                    $resultRedirect->setPath('customer/group/edit', ['id' => $customerGroup->getId()]);
+                } else {
+                    $resultRedirect->setPath('customer/group');
+                }
             } catch (\Exception $e) {
                 $this->messageManager->addError($e->getMessage());
                 if ($customerGroup != null) {

--- a/app/code/Magento/Customer/Model/Group/DataProvider.php
+++ b/app/code/Magento/Customer/Model/Group/DataProvider.php
@@ -43,11 +43,11 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
     protected $taxHelper;
 
     /**
-     * Constructor
+     * Initialize dependencies.
      *
-     * @param $name
-     * @param $primaryFieldName
-     * @param $requestFieldName
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
      * @param CollectionFactory $customerGroupCollectionFactory
      * @param Registry $registry
      * @param GroupRepositoryInterface $groupRepository
@@ -66,11 +66,11 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         array $meta = [],
         array $data = []
     ) {
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
         $this->collection = $customerGroupCollectionFactory->create();
         $this->registry = $registry;
         $this->groupRepository = $groupRepository;
         $this->taxHelper = $taxHelper;
-        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
     }
 
     /**

--- a/app/code/Magento/Customer/Model/Group/DataProvider.php
+++ b/app/code/Magento/Customer/Model/Group/DataProvider.php
@@ -48,7 +48,7 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
      * @param string $name
      * @param string $primaryFieldName
      * @param string $requestFieldName
-     * @param CollectionFactory $customerGroupCollectionFactory
+     * @param CollectionFactory $groupCollectionFactory
      * @param Registry $registry
      * @param GroupRepositoryInterface $groupRepository
      * @param TaxHelper $taxHelper
@@ -59,7 +59,7 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         $name,
         $primaryFieldName,
         $requestFieldName,
-        CollectionFactory $customerGroupCollectionFactory,
+        CollectionFactory $groupCollectionFactory,
         Registry $registry,
         GroupRepositoryInterface $groupRepository,
         TaxHelper $taxHelper,
@@ -67,7 +67,7 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         array $data = []
     ) {
         parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
-        $this->collection = $customerGroupCollectionFactory->create();
+        $this->collection = $groupCollectionFactory->create();
         $this->registry = $registry;
         $this->groupRepository = $groupRepository;
         $this->taxHelper = $taxHelper;
@@ -110,12 +110,13 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         if ($groupId === null) {
             $meta['general']['children']['tax_class_id']['arguments']['data']['config']['default'] =
                 $this->taxHelper->getDefaultCustomerTaxClass();
-        } else {
-            $customerGroup = $this->groupRepository->getById($groupId);
+            return $meta;
+        }
 
-            if ($customerGroup->getId() == GroupManagement::NOT_LOGGED_IN_ID) {
-                $meta['general']['children']['customer_group_code']['arguments']['data']['config']['disabled'] = true;
-            }
+        $customerGroup = $this->groupRepository->getById($groupId);
+
+        if ($customerGroup->getId() == GroupManagement::NOT_LOGGED_IN_ID) {
+            $meta['general']['children']['customer_group_code']['arguments']['data']['config']['disabled'] = true;
         }
 
         return $meta;

--- a/app/code/Magento/Customer/Model/Group/DataProvider.php
+++ b/app/code/Magento/Customer/Model/Group/DataProvider.php
@@ -98,12 +98,13 @@ class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
     public function getMeta()
     {
         $meta = parent::getMeta();
-        $meta['general']['children']['customer_group_code']['arguments']['data']['config']['notice'] = __(
-            'Maximum length must be less then %1 characters.',
-            GroupManagement::GROUP_CODE_MAX_LENGTH
-        );
-        $meta['general']['children']['customer_group_code']['arguments']['data']['config']['validation']['max_text_length'] =
-            GroupManagement::GROUP_CODE_MAX_LENGTH;
+
+        $meta['general']['children']['customer_group_code']['arguments']['data']['config'] = [
+            'notice' => __('Maximum length must be less then %1 characters.', GroupManagement::GROUP_CODE_MAX_LENGTH),
+            'validation' => [
+                'max_text_length' => GroupManagement::GROUP_CODE_MAX_LENGTH,
+            ]
+        ];
 
         $groupId = $this->registry->registry(RegistryConstants::CURRENT_GROUP_ID);
 

--- a/app/code/Magento/Customer/Model/Group/DataProvider.php
+++ b/app/code/Magento/Customer/Model/Group/DataProvider.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Model\Group;
+
+use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Customer\Model\GroupManagement;
+use Magento\Customer\Model\ResourceModel\Group\CollectionFactory;
+use Magento\Framework\Registry;
+use Magento\Customer\Controller\RegistryConstants;
+use Magento\Tax\Helper\Data as TaxHelper;
+
+/**
+ * Class DataProvider
+ */
+class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
+{
+    /**
+     * @var \Magento\Customer\Model\ResourceModel\Group\Collection
+     */
+    protected $collection;
+
+    /**
+     * @var array
+     */
+    protected $loadedData;
+
+    /**
+     * @var Registry
+     */
+    protected $registry;
+
+    /**
+     * @var GroupRepositoryInterface
+     */
+    protected $groupRepository;
+
+    /**
+     * @var TaxHelper
+     */
+    protected $taxHelper;
+
+    /**
+     * Constructor
+     *
+     * @param $name
+     * @param $primaryFieldName
+     * @param $requestFieldName
+     * @param CollectionFactory $customerGroupCollectionFactory
+     * @param Registry $registry
+     * @param GroupRepositoryInterface $groupRepository
+     * @param TaxHelper $taxHelper
+     * @param array $meta
+     * @param array $data
+     */
+    public function __construct(
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        CollectionFactory $customerGroupCollectionFactory,
+        Registry $registry,
+        GroupRepositoryInterface $groupRepository,
+        TaxHelper $taxHelper,
+        array $meta = [],
+        array $data = []
+    ) {
+        $this->collection = $customerGroupCollectionFactory->create();
+        $this->registry = $registry;
+        $this->groupRepository = $groupRepository;
+        $this->taxHelper = $taxHelper;
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+    }
+
+    /**
+     * Get data
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        if (isset($this->loadedData)) {
+            return $this->loadedData;
+        }
+        $items = $this->collection->getItems();
+        /** @var \Magento\Customer\Model\Group $customerGroup */
+        foreach ($items as $customerGroup) {
+            $this->loadedData[$customerGroup->getId()] = $customerGroup->getData();
+        }
+
+        return $this->loadedData;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMeta()
+    {
+        $meta = parent::getMeta();
+        $meta['general']['children']['customer_group_code']['arguments']['data']['config']['notice'] = __(
+            'Maximum length must be less then %1 characters.',
+            GroupManagement::GROUP_CODE_MAX_LENGTH
+        );
+        $meta['general']['children']['customer_group_code']['arguments']['data']['config']['validation']['max_text_length'] =
+            GroupManagement::GROUP_CODE_MAX_LENGTH;
+
+        $groupId = $this->registry->registry(RegistryConstants::CURRENT_GROUP_ID);
+
+        if ($groupId === null) {
+            $meta['general']['children']['tax_class_id']['arguments']['data']['config']['default'] =
+                $this->taxHelper->getDefaultCustomerTaxClass();
+        } else {
+            $customerGroup = $this->groupRepository->getById($groupId);
+
+            if ($customerGroup->getId() == GroupManagement::NOT_LOGGED_IN_ID) {
+                $meta['general']['children']['customer_group_code']['arguments']['data']['config']['disabled'] = true;
+            }
+        }
+
+        return $meta;
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/DeleteButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/DeleteButtonTest.php
@@ -85,8 +85,8 @@ class DeleteButtonTest extends \PHPUnit\Framework\TestCase
             'label' => __('Delete Customer Group'),
             'class' => 'delete',
             'on_click' => 'deleteConfirm(\'' . __(
-                    'Are you sure you want to do this?'
-                ) . '\', \'' . $deleteUrl . '\')',
+                'Are you sure you want to do this?'
+            ) . '\', \'' . $deleteUrl . '\')',
             'sort_order' => 20,
         ];
 

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/DeleteButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/DeleteButtonTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Customer\Controller\RegistryConstants;
+
+/**
+ * Class DeleteButtonTest
+ *
+ * Test for class \Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DeleteButtonTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton
+     */
+    protected $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlBuilderMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $registryMock;
+
+    /**
+     * @var \Magento\Customer\Api\GroupManagementInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $groupManagement;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->registryMock = $this->createMock(\Magento\Framework\Registry::class);
+        $this->groupManagement = $this->createMock(\Magento\Customer\Api\GroupManagementInterface::class);
+        $contextMock = $this->createMock(\Magento\Backend\Block\Widget\Context::class);
+
+        $contextMock->expects($this->once())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
+
+        $this->model = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton::class,
+            [
+                'context' => $contextMock,
+                'registry' => $this->registryMock,
+                'groupManagement' => $this->groupManagement
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton::getButtonData
+     */
+    public function testGetButtonData()
+    {
+        $groupId = 22;
+        $deleteUrl = 'http://example.com/customer/group/' . $groupId;
+        $this->registryMock->expects($this->any())
+            ->method('registry')
+            ->with(RegistryConstants::CURRENT_GROUP_ID)
+            ->willReturn($groupId);
+        $this->urlBuilderMock->expects($this->once())
+            ->method('getUrl')
+            ->with('*/*/delete', ['id' => $groupId])
+            ->willReturn($deleteUrl);
+
+        $this->groupManagement->expects($this->once())
+            ->method('isReadonly')
+            ->with($groupId)
+            ->willReturn(false);
+
+        $data = [
+            'label' => __('Delete Customer Group'),
+            'class' => 'delete',
+            'on_click' => 'deleteConfirm(\'' . __(
+                    'Are you sure you want to do this?'
+                ) . '\', \'' . $deleteUrl . '\')',
+            'sort_order' => 20,
+        ];
+
+        $this->assertEquals($data, $this->model->getButtonData());
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton::getButtonData
+     */
+    public function testGetButtonDataWithoutGroup()
+    {
+        $this->assertEquals([], $this->model->getButtonData());
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton::getButtonData
+     */
+    public function testGetButtonDataWithReadonlyGroup()
+    {
+        $groupId = 22;
+        $this->registryMock->expects($this->any())
+            ->method('registry')
+            ->with(RegistryConstants::CURRENT_GROUP_ID)
+            ->willReturn($groupId);
+
+        $this->groupManagement->expects($this->once())
+            ->method('isReadonly')
+            ->with($groupId)
+            ->willReturn(true);
+
+        $this->assertEquals([], $this->model->getButtonData());
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/GenericButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/GenericButtonTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Customer\Controller\RegistryConstants;
+
+/**
+ * Class GenericButtonTest
+ *
+ * Test for class \Magento\Customer\Block\Adminhtml\Group\Edit\GenericButton
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class GenericButtonTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Block\Adminhtml\Group\Edit\GenericButton
+     */
+    protected $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlBuilderMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $registryMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->registryMock = $this->createMock(\Magento\Framework\Registry::class);
+        $contextMock = $this->createMock(\Magento\Backend\Block\Widget\Context::class);
+
+        $contextMock->expects($this->once())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
+
+        $this->model = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Block\Adminhtml\Group\Edit\GenericButton::class,
+            [
+                'context' => $contextMock,
+                'registry' => $this->registryMock
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\GenericButton::getUrl
+     */
+    public function testGetUrl()
+    {
+        $url = "http://example.com/customer/group/";
+        $route = 'button';
+        $params = ['unit' => 'test'];
+
+        $this->urlBuilderMock->expects($this->once())
+            ->method('getUrl')
+            ->with($route, $params)
+            ->willReturn($url);
+
+        $this->assertEquals($url, $this->model->getUrl($route, $params));
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\GenericButton::getGroupId
+     */
+    public function testGetGroupId()
+    {
+        $groupId = 22;
+        $this->registryMock->expects($this->once())
+            ->method('registry')
+            ->with(RegistryConstants::CURRENT_GROUP_ID)
+            ->willReturn($groupId);
+
+        $this->assertEquals($groupId, $this->model->getGroupId());
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\GenericButton::getGroupId
+     */
+    public function testGetGroupIdWithoutGroup()
+    {
+        $this->assertNull($this->model->getGroupId());
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/ResetButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/ResetButtonTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Customer\Controller\RegistryConstants;
+
+/**
+ * Class ResetButtonTest
+ *
+ * Test for class \Magento\Customer\Block\Adminhtml\Group\Edit\ResetButton
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ResetButtonTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Block\Adminhtml\Group\Edit\ResetButton
+     */
+    protected $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlBuilderMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $registryMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->registryMock = $this->createMock(\Magento\Framework\Registry::class);
+        $contextMock = $this->createMock(\Magento\Backend\Block\Widget\Context::class);
+
+        $contextMock->expects($this->once())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
+
+        $this->model = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Block\Adminhtml\Group\Edit\ResetButton::class,
+            [
+                'context' => $contextMock,
+                'registry' => $this->registryMock
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\ResetButton::getButtonData
+     */
+    public function testGetButtonData()
+    {
+        $data = [
+            'label' => __('Reset'),
+            'class' => 'reset',
+            'on_click' => 'location.reload();',
+            'sort_order' => 30,
+        ];
+
+        $this->assertEquals($data, $this->model->getButtonData());
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/SaveAndContinueButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/SaveAndContinueButtonTest.php
@@ -59,15 +59,15 @@ class SaveAndContinueButtonTest extends \PHPUnit\Framework\TestCase
     public function testGetButtonData()
     {
         $data = [
-        'label' => __('Save and Continue Edit'),
-        'class' => 'save',
-        'data_attribute' => [
-            'mage-init' => [
-                'button' => ['event' => 'saveAndContinueEdit'],
+            'label' => __('Save and Continue Edit'),
+            'class' => 'save',
+            'data_attribute' => [
+                'mage-init' => [
+                    'button' => ['event' => 'saveAndContinueEdit'],
+                ],
             ],
-        ],
-        'sort_order' => 80,
-    ];
+            'sort_order' => 80,
+        ];
 
         $this->assertEquals($data, $this->model->getButtonData());
     }

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/SaveAndContinueButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/SaveAndContinueButtonTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Customer\Controller\RegistryConstants;
+
+/**
+ * Class SaveAndContinueButtonTest
+ *
+ * Test for class \Magento\Customer\Block\Adminhtml\Group\Edit\SaveAndContinueButton
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class SaveAndContinueButtonTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Block\Adminhtml\Group\Edit\SaveAndContinueButton
+     */
+    protected $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlBuilderMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $registryMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->registryMock = $this->createMock(\Magento\Framework\Registry::class);
+        $contextMock = $this->createMock(\Magento\Backend\Block\Widget\Context::class);
+
+        $contextMock->expects($this->once())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
+
+        $this->model = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Block\Adminhtml\Group\Edit\SaveAndContinueButton::class,
+            [
+                'context' => $contextMock,
+                'registry' => $this->registryMock
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\SaveAndContinueButton::getButtonData
+     */
+    public function testGetButtonData()
+    {
+        $data = [
+        'label' => __('Save and Continue Edit'),
+        'class' => 'save',
+        'data_attribute' => [
+            'mage-init' => [
+                'button' => ['event' => 'saveAndContinueEdit'],
+            ],
+        ],
+        'sort_order' => 80,
+    ];
+
+        $this->assertEquals($data, $this->model->getButtonData());
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/SaveButtonTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Adminhtml/Group/Edit/SaveButtonTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Block\Adminhtml\Group\Edit;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Customer\Controller\RegistryConstants;
+
+/**
+ * Class SaveButtonTest
+ *
+ * Test for class \Magento\Customer\Block\Adminhtml\Group\Edit\SaveButton
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class SaveButtonTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Block\Adminhtml\Group\Edit\SaveButton
+     */
+    protected $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlBuilderMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $registryMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->registryMock = $this->createMock(\Magento\Framework\Registry::class);
+        $contextMock = $this->createMock(\Magento\Backend\Block\Widget\Context::class);
+
+        $contextMock->expects($this->once())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
+
+        $this->model = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Block\Adminhtml\Group\Edit\SaveButton::class,
+            [
+                'context' => $contextMock,
+                'registry' => $this->registryMock
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Block\Adminhtml\Group\Edit\SaveButton::getButtonData
+     */
+    public function testGetButtonData()
+    {
+        $data = [
+            'label' => __('Save Customer Group'),
+            'class' => 'save primary',
+            'data_attribute' => [
+                'mage-init' => ['button' => ['event' => 'save']],
+                'form-role' => 'save',
+            ],
+            'sort_order' => 90,
+        ];
+
+        $this->assertEquals($data, $this->model->getButtonData());
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Group/SaveTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Group/SaveTest.php
@@ -139,12 +139,13 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $groupId = 0;
         $code = 'NOT LOGGED IN';
 
-        $this->request->expects($this->exactly(3))
+        $this->request->expects($this->exactly(4))
             ->method('getParam')
             ->withConsecutive(
-                ['tax_class'],
-                ['id'],
-                ['code']
+                ['tax_class_id'],
+                ['customer_group_id'],
+                ['customer_group_code'],
+                ['back']
             )
             ->willReturnOnConsecutiveCalls($taxClass, $groupId, null);
         $this->resultRedirectFactory->expects($this->once())
@@ -165,7 +166,8 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with($taxClass);
         $this->groupRepositoryMock->expects($this->once())
             ->method('save')
-            ->with($this->group);
+            ->with($this->group)
+            ->willReturn($this->group);
         $this->messageManager->expects($this->once())
             ->method('addSuccess')
             ->with(__('You saved the customer group.'));
@@ -194,7 +196,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     {
         $this->request->expects($this->once())
             ->method('getParam')
-            ->with('tax_class')
+            ->with('tax_class_id')
             ->willReturn(null);
         $this->forwardFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Customer/Test/Unit/Model/Group/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Group/DataProviderTest.php
@@ -13,6 +13,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
  * Test for class \Magento\Customer\Model\Group\DataProvider
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.LongVariable)
  */
 class DataProviderTest extends \PHPUnit\Framework\TestCase
 {
@@ -89,7 +90,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
                 'name' => 'test-name',
                 'primaryFieldName' => 'primary-field-name',
                 'requestFieldName' => 'request-field-name',
-                'customerGroupCollectionFactory' => $this->collectionFactoryMock,
+                'groupCollectionFactory' => $this->collectionFactoryMock,
                 'registry' => $this->registryMock,
                 'groupRepository' => $this->groupRepositoryMock,
                 'taxHelper' => $this->taxHelperMock,
@@ -114,7 +115,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
                 'name' => 'test-name',
                 'primaryFieldName' => 'primary-field-name',
                 'requestFieldName' => 'request-field-name',
-                'customerGroupCollectionFactory' => $this->collectionFactoryMock,
+                'groupCollectionFactory' => $this->collectionFactoryMock,
                 'registry' => $this->registryMock,
                 'groupRepository' => $this->groupRepositoryMock,
                 'taxHelper' => $this->taxHelperMock,

--- a/app/code/Magento/Customer/Test/Unit/Model/Group/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Group/DataProviderTest.php
@@ -138,6 +138,8 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
         $meta = $dataProvider->getMeta();
         $this->assertNotEmpty($meta);
-        $this->assertTrue($meta['general']['children']['customer_group_code']['arguments']['data']['config']['disabled']);
+        $this->assertTrue(
+            $meta['general']['children']['customer_group_code']['arguments']['data']['config']['disabled']
+        );
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/Group/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Group/DataProviderTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Model\Group;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * Class DataProviderTest
+ *
+ * Test for class \Magento\Customer\Model\Group\DataProvider
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DataProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Model\ResourceModel\Group\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $collectionFactoryMock;
+
+    /**
+     * @var \Magento\Framework\Registry|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $registryMock;
+
+    /**
+     * @var \Magento\Customer\Api\GroupRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $groupRepositoryMock;
+
+    /**
+     * @var \Magento\Tax\Helper\Data|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $taxHelperMock;
+
+    /**
+     * @var \Magento\Customer\Model\ResourceModel\Group\Collection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $collectionMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->collectionFactoryMock = $this->createPartialMock(
+            \Magento\Customer\Model\ResourceModel\Group\CollectionFactory::class,
+            ['create']
+        );
+
+        $this->collectionMock = $this->createMock(\Magento\Customer\Model\ResourceModel\Group\Collection::class);
+        $this->collectionFactoryMock->expects($this->once())->method('create')->willReturn($this->collectionMock);
+        $this->registryMock = $this->createMock(\Magento\Framework\Registry::class);
+        $this->groupRepositoryMock = $this->getMockBuilder(\Magento\Customer\Api\GroupRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->taxHelperMock = $this->getMockBuilder(\Magento\Tax\Helper\Data::class)
+            ->setMethods(['getDefaultCustomerTaxClass'])
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Model\Group\DataProvider::getData
+     */
+    public function testGetData()
+    {
+        $groupId = 22;
+        $groupData = ['customer_group_code' => 'Customer Group Code', 'tax_class_id' => 1];
+
+        $groupMock = $this->createPartialMock(\Magento\Customer\Model\Group::class, [
+            'load',
+            'getId',
+            'getData'
+        ]);
+        $this->collectionMock->expects($this->once())->method('getItems')->willReturn([$groupMock]);
+
+        $groupMock->expects($this->atLeastOnce())->method('getId')->willReturn($groupId);
+        $groupMock->expects($this->once())->method('getData')->willReturn($groupData);
+
+        /** @var \Magento\Customer\Model\Group\DataProvider $dataProvider */
+        $dataProvider = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Model\Group\DataProvider::class,
+            [
+                'name' => 'test-name',
+                'primaryFieldName' => 'primary-field-name',
+                'requestFieldName' => 'request-field-name',
+                'customerGroupCollectionFactory' => $this->collectionFactoryMock,
+                'registry' => $this->registryMock,
+                'groupRepository' => $this->groupRepositoryMock,
+                'taxHelper' => $this->taxHelperMock,
+            ]
+        );
+
+        $this->assertEquals([$groupId => $groupData], $dataProvider->getData());
+        // Load from object-cache the second time
+        $this->assertEquals([$groupId => $groupData], $dataProvider->getData());
+    }
+
+    /**
+     * @return void
+     * @covers \Magento\Customer\Model\Group\DataProvider::getMeta
+     */
+    public function testGetMetaForNotLoggedInGroup()
+    {
+        /** @var \Magento\Customer\Model\Group\DataProvider $dataProvider */
+        $dataProvider = (new ObjectManager($this))->getObject(
+            \Magento\Customer\Model\Group\DataProvider::class,
+            [
+                'name' => 'test-name',
+                'primaryFieldName' => 'primary-field-name',
+                'requestFieldName' => 'request-field-name',
+                'customerGroupCollectionFactory' => $this->collectionFactoryMock,
+                'registry' => $this->registryMock,
+                'groupRepository' => $this->groupRepositoryMock,
+                'taxHelper' => $this->taxHelperMock,
+            ]
+        );
+
+        $this->registryMock->expects($this->any())
+            ->method('registry')
+            ->willReturn('0');
+
+        $customerGroupMock = $this->getMockBuilder(\Magento\Customer\Api\Data\GroupInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $customerGroupMock->expects($this->any())
+            ->method('getId')
+            ->willReturn(\Magento\Customer\Model\GroupManagement::NOT_LOGGED_IN_ID);
+        $customerGroupMock->expects($this->any())->method('getCode')->willReturn('NOT LOGGED IN');
+
+        $this->groupRepositoryMock->expects($this->any())->method('getById')->willReturn($customerGroupMock);
+
+        $meta = $dataProvider->getMeta();
+        $this->assertNotEmpty($meta);
+        $this->assertTrue($meta['general']['children']['customer_group_code']['arguments']['data']['config']['disabled']);
+    }
+}

--- a/app/code/Magento/Customer/view/adminhtml/layout/customer_group_edit.xml
+++ b/app/code/Magento/Customer/view/adminhtml/layout/customer_group_edit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="customer_group_new"/>
+    <body/>
+</page>

--- a/app/code/Magento/Customer/view/adminhtml/layout/customer_group_new.xml
+++ b/app/code/Magento/Customer/view/adminhtml/layout/customer_group_new.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="styles"/>
+    <update handle="editor"/>
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="customer_group_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Magento/Customer/view/adminhtml/ui_component/customer_group_form.xml
+++ b/app/code/Magento/Customer/view/adminhtml/ui_component/customer_group_form.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">customer_group_form.customer_group_form_data_source</item>
+        </item>
+        <item name="template" xsi:type="string">templates/form/collapsible</item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="save_and_continue" class="Magento\Customer\Block\Adminhtml\Group\Edit\SaveAndContinueButton"/>
+            <button name="save" class="Magento\Customer\Block\Adminhtml\Group\Edit\SaveButton"/>
+            <button name="reset" class="Magento\Customer\Block\Adminhtml\Group\Edit\ResetButton"/>
+            <button name="delete" class="Magento\Customer\Block\Adminhtml\Group\Edit\DeleteButton"/>
+            <button name="back" class="Magento\Customer\Block\Adminhtml\Group\Edit\BackButton"/>
+        </buttons>
+        <namespace>customer_group_form</namespace>
+        <dataScope>data</dataScope>
+        <deps>
+            <dep>customer_group_form.customer_group_form_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="customer_group_form_data_source">
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+        <settings>
+            <submitUrl path="customer/group/save"/>
+        </settings>
+        <dataProvider class="Magento\Customer\Model\Group\DataProvider" name="customer_group_form_data_source">
+            <settings>
+                <requestFieldName>id</requestFieldName>
+                <primaryFieldName>customer_group_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <fieldset name="general">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="label" xsi:type="string" translate="true">Group Information</item>
+                <item name="collapsible" xsi:type="boolean">false</item>
+                <item name="sortOrder" xsi:type="number">10</item>
+                <item name="opened" xsi:type="boolean">true</item>
+            </item>
+        </argument>
+        <field name="customer_group_id" sortOrder="10" formElement="input">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">customer_group</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>text</dataType>
+                <visible>false</visible>
+                <dataScope>customer_group_id</dataScope>
+            </settings>
+        </field>
+        <field name="customer_group_code" sortOrder="20" formElement="input">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">customer_group</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+                <dataType>text</dataType>
+                <label translate="true">Group Name</label>
+                <dataScope>customer_group_code</dataScope>
+            </settings>
+        </field>
+        <field name="tax_class_id" sortOrder="30" formElement="select">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">customer_group</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+                <dataType>number</dataType>
+                <label translate="true">Tax Class</label>
+                <dataScope>tax_class_id</dataScope>
+            </settings>
+            <formElements>
+                <select>
+                    <settings>
+                        <options class="Magento\Tax\Model\TaxClass\Source\Customer"/>
+                    </settings>
+                </select>
+            </formElements>
+        </field>
+    </fieldset>
+</form>


### PR DESCRIPTION
### Description
Several versions ago backend form widgets (`\Magento\Backend\Block\Widget\Form`) were marked as 
deprecated in favour of UI component implementation. This PR refactors customer group form to use UI components. Also was added "Save and Continue Edit" button.
At least it will save time of third party developers who needs to extend customer groups form :)

Customer group grid was implemented in scope of #13501

### Manual testing scenarios
Before changes:
![image](https://image.prntscr.com/image/oBMGNBSnSHmUdZXNKH3ayw.png)

After changes:
![image](https://image.prntscr.com/image/QJ2aAibvRU2WVp8vJJmt-w.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
