### PR TITLE
[FIX] Remove not used and empty template

### DIFF
--- a/app/code/Magento/Tax/view/frontend/templates/checkout/discount.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/discount.phtml
@@ -1,5 +1,0 @@
-<?php
-/**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */


### PR DESCRIPTION
### Description
Hello,
I found that the `app/code/Magento/Tax/view/frontend/templates/checkout/discount.phtml` was empty since initial commit and currently/previously it wasn't used. File deleted.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
