### PR TITLE
Typo in SSL port number

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -268,7 +268,7 @@ class Processor
         $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off');
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 
-        if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 433])
+        if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 443])
             && !preg_match('/.*?\:[0-9]+$/', $url)
         ) {
             $url .= ':' . $_SERVER['SERVER_PORT'];


### PR DESCRIPTION
### Description
SSL is run on port 433, but in `pub/errors/processor.php` we check for port `433`. This looks like a typo. I ran in to this problem when visiting an url of an image that was not on the server. It resulted in a weird base url with the port number `443`.

### Manual testing scenarios
1. Make sure your shop runs on SSL
1. Visit a non existing image: https://www.yourshop.com/media/email/logo/default/logo_default.png
1. Check the <base href="..."/> tag in the header

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
