### PR TITLE
[Forwardport] Fix typo in securityCheckers array

### DIFF
--- a/app/code/Magento/Security/etc/adminhtml/di.xml
+++ b/app/code/Magento/Security/etc/adminhtml/di.xml
@@ -24,7 +24,7 @@
         <arguments>
             <argument name="securityCheckers" xsi:type="array">
                 <item name="frequency" xsi:type="object">Magento\Security\Model\SecurityChecker\Frequency</item>
-                <item name="wuantity" xsi:type="object">Magento\Security\Model\SecurityChecker\Quantity</item>
+                <item name="quantity" xsi:type="object">Magento\Security\Model\SecurityChecker\Quantity</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Original Pull Request
https://github.com/magento/magento2/pull/13897

Description
Update wuantity to quantity to match the key used in https://github.com/magento/magento2/blob/4cfedb97d92b887e68a8d9c2f14bf75f1854ba0c/app/code/Magento/Security/etc/di.xml

Fixed Issues (if relevant)
n/a

Manual testing scenarios
Set admin reset quantity limits
Attempt exceeding admin password reset quantity limit
Should continue to work as it did before

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
