### PR TITLE
Subscribe to Newsletter. Multistore. Issue#13258

### DIFF
--- a/app/code/Magento/Customer/Block/Account/Dashboard/Info.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Info.php
@@ -102,7 +102,7 @@ class Info extends \Magento\Framework\View\Element\Template
             $this->_subscription = $this->_createSubscriber();
             $customer = $this->getCustomer();
             if ($customer) {
-                $this->_subscription->loadByEmail($customer->getEmail());
+                $this->_subscription->loadByEmailAndStore($customer->getEmail(),$customer->getStoreId());
             }
         }
         return $this->_subscription;

--- a/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
@@ -124,7 +124,9 @@ class NewAction extends \Magento\Newsletter\Controller\Subscriber
                 $this->validateGuestSubscription();
                 $this->validateEmailAvailable($email);
 
-                $subscriber = $this->_subscriberFactory->create()->loadByEmail($email);
+                $websiteId = $this->_storeManager->getStore()->getWebsiteId();
+                $subscriber = $this->_subscriberFactory->create()->loadByEmailAndStore($email, $websiteId);
+
                 if ($subscriber->getId()
                     && $subscriber->getSubscriberStatus() == \Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED
                 ) {
@@ -133,7 +135,7 @@ class NewAction extends \Magento\Newsletter\Controller\Subscriber
                     );
                 }
 
-                $status = $this->_subscriberFactory->create()->subscribe($email);
+                $status = $this->_subscriberFactory->create()->subscribe($email,$websiteId);
                 if ($status == \Magento\Newsletter\Model\Subscriber::STATUS_NOT_ACTIVE) {
                     $this->messageManager->addSuccess(__('The confirmation request has been sent.'));
                 } else {

--- a/app/code/Magento/Newsletter/Model/ResourceModel/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/ResourceModel/Subscriber.php
@@ -111,6 +111,30 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     }
 
     /**
+     * Load subscriber from DB by email and storeId
+     *
+     * @param string $subscriberEmail
+     * @param int $storeId
+     * @return array
+     */
+    public function loadByEmailAndStore($subscriberEmail, $storeId)
+    {
+        $select = $this->connection->select()
+            ->from($this->getMainTable())
+            ->where('subscriber_email=:subscriber_email')
+            ->where('store_id=:store_Id');
+
+        $result = $this->connection
+            ->fetchRow($select, ['subscriber_email' => $subscriberEmail, 'store_Id' => $storeId]);
+
+        if (!$result) {
+            return [];
+        }
+
+        return $result;
+    }
+
+    /**
      * Load subscriber by customer
      *
      * @param \Magento\Customer\Api\Data\CustomerInterface $customer
@@ -147,6 +171,52 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 [
                     'subscriber_email' => $customer->getEmail(),
                     'store_id' => $customer->getStoreId()
+                ]
+            );
+
+        if ($result) {
+            return $result;
+        }
+
+        return [];
+    }
+
+    /**
+     * Load subscriber by customer
+     *
+     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     * @return array
+     */
+    public function loadByCustomerDataAndStore(\Magento\Customer\Api\Data\CustomerInterface $customer)
+    {
+        $select = $this->connection
+            ->select()->from($this->getMainTable())
+            ->where('customer_id=:customer_id and store_id=:store_id');
+
+        $result = $this->connection
+            ->fetchRow(
+                $select,
+                [
+                    'customer_id' => $customer->getId(),
+                    'store_id' => $customer->getStoreId()
+                ]
+            );
+
+        if ($result) {
+            return $result;
+        }
+
+        $select = $this->connection
+            ->select()
+            ->from($this->getMainTable())
+            ->where('subscriber_email=:subscriber_email and store_id=:store_id');
+
+        $result = $this->connection
+            ->fetchRow(
+                $select,
+                [
+                    'subscriber_email' => $customer->getEmail(),
+                    'store_Id' => $customer->getStoreId()
                 ]
             );
 

--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
@@ -114,6 +114,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
     public function testSubscribe()
     {
         $email = 'subscriber_email@magento.com';
+        $storeId = 1;
         $this->resource->expects($this->any())->method('loadByEmail')->willReturn(
             [
                 'subscriber_status' => 3,
@@ -133,12 +134,13 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->sendEmailCheck();
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
 
-        $this->assertEquals(1, $this->subscriber->subscribe($email));
+        $this->assertEquals(1, $this->subscriber->subscribe($email,$storeId));
     }
 
     public function testSubscribeNotLoggedIn()
     {
         $email = 'subscriber_email@magento.com';
+        $storeId = 1;
         $this->resource->expects($this->any())->method('loadByEmail')->willReturn(
             [
                 'subscriber_status' => 3,
@@ -158,7 +160,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->sendEmailCheck();
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
 
-        $this->assertEquals(2, $this->subscriber->subscribe($email));
+        $this->assertEquals(2, $this->subscriber->subscribe($email,$storeId));
     }
 
     public function testUpdateSubscription()


### PR DESCRIPTION

### Description
This fix solves the problem of subscribe to the Newsletter in Multistore setup.
With this fix, the newsletter subscritions are related to the store. The newsletter subscritions are now linked to the email and the store ID, allowing the same user to subscribe the newsletter in store A and store B.

### Fixed Issues (if relevant)
1. magento/magento2#13258 Subscribe to Newsletter. Multistore.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a multistore setup
2. Subscribe one email in store A
3. Subscribe the same email adress in Store B
4. Verify that the Newsletter list has two entries for the same email address but for different stores
5. Try to subscribe the same email adress on store A
6. Verify that you receive the error related with the email address already subscribed
7. Repeat the same steps, now with customer registration
8. On the customer menu you sould see the correct subscription status related with each store
9. Edit the subscripton on store A or B and see that you are changing the corresponding line on the newsletter subscription list.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
