### PR TITLE
[Forwardport] Fix $useCache for container child blocks

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout.php
+++ b/lib/internal/Magento/Framework/View/Layout.php
@@ -533,7 +533,7 @@ class Layout extends \Magento\Framework\Simplexml\Config implements \Magento\Fra
             } elseif ($this->isBlock($name)) {
                 $result = $this->_renderBlock($name);
             } else {
-                $result = $this->_renderContainer($name);
+                $result = $this->_renderContainer($name, false);
             }
         } catch (\Exception $e) {
             if ($this->appState->getMode() === AppState::MODE_DEVELOPER) {
@@ -575,14 +575,15 @@ class Layout extends \Magento\Framework\Simplexml\Config implements \Magento\Fra
      * Gets HTML of container element
      *
      * @param string $name
+     * @param bool $useCache
      * @return string
      */
-    protected function _renderContainer($name)
+    protected function _renderContainer($name, $useCache = true)
     {
         $html = '';
         $children = $this->getChildNames($name);
         foreach ($children as $child) {
-            $html .= $this->renderElement($child);
+            $html .= $this->renderElement($child, $useCache);
         }
         if ($html == '' || !$this->structure->getAttribute($name, Element::CONTAINER_OPT_HTML_TAG)) {
             return $html;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14029
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This is a follow-up from PR #4919. 

When one would use `getChildHtml()` like the following to output a container uncached:
`<?= $block->getChildHtml('category.products.list.product_meta', false); ?>`
The container's child blocks would still be cached.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4919: getChildHtml, $useCache and child containers

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add a container to block `category.products.list`.
2. Add a custom template to the container and output something that should be different every time it gets rendered, like `<?= rand() ?>`. 
2. Output the container in `Magento/Catalog/templates/products/list.phtml` using `getChildHtml()` and set `$useCache` to `false`.
for ($i = 0; $i < 5; $i++) {
        echo $this->getChildHtml('my.container', false);
    }
3. The output is the same with each `getChildHtml()` of the container.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
