### PR TITLE
Added translation for delete confirm popup box

### DIFF
--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -48,13 +48,3 @@
 </script>
 
 <div id="integration-popup-container" style="display: none;"></div>
-<div id="integration-delete-container"
-     class="messages"
-     style="display: none;"
-     title="<?= /* @escapeNotVerified */ __('Are you sure ?') ?>">
-    <div class="message message-notice notice">
-        <div>
-            <?= /* @escapeNotVerified */ __("Are you sure you want to delete this integration? You can't undo this action.") ?>
-        </div>
-    </div>
-</div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -33,8 +33,8 @@
             $('div#integrationGrid').on('click', 'button#delete', function (e) {
 
                 new Confirm({
-                    title: 'Are you sure?',
-                    content: "Are you sure you want to delete this integration? You can't undo this action.",
+                    title: '<?= /* @escapeNotVerified */ __('Are you sure ?') ?>',
+                    content: "<?= /* @escapeNotVerified */ __("Are you sure you want to delete this integration? You can't undo this action.") ?>",
                     actions: {
                         confirm: function () {
                             window.location.href = $(e.target).data('url');


### PR DESCRIPTION
Added language translation for two message appears inside modal popup on click delete event of integration.

Delete confirm box appears on triggering click event of delete icon at integration grid through **Confirm (Magento_Ui/js/modal/confirm)** javascript class.

Delete confirm box appears through **Confirm** class so there is no use of **#integration-delete-container** html block

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)