### PR TITLE
Fixed TypeError when search term does not exist on pressing Home or End button #14274

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -206,14 +206,14 @@ define([
 
             switch (keyCode) {
                 case $.ui.keyCode.HOME:
-                    if(this._getFirstVisibleElement()) {
+                    if (this._getFirstVisibleElement()) {
                         this._getFirstVisibleElement().addClass(this.options.selectClass);
                         this.responseList.selected = this._getFirstVisibleElement();
                     }
                     break;
 
                 case $.ui.keyCode.END:
-                    if(this._getFirstVisibleElement()) {
+                    if (this._getFirstVisibleElement()) {
                         this._getLastElement().addClass(this.options.selectClass);
                         this.responseList.selected = this._getLastElement();
                     }

--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -206,13 +206,17 @@ define([
 
             switch (keyCode) {
                 case $.ui.keyCode.HOME:
-                    this._getFirstVisibleElement().addClass(this.options.selectClass);
-                    this.responseList.selected = this._getFirstVisibleElement();
+                    if(this._getFirstVisibleElement()) {
+                        this._getFirstVisibleElement().addClass(this.options.selectClass);
+                        this.responseList.selected = this._getFirstVisibleElement();
+                    }
                     break;
 
                 case $.ui.keyCode.END:
-                    this._getLastElement().addClass(this.options.selectClass);
-                    this.responseList.selected = this._getLastElement();
+                    if(this._getFirstVisibleElement()) {
+                        this._getLastElement().addClass(this.options.selectClass);
+                        this.responseList.selected = this._getLastElement();
+                    }
                     break;
 
                 case $.ui.keyCode.ESCAPE:

--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -213,7 +213,7 @@ define([
                     break;
 
                 case $.ui.keyCode.END:
-                    if (this._getFirstVisibleElement()) {
+                    if (this._getLastElement()) {
                         this._getLastElement().addClass(this.options.selectClass);
                         this.responseList.selected = this._getLastElement();
                     }


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->
 `this._getFirstVisibleElement()` returns false if there are no elements in the search autocomplete. I added check if `this._getFirstVisibleElement()` does not return `false` before adding select class to the first element when Home or End  buttons on keyboard are pressed.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
#14274: Quick search fires error

### Manual testing scenarios
1.Type a term into the quick Ajax search field (#search) that doesn't exist in the database
2. Press Home or End keyboard key
3. No TypeError: this._getFirstVisibleElement(...).addClass is not a function

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
