### PR TITLE
Type cast Ids from `String` to `Integer`

### DIFF
--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -886,7 +886,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel
                 ScopeInterface::SCOPE_STORE,
                 $storeId
             );
-            $this->setData('group_id', $groupId);
+            $this->setData('group_id', (int)$groupId);
         }
         return $this->getData('group_id');
     }
@@ -900,7 +900,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel
     {
         if (!$this->getData('tax_class_id')) {
             $groupTaxClassId = $this->_groupRepository->getById($this->getGroupId())->getTaxClassId();
-            $this->setData('tax_class_id', $groupTaxClassId);
+            $this->setData('tax_class_id', (int)$groupTaxClassId);
         }
         return $this->getData('tax_class_id');
     }
@@ -949,10 +949,10 @@ class Customer extends \Magento\Framework\Model\AbstractModel
         if ($ids === null) {
             $ids = [];
             if ((bool)$this->getSharingConfig()->isWebsiteScope()) {
-                $ids[] = $this->getWebsiteId();
+                $ids[] = (int)$this->getWebsiteId();
             } else {
                 foreach ($this->_storeManager->getWebsites() as $website) {
-                    $ids[] = $website->getId();
+                    $ids[] = (int)$website->getId();
                 }
             }
             $this->setData('shared_website_ids', $ids);


### PR DESCRIPTION
The methods `getGroupId` and `getTaxClassId` should set and return the **Integer** value of Id but they are returning **String** values.
And the method `getSharedWebsiteIds` should return integer type array of website Ids but it's returning the string type array of website Ids.
So before setting the value of Ids, I've typecast the value of Id from String to Integer.

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
1. magento/magento2#14055: Getting group id from customer session returns wrong data type.

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
