### PR TITLE
[Forwardport] Invoice grid shows wrong subtotal for partial items invoice. It shows order's subtotal instead if invoiced item's subtotal

### DIFF
--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -685,7 +685,7 @@
                 <item name="billing_address" xsi:type="object">BillingAddressAggregator</item>
                 <item name="shipping_address" xsi:type="object">ShippingAddressAggregator</item>
                 <item name="shipping_information" xsi:type="string">sales_order.shipping_description</item>
-                <item name="subtotal" xsi:type="string">sales_order.base_subtotal</item>
+                <item name="subtotal" xsi:type="string">sales_invoice.base_subtotal</item>
                 <item name="shipping_and_handling" xsi:type="string">sales_order.base_shipping_amount</item>
                 <item name="base_grand_total" xsi:type="string">sales_invoice.base_grand_total</item>
                 <item name="grand_total" xsi:type="string">sales_invoice.grand_total</item>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13855
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13804: Invoice grid shows wrong subtotal for partial items invoice. It shows order's subtotal instead if invoiced item's subtotal

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Place order with multiple taxable items
2. Generate separate invoice for each items. (In short generate multiple invoices for same order with different items)
3. Do check value of **Subtotal** column value in Invoice grid.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
