### PR TITLE
fix catalog_rule_promo_catalog_edit.xml layout

### DIFF
--- a/app/code/Magento/CatalogRule/view/adminhtml/layout/catalog_rule_promo_catalog_edit.xml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/layout/catalog_rule_promo_catalog_edit.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
             <referenceBlock name="catalog_rule_form">


### PR DESCRIPTION
fixed layout attribute value from admin-2columns-left to admin-1column, because it has no sidebar.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
changed layout attribute value from admin-2columns-left to admin-1column, because it has no sidebar.
version 2.0 was with sidebar and has correct admin-2columns-left
version 2.2 and 2.3 have also correct layout admin-1column 

<!--- Provide a description of the changes proposed in the pull request -->



### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Magento version 2.1.x 
2. Admin -> MARKETING -> Catalog Price Rule -> Add New Rule
3. New Catalog Price Rule edit page has layout page-layout-admin-2columns-left, but should be 1column

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
