### PR TITLE
The autoloader throws an exception on class_exists.

### DIFF
--- a/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
@@ -153,6 +153,20 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * We have to make sure `class_exists` works for third-party classes
+     */
+    public function testGenerateClassWithNonMagentoCode()
+    {
+        $objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $entityGeneratorMock = $this->getMockBuilder(\Magento\Framework\Code\Generator\EntityAbstract::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $objectManagerMock->expects($this->once())->method('create')->willReturn($entityGeneratorMock);
+        $this->model->setObjectManager($objectManagerMock);
+        $this->assertFalse(Generator::GENERATION_SUCCESS === $this->model->generateClass('\FooFactory'));
+    }
+
+    /**
      * Build SUT object
      *
      * @param Io $ioObject


### PR DESCRIPTION
### Description
The autoloader throws an exception on `class_exists`. That is clearly an unexpected behavior according to the documentation: http://php.net/manual/en/function.class-exists.php

This will cause issues when including third party libraries that is not written for Magento. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/14074: Magento code generation bug, resulting in mails not sending!

### Manual testing scenarios
Run `class_exists('FooFactory')`. It should return `false` but an error is thrown instead. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)


-----------

FYI @NickvdMeij 