### PR TITLE
Disable add to cart button when redirect to cart enabled

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -40,17 +40,6 @@
     </div>
 </div>
 <?php endif; ?>
-<?php if ($block->isRedirectToCartEnabled()) : ?>
-<script type="text/x-magento-init">
-    {
-        "#product_addtocart_form": {
-            "Magento_Catalog/product/view/validation": {
-                "radioCheckboxClosest": ".nested"
-            }
-        }
-    }
-</script>
-<?php else : ?>
 <script type="text/x-magento-init">
     {
         "#product_addtocart_form": {
@@ -58,4 +47,3 @@
         }
     }
 </script>
-<?php endif; ?>


### PR DESCRIPTION
### Description
Disable add to cart button when redirect to cart enabled, it includes product validation.

### Fixed Issues (if relevant)
N/A

### Pre-requisites
1. Install Magento 2.2.3
2. Go to Admin >> Stores >> Configuration >> Sales >> Checkout
3. In "Shopping Cart" section change "After Adding a Product Redirect to Shopping Cart" to "Yes"

### Manual testing scenarios
1. Go to product page on frontend with very slow internet connection (could be emulated in chrome)
2. Click "Add to Cart" button

### Expected result
1. After clicking "Add to cart" button should became to disabled
2. Button color should be changed to "disabled" (grey)
3. Text on "add to cart" is changed to "Adding...", then to "Added"

### Actual result
1. After clicking "Add to cart" button is not became to disabled
2. Button color is not changed to "disabled" (grey)
3. Text on "add to cart" is not changed to "Adding...", then to "Added"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
