### PR TITLE
Forwardport of PR-13777. Mobile 'Payments methods' step looks bad on mobile

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -162,6 +162,11 @@
             .lib-css(margin, 0 -(@checkout-payment-method-title-mobile__padding));
         }
 
+        .step-title {
+            .lib-css(padding-left, @checkout-payment-method-title-mobile__padding);
+            .lib-css(padding-right, @checkout-payment-method-title-mobile__padding)
+        }
+
         .payment-method-title {
             .lib-css(padding, @checkout-payment-method-title-mobile__padding)
         }

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -162,6 +162,11 @@
             .lib-css(margin, 0 -(@checkout-payment-method-title-mobile__padding));
         }
 
+        .step-title {
+            .lib-css(padding-left, @checkout-payment-method-title-mobile__padding);
+            .lib-css(padding-right, @checkout-payment-method-title-mobile__padding)
+        }
+
         .payment-method-title {
             .lib-css(padding, @checkout-payment-method-title-mobile__padding)
         }


### PR DESCRIPTION
### Description
This is the forwardport of #13777 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13315: I "Payment Methods" step looks bad on mobile 

### Manual testing scenarios
1. Go to frontend, add some product to shopping cart on mobile (or in iphone emulation mode on chrome)
2. Go to Checkout, fill "shipping" step, click "Next" button
3. See "Payment Methods" block
4. Step title heading "Payment Method" should be correctly aligned with other elements in this section 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
