### PR TITLE
Backport of PR-10748 for Magento 2.2: Always use https for Vimeo vide…

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -302,7 +302,7 @@ define([
                     additionalParams += '&autoplay=1';
                 }
 
-                src = window.location.protocol + '//player.vimeo.com/video/' +
+                src = 'https://player.vimeo.com/video/' +
                     this._code + '?api=1&player_id=vimeo' +
                     this._code +
                     timestamp +
@@ -525,7 +525,7 @@ define([
                     );
                 } else if (type === 'vimeo') {
                     $.ajax({
-                        url: window.location.protocol + '//www.vimeo.com/api/v2/video/' + id + '.json',
+                        url: 'https://www.vimeo.com/api/v2/video/' + id + '.json',
                         dataType: 'jsonp',
                         data: {
                             format: 'json'

--- a/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
@@ -317,7 +317,7 @@ define(['jquery', 'jquery/ui'], function ($) {
             if (this._loop) {
                 additionalParams += '&loop=1';
             }
-            src = window.location.protocol + '//player.vimeo.com/video/' +
+            src = 'https://player.vimeo.com/video/' +
                 this._code + '?api=1&player_id=vimeo' +
                 this._code +
                 timestamp +


### PR DESCRIPTION
…o's.

(cherry picked from commit c4da890ed291ba5333a3871a4098d04ea58d255c)

### Description
This is a backport of https://github.com/magento/magento2/pull/10768 for Magento 2.2
This was also fixed in Magento 2.1 in: https://github.com/magento/magento2/pull/10748

But due to the fact that the Magento 2.2 branch was closed for new changes at that time (because 2.2.0 was close to being released), this was somewhat forgotten, so here I'm trying to streamline the code in between [2.1](https://github.com/magento/magento2/blob/2.1.12/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js#L306), [2.2](https://github.com/magento/magento2/blob/2.2.3/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js#L305) and [2.3](https://github.com/magento/magento2/blob/786e0e6/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js#L305)

### Fixed Issues (if relevant)
There currently isn't an issue, it's just streamlining the code.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
