### PR TITLE
Correctly convert config integration api resources

### DIFF
--- a/app/code/Magento/Integration/Model/Config/Consolidated/Converter.php
+++ b/app/code/Magento/Integration/Model/Config/Consolidated/Converter.php
@@ -80,6 +80,12 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
                     $result[$integrationName][self::API_RESOURCES][] = $name;
                 }
             }
+
+            // Add root resource if any child has been added
+            if (! empty($result[$integrationName][self::API_RESOURCES])) {
+                array_unshift($result[$integrationName][self::API_RESOURCES], $allResources[1]['id']);
+            }
+
             // Remove any duplicates added parents
             $result[$integrationName][self::API_RESOURCES] =
                 array_values(array_unique($result[$integrationName][self::API_RESOURCES]));

--- a/app/code/Magento/Integration/Model/Config/Consolidated/Converter.php
+++ b/app/code/Magento/Integration/Model/Config/Consolidated/Converter.php
@@ -82,13 +82,14 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             }
 
             // Add root resource if any child has been added
-            if (! empty($result[$integrationName][self::API_RESOURCES])) {
+            if (!empty($result[$integrationName][self::API_RESOURCES])) {
                 array_unshift($result[$integrationName][self::API_RESOURCES], $allResources[1]['id']);
             }
 
             // Remove any duplicates added parents
-            $result[$integrationName][self::API_RESOURCES] =
-                array_values(array_unique($result[$integrationName][self::API_RESOURCES]));
+            $result[$integrationName][self::API_RESOURCES] = array_values(
+                array_unique($result[$integrationName][self::API_RESOURCES])
+            );
         }
         return $result;
     }

