### PR TITLE
magento/magento2#13982: Customer Login Block sets the title for the p…

### DIFF
--- a/app/code/Magento/Customer/Block/Form/Login.php
+++ b/app/code/Magento/Customer/Block/Form/Login.php
@@ -48,15 +48,6 @@ class Login extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return $this
-     */
-    protected function _prepareLayout()
-    {
-        $this->pageConfig->getTitle()->set(__('Customer Login'));
-        return parent::_prepareLayout();
-    }
-
-    /**
      * Retrieve form posting url
      *
      * @return string

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
@@ -6,6 +6,9 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <title>Customer Login</title>
+    </head>
     <body>
         <referenceContainer name="content">
             <!-- customer.form.login.extra -->


### PR DESCRIPTION
…age when rendered

### Description
The Customer Login Block, defined as Magento\Customer\Block\Form\Login currently has logic that would set the overall page title, which is unexpected behavior.

I moved the login page title setting from Login Block to cutomer_account_login layout and now its possible to override login page title via layout xml also is possible to insert Login Block into any page and this block should not overwrite the page on which it was placed.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13982: magento/magento2#13982: Customer Login Block sets the title for the page when rendered

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Magento login page. The title of the page should be equal to "Customer Login"
1. Insert Magento/Customer/Block/Login Block into any custom page
2. The title of the page where you insert the Login block should not be overridden with "Customer Login" string

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
