### PR TITLE
Avoid getShippingRates().subscribe to be called twice

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-service.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-service.js
@@ -21,7 +21,6 @@ define([
          */
         setShippingRates: function (ratesData) {
             shippingRates(ratesData);
-            shippingRates.valueHasMutated();
             checkoutDataResolver.resolveShippingRates(ratesData);
         },
 


### PR DESCRIPTION
### Description
Change the `shipping-service.js` to remove the `shippingRates.valueHasMutated();`
Special thanks to Jordann Gamba who told be this bug

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14081: Avoid getShippingRates().subscribe to be called twice

### Manual testing scenarios
1. Add console.log in `app/code/Magento/Checkout/view/frontend/web/js/view/cart/totals.js` between l.24 and l.25
2. Add product to cart
3. Show console and when total is loaded, the log is shown only one time (shown twice before the patch)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
