### PR TITLE
Change returning value for attribute option cretaion from 'true' to option record

### DIFF
--- a/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
@@ -29,7 +29,7 @@ interface ProductAttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return bool
+     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
      */
     public function add($attributeCode, $option);
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/OptionManagementTest.php
@@ -43,7 +43,7 @@ class OptionManagementTest extends \PHPUnit\Framework\TestCase
             \Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE,
             $attributeCode,
             $optionMock
-        )->willReturn(true);
+        )->willReturn($optionMock);
         $this->assertTrue($this->model->add($attributeCode, $optionMock));
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/OptionManagementTest.php
@@ -44,7 +44,7 @@ class OptionManagementTest extends \PHPUnit\Framework\TestCase
             $attributeCode,
             $optionMock
         )->willReturn($optionMock);
-        $this->assertTrue($this->model->add($attributeCode, $optionMock));
+        $this->assertEquals($optionMock, $this->model->add($attributeCode, $optionMock));
     }
 
     public function testDelete()

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -71,7 +71,7 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
             throw new StateException(__('Cannot save attribute %1', $attributeCode));
         }
 
-        return true;
+        return $option;
     }
 
     /**


### PR DESCRIPTION
### Description
Fix for: Successful attribute option POST returns 'true', not the option hash or value

### Fixed Issues (if relevant)
1. magento/magento2#6300: Successful attribute option POST returns 'true', not the option hash or value

### Manual testing scenarios

1. POST an new option value using /V1/products/attributes/{attributeCode}/options. Request body looks like {"option": {"label": "FOOBAR"} }
2. Response should contain new inserted option data

