### PR TITLE
[issues/14143] Allow to disable module via installer using enable_mod…

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -432,11 +432,11 @@ class Installer
             } else {
                 $result[$module] = 1;
             }
-            if (in_array($module, $disable)) {
-                $result[$module] = 0;
-            }
             if (in_array($module, $enable)) {
                 $result[$module] = 1;
+            }
+            if (in_array($module, $disable)) {
+                $result[$module] = 0;
             }
         }
         if (!$dryRun) {


### PR DESCRIPTION
…ules = all

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
When installing via the installer you can use the options disable_modules and enable_modules
How it works now is that you need to list all modules in the enable_modules list if you want to be able to disable a module for install.

### Fixed Issues (if relevant)
1. magento/magento2#14143: Allow to disable module via installer using enable_modules = all

### Manual testing scenarios
See: https://github.com/magento/magento2/issues/14143

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
