### PR TITLE
[Backport 2.1] Schedule generation was broken

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -454,7 +454,6 @@ class ProcessCronQueueObserver implements ObserverInterface
             if ($schedule->trySchedule()) {
                 // time matches cron expression
                 $schedule->save();
-                return;
             }
         }
     }


### PR DESCRIPTION
Backported (with tests updates) pull request #4897 that fixed issue #4173

### Description
Only one schedule entry was generated at schedule generation because of this return;

### Manual testing scenarios
As explained in #4897