### PR TITLE
#13899 Solve Canada Zip Code pattern 

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -81,6 +81,7 @@
     <zip countryCode="CA">
         <codes>
             <code id="pattern_1" active="true" example="A1B 2C3">^[a-zA-z]{1}[0-9]{1}[a-zA-z]{1}\s[0-9]{1}[a-zA-z]{1}[0-9]{1}$</code>
+            <code id="pattern_2" active="true" example="A1B2C3">^[a-zA-z]{1}[0-9]{1}[a-zA-z]{1}[0-9]{1}[a-zA-z]{1}[0-9]{1}$</code>
         </codes>
     </zip>
     <zip countryCode="IC">

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -42,6 +42,24 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $this->validator->validate('12345', 'INVALID-CODE');
     }
 
+    public function testInvalidCanadaZipCode() {
+        $resultOnlyDigits               = $this->validator->validate('12345', 'CA');
+        $resultMoreCharactersThanNeeded = $this->validator->validate('A1B2C3D', 'CA');
+        $resultLessCharactersThanNeeded = $this->validator->validate('A1B2C', 'CA');
+        $resultMoreThanOneSpace         = $this->validator->validate('A1B  2C3', 'CA');
+        $this->assertFalse($resultOnlyDigits);
+        $this->assertFalse($resultMoreCharactersThanNeeded);
+        $this->assertFalse($resultLessCharactersThanNeeded);
+        $this->assertFalse($resultMoreThanOneSpace);
+    }
+
+    public function testValidCanadaZipCode() {
+        $resultPattern1 = $this->validator->validate('A1B2C3', 'CA');
+        $resultPattern2 = $this->validator->validate('A1B 2C3', 'CA');
+        $this->assertTrue($resultPattern1);
+        $this->assertTrue($resultPattern2);
+    }
+
     /**
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -42,22 +42,33 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $this->validator->validate('12345', 'INVALID-CODE');
     }
 
-    public function testInvalidCanadaZipCode() {
-        $resultOnlyDigits               = $this->validator->validate('12345', 'CA');
-        $resultMoreCharactersThanNeeded = $this->validator->validate('A1B2C3D', 'CA');
-        $resultLessCharactersThanNeeded = $this->validator->validate('A1B2C', 'CA');
-        $resultMoreThanOneSpace         = $this->validator->validate('A1B  2C3', 'CA');
-        $this->assertFalse($resultOnlyDigits);
-        $this->assertFalse($resultMoreCharactersThanNeeded);
-        $this->assertFalse($resultLessCharactersThanNeeded);
-        $this->assertFalse($resultMoreThanOneSpace);
+    /**
+     * @dataProvider getCanadaInvalidPostCodes
+     */
+    public function testInvalidCanadaZipCode($countryId, $invalidPostCode) {
+        $this->assertFalse($this->validator->validate($invalidPostCode, $countryId));
     }
 
+    /**
+     *
+     */
     public function testValidCanadaZipCode() {
         $resultPattern1 = $this->validator->validate('A1B2C3', 'CA');
         $resultPattern2 = $this->validator->validate('A1B 2C3', 'CA');
         $this->assertTrue($resultPattern1);
         $this->assertTrue($resultPattern2);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCanadaInvalidPostCodes() {
+        return [
+            ['countryId' => 'CA', 'postcode' => '12345'],
+            ['countryId' => 'CA', 'postcode' => 'A1B2C3D'],
+            ['countryId' => 'CA', 'postcode' => 'A1B2C'],
+            ['countryId' => 'CA', 'postcode' => 'A1B  2C3'],
+        ];
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -50,13 +50,10 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     *
+     * @dataProvider getCanadaValidPostCodes
      */
-    public function testValidCanadaZipCode() {
-        $resultPattern1 = $this->validator->validate('A1B2C3', 'CA');
-        $resultPattern2 = $this->validator->validate('A1B 2C3', 'CA');
-        $this->assertTrue($resultPattern1);
-        $this->assertTrue($resultPattern2);
+    public function testValidCanadaZipCode($countryId, $validPostCode) {
+        $this->assertTrue($this->validator->validate($validPostCode, $countryId));
     }
 
     /**
@@ -68,6 +65,18 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             ['countryId' => 'CA', 'postcode' => 'A1B2C3D'],
             ['countryId' => 'CA', 'postcode' => 'A1B2C'],
             ['countryId' => 'CA', 'postcode' => 'A1B  2C3'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getCanadaValidPostCodes() {
+        return [
+            ['countryId' => 'CA', 'postcode' => 'A1B2C3'],
+            ['countryId' => 'CA', 'postcode' => 'A1B 2C3'],
+            ['countryId' => 'CA', 'postcode' => 'Z9Y 8X7'],
+            ['countryId' => 'CA', 'postcode' => 'Z9Y8X7'],
         ];
     }
 

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -45,21 +45,24 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getCanadaInvalidPostCodes
      */
-    public function testInvalidCanadaZipCode($countryId, $invalidPostCode) {
+    public function testInvalidCanadaZipCode($countryId, $invalidPostCode)
+    {
         $this->assertFalse($this->validator->validate($invalidPostCode, $countryId));
     }
 
     /**
      * @dataProvider getCanadaValidPostCodes
      */
-    public function testValidCanadaZipCode($countryId, $validPostCode) {
+    public function testValidCanadaZipCode($countryId, $validPostCode)
+    {
         $this->assertTrue($this->validator->validate($validPostCode, $countryId));
     }
 
     /**
      * @return array
      */
-    public function getCanadaInvalidPostCodes() {
+    public function getCanadaInvalidPostCodes()
+    {
         return [
             ['countryId' => 'CA', 'postcode' => '12345'],
             ['countryId' => 'CA', 'postcode' => 'A1B2C3D'],
@@ -71,7 +74,8 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function getCanadaValidPostCodes() {
+    public function getCanadaValidPostCodes()
+    {
         return [
             ['countryId' => 'CA', 'postcode' => 'A1B2C3'],
             ['countryId' => 'CA', 'postcode' => 'A1B 2C3'],


### PR DESCRIPTION
Add new pattern to validate Canada Zip Codes

### Description
Change pattern validation for Canada Zip Codes

### Fixed Issues (if relevant)
1. magento/magento2#13899: Postal code (zip code) for Canada should allow postal codes without space

### Manual testing scenarios
1. Add Product to Cart
2. Go to shopping cart
3. Select Canda Country
4. Put ZipCode: A1B2C3

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
