### PR TITLE
Add website- and storeview-code in stores admin grid

### DIFF
--- a/app/code/Magento/Backend/Block/System/Store/Grid/Render/Group.php
+++ b/app/code/Magento/Backend/Block/System/Store/Grid/Render/Group.php
@@ -27,6 +27,7 @@ class Group extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
         $this->getUrl('adminhtml/*/editGroup', ['group_id' => $row->getGroupId()]) .
         '">' .
         $this->escapeHtml($row->getData($this->getColumn()->getIndex())) .
-        '</a>';
+        '</a><br />'
+        . '(Code: ' . $row->getGroupCode() . ')';
     }
 }

--- a/app/code/Magento/Backend/Block/System/Store/Grid/Render/Group.php
+++ b/app/code/Magento/Backend/Block/System/Store/Grid/Render/Group.php
@@ -28,6 +28,6 @@ class Group extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
         '">' .
         $this->escapeHtml($row->getData($this->getColumn()->getIndex())) .
         '</a><br />'
-        . '(Code: ' . $row->getGroupCode() . ')';
+        . '(' . __('Code') . ': ' . $row->getGroupCode() . ')';
     }
 }

--- a/app/code/Magento/Backend/Block/System/Store/Grid/Render/Store.php
+++ b/app/code/Magento/Backend/Block/System/Store/Grid/Render/Store.php
@@ -28,6 +28,6 @@ class Store extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
         '">' .
         $this->escapeHtml($row->getData($this->getColumn()->getIndex())) .
         '</a><br />' .
-        '(Code: ' . $row->getStoreCode() . ')';
+        '(' . __('Code') . ': ' . $row->getStoreCode() . ')';
     }
 }

--- a/app/code/Magento/Backend/Block/System/Store/Grid/Render/Store.php
+++ b/app/code/Magento/Backend/Block/System/Store/Grid/Render/Store.php
@@ -27,6 +27,7 @@ class Store extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
         $this->getUrl('adminhtml/*/editStore', ['store_id' => $row->getStoreId()]) .
         '">' .
         $this->escapeHtml($row->getData($this->getColumn()->getIndex())) .
-        '</a>';
+        '</a><br />' .
+        '(Code: ' . $row->getStoreCode() . ')';
     }
 }

--- a/app/code/Magento/Backend/Block/System/Store/Grid/Render/Website.php
+++ b/app/code/Magento/Backend/Block/System/Store/Grid/Render/Website.php
@@ -24,6 +24,7 @@ class Website extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstrac
         $this->getUrl('adminhtml/*/editWebsite', ['website_id' => $row->getWebsiteId()]) .
         '">' .
         $this->escapeHtml($row->getData($this->getColumn()->getIndex())) .
-        '</a>';
+        '</a><br />' .
+        '(Code: ' . $row->getCode() . ')';
     }
 }

--- a/app/code/Magento/Backend/Block/System/Store/Grid/Render/Website.php
+++ b/app/code/Magento/Backend/Block/System/Store/Grid/Render/Website.php
@@ -25,6 +25,6 @@ class Website extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstrac
         '">' .
         $this->escapeHtml($row->getData($this->getColumn()->getIndex())) .
         '</a><br />' .
-        '(Code: ' . $row->getCode() . ')';
+        '(' . __('Code') . ': ' . $row->getCode() . ')';
     }
 }

--- a/app/code/Magento/Store/Model/ResourceModel/Website/Collection.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website/Collection.php
@@ -142,7 +142,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             )->joinLeft(
                 ['store_table' => $this->getTable('store')],
                 'group_table.group_id = store_table.group_id',
-                ['store_id' => 'store_id', 'store_title' => 'name']
+                ['store_id' => 'store_id', 'store_title' => 'name', 'store_code' => 'code']
             );
             $this->addOrder('group_table.name', \Magento\Framework\DB\Select::SQL_ASC)       // store name
                 ->addOrder(

--- a/app/code/Magento/Store/Model/ResourceModel/Website/Collection.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website/Collection.php
@@ -138,7 +138,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             $this->getSelect()->joinLeft(
                 ['group_table' => $this->getTable('store_group')],
                 'main_table.website_id = group_table.website_id',
-                ['group_id' => 'group_id', 'group_title' => 'name']
+                ['group_id' => 'group_id', 'group_title' => 'name', 'group_code' => 'code']
             )->joinLeft(
                 ['store_table' => $this->getTable('store')],
                 'group_table.group_id = store_table.group_id',


### PR DESCRIPTION
This PR adds the webiste- and storeview-code in the stores admin grid like in Magento 1 stores overview.

### Description
The PR joins additionally the `code` field from the `store` table to the admin grids row and adds the website code as well as the store view code in the respective renderers.

### Fixed Issues (if relevant)
-

### Manual testing scenarios
1. Go to "Stores" > "Settings / All Stores"
2. Before applying the PR there are only listed Website, Store and StoreView by their names
3. After applying the PR there are the respective codes shown beneath the Website and StoreView names

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
