### PR TITLE
[Backport 2.1] 8373: Fix CURL Json POST

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -222,8 +222,11 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     /**
      * Make POST request
      *
+     * String type was added to parameter $param in order to support sending JSON or XML requests.
+     * This feature was added base on Community Pull Request https://github.com/magento/magento2/pull/8373
+     *
      * @param string $uri
-     * @param array $params
+     * @param array|string $params
      * @return void
      *
      * @see \Magento\Framework\HTTP\Client#post($uri, $params)
@@ -327,9 +330,13 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
 
     /**
      * Make request
+     *
+     * String type was added to parameter $param in order to support sending JSON or XML requests.
+     * This feature was added base on Community Pull Request https://github.com/magento/magento2/pull/8373
+     *
      * @param string $method
      * @param string $uri
-     * @param array $params
+     * @param array|string $params - use $params as a string in case of JSON or XML POST request.
      * @return void
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -340,7 +347,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
         $this->curlOption(CURLOPT_URL, $uri);
         if ($method == 'POST') {
             $this->curlOption(CURLOPT_POST, 1);
-            $this->curlOption(CURLOPT_POSTFIELDS, http_build_query($params));
+            $this->curlOption(CURLOPT_POSTFIELDS, is_array($params) ? http_build_query($params) : $params);
         } elseif ($method == "GET") {
             $this->curlOption(CURLOPT_HTTPGET, 1);
         } else {


### PR DESCRIPTION
This is a backport of 8373 (MAGETWO-64313) for Magento 2.1 that fixed issue #3489

### Description
Using \Magento\Framework\HTTP\Client\Curl doesn't support json posts, because it used only

$this->curlOption(CURLOPT_POSTFIELDS, http_build_query($params));

### Manual testing scenarios
As explained in #8373

That functionality doesn't break backward compatibility will be very useful for most projects.