### PR TITLE
Use event object in 'ajax:addToCart' trigger when adding a product to the cart

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
@@ -97,7 +97,11 @@ define([
                 success: function (res) {
                     var eventData, parameters;
 
-                    $(document).trigger('ajax:addToCart', form.data().productSku, form, res);
+                    $(document).trigger('ajax:addToCart', {
+                        'sku': form.data().productSku,
+                        'form': form,
+                        'response': res
+                    });
 
                     if (self.isLoaderEnabled()) {
                         $('body').trigger(self.options.processStop);


### PR DESCRIPTION
### Description
Refactored the implementation of the 'ajax:addToCart' trigger that was used in the ajaxSubmit function when adding a product to the cart. The code now leans more closely towards how Magento has already implemented this type of event triggering.

Also by passing an object in the trigger function instead of passing x number of variables, we allow for more generic solutions when trying to observe multiple triggers with a single function.

### Fixed Issues (if relevant)
1. Follow up on https://github.com/magento/magento2/pull/12875

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
