### PR TITLE
[Forwardport] Add missing implementation for applySortOrder()

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Totals.php
+++ b/app/code/Magento/Sales/Block/Order/Totals.php
@@ -293,6 +293,12 @@ class Totals extends \Magento\Framework\View\Element\Template
      */
     public function applySortOrder($order)
     {
+        \uksort(
+            $this->_totals,
+            function ($code1, $code2) use ($order) {
+                return ($order[$code1] ?? 0) <=> ($order[$code2] ?? 0);
+            }
+        );
         return $this;
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Block/Order/TotalsTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Order/TotalsTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Sales\Test\Unit\Block\Order;
+
+use Magento\Framework\Registry;
+use Magento\Sales\Block\Order\Totals;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Total;
+
+class TotalsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Sales\Block\Order\Totals
+     */
+    protected $block;
+
+    /**
+     * @var \Magento\Framework\View\Element\Template\Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $context;
+
+    protected function setUp()
+    {
+        $this->context = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);
+        $this->block = new Totals($this->context, new Registry);
+        $this->block->setOrder($this->createMock(Order::class));
+    }
+
+    public function testApplySortOrder()
+    {
+        $this->block->addTotal(new Total(['code' => 'one']), 'last');
+        $this->block->addTotal(new Total(['code' => 'two']), 'last');
+        $this->block->addTotal(new Total(['code' => 'three']), 'last');
+        $this->block->applySortOrder(
+            [
+                'one' => 10,
+                'two' => 30,
+                'three' => 20,
+            ]
+        );
+        $this->assertEqualsSorted(
+            [
+                'one' => new Total(['code' => 'one']),
+                'three' => new Total(['code' => 'three']),
+                'two' => new Total(['code' => 'two']),
+            ],
+            $this->block->getTotals()
+        );
+    }
+
+    private function assertEqualsSorted(array $expected, array $actual)
+    {
+        $this->assertEquals($expected, $actual, 'Array contents should be equal.');
+        $this->assertEquals(array_keys($expected), array_keys($actual), 'Array sort order should be equal.');
+    }
+}


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13641
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The totals block for the frontend order view has a method `applySortOrder` to manipulate  ordering of already added totals. Alas this method was never implemented.

It is also currently not used in the core, so this PR is only a partial solution to the issue linked below. But having it implemented is useful for third party extensions as a sensible way to reorder the totals.

### Fixed Issues (if relevant)
1. magento/magento2#13631:Totals sort order is not respected in customer account order view **(not fixed but related)**

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
