### PR TITLE
[Forwardport] magento/magento2#13820: IE11 minicart not updating on configurable pr…

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
@@ -1,7 +1,8 @@
 define([
     'jquery',
+    'underscore',
     'Magento_Customer/js/customer-data'
-], function ($, customerData) {
+], function ($, _, customerData) {
     'use strict';
 
     var selectors = {
@@ -23,7 +24,7 @@ define([
         if (!(data && data.items && data.items.length && productId)) {
             return false;
         }
-        changedProductOptions = data.items.find(function (item) {
+        changedProductOptions = _.find(data.items, function (item) {
             return item['product_id'] === productId;
         });
         changedProductOptions = changedProductOptions && changedProductOptions.options &&


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14105
…oduct page (ES6)

### Description
In `setProductOptions` function in `app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js` i used `underscore.find` method instead of  ES6 `array.find`. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13820: IE11 minicart not updating on configurable product page (ES6)

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open  Internet Explorer 11 and go to configurable product page 
2. Select swatch attribute values
3. Add product to cart
4. product should be added and mini cart should be updated

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
