### PR TITLE
Open link "Report an Issue" in a new tab

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/page/report.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/report.phtml
@@ -8,5 +8,7 @@
 
 ?>
 <?php if ($block->getBugreportUrl()): ?>
-    <a class="link-report" href="<?= /* @escapeNotVerified */ $block->getBugreportUrl() ?>" id="footer_bug_tracking"><?= /* @escapeNotVerified */ __('Report an Issue') ?></a>
+    <a class="link-report" href="<?= /* @escapeNotVerified */ $block->getBugreportUrl() ?>" id="footer_bug_tracking" target="_blank">
+        <?= /* @escapeNotVerified */ __('Report an Issue') ?>
+    </a>
 <?php endif; ?>


### PR DESCRIPTION
With this pull request the "Report an Issue" link will open in a new tab instead of the current page.
This is useful because in this way you don't loose your currently opened admin page.

### Description
Added attribute target

### Fixed Issues (if relevant)
1. magento/magento2/issues/14010 Why Report Bugs link not open in new tab? #14010 

### Manual testing scenarios
1. Go to the admin panel
2. Click on the footer link "Report an Issue"

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
