### PR TITLE
Backport of PR-8772 for Magento 2.1: magento/magento2#3882

### DIFF
--- a/app/code/Magento/Widget/Model/Config/Converter.php
+++ b/app/code/Magento/Widget/Model/Config/Converter.php
@@ -44,7 +44,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
                     case 'parameters':
                         /** @var $parameter \DOMNode */
                         foreach ($widgetSubNode->childNodes as $parameter) {
-                            if ($parameter->nodeName === '#text') {
+                            if ($parameter->nodeName === '#text' || $parameter->nodeName === '#comment') {
                                 continue;
                             }
                             $subNodeAttributes = $parameter->attributes;
@@ -57,7 +57,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
                             $widgetArray['supported_containers'] = [];
                         }
                         foreach ($widgetSubNode->childNodes as $container) {
-                            if ($container->nodeName === '#text') {
+                            if ($container->nodeName === '#text' || $container->nodeName === '#comment') {
                                 continue;
                             }
                             $widgetArray['supported_containers'] = array_merge(

--- a/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml
+++ b/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml
@@ -11,6 +11,7 @@
         <label translate="true">Orders and Returns</label>
         <description translate="true">Orders and Returns Search Form</description>
         <parameters>
+            <!-- Comment added to check fix to https://github.com/magento/magento2/issues/3882 -->
             <parameter name="title" xsi:type="text" visible="false">
                 <label translate="true">Anchor Custom Title</label>
             </parameter>
@@ -54,6 +55,7 @@
             </parameter>
         </parameters>
         <containers>
+            <!-- Comment added to check fix to https://github.com/magento/magento2/issues/3882 -->
             <container name="left">
                 <template name="default" value="default_template" />
             </container>


### PR DESCRIPTION
magento/magento2#3882:
- An XML comment node as parameter in widget.xml fails with fatal error
- Fixed also for comments in containers node

(cherry picked from commit 51da3d497fc78832a917120ccdf2292af4f82f3a)

MAGETWO-65436: [GitHub][PR] magento/magento2#3882 magento/magento2#8772

(cherry picked from commit 03c9c20f75c1bb4f4e56a2f54c1c5b442cad5e62)

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This is a backport of https://github.com/magento/magento2/pull/8772 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/3882: An XML comment node as parameter in widget.xml fails with fatal error
2. https://github.com/magento/magento2/pull/7439: Allow comments in widget.xml parameters

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
