### PR TITLE
[ForwardPort 2.3] [#14072] Add Zip Pattern for Japan JP

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -207,7 +207,7 @@
     <zip countryCode="JP">
         <codes>
             <code id="pattern_1" active="true" example="123-4567">^[0-9]{3}-[0-9]{4}$</code>
-            <code id="pattern_2" active="true" example="123">^[0-9]{3}$</code>
+            <code id="pattern_2" active="true" example="1234567">^[0-9]{7}$</code>
         </codes>
     </zip>
     <zip countryCode="JE">

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -133,7 +133,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             ['countryId' => 'IL', 'postcode' => '12345'],
             ['countryId' => 'IT', 'postcode' => '12345'],
             ['countryId' => 'JP', 'postcode' => '123-4567'],
-            ['countryId' => 'JP', 'postcode' => '123'],
+            ['countryId' => 'JP', 'postcode' => '1234567'],
             ['countryId' => 'JE', 'postcode' => 'TY8 9PL'],
             ['countryId' => 'KZ', 'postcode' => '123456'],
             ['countryId' => 'KE', 'postcode' => '12345'],


### PR DESCRIPTION
Add validation for Zip Code in Japan
### Description
"1234567" or "123-4567" only can pass the validation. Since 1998, Japanese postoffice only uses 7 digits for zipcode.

### Fixed Issues (if relevant)
1. magento/magento2#14072: Change zip code validation pattern for Japan

### Manual testing scenarios
1. Add one more item into cart
2. Proceed checkout step
3. Choose "Japan" for country
4. Set zip code like "123-4567" or "123-4567"

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
