### PR TITLE
Fix duplicate URL key error output

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2678,8 +2678,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
 
             $source->next();
         }
-        $this->
-            ();
+        $this->checkUrlKeyDuplicates();
         $this->getOptionEntity()->validateAmbiguousData();
         return parent::_saveValidatedBunches();
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2678,7 +2678,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
 
             $source->next();
         }
-        $this->checkUrlKeyDuplicates();
+        $this->
+            ();
         $this->getOptionEntity()->validateAmbiguousData();
         return parent::_saveValidatedBunches();
     }
@@ -2706,7 +2707,12 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
             );
             foreach ($urlKeyDuplicates as $entityData) {
                 $rowNum = $this->rowNumbers[$entityData['store_id']][$entityData['request_path']];
-                $this->addRowError(ValidatorInterface::ERROR_DUPLICATE_URL_KEY, $rowNum);
+                $message = sprintf(
+                    $this->retrieveMessageTemplate(ValidatorInterface::ERROR_DUPLICATE_URL_KEY),
+                    $entityData['request_path'],
+                    $entityData['sku']
+                );
+                $this->addRowError($message, $rowNum);
             }
         }
     }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1402,7 +1402,7 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
             [
                 'products_to_check_duplicated_url_keys.csv',
                 [
-                    RowValidatorInterface::ERROR_DUPLICATE_URL_KEY => 2
+                    RowValidatorInterface::ERROR_DUPLICATE_URL_KEY => 1
                 ]
             ],
             [


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Message was;
`Url key: '%s' was already generated for an item with the SKU: '%s'. You need to specify the unique URL key manually in row(s): 1124`

Fixed message;
`3: Url key: 'venotrain-impuls' was already generated for an item with the SKU: 'Venotrain Impuls'. You need to specify the unique URL key manually in row(s): 1124`
