### PR TITLE
Issue #13582 show message for qty minAllowed, maxAllowed, qtyIncremen…

### DIFF
--- a/app/code/Magento/CatalogInventory/Block/Plugin/ProductView.php
+++ b/app/code/Magento/CatalogInventory/Block/Plugin/ProductView.php
@@ -40,7 +40,7 @@ class ProductView
         $params = [];
         $params['minAllowed']  = (float)$stockItem->getMinSaleQty();
         if ($stockItem->getMaxSaleQty()) {
-            $params['maxAllowed'] = $stockItem->getMaxSaleQty();
+            $params['maxAllowed'] = (float)$stockItem->getMaxSaleQty();
         }
         if ($stockItem->getQtyIncrements() > 0) {
             $params['qtyIncrements'] = (float)$stockItem->getQtyIncrements();

--- a/app/code/Magento/CatalogInventory/Block/Plugin/ProductView.php
+++ b/app/code/Magento/CatalogInventory/Block/Plugin/ProductView.php
@@ -39,8 +39,8 @@ class ProductView
 
         $params = [];
         $params['minAllowed']  = (float)$stockItem->getMinSaleQty();
-        if ($stockItem->getQtyMaxAllowed()) {
-            $params['maxAllowed'] = $stockItem->getQtyMaxAllowed();
+        if ($stockItem->getMaxSaleQty()) {
+            $params['maxAllowed'] = $stockItem->getMaxSaleQty();
         }
         if ($stockItem->getQtyIncrements() > 0) {
             $params['qtyIncrements'] = (float)$stockItem->getQtyIncrements();

--- a/app/code/Magento/CatalogInventory/Test/Unit/Block/Plugin/ProductViewTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Block/Plugin/ProductViewTest.php
@@ -28,7 +28,7 @@ class ProductViewTest extends \PHPUnit\Framework\TestCase
 
         $this->stockItem = $this->getMockBuilder(\Magento\CatalogInventory\Model\Stock\Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getMinSaleQty', 'getQtyMaxAllowed', 'getQtyIncrements'])
+            ->setMethods(['getMinSaleQty', 'getMaxSaleQty', 'getQtyIncrements'])
             ->getMock();
 
         $this->stockRegistry = $this->getMockBuilder(\Magento\CatalogInventory\Api\StockRegistryInterface::class)
@@ -74,7 +74,7 @@ class ProductViewTest extends \PHPUnit\Framework\TestCase
             ->with('productId', 'websiteId')
             ->willReturn($this->stockItem);
         $this->stockItem->expects($this->once())->method('getMinSaleQty')->willReturn(0.5);
-        $this->stockItem->expects($this->any())->method('getQtyMaxAllowed')->willReturn(5);
+        $this->stockItem->expects($this->any())->method('getMaxSaleQty')->willReturn(5);
         $this->stockItem->expects($this->any())->method('getQtyIncrements')->willReturn(3);
 
         $this->assertEquals($result, $this->block->afterGetQuantityValidators($productViewBlock, $validators));

--- a/app/code/Magento/CatalogInventory/Test/Unit/Block/Plugin/ProductViewTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Block/Plugin/ProductViewTest.php
@@ -48,8 +48,8 @@ class ProductViewTest extends \PHPUnit\Framework\TestCase
             'validate-item-quantity' =>
                 [
                     'minAllowed' => 0.5,
-                    'maxAllowed' => 5,
-                    'qtyIncrements' => 3
+                    'maxAllowed' => 5.0,
+                    'qtyIncrements' => 3.0
                 ]
         ];
         $validators = [];

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -910,6 +910,7 @@ define([
         'validate-item-quantity': [
             function (value, params) {
                 var validator = this,
+                    result = false,
                     // obtain values for validation
                     qty = utils.parseNumber(value),
                     isMinAllowedValid = typeof params.minAllowed === 'undefined' ||
@@ -919,7 +920,7 @@ define([
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
                         qty % utils.parseNumber(params.qtyIncrements) === 0;
 
-                var result = qty > 0;
+                result = qty > 0;
 
                 if (result === false) {
                   validator.itemQtyErrorMessage = $.mage.__("Please enter a quantity greater than 0.");//eslint-disable-line max-len
@@ -927,7 +928,7 @@ define([
                   return result;
                 }
 
-                var result = isMinAllowedValid;
+                result = isMinAllowedValid;
 
                 if (result === false) {
                   validator.itemQtyErrorMessage = $.mage.__("The fewest you may purchase is %1.").replace('%1', params.minAllowed);//eslint-disable-line max-len

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -923,39 +923,39 @@ define([
                 result = qty > 0;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("Please enter a quantity greater than 0.");//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('Please enter a quantity greater than 0.');//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 result = isMinAllowedValid;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("The fewest you may purchase is %1.").replace('%1', params.minAllowed);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('The fewest you may purchase is %1.').replace('%1', params.minAllowed);//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 result = isMaxAllowedValid;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("The maximum you may purchase is %1.").replace('%1', params.maxAllowed);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('The maximum you may purchase is %1.').replace('%1', params.maxAllowed);//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 result = isQtyIncrementsValid;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("You can buy this product only in quantities of %1 at a time.").replace('%1', params.qtyIncrements);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('You can buy this product only in quantities of %1 at a time.').replace('%1', params.qtyIncrements);//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 return result;
             }, function () {
-            return this.itemQtyErrorMessage;
-          }
+                return this.itemQtyErrorMessage;
+            }
         ],
         'equalTo': [
             function (value, param) {

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -909,8 +909,9 @@ define([
         ],
         'validate-item-quantity': [
             function (value, params) {
-                // obtain values for validation
-                var qty = utils.parseNumber(value),
+                var validator = this,
+                    // obtain values for validation
+                    qty = utils.parseNumber(value),
                     isMinAllowedValid = typeof params.minAllowed === 'undefined' ||
                         qty >= utils.parseNumber(params.minAllowed),
                     isMaxAllowedValid = typeof params.maxAllowed === 'undefined' ||
@@ -918,9 +919,42 @@ define([
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
                         qty % utils.parseNumber(params.qtyIncrements) === 0;
 
-                return isMaxAllowedValid && isMinAllowedValid && isQtyIncrementsValid && qty > 0;
-            },
-            ''
+                var result = qty > 0;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("Please enter a quantity greater than 0.");//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                var result = isMinAllowedValid;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("The fewest you may purchase is %1.").replace('%1', params.minAllowed);//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                result = isMaxAllowedValid;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("The maximum you may purchase is %1.").replace('%1', params.maxAllowed);//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                result = isQtyIncrementsValid;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("You can buy this product only in quantities of %1 at a time.").replace('%1', params.qtyIncrements);//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                return result;
+            }, function () {
+            return this.itemQtyErrorMessage;
+          }
         ],
         'equalTo': [
             function (value, param) {

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1566,8 +1566,9 @@
         ],
         'validate-item-quantity': [
             function (value, element, params) {
-                // obtain values for validation
-                var qty = $.mage.parseNumber(value),
+                var validator = this,
+                    // obtain values for validation
+                    qty = $.mage.parseNumber(value),
                     isMinAllowedValid = typeof params.minAllowed === 'undefined' ||
                         qty >= $.mage.parseNumber(params.minAllowed),
                     isMaxAllowedValid = typeof params.maxAllowed === 'undefined' ||
@@ -1575,9 +1576,42 @@
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
                         qty % $.mage.parseNumber(params.qtyIncrements) === 0;
 
-                return isMaxAllowedValid && isMinAllowedValid && isQtyIncrementsValid && qty > 0;
-            },
-            ''
+                var result = qty > 0;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("Please enter a quantity greater than 0.");//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                var result = isMinAllowedValid;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("The fewest you may purchase is %1.").replace('%1', params.minAllowed);//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                result = isMaxAllowedValid;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("The maximum you may purchase is %1.").replace('%1', params.maxAllowed);//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                result = isQtyIncrementsValid;
+
+                if (result === false) {
+                  validator.itemQtyErrorMessage = $.mage.__("You can buy this product only in quantities of %1 at a time.").replace('%1', params.qtyIncrements);//eslint-disable-line max-len
+
+                  return result;
+                }
+
+                return result;
+              }, function () {
+              return this.itemQtyErrorMessage;
+            }
         ],
         'password-not-equal-to-user-name': [
             function (value, element, params) {

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1580,38 +1580,38 @@
                 result = qty > 0;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("Please enter a quantity greater than 0.");//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('Please enter a quantity greater than 0.');//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 result = isMinAllowedValid;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("The fewest you may purchase is %1.").replace('%1', params.minAllowed);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('The fewest you may purchase is %1.').replace('%1', params.minAllowed);//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 result = isMaxAllowedValid;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("The maximum you may purchase is %1.").replace('%1', params.maxAllowed);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('The maximum you may purchase is %1.').replace('%1', params.maxAllowed);//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 result = isQtyIncrementsValid;
 
                 if (result === false) {
-                  validator.itemQtyErrorMessage = $.mage.__("You can buy this product only in quantities of %1 at a time.").replace('%1', params.qtyIncrements);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('You can buy this product only in quantities of %1 at a time.').replace('%1', params.qtyIncrements);//eslint-disable-line max-len
 
-                  return result;
+                    return result;
                 }
 
                 return result;
-              }, function () {
-              return this.itemQtyErrorMessage;
+            }, function () {
+                return this.itemQtyErrorMessage;
             }
         ],
         'password-not-equal-to-user-name': [

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1567,6 +1567,7 @@
         'validate-item-quantity': [
             function (value, element, params) {
                 var validator = this,
+                    result = false,
                     // obtain values for validation
                     qty = $.mage.parseNumber(value),
                     isMinAllowedValid = typeof params.minAllowed === 'undefined' ||
@@ -1576,7 +1577,7 @@
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
                         qty % $.mage.parseNumber(params.qtyIncrements) === 0;
 
-                var result = qty > 0;
+                result = qty > 0;
 
                 if (result === false) {
                   validator.itemQtyErrorMessage = $.mage.__("Please enter a quantity greater than 0.");//eslint-disable-line max-len
@@ -1584,7 +1585,7 @@
                   return result;
                 }
 
-                var result = isMinAllowedValid;
+                result = isMinAllowedValid;
 
                 if (result === false) {
                   validator.itemQtyErrorMessage = $.mage.__("The fewest you may purchase is %1.").replace('%1', params.minAllowed);//eslint-disable-line max-len


### PR DESCRIPTION
…ts validation. Fix ProductView plugin for maxAllowed

Product with max sale qty, min sale qty or increment qty will not show error message on frontend

### Description
Fixed how Plugin extract max sale qty
Add parametric message for js validation

### Fixed Issues
1. magento/magento2#13582: Magento 2.1.11 minimum quantity validation message not showing

### Manual testing scenarios
1. Set Min sale qty (3), max sale qty (100) or qty increments (3) on a simple product visible in catalog
2. Try to add that product to cart with qty that triggers the js validation error. eg: 0, 2, 7, 101
