### PR TITLE
Setup Lists - Make allowedCurrencies property private

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -26,7 +26,7 @@ class Lists
      *
      * @var array
      */
-    protected $allowedCurrencies;
+    private $allowedCurrencies;
 
     /**
      * @param ConfigInterface $localeConfig


### PR DESCRIPTION
### Description
In https://github.com/magento/magento2/pull/13770 was introduced new property with protected visibility, should be private.
This commit wasn't included into any release, so we still can fix this issue.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
