### PR TITLE
Use `^1.4` for `composer/composer`

### DIFF
--- a/lib/internal/Magento/Framework/composer.json
+++ b/lib/internal/Magento/Framework/composer.json
@@ -23,7 +23,7 @@
         "ext-bcmath": "*",
         "symfony/process": "~2.1",
         "colinmollenhour/php-redis-session-abstract": "1.3.4",
-        "composer/composer": "1.4.1",
+        "composer/composer": "^1.4",
         "monolog/monolog": "^1.17",
         "oyejorge/less.php": "~1.7.0",
         "symfony/console": "~2.3, !=2.7.0",


### PR DESCRIPTION
Some modules require a more recent version of composer. To allow for this we use "^1.4" for the composer version

### Description
Using the "1.4 and above" will mean it's backwards compatible for current use of 1.4 and uses newer versions in installations where possible.
This will allow for installing modules that use newer versions

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
