### PR TITLE
Trim SKU before product save

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -159,6 +159,7 @@ class Helper
         }
 
         $productData = $this->normalize($productData);
+        $productData = $this->trimData($productData);
 
         if (!empty($productData['is_downloadable'])) {
             $productData['product_has_weight'] = 0;
@@ -311,6 +312,25 @@ class Helper
                 }
             } elseif (is_array($value)) {
                 $productData[$key] = $this->normalize($value);
+            }
+        }
+
+        return $productData;
+    }
+
+    /**
+     * Internal trim data
+     *
+     * @param array $productData
+     * @return array
+     */
+    protected function trimData(array $productData)
+    {
+        foreach ($productData as $key => $value) {
+            if (is_scalar($value)) {
+                $productData[$key] = trim($value);
+            } elseif (is_array($value)) {
+                $productData[$key] = $this->trimData($value);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
There is a problem with spaces before and after attributes value. The problem is very annoying at SKU. It leads to many misunderstandings because for example 'my-sku' is different than 'my-sku ' (look at the space).
I fixed it adding trim function to every product data value.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set the SKU with space before or after the right value in admin.
2. Save product.
3. Space on the beginning and on the end of SKU value should disappear.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
