### PR TITLE
Use cartId from REST URL

### DIFF
--- a/app/code/Magento/Quote/Model/Webapi/SaveCartItemWithCartId.php
+++ b/app/code/Magento/Quote/Model/Webapi/SaveCartItemWithCartId.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Quote\Model\Webapi;
+
+use Magento\Quote\Api\CartItemRepositoryInterface;
+use Magento\Quote\Api\Data\CartItemInterface;
+
+/**
+ * CartItemRepository extension to save a cart item for a specific guest cart
+ */
+class SaveCartItemWithCartId implements SaveCartItemWithCartIdInterface
+{
+    /**
+     * @var CartItemRepositoryInterface
+     */
+    private $cartItemRepository;
+
+    /**
+     * Constructor.
+     *
+     * @param CartItemRepositoryInterface $cartItemRepository
+     */
+    public function __construct(CartItemRepositoryInterface $cartItemRepository)
+    {
+        $this->cartItemRepository = $cartItemRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveForCart($cartId, CartItemInterface $cartItem)
+    {
+        $cartItem->setQuoteId($cartId);
+
+        return $this->cartItemRepository->save($cartItem);
+    }
+}

--- a/app/code/Magento/Quote/Model/Webapi/SaveCartItemWithCartIdInterface.php
+++ b/app/code/Magento/Quote/Model/Webapi/SaveCartItemWithCartIdInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Quote\Model\Webapi;
+
+/**
+ * Interface SaveCartItemWithCartIdInterface
+ */
+interface SaveCartItemWithCartIdInterface
+{
+    /**
+     * Add/update the specified cart item for given cartId.
+     *
+     * @param int $cartId The cart ID.
+     * @param \Magento\Quote\Api\Data\CartItemInterface $cartItem The item.
+     * @return \Magento\Quote\Api\Data\CartItemInterface Item.
+     * @throws \Magento\Framework\Exception\NoSuchEntityException The specified cart does not exist.
+     * @throws \Magento\Framework\Exception\CouldNotSaveException The specified item could not be saved to the cart.
+     * @throws \Magento\Framework\Exception\InputException The specified item or cart is not valid.
+     */
+    public function saveForCart($cartId, \Magento\Quote\Api\Data\CartItemInterface $cartItem);
+}

--- a/app/code/Magento/Quote/Model/Webapi/SaveGuestCartItemWithCartId.php
+++ b/app/code/Magento/Quote/Model/Webapi/SaveGuestCartItemWithCartId.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Quote\Model\Webapi;
+
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Api\GuestCartItemRepositoryInterface;
+
+/**
+ * GuestCartItemRepository extension to save a cart item for a specific guest cart
+ */
+class SaveGuestCartItemWithCartId implements SaveGuestCartItemWithCartIdInterface
+{
+    /**
+     * @var GuestCartItemRepositoryInterface
+     */
+    protected $guestCartItemRepo;
+
+    /**
+     * Constructor.
+     *
+     * @param GuestCartItemRepositoryInterface $guestCartItemRepo
+     */
+    public function __construct(GuestCartItemRepositoryInterface $guestCartItemRepo)
+    {
+        $this->guestCartItemRepo = $guestCartItemRepo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveForCart($cartId, CartItemInterface $cartItem)
+    {
+        $cartItem->setQuoteId($cartId);
+
+        return $this->guestCartItemRepo->save($cartItem);
+    }
+}

--- a/app/code/Magento/Quote/Model/Webapi/SaveGuestCartItemWithCartIdInterface.php
+++ b/app/code/Magento/Quote/Model/Webapi/SaveGuestCartItemWithCartIdInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Quote\Model\Webapi;
+
+/**
+ * Interface SaveGuestCartItemWithCartIdInterface
+ */
+interface SaveGuestCartItemWithCartIdInterface
+{
+    /**
+     * Add/update the specified cart item for given cartId.
+     *
+     * @param string $cartId The cart ID.
+     * @param \Magento\Quote\Api\Data\CartItemInterface $cartItem The item.
+     * @return \Magento\Quote\Api\Data\CartItemInterface Item.
+     * @throws \Magento\Framework\Exception\NoSuchEntityException The specified cart does not exist.
+     * @throws \Magento\Framework\Exception\CouldNotSaveException The specified item could not be saved to the cart.
+     * @throws \Magento\Framework\Exception\InputException The specified item or cart is not valid.
+     */
+    public function saveForCart($cartId, \Magento\Quote\Api\Data\CartItemInterface $cartItem);
+}

--- a/app/code/Magento/Quote/Test/Unit/Model/Webapi/SaveCartItemWithCartIdTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Webapi/SaveCartItemWithCartIdTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Test\Unit\Model\Webapi;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Api\CartItemRepositoryInterface;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Model\Webapi\SaveCartItemWithCartId;
+
+/**
+ * Test for \Magento\Quote\Model\Webapi\SaveCartItemWithCartId
+ */
+class SaveCartItemWithCartIdTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var CartItemRepositoryInterface
+     */
+    private $cartItemRepository;
+
+    /**
+     * @var SaveCartItemWithCartId
+     */
+    private $model;
+
+    protected function setUp()
+    {
+        $this->cartItemRepository = $this->getMockBuilder(CartItemRepositoryInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->model = (new ObjectManager($this))->getObject(
+            SaveCartItemWithCartId::class,
+            [
+                'cartItemRepository' => $this->cartItemRepository
+            ]
+        );
+    }
+
+    public function testQuoteIdIsCorrectlySet()
+    {
+        $cartId = 44;
+
+        /** @var CartItemInterface $cartItem */
+        $cartItem = $this->getMockBuilder(CartItemInterface::class)->getMockForAbstractClass();
+        $cartItem->expects($this->once())
+            ->method('setQuoteId')
+            ->with($cartId)
+            ->willReturnSelf();
+
+        $this->model->saveForCart($cartId, $cartItem);
+    }
+
+    public function testQuoteItemIsCorrectlySaved()
+    {
+        $cartId = 44;
+
+        /** @var CartItemInterface $cartItem */
+        $cartItem = $this->getMockBuilder(CartItemInterface::class)->getMockForAbstractClass();
+        $cartItem->expects($this->once())
+            ->method('setQuoteId')
+            ->with($cartId)
+            ->willReturnSelf();
+
+        $this->cartItemRepository->expects($this->once())
+            ->method('save')
+            ->with($cartItem)
+            ->willReturn($cartItem);
+
+        $this->model->saveForCart($cartId, $cartItem);
+    }
+}

--- a/app/code/Magento/Quote/Test/Unit/Model/Webapi/SaveGuestCartItemWithCartIdTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Webapi/SaveGuestCartItemWithCartIdTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Quote\Test\Unit\Model\Webapi;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Api\GuestCartItemRepositoryInterface;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Model\Webapi\SaveGuestCartItemWithCartId;
+
+/**
+ * Test for \Magento\Quote\Model\Webapi\SaveGuestCartItemWithCartId
+ */
+class SaveGuestCartItemWithCartIdTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var GuestCartItemRepositoryInterface
+     */
+    private $guestCartItemRepo;
+
+    /**
+     * @var SaveGuestCartItemWithCartId
+     */
+    private $model;
+
+    protected function setUp()
+    {
+        $this->guestCartItemRepo = $this->getMockBuilder(GuestCartItemRepositoryInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->model = (new ObjectManager($this))->getObject(
+            SaveGuestCartItemWithCartId::class,
+            [
+                'guestCartItemRepo' => $this->guestCartItemRepo
+            ]
+        );
+    }
+
+    public function testQuoteIdIsCorrectlySet()
+    {
+        $cartId = '298047a8923470823';
+
+        /** @var CartItemInterface $cartItem */
+        $cartItem = $this->getMockBuilder(CartItemInterface::class)->getMockForAbstractClass();
+        $cartItem->expects($this->once())
+            ->method('setQuoteId')
+            ->with($cartId)
+            ->willReturnSelf();
+
+        $this->model->saveForCart($cartId, $cartItem);
+    }
+
+    public function testQuoteItemIsCorrectlySaved()
+    {
+        $cartId = '298047a8923470823';
+
+        /** @var CartItemInterface $cartItem */
+        $cartItem = $this->getMockBuilder(CartItemInterface::class)->getMockForAbstractClass();
+        $cartItem->expects($this->once())
+            ->method('setQuoteId')
+            ->with($cartId)
+            ->willReturnSelf();
+
+        $this->guestCartItemRepo->expects($this->once())
+            ->method('save')
+            ->with($cartItem)
+            ->willReturn($cartItem);
+
+        $this->model->saveForCart($cartId, $cartItem);
+    }
+}

--- a/app/code/Magento/Quote/etc/di.xml
+++ b/app/code/Magento/Quote/etc/di.xml
@@ -15,6 +15,7 @@
     <preference for="Magento\Quote\Api\Data\CartItemInterface" type="Magento\Quote\Model\Quote\Item" />
     <preference for="Magento\Quote\Api\Data\CartInterface" type="Magento\Quote\Model\Quote" />
     <preference for="Magento\Quote\Api\CartItemRepositoryInterface" type="Magento\Quote\Model\Quote\Item\Repository" />
+    <preference for="Magento\Quote\Model\Webapi\SaveCartItemWithCartIdInterface" type="Magento\Quote\Model\Webapi\SaveCartItemWithCartId" />
     <preference for="Magento\Quote\Api\CartRepositoryInterface" type="Magento\Quote\Model\QuoteRepository" />
     <preference for="Magento\Quote\Api\Data\CartSearchResultsInterface" type="Magento\Framework\Api\SearchResults" />
     <preference for="Magento\Quote\Api\PaymentMethodManagementInterface" type="Magento\Quote\Model\PaymentMethodManagement" />
@@ -30,6 +31,7 @@
     <preference for="Magento\Quote\Api\GuestCartManagementInterface" type="Magento\Quote\Model\GuestCart\GuestCartManagement" />
     <preference for="Magento\Quote\Api\GuestCartRepositoryInterface" type="Magento\Quote\Model\GuestCart\GuestCartRepository" />
     <preference for="Magento\Quote\Api\GuestCartItemRepositoryInterface" type="Magento\Quote\Model\GuestCart\GuestCartItemRepository" />
+    <preference for="Magento\Quote\Model\Webapi\SaveGuestCartItemWithCartIdInterface" type="Magento\Quote\Model\Webapi\SaveGuestCartItemWithCartId" />
     <preference for="Magento\Quote\Api\GuestCouponManagementInterface" type="Magento\Quote\Model\GuestCart\GuestCouponManagement" />
     <preference for="Magento\Quote\Api\GuestPaymentMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestPaymentMethodManagement" />
     <preference for="Magento\Quote\Api\GuestCartTotalRepositoryInterface" type="Magento\Quote\Model\GuestCart\GuestCartTotalRepository" />

--- a/app/code/Magento/Quote/etc/webapi.xml
+++ b/app/code/Magento/Quote/etc/webapi.xml
@@ -176,14 +176,14 @@
             <resource ref="Magento_Cart::manage" />
         </resources>
     </route>
-    <route url="/V1/carts/:quoteId/items" method="POST">
-        <service class="Magento\Quote\Api\CartItemRepositoryInterface" method="save"/>
+    <route url="/V1/carts/:cartId/items" method="POST">
+        <service class="Magento\Quote\Model\Webapi\SaveCartItemWithCartIdInterface" method="saveForCart"/>
         <resources>
             <resource ref="Magento_Cart::manage" />
         </resources>
     </route>
     <route url="/V1/carts/:cartId/items/:itemId" method="PUT">
-        <service class="Magento\Quote\Api\CartItemRepositoryInterface" method="save"/>
+        <service class="Magento\Quote\Model\Webapi\SaveCartItemWithCartIdInterface" method="saveForCart"/>
         <resources>
             <resource ref="Magento_Cart::manage" />
         </resources>
@@ -203,13 +203,13 @@
         </resources>
     </route>
     <route url="/V1/guest-carts/:cartId/items" method="POST">
-        <service class="Magento\Quote\Api\GuestCartItemRepositoryInterface" method="save"/>
+        <service class="Magento\Quote\Model\Webapi\SaveGuestCartItemWithCartIdInterface" method="saveForCart"/>
         <resources>
             <resource ref="anonymous" />
         </resources>
     </route>
     <route url="/V1/guest-carts/:cartId/items/:itemId" method="PUT">
-        <service class="Magento\Quote\Api\GuestCartItemRepositoryInterface" method="save"/>
+        <service class="Magento\Quote\Model\Webapi\SaveGuestCartItemWithCartIdInterface" method="saveForCart"/>
         <resources>
             <resource ref="anonymous" />
         </resources>
@@ -232,7 +232,7 @@
         </data>
     </route>
     <route url="/V1/carts/mine/items" method="POST">
-        <service class="Magento\Quote\Api\CartItemRepositoryInterface" method="save"/>
+        <service class="Magento\Quote\Model\Webapi\SaveCartItemWithCartIdInterface" method="saveForCart"/>
         <resources>
             <resource ref="self" />
         </resources>
@@ -241,7 +241,7 @@
         </data>
     </route>
     <route url="/V1/carts/mine/items/:itemId" method="PUT">
-        <service class="Magento\Quote\Api\CartItemRepositoryInterface" method="save"/>
+        <service class="Magento\Quote\Model\Webapi\SaveCartItemWithCartIdInterface" method="saveForCart"/>
         <resources>
             <resource ref="self" />
         </resources>


### PR DESCRIPTION
Resolution for Guest cart API ignoring cartId in url for some methods

### Description
For /V1/carts/mine/items and /V1/carts/mine/items the quoteId from the
quote item is used. For guest cart this is confusing as it makes the
cartId in the URL useless. For logged in carts it makes it unsafe as it
allows adding products to any active cart.

### Fixed Issues
1. magento/magento2#14086: Guest cart API ignoring cartId in url for some methods

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
