### PR TITLE
Fix product attribute ordering when more than 10 attributes.

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -315,7 +315,7 @@ define([
          */
         _sortAttributes: function () {
             this.options.jsonConfig.attributes = _.sortBy(this.options.jsonConfig.attributes, function (attribute) {
-                return parseInt(attribute.position);
+                return parseInt(attribute.position, 10);
             });
         },
 

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -315,7 +315,7 @@ define([
          */
         _sortAttributes: function () {
             this.options.jsonConfig.attributes = _.sortBy(this.options.jsonConfig.attributes, function (attribute) {
-                return attribute.position;
+                return parseInt(attribute.position);
             });
         },
 


### PR DESCRIPTION
When a product has more than 10 attributes, when viewing the product page, the order of the attributes becomes incorrect due to sorting alphabetically rather than numerically.  (ie. 0,1,10,11,12,13,2,3,4,5,6,7,8,9)

Magento version 2.x

Trivial bugfix to force the javascript to interpret the position as a number.