### PR TITLE
[Backport] Can't cancel removal of a block or container in layout by setting remove attribute value to false

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/LayoutDirectivesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/LayoutDirectivesTest.php
@@ -201,6 +201,18 @@ class LayoutDirectivesTest extends \PHPUnit_Framework_TestCase
     /**
      * @magentoAppIsolation enabled
      */
+    public function testRemoveCancellation()
+    {
+        $layout = $this->_getLayoutModel('remove_cancellation.xml');
+        $this->assertTrue($layout->isContainer('container1'));
+        $this->assertTrue($layout->isBlock('child_block1'));
+        $this->assertTrue($layout->isBlock('no_name2'));
+        $this->assertFalse($layout->getBlock('not_exist'));
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
     public function testMove()
     {
         $layout = $this->_getLayoutModel('move.xml');

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/remove_cancellation.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/remove_cancellation.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<layout>
+    <container name="container1" label="Container 1">
+        <block class="Magento\Framework\View\Element\Text" name="no_name2"/>
+    </container>
+    <referenceContainer name="container1" remove="true"/>
+    <referenceBlock name="child_block1" remove="true"/>
+    <block class="Magento\Framework\View\Element\Text" name="block_container" as="block.container">
+        <block class="Magento\Framework\View\Element\Text" name="child_block1"/>
+        <block class="Magento\Framework\View\Element\Text" name="child_block2"/>
+    </block>
+    <referenceContainer name="not_exist" remove="false"/>
+    <referenceContainer name="container1" remove="false"/>
+    <referenceBlock name="child_block1" remove="false"/>
+</layout>

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Block.php
@@ -207,13 +207,15 @@ class Block implements Layout\ReaderInterface
         $elementRemove = filter_var($currentElement->getAttribute('remove'), FILTER_VALIDATE_BOOLEAN);
         if ($elementRemove) {
             $scheduledStructure->setElementToRemoveList($elementName);
-        } else {
-            $data = $scheduledStructure->getStructureElementData($elementName, []);
-            $data['attributes'] = $this->mergeBlockAttributes($data, $currentElement);
-            $this->updateScheduledData($currentElement, $data);
-            $this->evaluateArguments($currentElement, $data);
-            $scheduledStructure->setStructureElementData($elementName, $data);
+            return;
+        } elseif ($currentElement->getAttribute('remove')) {
+            $scheduledStructure->unsetElementFromListToRemove($elementName);
         }
+        $data = $scheduledStructure->getStructureElementData($elementName, []);
+        $data['attributes'] = $this->mergeBlockAttributes($data, $currentElement);
+        $this->updateScheduledData($currentElement, $data);
+        $this->evaluateArguments($currentElement, $data);
+        $scheduledStructure->setStructureElementData($elementName, $data);
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
@@ -141,11 +141,12 @@ class Container implements Layout\ReaderInterface
     ) {
         $containerName = $currentElement->getAttribute('name');
         $containerRemove = filter_var($currentElement->getAttribute('remove'), FILTER_VALIDATE_BOOLEAN);
-
         if ($containerRemove) {
             $scheduledStructure->setElementToRemoveList($containerName);
-        } else {
-            $this->mergeContainerAttributes($scheduledStructure, $currentElement);
+            return;
+        } elseif ($currentElement->getAttribute('remove')) {
+            $scheduledStructure->unsetElementFromListToRemove($containerName);
         }
+        $this->mergeContainerAttributes($scheduledStructure, $currentElement);
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/BlockTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/BlockTest.php
@@ -188,6 +188,12 @@ class BlockTest extends \PHPUnit_Framework_TestCase
         $setCondition,
         $setRemoveCondition
     ) {
+        if ($literal == 'referenceBlock' && $remove == 'false') {
+            $this->scheduledStructure->expects($this->once())
+                ->method('unsetElementFromListToRemove')
+                ->with($literal);
+        }
+
         $this->context->expects($this->once())->method('getScheduledStructure')
             ->will($this->returnValue($this->scheduledStructure));
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/ContainerTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/ContainerTest.php
@@ -102,6 +102,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             ->with($contextMock, $elementCurrent)
             ->willReturnSelf();
 
+        if ($elementCurrent->getAttribute('remove') == 'false') {
+            $scheduledStructureMock->expects($this->once())
+                ->method('unsetElementFromListToRemove')
+                ->with($elementCurrent->getAttribute('name'));
+        }
+        
         $this->container->interpret($contextMock, $elementCurrent);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
MAGETWO-69715
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#1931: Can't cancel removal of a block or container in layout by setting remove attribute value to false

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
