### PR TITLE
Replace the existing headers with the no cache headers

### DIFF
--- a/app/code/Magento/Customer/Controller/Section/Load.php
+++ b/app/code/Magento/Customer/Controller/Section/Load.php
@@ -64,8 +64,8 @@ class Load extends \Magento\Framework\App\Action\Action
     {
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
         $resultJson = $this->resultJsonFactory->create();
-        $resultJson->setHeader('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store');
-        $resultJson->setHeader('Pragma', 'no-cache');
+        $resultJson->setHeader('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store', true);
+        $resultJson->setHeader('Pragma', 'no-cache', true);
         try {
             $sectionNames = $this->getRequest()->getParam('sections');
             $sectionNames = $sectionNames ? array_unique(\explode(',', $sectionNames)) : null;


### PR DESCRIPTION
The headers 'Cache-Control' and 'Pragma' need to be replaced otherwise they will be ignored because ZendHttp will always return the first entry.

https://github.com/zendframework/zend-http/blob/master/src/Headers.php#L257

This fixes issue https://github.com/magento/magento2/issues/14049

Preconditions
It happens on a fresh Magento 2.2.2 installation via composer.
PHP 7.1
MySQL 5.6
Steps to reproduce
Installed Magento 2.2.2 via composer
Go to frontend and register a new customer. Logoff and login with this customer.
Open a new browser or use another device to repeat the step (2).
Under device 1, open a new tab and go to http://localhost/customer/section/load/?sections=&update_section_id=true
Using device 2, go to the same URL, http://localhost/customer/section/load/?sections=&update_section_id=true
Logoff from device 1 and 2. Execute the URL under both devices.
It is important to create more than 1 user browsing the store in order to get the problem.

During some tests, we confirmed this issue under live stores, that affects the store header that contains the customer name.

Actual result
It is possible to get another customer session information from sections controller, without timestamp.
Sometimes, this url is trigged from knockout without timestamp, and shows another customer name in the store header.

Expected result
Always return the user data for the current logged user.
In case of no session, return no data from cache.

Suggestion
Enforce session id check in order to avoid send cached data to another session.
It works with timestamp url hint, but for sensitive data, it is easy to decrement the timestamp and start to get customers who logged and visited the store.