### PR TITLE
Make scope parameters of methods to save/delete config optional

### DIFF
--- a/app/code/Magento/Config/Model/ResourceModel/Config.php
+++ b/app/code/Magento/Config/Model/ResourceModel/Config.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Config\Model\ResourceModel;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
 /**
  * Core Resource Resource Model
  *
@@ -34,7 +36,7 @@ class Config extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implem
      * @param int $scopeId
      * @return $this
      */
-    public function saveConfig($path, $value, $scope, $scopeId)
+    public function saveConfig($path, $value, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeId = 0)
     {
         $connection = $this->getConnection();
         $select = $connection->select()->from(
@@ -70,7 +72,7 @@ class Config extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implem
      * @param int $scopeId
      * @return $this
      */
-    public function deleteConfig($path, $scope, $scopeId)
+    public function deleteConfig($path, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeId = 0)
     {
         $connection = $this->getConnection();
         $connection->delete(

--- a/lib/internal/Magento/Framework/App/Config/ConfigResource/ConfigInterface.php
+++ b/lib/internal/Magento/Framework/App/Config/ConfigResource/ConfigInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\App\Config\ConfigResource;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
 /**
  * Resource for storing store configuration values
  */
@@ -19,7 +21,7 @@ interface ConfigInterface
      * @param int $scopeId
      * @return $this
      */
-    public function saveConfig($path, $value, $scope, $scopeId);
+    public function saveConfig($path, $value, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeId = 0);
 
     /**
      * Delete config value from the storage resource
@@ -29,5 +31,5 @@ interface ConfigInterface
      * @param int $scopeId
      * @return $this
      */
-    public function deleteConfig($path, $scope, $scopeId);
+    public function deleteConfig($path, $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeId = 0);
 }


### PR DESCRIPTION
### Description
If you want to save configuration values to the database, you won't need to give parameters for scope type and scope id any more if you just want to use the default scope.

### Manual testing scenarios
1. Create a data setup script. 
2. Add the `\Magento\Framework\App\Config\ConfigResource\ConfigInterface` as a dependency to the constructor as `$config`
3. Set a config value by calling:

```
            $this->config->saveConfig(
                'general/store_information/name',
                'My Store'
            );
```

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
