### PR TITLE
Fix type casting for stock item qty increment

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -392,7 +392,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
     /**
      * Retrieve Quantity Increments
      *
-     * @return int|false
+     * @return float|false
      */
     public function getQtyIncrements()
     {
@@ -401,7 +401,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
                 if ($this->getUseConfigQtyIncrements()) {
                     $this->qtyIncrements = $this->stockConfiguration->getQtyIncrements($this->getStoreId());
                 } else {
-                    $this->qtyIncrements = (int) $this->getData(static::QTY_INCREMENTS);
+                    $this->qtyIncrements = (float) $this->getData(static::QTY_INCREMENTS);
                 }
             }
             if ($this->qtyIncrements <= 0) {


### PR DESCRIPTION
This PR is intended to fix the `getQtyIncrements()` method that didn't respect implemented interface according to which a float or a boolean value has to be returned.

Wrong typecasting to `int` doesn't allow to use decimal stock qty increments.