### PR TITLE
[Backport 2.1]  MAGETWO-59258: Override module-directory/etc/zip_codes.xml only the last code of a country gets include

### DIFF
--- a/app/code/Magento/Directory/Model/Country/Postcode/Config/Reader.php
+++ b/app/code/Magento/Directory/Model/Country/Postcode/Config/Reader.php
@@ -12,7 +12,10 @@ class Reader extends \Magento\Framework\Config\Reader\Filesystem
      *
      * @var array
      */
-    protected $_idAttributes = ['/config/zip' => 'countryCode'];
+    protected $_idAttributes = [
+        '/config/zip' => 'countryCode',
+        '/config/zip/codes/code' => 'id',
+    ];
 
     /**
      * Construct the FileSystem Reader Class


### PR DESCRIPTION
This is a backport of MAGETWO-59258 for Magento 2.1 that fixed issue #6694

### Description
When trying to override module-directory/etc/zip_codes.xml from a local module, only the last code of a country gets included.

### Manual testing scenarios
As explained in #6694

Please pay attention that current PR was created without tests from original task. Unfortunately integration tests were changed a lot.