### PR TITLE
[Forwardport] Improve array output format for etc.php and config.php

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -12,9 +12,9 @@ namespace Magento\Framework\App\DeploymentConfig\Writer;
 class PhpFormatter implements FormatterInterface
 {
     /**
-     * 2 space indentation for array formatting.
+     * 4 space indentation for array formatting.
      */
-    const INDENT = '  ';
+    const INDENT = '    ';
 
     /**
      * Format deployment configuration.
@@ -39,7 +39,7 @@ class PhpFormatter implements FormatterInterface
      * @param string $prefix
      * @return string
      */
-    private function formatData($data, $comments = [], $prefix = '  ')
+    private function formatData($data, $comments = [], $prefix = '    ')
     {
         $elements = [];
 
@@ -56,13 +56,12 @@ class PhpFormatter implements FormatterInterface
                     $elements[] = $prefix . " */";
                 }
 
-                $elements[] = $prefix . $this->varExportShort($key) . ' => ' .
-                    (!is_array($value) ? $this->varExportShort($value) . ',' : '');
-
                 if (is_array($value)) {
-                    $elements[] = $prefix . '[';
-                    $elements[] = $this->formatData($value, [], '  ' . $prefix);
+                    $elements[] = $prefix . $this->varExportShort($key) . ' => [';
+                    $elements[] = $this->formatData($value, [], '    ' . $prefix);
                     $elements[] = $prefix . '],';
+                } else {
+                    $elements[] = $prefix . $this->varExportShort($key) . ' => ' . $this->varExportShort($value) . ',';
                 }
             }
             return implode("\n", $elements);

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -56,77 +56,67 @@ class PhpFormatterTest extends \PHPUnit\Framework\TestCase
         $expectedResult1 = <<<TEXT
 <?php
 return [
-  'ns1' => 
-  [
-    's1' => 
-    [
-      0 => 's11',
-      1 => 's12',
+    'ns1' => [
+        's1' => [
+            0 => 's11',
+            1 => 's12',
+        ],
+        's2' => [
+            0 => 's21',
+            1 => 's22',
+        ],
     ],
-    's2' => 
-    [
-      0 => 's21',
-      1 => 's22',
+    /**
+     * For the section: ns2
+     * comment for namespace 2
+     */
+    'ns2' => [
+        's1' => [
+            0 => 's11',
+        ],
     ],
-  ],
-  /**
-   * For the section: ns2
-   * comment for namespace 2
-   */
-  'ns2' => 
-  [
-    's1' => 
-    [
-      0 => 's11',
-    ],
-  ],
-  'ns3' => 'just text',
-  'ns4' => 'just text',
+    'ns3' => 'just text',
+    'ns4' => 'just text',
 ];
 
 TEXT;
         $expectedResult2 = <<<TEXT
 <?php
 return [
-  /**
-   * For the section: ns1
-   * comment for' namespace 1
-   */
-  'ns1' => 
-  [
-    's1' => 
-    [
-      0 => 's11',
-      1 => 's12',
+    /**
+     * For the section: ns1
+     * comment for' namespace 1
+     */
+    'ns1' => [
+        's1' => [
+            0 => 's11',
+            1 => 's12',
+        ],
+        's2' => [
+            0 => 's21',
+            1 => 's22',
+        ],
     ],
-    's2' => 
-    [
-      0 => 's21',
-      1 => 's22',
+    /**
+     * For the section: ns2
+     * comment for namespace 2.
+     * Next comment for' namespace 2
+     */
+    'ns2' => [
+        's1' => [
+            0 => 's11',
+        ],
     ],
-  ],
-  /**
-   * For the section: ns2
-   * comment for namespace 2.
-   * Next comment for' namespace 2
-   */
-  'ns2' => 
-  [
-    's1' => 
-    [
-      0 => 's11',
-    ],
-  ],
-  /**
-   * For the section: ns3
-   * comment for" namespace 3
-   */
-  'ns3' => 'just text',
-  /**
-   * For the section: ns4
-   * comment for namespace 4
-   */
-  'ns4' => 'just text',
+    /**
+     * For the section: ns3
+     * comment for" namespace 3
+     */
+    'ns3' => 'just text',
+    /**
+     * For the section: ns4
+     * comment for namespace 4
+     */
+    'ns4' => 'just text',
 ];
 
 TEXT;
@@ -134,23 +124,23 @@ TEXT;
         $expectedResult3 = <<<TEXT
 <?php
 return [
-  'ns1' => [
-    's1' => [
-      's11',
-      's12'
+    'ns1' => [
+        's1' => [
+            's11',
+            's12'
+        ],
+        's2' => [
+            's21',
+            's22'
+        ]
     ],
-    's2' => [
-      's21',
-      's22'
-    ]
-  ],
-  'ns2' => [
-    's1' => [
-      's11'
-    ]
-  ],
-  'ns3' => 'just text',
-  'ns4' => 'just text'
+    'ns2' => [
+        's1' => [
+            's11'
+        ]
+    ],
+    'ns3' => 'just text',
+    'ns4' => 'just text'
 ];
 
 TEXT;


### PR DESCRIPTION
### Original pull request
https://github.com/magento/magento2/pull/14042

### Description
This improved the syntax of the generated files app/etc/env.php and app/etc/config.php by using 4 instead of 2 spaces and by removing whitelines after "=>".

### Fixed Issues (if relevant)
The generated array code wasn't compliant to formatting standard. Example from config.php:

```
<?php
return [
  'modules' => 
  [
    'Magento_Store' => 1,
    'Magento_AdvancedPricingImportExport' => 1,
```

### Manual testing scenarios
1. Run a command which regenerates env.php and/or config.php, i.e. `bin/magento config:set general/store_information/name "My Store" --lock-config`
2. Check that the generated file (i.e. app/etc/config.php) is formatted like this, with 4 space indent and removed line breaks:

```
<?php
return [
    'modules' => [
        'Magento_Store' => 1,
        'Magento_AdvancedPricingImportExport' => 1,
```

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
