### PR TITLE
Act better on existing input focus instead of removing it

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -98,7 +98,9 @@ define([
                 }, this), 250);
             }, this));
 
-            this.element.trigger('blur');
+            if (this.element.get(0) === document.activeElement) {
+                this.setActiveState(true);
+            }
 
             this.element.on('focus', this.setActiveState.bind(this, true));
             this.element.on('keydown', this._onKeyDown);


### PR DESCRIPTION
The focus of the input field is maintained, proper classes are added and autocomplete fires once the component is initialized. Fixes #13988.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
As already mentioned in issue referenced above this change proposes better approach when the user is already focused on the search input by detecting it and triggering appropriate methods.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13988 Mini search field looses focus after its JavaScript is initialized

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Load Magento 2 shop.
2. Focus on mini search form field.
3. Check that input no longer loses focus once its JavaScript is initialized.
4. Check that proper active classes are applied when the user is focused on the search field and JavaScript gets initialized.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
