### PR TITLE
Fix mutliselect attributes save for bundle products (and other cases)

### DIFF
--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -1073,4 +1073,9 @@
             <argument name="productRepository" xsi:type="object">Magento\Catalog\Api\ProductRepositoryInterface\Proxy</argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\Product">
+        <arguments>
+            <argument name="resource" xsi:type="object" shared="false">Magento\Catalog\Model\ResourceModel\Product</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Fix multi select attributes saving, for product with bundle options
https://github.com/magento/magento2/issues/10540

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

To make long story short - 
 product model instance Magento\Catalog\Model\Product, has shared instance inside Magento\Catalog\Model\ResourceModel\Product - if we save a bundle product (possible another cases) thru admin panel, and load simple product childs inside with different attribute set - we will have an issues with saving of multiselect attributes that do not not exist in child product attribute set 
because of attribute list Magento\Catalog\Model\ResourceModel\Product _attributesByCode here will be from last loaded product 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10540
2. magento/magento2#13520

### Preconditions
Magento 2.2.3 EE
PHP 7.0.15
MariaDB 10.1

### Steps to reproduce
Create a Bundle Product with a multi-select attribute (multiselect attribute in bundle product attribute set, that does not exist in child product attribute set)
Select one or more new values for that attribute
Add to the bundle childs,  that have different attribute set from parent 
Save
### Expected result
The multiselect attribute is updated
### Actual result
The original attribute multiselect value is still there


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)


