### PR TITLE
ScopeConfigInterface doesn't define a 'clean' method, so this shouldn…

### DIFF
--- a/app/code/Magento/Store/Model/StoreManager.php
+++ b/app/code/Magento/Store/Model/StoreManager.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Store\Model;
 
+use Magento\Framework\App\Config;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Api\StoreResolverInterface;
 use Magento\Store\Model\ResourceModel\StoreWebsiteRelation;
@@ -235,7 +236,9 @@ class StoreManager implements
     {
         $this->currentStoreId = null;
         $this->cache->clean(\Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, [StoreResolver::CACHE_TAG, Store::CACHE_TAG]);
-        $this->scopeConfig->clean();
+        if ($this->scopeConfig instanceof Config) {
+            $this->scopeConfig->clean();
+        }
         $this->storeRepository->clean();
         $this->websiteRepository->clean();
         $this->groupRepository->clean();


### PR DESCRIPTION
…'t get called on all implementations of this interface.

### Description
This is something I discovered by accident while debugging something else, and is probably a minor issue.
Anyway, so the [ScopeConfigInterface](https://github.com/magento/magento2/blob/2.2.3/lib/internal/Magento/Framework/App/Config/ScopeConfigInterface.php) doesn't define a `clean` method, it is however defined in the [Config](https://github.com/magento/magento2/blob/2.2.3/lib/internal/Magento/Framework/App/Config.php) implementation of that interface.

So the `clean` method can't be called on all implementations of the `ScopeConfigInterface` but only on the `Config` implementation.

I found inspiration over here where the same solution is being used:
- https://github.com/magento/magento2/blob/2.2.3/app/code/Magento/Config/Model/Config/Importer.php#L123-L125
- https://github.com/magento/magento2/blob/2.2.3/app/code/Magento/Config/Console/Command/ConfigSet/ProcessorFacade.php#L126-L128

### Fixed Issues (if relevant)
None that I could find

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
