### PR TITLE
Allow using a symlinked sitemap path

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -570,6 +570,11 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
         }
 
         $path = rtrim($this->getSitemapPath(), '/') . '/' . $fileName;
+
+        if (is_link($path) && readlink($path)) {
+            $path = readlink($path);
+        }
+
         $this->_stream = $this->_directory->openFile($path);
 
         $fileHeader = sprintf($this->_tags[$type][self::OPEN_TAG_KEY], $type);


### PR DESCRIPTION
### Description

This will fix an issue with symlinked sitemaps where the symlink is replaced instead of the symlink target.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. share a sitemap.xml through symlinks throughout releases
2. regenerate a sitemap