### PR TITLE
Fix misnamed namespace

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\Cron\Observer;
 
-use Magento\Framework\Console\CLI;
+use Magento\Framework\Console\Cli;
 use Magento\Framework\Event\ObserverInterface;
 use \Magento\Cron\Model\Schedule;
 


### PR DESCRIPTION
### Description

Fixes misnamed namespace in Magento\Cron\Observer\ProcessCronQueueObserver.php by lower-casing "CLI"

Instantiating this class and running execute() will cause a php fatal error because it cannot find the class `Magento\Framework\Console\CLI`:

![image](https://user-images.githubusercontent.com/6549623/36955193-098ceb7a-1ff5-11e8-8290-b700f101639b.png)

I think this wasn't backported to [v2.1.x](https://github.com/magento/magento2/blob/2.1-develop/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php#L12) yet. I see this fixed in [v2.2.x](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php#L13) and [v2.3.x](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php#L13). Couldn't find any open PRs for this either.