### PR TITLE
[Forwardport] Minicart should require dropdownDialog

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
@@ -10,7 +10,8 @@ define([
     'ko',
     'underscore',
     'sidebar',
-    'mage/translate'
+    'mage/translate',
+    'mage/dropdown'
 ], function (Component, customerData, $, ko, _) {
     'use strict';
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13830
The dropdownDialog is used below, so it should be required