### PR TITLE
Use Default Value gets unchecked, when product data is saved #9486

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
@@ -124,7 +124,7 @@ class ProductUrlPathGenerator
      */
     public function getUrlKey($product)
     {
-        return $product->getUrlKey() === false ? false : $this->prepareProductUrlKey($product);
+        return $product->getUrlKey() === null ? false : $this->prepareProductUrlKey($product);
     }
 
     /**


### PR DESCRIPTION
Make Checkbox "Use Default Value" on product edit page works

### Description
In commit b3391d1e023730616c15a5c1859320bee914d05d MAGETWO-47792: Issue when updating a categories through the SOAP API
Value for checkbox  "Use Default Value" was changed from false to null
Condition in app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php wasn't changed to null. 

### Fixed Issues (if relevant)

1. magento/magento2#9486: "Use Default Value" gets unchecked, when product data is saved

### Manual testing scenarios

1. Open a product in Admin, select a store view, say Default Store View
2. Uncheck 'Use Default Value' checkbox in 'Search Engine Optimisation' tab on Url Key field and save product.
2. Go to  'Search Engine Optimisation' and check 'Use Default Value' checkbox on Url key field. 


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
