### PR TITLE
[Forwardport] Fix cache issue for currencies with no symbol

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -126,7 +126,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
     public function getCacheKeyInfo()
     {
         $parentData = parent::getCacheKeyInfo();
-        $parentData[] = $this->priceCurrency->getCurrencySymbol();
+        $parentData[] = $this->priceCurrency->getCurrency()->getCode();
         $parentData[] = $this->customerSession->getCustomerGroupId();
         return $parentData;
     }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -49,6 +49,11 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
     private $priceCurrency;
 
     /**
+     * @var \Magento\Directory\Model\Currency|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $currency;
+
+    /**
      * @var \Magento\ConfigurableProduct\Model\ConfigurableAttributeData|\PHPUnit_Framework_MockObject_MockObject
      */
     private $configurableAttributeData;
@@ -122,6 +127,9 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         $this->context->expects($this->once())
             ->method('getResolver')
             ->willReturn($fileResolverMock);
+        $this->currency = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->configurableAttributeData = $this->getMockBuilder(
             \Magento\ConfigurableProduct\Model\ConfigurableAttributeData::class
         )
@@ -192,10 +200,10 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                     2 => null,
                     'base_url' => null,
                     'template' => null,
-                    3 => '$',
+                    3 => 'USD',
                     4 => null,
                 ],
-                '$',
+                'USD',
                 null,
             ]
         ];
@@ -223,7 +231,10 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
             ->method('getStore')
             ->willReturn($storeMock);
         $this->priceCurrency->expects($this->once())
-            ->method('getCurrencySymbol')
+            ->method('getCurrency')
+            ->willReturn($this->currency);
+        $this->currency->expects($this->once())
+            ->method('getCode')
             ->willReturn($priceCurrency);
         $this->customerSession->expects($this->once())
             ->method('getCustomerGroupId')


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13894

Using getCurrencySymbol() leads to a bug for currencies where there is no currency symbol - cache ends up being non-unique. Using currency code for caching is a more foolproof way.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
