### PR TITLE
Add Magento\Framework\HTTP\ClientFactory to the public API

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/ClientFactory.php
+++ b/lib/internal/Magento/Framework/HTTP/ClientFactory.php
@@ -10,6 +10,7 @@ namespace Magento\Framework\HTTP;
  * Factory for HTTP client classes
  *
  * @author      Magento Core Team <core@magentocommerce.com>
+ * @api
  */
 class ClientFactory
 {


### PR DESCRIPTION
I want to be able to grab a factory for HTTP ClientInterfaces, so please add ClientFactory to the API.

I first attempted to do this by grabbing a \Magento\Framework\HTTP\ClientInterfaceFactory, but there was no preference set for ClientInterface

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
