### PR TITLE
Configure bundle product from cart results in loss of selected checkbox/multiselect and user defined quantities

### DIFF
--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -178,6 +178,16 @@ class Bundle extends \Magento\Catalog\Block\Product\View\AbstractView
                 $configValue = $preConfiguredValues->getData('bundle_option/' . $optionId);
                 if ($configValue) {
                     $defaultValues[$optionId] = $configValue;
+
+                    // Overwrite default QTY (if set)
+                    $qtyValue = $preConfiguredValues->getData('bundle_option_qty/' . $optionId);
+                    if ($qtyValue) {
+                        $configValues = (is_array($configValue)) ? $configValue : [$configValue] ;
+                        $qtyValues = (is_array($qtyValue)) ? $qtyValue : [$qtyValue] ;
+                        foreach ($configValues as $configValueKey => $configValueId) {
+                            $options[$optionId]['selections'][$configValueId]['qty'] = $qtyValues[$configValueKey];
+                        }
+                    }
                 }
             }
             $position++;

--- a/app/code/Magento/Bundle/Model/Option.php
+++ b/app/code/Magento/Bundle/Model/Option.php
@@ -122,14 +122,15 @@ class Option extends \Magento\Framework\Model\AbstractExtensibleModel implements
     /**
      * Return selection by it's id
      *
-     * @param int $selectionId
+     * @param mixed $selectionId
      * @return \Magento\Catalog\Model\Product|null
      */
     public function getSelectionById($selectionId)
     {
         $foundSelection = null;
+        $selectionId = (is_array($selectionId)) ? $selectionId : [$selectionId] ;
         foreach ($this->getSelections() as $selection) {
-            if ($selection->getSelectionId() == $selectionId) {
+            if (in_array($selection->getSelectionId(), $selectionId)) {
                 $foundSelection = $selection;
                 break;
             }


### PR DESCRIPTION
### Description
The param `$selectionId` in `\Magento\Bundle\Model\Option::getSelectionById` is a `string` for `Drop-down` and `Radio Buttons` input types. But it's an `array` for `Checkbox` and `Multiple select` input types. In method `\Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option::assignSelection` where the method `getSelectionById` is executed the param `$selectionId` is already defined as `mixed`, but in `\Magento\Bundle\Model\Option::getSelectionById` this isn't the case.

The change we've made is making sure that `$selectionId` is always an array and then instead of doing `$selection->getSelectionId() == $selectionId` we check if the selection ID is in the array `in_array($selection->getSelectionId(), $selectionId)`.

The `JSON` output from `\Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::getJsonConfig` is being used by Javascript to set some default values etc. In this method there's already some code that checks if there are pre-configured values. But this only overwrites the default values and doesn't overwrite the default QTY. Again in this case the variable `$configValue` and `$qtyValue` can be either a `string` or an `array`. So for the QTY check we use the new variables `$configValues` and `$qtyValues` and for each option overwrite the QTY.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4942: On editing a Bundle product from shopping cart the user defined quantities of the options are overwritten

### Manual testing scenarios
1. Create a bundle product with 4 options, each option having a different input type (Radio buttons, checkboxes, Drop-down, Multiple Select)
2. Add bundle product to cart and click on the configure/ediot button on the cart page
3. Test if selected options and QTY are remembered

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
