### PR TITLE
Resolves PHPdoc issue in ticket #13992

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Item.php
@@ -144,7 +144,7 @@ class Item extends AbstractModel implements ShipmentItemInterface
      * Declare qty
      *
      * @param float $qty
-     * @return \Magento\Sales\Model\Order\Invoice\Item
+     * @return \Magento\Sales\Model\Order\Shipment\Item
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function setQty($qty)


### PR DESCRIPTION
### Description
Forwardpull of PR 14303

Incorrect PHPdoc causes warnings in IDE. I just changed the return type to the type it actually returns in the PHPdoc.

### Fixed Issues (if relevant)
1. magento/magento2#13992: Incorrect phpdoc should be Shipment\Item not Invoice\Item

### Manual testing scenarios
1. This is not necessary, this just resolves warnings in the IDE. 

### Contribution checklist
 - [✓] Pull request has a meaningful description of its purpose
 - [✓] All commits are accompanied by meaningful commit messages
 - [✓] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds on Travis CI are green)