### PR TITLE
[Forwardport] Issues #10559 - Extend swatch using mixins (M2.2)

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
@@ -115,7 +115,8 @@ class FinalPriceBox extends BasePriceBox
     {
         return '<div class="price-box ' . $this->getData('css_classes') . '" ' .
             'data-role="priceBox" ' .
-            'data-product-id="' . $this->getSaleableItem()->getId() . '"' .
+            'data-product-id="' . $this->getSaleableItem()->getId() . '" ' .
+            'data-price-box="product-id-' . $this->getSaleableItem()->getId() . '"' .
             '>' . $html . '</div>';
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
@@ -246,7 +246,8 @@ class FinalPriceBoxTest extends \PHPUnit\Framework\TestCase
 
         //assert price wrapper
         $this->assertEquals(
-            '<div class="price-box price-final_price" data-role="priceBox" data-product-id="">test</div>',
+            '<div class="price-box price-final_price" data-role="priceBox" data-product-id="" ' .
+            'data-price-box="product-id-">test</div>',
             $result
         );
     }

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -67,7 +67,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
     /**
      * @var Format
      */
-    private $localeFormat;
+    protected $localeFormat;
 
     /**
      * @var Session
@@ -211,9 +211,6 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $store = $this->getCurrentStore();
         $currentProduct = $this->getProduct();
 
-        $regularPrice = $currentProduct->getPriceInfo()->getPrice('regular_price');
-        $finalPrice = $currentProduct->getPriceInfo()->getPrice('final_price');
-
         $options = $this->helper->getOptions($currentProduct, $this->getAllowProducts());
         $attributesData = $this->configurableAttributeData->getAttributesData($currentProduct, $options);
 
@@ -223,17 +220,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             'currencyFormat' => $store->getCurrentCurrency()->getOutputFormat(),
             'optionPrices' => $this->getOptionPrices(),
             'priceFormat' => $this->localeFormat->getPriceFormat(),
-            'prices' => [
-                'oldPrice' => [
-                    'amount' => $this->localeFormat->getNumber($regularPrice->getAmount()->getValue()),
-                ],
-                'basePrice' => [
-                    'amount' => $this->localeFormat->getNumber($finalPrice->getAmount()->getBaseAmount()),
-                ],
-                'finalPrice' => [
-                    'amount' => $this->localeFormat->getNumber($finalPrice->getAmount()->getValue()),
-                ],
-            ],
+            'prices' => $this->getPrices(),
             'productId' => $currentProduct->getId(),
             'chooseText' => __('Choose an Option...'),
             'images' => $this->getOptionImages(),
@@ -247,6 +234,32 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $config = array_merge($config, $this->_getAdditionalConfig());
 
         return $this->jsonEncoder->encode($config);
+    }
+    
+    /**
+     * Get product prices for configurable variations
+     *
+     * @return array
+     * @since 100.2.0
+     */
+    protected function getPrices()
+    {
+        $currentProduct = $this->getProduct();
+
+        $regularPrice = $currentProduct->getPriceInfo()->getPrice('regular_price');
+        $finalPrice = $currentProduct->getPriceInfo()->getPrice('final_price');
+
+        return [
+            'oldPrice' => [
+                'amount' => $this->localeFormat->getNumber($regularPrice->getAmount()->getValue()),
+            ],
+            'basePrice' => [
+                'amount' => $this->localeFormat->getNumber($finalPrice->getAmount()->getBaseAmount()),
+            ],
+            'finalPrice' => [
+                'amount' => $this->localeFormat->getNumber($finalPrice->getAmount()->getValue()),
+            ],
+        ];
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Variations/Prices.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Variations/Prices.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations;
+
+/**
+ * Configurable product variation prices.
+ */
+class Prices
+{
+    /**
+     * @var \Magento\Framework\Locale\Format
+     */
+    private $localeFormat;
+
+    /**
+     * Prices constructor.
+     * @param \Magento\Framework\Locale\Format $localeFormat
+     */
+    public function __construct(\Magento\Framework\Locale\Format $localeFormat)
+    {
+        $this->localeFormat = $localeFormat;
+    }
+
+    /**
+     * Get product prices for configurable variations
+     *
+     * @param \Magento\Framework\Pricing\PriceInfo\Base $priceInfo
+     * @return array
+     */
+    public function getFormattedPrices(\Magento\Framework\Pricing\PriceInfo\Base $priceInfo)
+    {
+        $regularPrice = $priceInfo->getPrice('regular_price');
+        $finalPrice = $priceInfo->getPrice('final_price');
+
+        return [
+            'oldPrice' => [
+                'amount' => $this->localeFormat->getNumber($regularPrice->getAmount()->getValue()),
+            ],
+            'basePrice' => [
+                'amount' => $this->localeFormat->getNumber($finalPrice->getAmount()->getBaseAmount()),
+            ],
+            'finalPrice' => [
+                'amount' => $this->localeFormat->getNumber($finalPrice->getAmount()->getValue()),
+            ],
+        ];
+    }
+}

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/Configurable/Variations/PricesTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/Configurable/Variations/PricesTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\ConfigurableProduct\Test\Unit\Model\Product\Type\Configurable\Variations;
+
+use PHPUnit\Framework\TestCase;
+
+class PricesTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $localeFormatMock;
+
+    /**
+     * @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices
+     */
+    private $model;
+
+    protected function setUp()
+    {
+        $this->localeFormatMock = $this->createMock(\Magento\Framework\Locale\Format::class);
+        $this->model = new \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices(
+            $this->localeFormatMock
+        );
+    }
+
+    public function testGetFormattedPrices()
+    {
+        $expected = [
+            'oldPrice' => [
+                'amount' => 500
+            ],
+            'basePrice' => [
+                'amount' => 1000
+            ],
+            'finalPrice' => [
+                'amount' => 500
+            ]
+        ];
+        $priceInfoMock = $this->createMock(\Magento\Framework\Pricing\PriceInfo\Base::class);
+        $priceMock = $this->createMock(\Magento\Framework\Pricing\Price\PriceInterface::class);
+        $priceInfoMock->expects($this->atLeastOnce())->method('getPrice')->willReturn($priceMock);
+
+        $amountMock = $this->createMock(\Magento\Framework\Pricing\Amount\AmountInterface::class);
+        $amountMock->expects($this->atLeastOnce())->method('getValue')->willReturn(500);
+        $amountMock->expects($this->atLeastOnce())->method('getBaseAmount')->willReturn(1000);
+        $priceMock->expects($this->atLeastOnce())->method('getAmount')->willReturn($amountMock);
+
+        $this->localeFormatMock->expects($this->atLeastOnce())
+            ->method('getNumber')
+            ->withConsecutive([500], [1000], [500])
+            ->will($this->onConsecutiveCalls(500, 1000, 500));
+
+        $this->assertEquals($expected, $this->model->getFormattedPrices($priceInfoMock));
+    }
+}

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
@@ -66,6 +66,26 @@ class Configurable extends \Magento\Swatches\Block\Product\Renderer\Configurable
         $this->unsetData('allow_products');
         return parent::getJsonConfig();
     }
