### PR TITLE
Fix missing `use AbstractAddress` in `DefaultRenderer`.

### DIFF
--- a/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Customer\Block\Address\Renderer;
 
+use Magento\Customer\Model\Address\AbstractAddress;
 use Magento\Customer\Model\Address\AddressModelInterface;
 use Magento\Customer\Model\Address\Mapper;
 use Magento\Customer\Model\Metadata\ElementFactory;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Fixes "Class Magento\Customer\Block\Address\Renderer\AbstractAddress does not exist" error when running `bin/magento setup:di:compile-multi-tenant` on `Magento 2 2.0.17`.

The issue https://github.com/magento/magento2/issues/3448 and the pull request https://github.com/magento/magento2/pull/3819 were supposed to solve this issue, but somehow the issue still existed.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#3448: Class Magento\Customer\Block\Address\Renderer\AbstractAddress does not exist
2. magento/magento2#3819: Fixes MAGETWO-49425 ( #3448 )

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Run `bin/magento setup:di:compile-multi-tenant` on 'magento 2.0.17' and the command should work without the error.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
