### PR TITLE
[Forwardport] Modify Report processor to return 500

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -215,7 +215,7 @@ class Processor
     public function processReport()
     {
         $this->pageTitle = 'There has been an error processing your request';
-        $this->_response->setHttpResponseCode(503);
+        $this->_response->setHttpResponseCode(500);
 
         $this->showErrorMsg = false;
         $this->showSentMsg  = false;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11513
The report processor is currently returning a HTTP 503 status
code; generally used for temporarily failures to connect to a service
such as when that service is in maintenance mode, when an upstream
proxy is unavailable etc.

This commit modifies the report HTTP code to be a 500. The author
believes this to be a better reflection that the error is miscellaneous
in nature, and that action is required in order to change it (i.e.
it is not a temporary condition)

Fixes #11512 