### PR TITLE
Forwardport of PR-13709: Changes static content deploy log levels ver…

### DIFF
--- a/app/code/Magento/Deploy/Console/ConsoleLogger.php
+++ b/app/code/Magento/Deploy/Console/ConsoleLogger.php
@@ -82,8 +82,8 @@ class ConsoleLogger extends AbstractLogger
         LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::NOTICE => OutputInterface::VERBOSITY_VERBOSE,
-        LogLevel::INFO => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::INFO => OutputInterface::VERBOSITY_VERBOSE,
         LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG
     ];
 

--- a/app/code/Magento/Deploy/Process/Queue.php
+++ b/app/code/Magento/Deploy/Process/Queue.php
@@ -161,7 +161,7 @@ class Queue
             foreach ($packages as $name => $packageJob) {
                 $this->assertAndExecute($name, $packages, $packageJob);
             }
-            $this->logger->notice('.');
+            $this->logger->info('.');
             sleep(3);
             foreach ($this->inProgress as $name => $package) {
                 if ($this->isDeployed($package)) {
@@ -214,7 +214,7 @@ class Queue
                     unset($this->inProgress[$name]);
                 }
             }
-            $this->logger->notice('.');
+            $this->logger->info('.');
             sleep(5);
         }
         if ($this->isCanBeParalleled()) {

--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -267,7 +267,7 @@ class DeployPackage
         $this->deployStaticFile->writeTmpFile('info.json', $package->getPath(), json_encode($info));
 
         if (!$skipLogging) {
-            $this->logger->notice($logMessage);
+            $this->logger->info($logMessage);
         }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
@@ -127,7 +127,7 @@ class DeployStaticContentCommand extends Command
 
         $logger = $this->consoleLoggerFactory->getLogger($output, $verbose);
         if (!$refreshOnly) {
-            $logger->alert(PHP_EOL . "Deploy using {$options[Options::STRATEGY]} strategy");
+            $logger->notice(PHP_EOL . "Deploy using {$options[Options::STRATEGY]} strategy");
         }
 
         $this->mockCache();
@@ -140,7 +140,7 @@ class DeployStaticContentCommand extends Command
         $deployService->deploy($options);
 
         if (!$refreshOnly) {
-            $logger->alert(PHP_EOL . "Execution time: " . (microtime(true) - $time));
+            $logger->notice(PHP_EOL . "Execution time: " . (microtime(true) - $time));
         }
 
         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DeployStaticContentCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DeployStaticContentCommandTest.php
@@ -102,7 +102,7 @@ class DeployStaticContentCommandTest extends \PHPUnit\Framework\TestCase
 
         $this->consoleLoggerFactory->expects($this->once())
             ->method('getLogger')->willReturn($this->logger);
-        $this->logger->expects($this->exactly(2))->method('alert');
+        $this->logger->expects($this->exactly(2))->method('notice');
 
         $this->objectManager->expects($this->once())->method('create')->willReturn($this->deployService);
         $this->deployService->expects($this->once())->method('deploy');


### PR DESCRIPTION
…bosity #13709

(cherry picked from commit c8dc954d8702fcb7d0416247597fffa8e6e5b247)

### Description
This is a forwardport of https://github.com/magento/magento2/pull/13709 for `2.3-develop`

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/12404: Output of setup:static-content:deploy contains red color, should be a friendlier color
2. https://github.com/magento/community-features/issues/15: Output of setup:static-content:deploy contains red color, should be a friendlier color

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