--- a/app/code/Magento/Integration/Test/Unit/Model/Config/Consolidated/_files/acl.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Config/Consolidated/_files/acl.php
@@ -6,6 +6,8 @@
 return [
     [],
     [
+        'id' => 'Magento_Backend::admin',
+        'title' => 'Magento Admin (Root)',
         'children' =>
             [
                 [

--- a/app/code/Magento/Integration/Test/Unit/Model/Config/Consolidated/_files/integration.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Config/Consolidated/_files/integration.php
@@ -9,6 +9,7 @@ return [
         'endpoint_url' => 'http://endpoint.com',
         'identity_link_url' => 'http://www.example.com/identity',
         'resource' => [
+            'Magento_Backend::admin',
             'Magento_Customer::manageParent',
             'Magento_Customer::manage',
             'Magento_SalesRule::quoteParent',
@@ -17,6 +18,9 @@ return [
     ],
     'TestIntegration2' => [
         'email' => 'test-integration2@magento.com',
-        'resource' => ['Magento_Sales::sales']
+        'resource' => [
+            'Magento_Backend::admin',
+            'Magento_Sales::sales'
+        ]
     ]
 ];

--- a/app/code/Magento/Integration/Test/Unit/Model/Config/Consolidated/_files/integration.xml
+++ b/app/code/Magento/Integration/Test/Unit/Model/Config/Consolidated/_files/integration.xml
@@ -18,6 +18,7 @@
     <integration name="TestIntegration2">
         <email>test-integration2@magento.com</email>
         <resources>
+            <resource name="Magento_Backend::admin" />
             <resource name="Magento_Sales::sales" />
         </resources>
     </integration>

--- a/dev/tests/integration/testsuite/Magento/Integration/Model/Config/Consolidated/_files/integration.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Model/Config/Consolidated/_files/integration.php
@@ -9,6 +9,7 @@ return [
         'endpoint_url' => 'http://example.com/endpoint1',
         'identity_link_url' => 'http://www.example.com/identity1',
         'resource' => [
+            'Magento_Backend::admin',
             'Magento_Customer::customer',
             'Magento_Customer::manage',
             'Magento_Sales::sales',
@@ -26,6 +27,7 @@ return [
         'endpoint_url' => 'http://example.com/integration2',
         'identity_link_url' => 'http://www.example.com/identity2',
         'resource' => [
+            'Magento_Backend::admin',
             'Magento_Sales::sales',
             'Magento_Sales::sales_operation',
             'Magento_Sales::sales_order',
@@ -40,6 +42,7 @@ return [
     'TestIntegration3' => [
         'email' => 'test-integration3@example.com',
         'resource' => [
+            'Magento_Backend::admin',
             'Magento_Sales::sales',
             'Magento_Sales::sales_operation',
             'Magento_Sales::sales_order',

--- a/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
@@ -85,7 +85,7 @@ class ConfigBasedIntegrationManagerTest extends \PHPUnit\Framework\TestCase
             $createdIntegrations[$integrationName] = $integration;
         }
 
-        // Rerun integration creation
+        // Rerun integration creation with the same data (data has not changed)
         $this->assertEquals(
             $newIntegrations,
             $this->integrationManager->processConfigBasedIntegrations($newIntegrations),

--- a/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Integration\Model;
+
+/**
+ * Test class for \Magento\Integration\Model\ConfigBasedIntegrationManager.php.
+ */
+class ConfigBasedIntegrationManagerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $consolidatedConfigMock;
+
+    /**
+     * @var \Magento\Integration\Model\ConfigBasedIntegrationManager
+     */
+    protected $integrationManager;
+
+    /**
+     * @var \Magento\Integration\Api\IntegrationServiceInterface
+     */
+    protected $integrationService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        /**
+         * @var $objectManager \Magento\TestFramework\ObjectManager
+         */
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->consolidatedConfigMock = $this->createMock(\Magento\Integration\Model\ConsolidatedConfig::class);
+        $objectManager->addSharedInstance(
+            $this->consolidatedConfigMock,
+            \Magento\Integration\Model\ConsolidatedConfig::class
+        );
+        $this->integrationManager = $objectManager->create(
+            \Magento\Integration\Model\ConfigBasedIntegrationManager::class,
+            []
+        );
+        $this->integrationService = $objectManager->create(
+            \Magento\Integration\Api\IntegrationServiceInterface::class,
+            []
+        );
+    }
+
+    /**
+     * @magentoDbIsolation enabled
+     */
+    public function testProcessConfigBasedIntegrations()
+    {
+        $newIntegrations = require __DIR__ . '/Config/Consolidated/_files/integration.php';
+        $this->consolidatedConfigMock
+            ->expects($this->any())
+            ->method('getIntegrations')
+            ->willReturn($newIntegrations);
+
+        // Check that the integrations do not exist already
+        foreach ($newIntegrations as $integrationName => $integrationData) {
+            $integration = $this->integrationService->findByName($integrationName);
+            $this->assertEquals(null, $integration->getId(), 'Integration already exists');
+        }
+
+        // Create new integrations
+        $this->assertEquals(
+            $newIntegrations,
+            $this->integrationManager->processConfigBasedIntegrations($newIntegrations),
+            'Error processing config based integrations.'
+        );
+        $createdIntegrations = [];
+
+        // Check that the integrations are new with "inactive" status
+        foreach ($newIntegrations as $integrationName => $integrationData) {
+            $integration = $this->integrationService->findByName($integrationName);
+            $this->assertNotEmpty($integration->getId(), 'Integration was not created');
+            $this->assertEquals(
+                $integration::STATUS_INACTIVE,
+                $integration->getStatus(),
+                'Integration is not created with "inactive" status'
+            );
+            $createdIntegrations[$integrationName] = $integration;
+        }
+
+        // Rerun integration creation
+        $this->assertEquals(
+            $newIntegrations,
+            $this->integrationManager->processConfigBasedIntegrations($newIntegrations),
+            'Error processing config based integrations.'
+        );
+
+        // Check that the integrations are not recreated when data has not actually changed
+        foreach ($newIntegrations as $integrationName => $integrationData) {
+            $integration = $this->integrationService->findByName($integrationName);
+            $this->assertEquals(
+                $createdIntegrations[$integrationName]->getId(),
+                $integration->getId(),
+                'Integration ID has changed'
+            );
+            $this->assertEquals(
+                $createdIntegrations[$integrationName]->getStatus(),
+                $integration->getStatus(),
+                'Integration status has changed'
+            );
+        }
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
@@ -14,7 +14,7 @@ class ConfigBasedIntegrationManagerTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    protected $consolidatedConfigMock;
+    protected $consolidatedMock;
 
     /**
      * @var \Magento\Integration\Model\ConfigBasedIntegrationManager
@@ -26,26 +26,40 @@ class ConfigBasedIntegrationManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $integrationService;
 
+    /**
+     * @var \Magento\TestFramework\ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
         parent::setUp();
-        /**
-         * @var $objectManager \Magento\TestFramework\ObjectManager
-         */
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->consolidatedConfigMock = $this->createMock(\Magento\Integration\Model\ConsolidatedConfig::class);
-        $objectManager->addSharedInstance(
-            $this->consolidatedConfigMock,
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->consolidatedMock = $this->createMock(\Magento\Integration\Model\ConsolidatedConfig::class);
+        $this->objectManager->addSharedInstance(
+            $this->consolidatedMock,
             \Magento\Integration\Model\ConsolidatedConfig::class
         );
-        $this->integrationManager = $objectManager->create(
+        $this->integrationManager = $this->objectManager->create(
             \Magento\Integration\Model\ConfigBasedIntegrationManager::class,
             []
         );
-        $this->integrationService = $objectManager->create(
+        $this->integrationService = $this->objectManager->create(
             \Magento\Integration\Api\IntegrationServiceInterface::class,
             []
         );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown()
+    {
+        $this->objectManager->removeSharedInstance(\Magento\Integration\Model\ConsolidatedConfig::class);
+        parent::tearDown();
     }
 
     /**
@@ -54,7 +68,7 @@ class ConfigBasedIntegrationManagerTest extends \PHPUnit\Framework\TestCase
     public function testProcessConfigBasedIntegrations()
     {
         $newIntegrations = require __DIR__ . '/Config/Consolidated/_files/integration.php';
-        $this->consolidatedConfigMock
+        $this->consolidatedMock
             ->expects($this->any())
             ->method('getIntegrations')
             ->willReturn($newIntegrations);


### PR DESCRIPTION
### Description
Correctly return config based integration api resources. Currently it does not append "root api resource" (`Magento_Backend::admin`) which causes the integrations to be reset all the time even when there are no data changes when the `Magento\Integration\Setup\Recurring` is run (`setup:upgrade`) because `Magento\Authorization\Model\Acl\AclRetriever::getAllowedResourcesByUser` returns resource tree including "root api resource" (`Magento_Backend::admin`) and when they are compared they do not match.

Detailed explanation:
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/ConfigBasedIntegrationManager.php#L128 (Get existing integration)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/Plugin/Integration.php#L109 (Append integration api resources)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/Plugin/Integration.php#L123 (Append config based integration api resources)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/ConsolidatedConfig.php#L68 (Read config based integrations)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/Config/Consolidated/Reader.php#L36 (Converter used to convert api resources from `etc/integration.xml)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/Config/Consolidated/Converter.php#L41 (Converts config integrations api resources without "root api resource" (`Magento_Backend::admin`)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/ConfigBasedIntegrationManager.php#L130 (Returns resource tree including "root api resource" (`Magento_Backend::admin`)
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Integration/Model/ConfigBasedIntegrationManager.php#L171 (Condition is true due one resource tree having "root api resource" (`Magento_Backend::admin`) and the other not)

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12095: Update 2.2.1: One or more integrations have been reset because of a change to their xml configs

### Manual testing scenarios
1. Create config based integration `etc/integration.xml` with "Magento_Catalog::catalog" resource and without "endpoint_url", "identity_link_url"
2. run `setup:upgrade` so the integration is created
3. activate integration in admin area under "System -> Integrations"
4. run `setup:upgrade` again - the integration should stay as "Authorized" but it is "Reset" due the issue described above

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
