### PR TITLE
Remove usage of $.browser as it's unused and deprecated in jQuery. Fixes #14267

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/step-navigator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/step-navigator.js
@@ -144,7 +144,7 @@ define([
          */
         navigateTo: function (code, scrollToElementId) {
             var sortedItems = steps().sort(this.sortItems),
-                bodyElem = $.browser.safari || $.browser.chrome ? $('body') : $('html');
+                bodyElem = $('body');
 
             scrollToElementId = scrollToElementId || null;
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/progress-bar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/progress-bar.js
@@ -8,8 +8,7 @@ define([
     'underscore',
     'ko',
     'uiComponent',
-    'Magento_Checkout/js/model/step-navigator',
-    'jquery/jquery.hashchange'
+    'Magento_Checkout/js/model/step-navigator'
 ], function ($, _, ko, Component, stepNavigator) {
     'use strict';
 
@@ -25,7 +24,7 @@ define([
         /** @inheritdoc */
         initialize: function () {
             this._super();
-            $(window).hashchange(_.bind(stepNavigator.handleHash, stepNavigator));
+            window.addEventListener('hashchange', _.bind(stepNavigator.handleHash, stepNavigator));
             stepNavigator.handleHash();
         },
 

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
@@ -32,7 +32,6 @@
 require([
     "jquery",
     "uiRegistry",
-    "jquery/jquery.hashchange",
     "mage/mage",
     "prototype",
     "mage/adminhtml/form",
@@ -379,7 +378,7 @@ require([
         return false;
     };
 
-    jQuery(window).hashchange(handleHash);
+    window.addEventListener('hashchange', handleHash);
     handleHash();
 
     registry.set('adminSystemConfig', adminSystemConfig);

--- a/app/code/Magento/Theme/view/base/requirejs-config.js
+++ b/app/code/Magento/Theme/view/base/requirejs-config.js
@@ -15,7 +15,6 @@ var config = {
     },
     'shim': {
         'jquery/jquery-migrate': ['jquery'],
-        'jquery/jquery.hashchange': ['jquery', 'jquery/jquery-migrate'],
         'jquery/jstree/jquery.hotkeys': ['jquery'],
         'jquery/hover-intent': ['jquery'],
         'mage/adminhtml/backup': ['prototype'],
@@ -39,7 +38,6 @@ var config = {
         'jquery/validate': 'jquery/jquery.validate',
         'jquery/hover-intent': 'jquery/jquery.hoverIntent',
         'jquery/file-uploader': 'jquery/fileUploader/jquery.fileupload-fp',
-        'jquery/jquery.hashchange': 'jquery/jquery.ba-hashchange.min',
         'prototype': 'legacy-build.min',
         'jquery/jquery-storageapi': 'jquery/jquery.storageapi.min',
         'text': 'mage/requirejs/text',

--- a/app/code/Magento/User/view/adminhtml/web/app-config.js
+++ b/app/code/Magento/User/view/adminhtml/web/app-config.js
@@ -9,7 +9,6 @@
 require.config({
     'waitSeconds': 0,
     'shim': {
-        'jquery/jquery.hashchange': ['jquery'],
         'jquery/jstree/jquery.hotkeys': ['jquery'],
         'jquery/hover-intent': ['jquery'],
         'mage/adminhtml/backup': ['prototype'],
@@ -28,7 +27,6 @@ require.config({
         'jquery/validate': 'jquery/jquery.validate',
         'jquery/hover-intent': 'jquery/jquery.hoverIntent',
         'jquery/file-uploader': 'jquery/fileUploader/jquery.fileupload-fp',
-        'jquery/jquery.hashchange': 'jquery/jquery.ba-hashchange.min',
         'prototype': 'prototype/prototype-amd',
         'text': 'requirejs/text',
         'domReady': 'requirejs/domReady',

--- a/app/design/frontend/Magento/blank/etc/view.xml
+++ b/app/design/frontend/Magento/blank/etc/view.xml
@@ -260,7 +260,6 @@
     <exclude>
         <item type="file">Lib::jquery/jquery.min.js</item>
         <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
-        <item type="file">Lib::jquery/jquery.ba-hashchange.min.js</item>
         <item type="file">Lib::jquery/jquery.details.js</item>
         <item type="file">Lib::jquery/jquery.details.min.js</item>
         <item type="file">Lib::jquery/jquery.hoverIntent.js</item>

--- a/app/design/frontend/Magento/luma/etc/view.xml
+++ b/app/design/frontend/Magento/luma/etc/view.xml
@@ -270,7 +270,6 @@
     <exclude>
         <item type="file">Lib::jquery/jquery.min.js</item>
         <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
-        <item type="file">Lib::jquery/jquery.ba-hashchange.min.js</item>
         <item type="file">Lib::jquery/jquery.details.js</item>
         <item type="file">Lib::jquery/jquery.details.min.js</item>
         <item type="file">Lib::jquery/jquery.hoverIntent.js</item>

--- a/app/design/frontend/Magento/rush/etc/view.xml
+++ b/app/design/frontend/Magento/rush/etc/view.xml
@@ -261,7 +261,6 @@
     <exclude>
         <item type="file">Lib::jquery/jquery.min.js</item>
         <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
-        <item type="file">Lib::jquery/jquery.ba-hashchange.min.js</item>
         <item type="file">Lib::jquery/jquery.details.js</item>
         <item type="file">Lib::jquery/jquery.details.min.js</item>
         <item type="file">Lib::jquery/jquery.hoverIntent.js</item>

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom1/etc/view.xml
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom1/etc/view.xml
@@ -12,7 +12,6 @@
     <exclude>
         <item type="file">Lib::jquery/jquery.min.js</item>
         <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
-        <item type="file">Lib::jquery/jquery.ba-hashchange.min.js</item>
         <item type="file">Lib::jquery/jquery.details.js</item>
         <item type="file">Lib::jquery/jquery.details.min.js</item>
         <item type="file">Lib::jquery/jquery.hoverIntent.js</item>

--- a/lib/web/jquery/jquery.ba-hashchange.min.js
+++ b/lib/web/jquery/jquery.ba-hashchange.min.js
@@ -1,9 +1,0 @@
-/*
- * jQuery hashchange event - v1.3 - 7/21/2010
- * http://benalman.com/projects/jquery-hashchange-plugin/
- * 
- * Copyright (c) 2010 "Cowboy" Ben Alman
- * Dual licensed under the MIT and GPL licenses.
- * http://benalman.com/about/license/
- */
-(function($,e,b){var c="hashchange",h=document,f,g=$.event.special,i=h.documentMode,d="on"+c in e&&(i===b||i>7);function a(j){j=j||location.href;return"#"+j.replace(/^[^#]*#?(.*)$/,"$1")}$.fn[c]=function(j){return j?this.bind(c,j):this.trigger(c)};$.fn[c].delay=50;g[c]=$.extend(g[c],{setup:function(){if(d){return false}$(f.start)},teardown:function(){if(d){return false}$(f.stop)}});f=(function(){var j={},p,m=a(),k=function(q){return q},l=k,o=k;j.start=function(){p||n()};j.stop=function(){p&&clearTimeout(p);p=b};function n(){var r=a(),q=o(m);if(r!==m){l(m=r,q);$(e).trigger(c)}else{if(q!==m){location.href=location.href.replace(/#.*/,"")+q}}p=setTimeout(n,$.fn[c].delay)}$.browser.msie&&!d&&(function(){var q,r;j.start=function(){if(!q){r=$.fn[c].src;r=r&&r+a();q=$('<iframe tabindex="-1" title="empty"/>').hide().one("load",function(){r||l(a());n()}).attr("src",r||"javascript:0").insertAfter("body")[0].contentWindow;h.onpropertychange=function(){try{if(event.propertyName==="title"){q.document.title=h.title}}catch(s){}}}};j.stop=k;o=function(){return a(q.location.href)};l=function(v,s){var u=q.document,t=$.fn[c].domain;if(v!==s){u.title=h.title;u.open();t&&u.write('<script>document.domain="'+t+'"<\/script>');u.close();q.location.hash=v}}})();return j})()})(jQuery,this);

--- a/lib/web/mage/popup-window.js
+++ b/lib/web/mage/popup-window.js
@@ -57,14 +57,8 @@ define([
             settings.windowURL = settings.windowURL || element.attr('href');
 
             if (settings.centerBrowser) {
-                if ($.browser.msie) { // Hacked together for IE browsers
-                    centeredY = window.screenTop - 120 +
-                        (((document.documentElement.clientHeight + 120) / 2 - settings.height / 2));
-                    centeredX = window.screenLeft + (((document.body.offsetWidth + 20) / 2 - settings.width / 2));
-                } else {
-                    centeredY = window.screenY + ((window.outerHeight / 2 - settings.height / 2));
-                    centeredX = window.screenX + ((window.outerWidth / 2 - settings.width / 2));
-                }
+                centeredY = window.screenY + ((window.outerHeight / 2 - settings.height / 2));
+                centeredX = window.screenX + ((window.outerWidth / 2 - settings.width / 2));
                 windowFeatures += ',left=' + centeredX + ',top=' + centeredY;
             } else if (settings.centerScreen) {
                 centeredY = (screen.height - settings.height) / 2;


### PR DESCRIPTION
### Description
Removed all usages of `$.browser` as the code appears to be old or unused.

Hashchange is now supported in IE9+ so there is no need for that library also.

As mentioned in https://github.com/magento/magento2/pull/14173#issuecomment-374541382 swagger will likely be updated and made to be more modular so I ignored the file:
- app/code/Magento/Swagger/view/frontend/web/swagger-ui/js/lib/jquery.ba-bbq.min.js:

### Fixed Issues (if relevant)
1. Migration of jQuery
2.  #14267

### Manual testing scenarios
1. Ensure that `step-navigator.js` works as expected in IE/Firefox.
2. Ensure `popup-window.js` looks correct in IE.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
