### PR TITLE
[Forwardport] catalog:images:resize CLI command fix

### DIFF
--- a/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
@@ -69,7 +69,6 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
         $productIds = $productCollection->getAllIds();
         if (!count($productIds)) {
             $output->writeln("<info>No product images to resize</info>");
-            // we must have an exit code higher than zero to indicate something was wrong
             return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         }
 


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/14154

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Updated `catalog:images:resize` CLI command to return correct exit code on failure. Currently, the conditional check to verify if there are any images to resize returns `\Magento\Framework\Console\Cli::RETURN_SUCCESS` (a const === 0) if there aren't any images. Per the comment above the return—_"we must have an exit code higher than zero to indicate something was wrong"_—this PR returns `\Magento\Framework\Console\Cli::RETURN_FAILURE` (a const === 1).

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios
n/a

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