+    
+    /**
+     * Composes configuration for js price format
+     *
+     * @return string
+     */
+    public function getPriceFormatJson()
+    {
+        return $this->jsonEncoder->encode($this->localeFormat->getPriceFormat());
+    }
+
+    /**
+     * Composes configuration for js price
+     *
+     * @return string
+     */
+    public function getPricesJson()
+    {
+        return $this->jsonEncoder->encode($this->getPrices());
+    }
 
     /**
      * Do not load images for Configurable product with swatches due to its loaded by request

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
@@ -5,7 +5,19 @@
  */
 namespace Magento\Swatches\Block\Product\Renderer\Listing;
 
+use Magento\Catalog\Block\Product\Context;
+use Magento\Catalog\Helper\Product as CatalogProduct;
 use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProduct\Helper\Data;
+use Magento\ConfigurableProduct\Model\ConfigurableAttributeData;
+use Magento\Customer\Helper\Session\CurrentCustomer;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Json\EncoderInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\Stdlib\ArrayUtils;
+use Magento\Swatches\Helper\Data as SwatchData;
+use Magento\Swatches\Helper\Media;
+use Magento\Swatches\Model\SwatchAttributesProvider;
 
 /**
  * Swatch renderer block in Category page
@@ -16,6 +28,71 @@ use Magento\Catalog\Model\Product;
  */
 class Configurable extends \Magento\Swatches\Block\Product\Renderer\Configurable
 {
+    /**
+     * @var \Magento\Framework\Locale\Format
+     */
+    private $localeFormat;
+
+    /**
+     * @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices
+     */
+    private $variationPrices;
+
+    /**
+     * @param Context $context
+     * @param ArrayUtils $arrayUtils
+     * @param EncoderInterface $jsonEncoder
+     * @param Data $helper
+     * @param CatalogProduct $catalogProduct
+     * @param CurrentCustomer $currentCustomer
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param ConfigurableAttributeData $configurableAttributeData
+     * @param SwatchData $swatchHelper
+     * @param Media $swatchMediaHelper
+     * @param array $data other data
+     * @param SwatchAttributesProvider $swatchAttributesProvider
+     * @param \Magento\Framework\Locale\Format|null $localeFormat
+     * @param \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices|null $variationPrices
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        Context $context,
+        ArrayUtils $arrayUtils,
+        EncoderInterface $jsonEncoder,
+        Data $helper,
+        CatalogProduct $catalogProduct,
+        CurrentCustomer $currentCustomer,
+        PriceCurrencyInterface $priceCurrency,
+        ConfigurableAttributeData $configurableAttributeData,
+        SwatchData $swatchHelper,
+        Media $swatchMediaHelper,
+        array $data = [],
+        SwatchAttributesProvider $swatchAttributesProvider = null,
+        \Magento\Framework\Locale\Format $localeFormat = null,
+        \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices $variationPrices = null
+    ) {
+        parent::__construct(
+            $context,
+            $arrayUtils,
+            $jsonEncoder,
+            $helper,
+            $catalogProduct,
+            $currentCustomer,
+            $priceCurrency,
+            $configurableAttributeData,
+            $swatchHelper,
+            $swatchMediaHelper,
+            $data,
+            $swatchAttributesProvider
+        );
+        $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(
+            \Magento\Framework\Locale\Format::class
+        );
+        $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
+            \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices::class
+        );
+    }
+
     /**
      * @return string
      */
@@ -85,7 +162,9 @@ class Configurable extends \Magento\Swatches\Block\Product\Renderer\Configurable
      */
     public function getPricesJson()
     {
-        return $this->jsonEncoder->encode($this->getPrices());
+        return $this->jsonEncoder->encode(
+            $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo())
+        );
     }
 
     /**

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
@@ -12,6 +12,7 @@ use Magento\Catalog\Model\Product;
  *
  * @api
  * @since 100.0.2
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Configurable extends \Magento\Swatches\Block\Product\Renderer\Configurable
 {

--- a/app/code/Magento/Swatches/Test/Unit/Block/Product/Renderer/Listing/ConfigurableTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Block/Product/Renderer/Listing/ConfigurableTest.php
@@ -9,6 +9,7 @@ use Magento\Swatches\Block\Product\Renderer\Configurable;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  */
 class ConfigurableTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Swatches/Test/Unit/Block/Product/Renderer/Listing/ConfigurableTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Block/Product/Renderer/Listing/ConfigurableTest.php
