### PR TITLE
[Forwardport] Fix for Issue-13556 - Sorting in Product Listing via Quantity not work

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Stock.php
@@ -43,6 +43,6 @@ class Stock extends AbstractSource
             []
         );
         $collection->getSelect()->order("stock_item_table.qty $dir");
-        return $this
+        return $this;
     }
 }

--- a/app/code/Magento/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Stock.php
@@ -26,4 +26,23 @@ class Stock extends AbstractSource
             ['value' => \Magento\CatalogInventory\Model\Stock::STOCK_OUT_OF_STOCK, 'label' => __('Out of Stock')]
         ];
     }
+
+    /**
+     * Add Value Sort To Collection Select
+     *
+     * @param \Magento\Eav\Model\Entity\Collection\AbstractCollection $collection
+     * @param string $dir
+     *
+     * @return $this
+     */
+    public function addValueSortToCollection($collection, $dir = \Magento\Framework\Data\Collection::SORT_ORDER_DESC)
+    {
+        $collection->getSelect()->joinLeft(
+            ['stock_item_table' => 'cataloginventory_stock_item'],
+            "e.entity_id=stock_item_table.product_id",
+            []
+        );
+        $collection->getSelect()->order("stock_item_table.qty $dir");
+        return $this
+    }
 }

--- a/app/code/Magento/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Stock.php
@@ -28,7 +28,7 @@ class Stock extends AbstractSource
     }
 
     /**
-     * Add Value Sort To Collection Select
+     * Add Value Sort To Collection Select.
      *
      * @param \Magento\Eav\Model\Entity\Collection\AbstractCollection $collection
      * @param string $dir

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Source/StockTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Source/StockTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\CatalogInventory\Test\Unit\Model\Source;
+
+use PHPUnit\Framework\TestCase;
+
+class StockTest extends TestCase
+{
+    /**
+     * @var \Magento\CatalogInventory\Model\Source\Stock
+     */
+    private $model;
+
+    protected function setUp()
+    {
+        $this->model = new \Magento\CatalogInventory\Model\Source\Stock();
+    }
+
+    public function testAddValueSortToCollection()
+    {
+        $selectMock = $this->createMock(\Magento\Framework\DB\Select::class);
+        $collectionMock = $this->createMock(\Magento\Eav\Model\Entity\Collection\AbstractCollection::class);
+        $collectionMock->expects($this->atLeastOnce())->method('getSelect')->willReturn($selectMock);
+
+        $selectMock->expects($this->once())
+            ->method('joinLeft')
+            ->with(
+                ['stock_item_table' => 'cataloginventory_stock_item'],
+                "e.entity_id=stock_item_table.product_id",
+                []
+            )
+            ->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('order')
+            ->with("stock_item_table.qty DESC")
+            ->willReturnSelf();
+
+        $this->model->addValueSortToCollection($collectionMock);
+    }
+}


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13691
### Fixed Issues
1. https://github.com/magento/magento2/issues/13556

### Problem
If you edit product attribute 'quantity_and_stock_status' and set "Used for Sorting in Product Listing" to "Yes" sort option will be displayed on category products page but sorting will not work. 

### Reason
1. Attribute 'quantity_and_stock_status' has source model, and for sorting magento calls addValueSortToCollection method of source model.
2. However source model of this attribute ("Magento\CatalogInventory\Model\Source\Stock") does not have its own method "addValueSortToCollection" only inherits parent one which just do nothing (return $this).

### Fix
We added to source model method which contain logic to join to collection (which is always product collection) cataloginventory_stock_item table and add order by qty field.

### Manual testing scenarios
Testing scenarios can be found in issue
https://github.com/magento/magento2/issues/13556

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
