### PR TITLE
[Forwardport] Performance: remove count() form the condition section of a loop

### DIFF
--- a/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
@@ -30,8 +30,8 @@ class Parser
         $expression = trim($expression);
         foreach ($this->_operations as $operation) {
             $splittedExpr = preg_split('/\\' . $operation . '/', $expression, -1, PREG_SPLIT_DELIM_CAPTURE);
-            if (!empty($splittedExpr)) {
-                $count = count($splittedExpr);
+            $count = count($splittedExpr);
+            if ($count > 1) {
                 for ($i = 0; $i < $count; $i++) {
                     $stack = array_merge($stack, $this->parseExpression($splittedExpr[$i]));
                     if ($i > 0) {

--- a/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
@@ -30,8 +30,9 @@ class Parser
         $expression = trim($expression);
         foreach ($this->_operations as $operation) {
             $splittedExpr = preg_split('/\\' . $operation . '/', $expression, -1, PREG_SPLIT_DELIM_CAPTURE);
-            if (count($splittedExpr) > 1) {
-                for ($i = 0; $i < count($splittedExpr); $i++) {
+            if (!empty($splittedExpr)) {
+                $count = count($splittedExpr);
+                for ($i = 0; $i < $count; $i++) {
                     $stack = array_merge($stack, $this->parseExpression($splittedExpr[$i]));
                     if ($i > 0) {
                         $stack[] = $operation;

--- a/app/code/Magento/Catalog/Model/Layer/Filter/DataProvider/Price.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/DataProvider/Price.php
@@ -282,7 +282,8 @@ class Price
     public function getPriorFilters($filterParams)
     {
         $priorFilters = [];
-        for ($i = 1; $i < count($filterParams); ++$i) {
+        $count = count($filterParams);
+        for ($i = 1; $i < $count; ++$i) {
             $priorFilter = $this->validateFilter($filterParams[$i]);
             if ($priorFilter) {
                 $priorFilters[] = $priorFilter;

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
@@ -98,7 +98,8 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     {
         $expected = [];
         $rowData = array_values($this->_testData);
-        for ($i = 0; $i < count($this->_testData); ++$i) {
+        $count = $this->_testData;
+        for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $dependentPath = 'some path ' . $i;
             $field = $this->_getField(
@@ -158,7 +159,8 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     {
         $expected = [];
         $rowData = array_values($this->_testData);
-        for ($i = 0; $i < count($this->_testData); ++$i) {
+        $count = count($this->_testData);
+        for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $field = $this->_getField(
                 true,

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
@@ -98,7 +98,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     {
         $expected = [];
         $rowData = array_values($this->_testData);
-        $count = $this->_testData;
+        $count = count($this->_testData);
         for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $dependentPath = 'some path ' . $i;

--- a/app/code/Magento/Paypal/Model/Report/Settlement.php
+++ b/app/code/Magento/Paypal/Model/Report/Settlement.php
@@ -369,7 +369,8 @@ class Settlement extends \Magento\Framework\Model\AbstractModel
                     // Section columns.
                     // In case ever the column order is changed, we will have the items recorded properly
                     // anyway. We have named, not numbered columns.
-                    for ($i = 1; $i < count($line); $i++) {
+                    $count = count($line);
+                    for ($i = 1; $i < $count; $i++) {
                         $sectionColumns[$line[$i]] = $i;
                     }
                     $flippedSectionColumns = array_flip($sectionColumns);

--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -2054,7 +2054,8 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
         if (preg_match('/[\\d\\w]{5}\\-[\\d\\w]{4}/', $zipString) != 0) {
             $zip = explode('-', $zipString);
         }
-        for ($i = 0; $i < count($zip); ++$i) {
+        $count = count($zip);
+        for ($i = 0; $i < $count; ++$i) {
             if (strlen($zip[$i]) == 5) {
                 $zip5 = $zip[$i];
             } elseif (strlen($zip[$i]) == 4) {

--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -749,7 +749,8 @@ class Generator extends AbstractSchemaGenerator
     private function convertPathParams($uri)
     {
         $parts = explode('/', $uri);
-        for ($i=0; $i < count($parts); $i++) {
+        $count = count($parts);
+        for ($i=0; $i < $count; $i++) {
             if (strpos($parts[$i], ':') === 0) {
                 $parts[$i] = '{' . substr($parts[$i], 1) . '}';
             }

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl/ComplexTypeStrategy.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl/ComplexTypeStrategy.php
@@ -229,7 +229,8 @@ class ComplexTypeStrategy extends AbstractComplexTypeStrategy
         $this->_processElementType($elementType, $documentation, $appInfoNode);
 
         if (preg_match_all('/{([a-z]+):(.+)}/Ui', $documentation, $matches)) {
-            for ($i = 0; $i < count($matches[0]); $i++) {
+            $count = count($matches[0]);
+            for ($i = 0; $i < $count; $i++) {
                 $appinfoTag = $matches[0][$i];
                 $tagName = $matches[1][$i];
                 $tagValue = $matches[2][$i];


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13173
### Description
In this PR I removed the `count()` method from condition section for some loops. When this method is used in the loop condition it will be executed every iteration which is not so good for process time (performance).

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