@@ -58,6 +58,9 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
     /** @var \Magento\Framework\UrlInterface|\PHPUnit_Framework_MockObject_MockObject  */
     private $urlBuilder;
 
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    private $variationPricesMock;
+
     public function setUp()
     {
         $this->arrayUtils = $this->createMock(\Magento\Framework\Stdlib\ArrayUtils::class);
@@ -76,6 +79,9 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         $this->scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
         $this->imageHelper = $this->createMock(\Magento\Catalog\Helper\Image::class);
         $this->urlBuilder = $this->createMock(\Magento\Framework\UrlInterface::class);
+        $this->variationPricesMock = $this->createMock(
+            \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices::class
+        );
 
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->configurable = $objectManagerHelper->getObject(
@@ -94,6 +100,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 'priceCurrency' => $this->priceCurrency,
                 'configurableAttributeData' => $this->configurableAttributeData,
                 'data' => [],
+                'variationPrices' => $this->variationPricesMock
             ]
         );
     }
@@ -201,5 +208,31 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
 
         $this->helper->expects($this->any())->method('getAllowAttributes')->with($this->product)
             ->willReturn([$attribute1]);
+    }
+
+    public function testGetPricesJson()
+    {
+        $expectedPrices = [
+            'oldPrice' => [
+                'amount' => 10,
+            ],
+            'basePrice' => [
+                'amount' => 15,
+            ],
+            'finalPrice' => [
+                'amount' => 20,
+            ],
+        ];
+
+        $priceInfoMock = $this->createMock(\Magento\Framework\Pricing\PriceInfo\Base::class);
+        $this->configurable->setProduct($this->product);
+        $this->product->expects($this->once())->method('getPriceInfo')->willReturn($priceInfoMock);
+        $this->variationPricesMock->expects($this->once())
+            ->method('getFormattedPrices')
+            ->with($priceInfoMock)
+            ->willReturn($expectedPrices);
+
+        $this->jsonEncoder->expects($this->once())->method('encode')->with($expectedPrices);
+        $this->configurable->getPricesJson();
     }
 }

