### PR TITLE
Added mage/translate component to customers's ajax login

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/action/login.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/action/login.js
@@ -7,8 +7,9 @@ define([
     'jquery',
     'mage/storage',
     'Magento_Ui/js/model/messageList',
-    'Magento_Customer/js/customer-data'
-], function ($, storage, globalMessageList, customerData) {
+    'Magento_Customer/js/customer-data',
+    'mage/translate'
+], function ($, storage, globalMessageList, customerData, $t) {
     'use strict';
 
     var callbacks = [],
@@ -48,7 +49,7 @@ define([
                 }
             }).fail(function () {
                 messageContainer.addErrorMessage({
-                    'message': 'Could not authenticate. Please try again later'
+                    'message': $t('Could not authenticate. Please try again later')
                 });
                 callbacks.forEach(function (callback) {
                     callback(loginData);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR adds `mage/translate` component to customer's ajax login action component, just to translate message `Could not authenticate. Please try again later` that occurs when ajax call fails. 
Currently Magento prints that message always in english, regardless of store front's language setting.

### Fixed Issues (if relevant)
none

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add a product to cart
2. Go to Checkout page as guest
3. Sign in with ajax login in checkout page
4. If ajax call fails (e.g. backend returns 40x or 50x http status), the message passed to message container will now be translated according to store front's language setting.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
