### PR TITLE
Fix for the ConcatExpression seperator

### DIFF
--- a/lib/internal/Magento/Framework/DB/Sql/ConcatExpression.php
+++ b/lib/internal/Magento/Framework/DB/Sql/ConcatExpression.php
@@ -65,7 +65,7 @@ class ConcatExpression extends Expression
         }
         return sprintf(
             'TRIM(%s)',
-            $this->adapter->getConcatSql($columns, ' ')
+            $this->adapter->getConcatSql($columns, $this->seperator)
         );
     }
 }

--- a/lib/internal/Magento/Framework/DB/Sql/ConcatExpression.php
+++ b/lib/internal/Magento/Framework/DB/Sql/ConcatExpression.php
@@ -65,7 +65,7 @@ class ConcatExpression extends Expression
         }
         return sprintf(
             'TRIM(%s)',
-            $this->adapter->getConcatSql($columns, $this->seperator)
+            $this->adapter->getConcatSql($columns, $this->separator)
         );
     }
 }


### PR DESCRIPTION
### Files changed
Magento\Framework\DB\Sql\ConcatExpression

### Reason
Currently if the seperator argument is given in di.xml it is ignored as the argument given to the "getConcatSql()" function is always a space.
The argument is of no use at this moment.

### Description
Modified the arguments given to the "getConcatSql()" function.
Made use of the already existing variable $seperator which is set with data from the construct.

### Manual testing scenarios
There are multiple scenarios, but i will make use of an existing scenario which went wrong
1. Create an order through either frontend or backend
2. Enter any address, example given: 
- [street] Ahornzoom 52
- [postcode] 2719GM 
- [city] Zoetermeer
- [region] Zuid-Holland
- [country] Netherlands
3. Check the order grid's Billing Address and Shipping Address.

### Expected Result
- Based on the di.xml the seperator for the fields should be a comma with a space and the address should be shown in the following format: Ahornzoom 52, Zoetermeer, Zuid-Holland, 2719GM

### Actual Result
- Address shown without a comma in the following format: Ahornzoom 52 Zoetermeer Zuid-Holland 2719GM