--- a/app/code/Magento/Swatches/view/frontend/templates/product/listing/renderer.phtml
+++ b/app/code/Magento/Swatches/view/frontend/templates/product/listing/renderer.phtml
@@ -4,37 +4,38 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Swatches\Block\Product\Renderer\Configurable */ ?>
-<div class="swatch-opt-<?= /* @escapeNotVerified */ $block->getProduct()->getId() ?>"></div>
-<script>
-    require([
-        'jquery',
-        'jquery/ui',
-        'Magento_Swatches/js/swatch-renderer',
-        'Magento_Swatches/js/catalog-add-to-cart',
-        'priceBox'
-    ], function ($) {
-        var jsonConfig = <?= /* @escapeNotVerified */ $block->getJsonConfig() ?>;
+<?php
+/** @var $block \Magento\Swatches\Block\Product\Renderer\Listing\Configurable */
+$productId = $block->getProduct()->getId();
+?>
+<div class="swatch-opt-<?= /* @escapeNotVerified */ $productId ?>"
+     data-role="swatch-option-<?= /* @escapeNotVerified */ $productId ?>"></div>
 
-        $('.swatch-opt-<?= /* @escapeNotVerified */ $block->getProduct()->getId() ?>').SwatchRenderer({
-            selectorProduct: '.product-item-details',
-            onlySwatches: true,
-            enableControlLabel: false,
-            numberToShow: <?= /* @escapeNotVerified */ $block->getNumberSwatchesPerProduct() ?>,
-            jsonConfig: jsonConfig,
-            jsonSwatchConfig: <?= /* @escapeNotVerified */ $block->getJsonSwatchConfig() ?>,
-            mediaCallback: '<?= /* @escapeNotVerified */ $block->getMediaCallback() ?>'
-        });
-
-        var dataPriceBoxSelector = '[data-role=priceBox]',
-            dataProductIdSelector = '[data-product-id=<?= $block->escapeHtml($block->getProduct()->getId()) ?>]',
-            priceBoxes = $(dataPriceBoxSelector + dataProductIdSelector);
-
-        priceBoxes.priceBox({
-            'priceConfig': {
-                priceFormat: jsonConfig.priceFormat,
-                prices: jsonConfig.prices
+<script type="text/x-magento-init">
+    {
+        "[data-role=swatch-option-<?= /* @escapeNotVerified */ $productId ?>]": {
+            "Magento_Swatches/js/swatch-renderer": {
+                "selectorProduct": ".product-item-details",
+                "onlySwatches": true,
+                "enableControlLabel": false,
+                "numberToShow": <?= /* @escapeNotVerified */ $block->getNumberSwatchesPerProduct(); ?>,
+                "jsonConfig": <?= /* @escapeNotVerified */ $block->getJsonConfig(); ?>,
+                "jsonSwatchConfig": <?= /* @escapeNotVerified */ $block->getJsonSwatchConfig(); ?>,
+                "mediaCallback": "<?= /* @escapeNotVerified */ $block->getMediaCallback() ?>"
             }
-        });
-    });
+        }
+    }
+</script>
+
+<script type="text/x-magento-init">
+    {
+        "[data-role=priceBox][data-price-box=product-id-<?= /* @escapeNotVerified */ $productId ?>]": {
+            "priceBox": {
+                "priceConfig": {
+                    "priceFormat": <?= /* @escapeNotVerified */ $block->getPriceFormatJson(); ?>,
+                    "prices": <?= /* @escapeNotVerified */ $block->getPricesJson(); ?>
+                }
+            }
+        }
+    }
 </script>


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/12929

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
magento/magento2#10559: Extending swatch functionality using javascript mixins does not work in Safari and MS Edge

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. See testing instruction in magento/magento2#10559

