### PR TITLE
Add a link to the cart to the success message when adding a product

### DIFF
--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -118,12 +118,7 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
             return $returnUrl;
         }
 
-        $shouldRedirectToCart = $this->_scopeConfig->getValue(
-            'checkout/cart/redirect_to_cart',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        );
-
-        if ($shouldRedirectToCart || $this->getRequest()->getParam('in_cart')) {
+        if ($this->shouldRedirectToCart() || $this->getRequest()->getParam('in_cart')) {
             if ($this->getRequest()->getActionName() == 'add' && !$this->getRequest()->getParam('in_cart')) {
                 $this->_checkoutSession->setContinueShoppingUrl($this->_redirect->getRefererUrl());
             }
@@ -131,5 +126,16 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
         }
 
         return $defaultUrl;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldRedirectToCart()
+    {
+        return $this->_scopeConfig->isSetFlag(
+            'checkout/cart/redirect_to_cart',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -131,7 +131,7 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
     /**
      * @return bool
      */
-    protected function shouldRedirectToCart()
+    private function shouldRedirectToCart()
     {
         return $this->_scopeConfig->isSetFlag(
             'checkout/cart/redirect_to_cart',

--- a/app/code/Magento/Checkout/Controller/Cart/Add.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Add.php
@@ -122,11 +122,14 @@ class Add extends \Magento\Checkout\Controller\Cart
 
             if (!$this->_checkoutSession->getNoCartRedirect(true)) {
                 if (!$this->cart->getQuote()->getHasError()) {
-                    $message = __(
-                        'You added %1 to your shopping cart.',
-                        $product->getName()
+                    $this->messageManager->addComplexSuccessMessage(
+                        'addCartSuccessMessage',
+                        [
+                            'product_name' => $product->getName(),
+                            'cart_url' => $this->getCartUrl(),
+                        ]
                     );
-                    $this->messageManager->addSuccessMessage($message);
+
                 }
                 return $this->goBack(null, $product);
             }
@@ -147,8 +150,7 @@ class Add extends \Magento\Checkout\Controller\Cart
             $url = $this->_checkoutSession->getRedirectUrl(true);
 
             if (!$url) {
-                $cartUrl = $this->_objectManager->get(\Magento\Checkout\Helper\Cart::class)->getCartUrl();
-                $url = $this->_redirect->getRedirectUrl($cartUrl);
+                $url = $this->_redirect->getRedirectUrl($this->getCartUrl());
             }
 
             return $this->goBack($url);
@@ -187,5 +189,13 @@ class Add extends \Magento\Checkout\Controller\Cart
         $this->getResponse()->representJson(
             $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($result)
         );
+    }
+
+    /**
+     * @return string
+     */
+    private function getCartUrl()
+    {
+        return $this->_url->getUrl('checkout/cart', ['_secure' => true]);
     }
 }

--- a/app/code/Magento/Checkout/Controller/Cart/Add.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Add.php
@@ -122,13 +122,21 @@ class Add extends \Magento\Checkout\Controller\Cart
 
             if (!$this->_checkoutSession->getNoCartRedirect(true)) {
                 if (!$this->cart->getQuote()->getHasError()) {
-                    $this->messageManager->addComplexSuccessMessage(
-                        'addCartSuccessMessage',
-                        [
-                            'product_name' => $product->getName(),
-                            'cart_url' => $this->getCartUrl(),
-                        ]
-                    );
+                    if ($this->shouldRedirectToCart()) {
+                        $message = __(
+                            'You added %1 to your shopping cart.',
+                            $product->getName()
+                        );
+                        $this->messageManager->addSuccessMessage($message);
+                    } else {
+                        $this->messageManager->addComplexSuccessMessage(
+                            'addCartSuccessMessage',
+                            [
+                                'product_name' => $product->getName(),
+                                'cart_url' => $this->getCartUrl(),
+                            ]
+                        );
+                    }
                 }
                 return $this->goBack(null, $product);
             }

--- a/app/code/Magento/Checkout/Controller/Cart/Add.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Add.php
@@ -205,4 +205,15 @@ class Add extends \Magento\Checkout\Controller\Cart
     {
         return $this->_url->getUrl('checkout/cart', ['_secure' => true]);
     }
+
+    /**
+     * @return bool
+     */
+    private function shouldRedirectToCart()
+    {
+        return $this->_scopeConfig->isSetFlag(
+            'checkout/cart/redirect_to_cart',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
 }

--- a/app/code/Magento/Checkout/Controller/Cart/Add.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Add.php
@@ -129,7 +129,6 @@ class Add extends \Magento\Checkout\Controller\Cart
                             'cart_url' => $this->getCartUrl(),
                         ]
                     );
-
                 }
                 return $this->goBack(null, $product);
             }

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -83,4 +83,16 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\View\Element\Message\MessageConfigurationsPool">
+        <arguments>
+            <argument name="configurationsMap" xsi:type="array">
+                <item name="addCartSuccessMessage" xsi:type="array">
+                    <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\BlockRenderer::CODE</item>
+                    <item name="data" xsi:type="array">
+                        <item name="template" xsi:type="string">Magento_Checkout::messages/addCartSuccessMessage.phtml</item>
+                    </item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Checkout/view/frontend/templates/messages/addCartSuccessMessage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/messages/addCartSuccessMessage.phtml
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+// @codingStandardsIgnoreFile
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+
+<?= $block->escapeHtml(__(
+    'You added %1 to your <a href="%2">shopping cart</a>.',
+    $block->getData('product_name'),
+    $block->getData('cart_url')
+), ['a']);

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
@@ -322,7 +322,10 @@ class CartTest extends \Magento\TestFramework\TestCase\AbstractController
 
         $this->dispatch('checkout/cart/add');
 
-        $this->assertEquals('{"backUrl":"http:\/\/localhost\/index.php\/checkout\/cart\/"}', $this->getResponse()->getBody());
+        $this->assertEquals(
+            '{"backUrl":"http:\/\/localhost\/index.php\/checkout\/cart\/"}',
+            $this->getResponse()->getBody()
+        );
 
         $this->assertSessionMessages(
             $this->contains(
@@ -359,7 +362,8 @@ class CartTest extends \Magento\TestFramework\TestCase\AbstractController
 
         $this->assertSessionMessages(
             $this->contains(
-                "\n" . 'You added Simple Product to your <a href="http://localhost/index.php/checkout/cart/">shopping cart</a>.'
+                "\n" . 'You added Simple Product to your ' .
+                '<a href="http://localhost/index.php/checkout/cart/">shopping cart</a>.'
             ),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
@@ -301,6 +301,71 @@ class CartTest extends \Magento\TestFramework\TestCase\AbstractController
     }
 
     /**
+     * Test for \Magento\Checkout\Controller\Cart\Add::execute() with simple product and activated redirect to cart
+     *
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     * @magentoConfigFixture current_store checkout/cart/redirect_to_cart 1
+     * @magentoAppIsolation enabled
+     */
+    public function testMessageAtAddToCartWithRedirect()
+    {
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $postData = [
+            'qty' => '1',
+            'product' => '1',
+            'custom_price' => 1,
+            'form_key' => $formKey->getFormKey(),
+            'isAjax' => 1
+        ];
+        \Magento\TestFramework\Helper\Bootstrap::getInstance()->loadArea('frontend');
+        $this->getRequest()->setPostValue($postData);
+
+        $this->dispatch('checkout/cart/add');
+
+        $this->assertEquals('{"backUrl":"http:\/\/localhost\/index.php\/checkout\/cart\/"}', $this->getResponse()->getBody());
+
+        $this->assertSessionMessages(
+            $this->contains(
+                'You added Simple Product to your shopping cart.'
+            ),
+            \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
+        );
+    }
+
+    /**
+     * Test for \Magento\Checkout\Controller\Cart\Add::execute() with simple product and deactivated redirect to cart
+     *
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     * @magentoConfigFixture current_store checkout/cart/redirect_to_cart 0
+     * @magentoAppIsolation enabled
+     */
+    public function testMessageAtAddToCartWithoutRedirect()
+    {
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $postData = [
+            'qty' => '1',
+            'product' => '1',
+            'custom_price' => 1,
+            'form_key' => $formKey->getFormKey(),
+            'isAjax' => 1
+        ];
+        \Magento\TestFramework\Helper\Bootstrap::getInstance()->loadArea('frontend');
+        $this->getRequest()->setPostValue($postData);
+
+        $this->dispatch('checkout/cart/add');
+
+        $this->assertFalse($this->getResponse()->isRedirect());
+        $this->assertEquals('[]', $this->getResponse()->getBody());
+
+        $this->assertSessionMessages(
+            $this->contains(
+                "\n" . 'You added Simple Product to your <a href="http://localhost/index.php/checkout/cart/">shopping cart</a>.'
+            ),
+            \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
+        );
+    }
+
+    /**
      * @covers \Magento\Checkout\Controller\Cart\Addgroup::execute()
      *
      * Test customer can add items to cart only if they belong to him.


### PR DESCRIPTION
### Description
If I add a product to the shopping cart, I want to go to the cart directly after that in many cases without having to search for a link. Thus, the link has been added to the success message now.

### Manual testing scenarios
1. Go to a product view page
2. Click "Add to Cart"
3. Check if the success message contains a link to the compare list:
![grafik](https://user-images.githubusercontent.com/662059/36836592-1c94e398-1d3a-11e8-9ab6-210948937aae.png)

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
