### PR TITLE
Fixed returning null on _getEavWebsiteTable results in describe table error

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/Attribute.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Attribute.php
@@ -62,7 +62,7 @@ abstract class Attribute extends \Magento\Eav\Model\ResourceModel\Entity\Attribu
     {
         $select = parent::_getLoadSelect($field, $value, $object);
         $websiteId = (int)$object->getWebsite()->getId();
-        if ($websiteId) {
+        if ($websiteId && $this->_getEavWebsiteTable()) {
             $connection = $this->getConnection();
             $columns = [];
             $scopeTable = $this->_getEavWebsiteTable();
@@ -115,7 +115,7 @@ abstract class Attribute extends \Magento\Eav\Model\ResourceModel\Entity\Attribu
 
         // save scope attributes
         $websiteId = (int)$object->getWebsite()->getId();
-        if ($websiteId) {
+        if ($websiteId && $this->_getEavWebsiteTable()) {
             $table = $this->_getEavWebsiteTable();
             $describe = $this->getConnection()->describeTable($table);
             $data = [];
@@ -148,20 +148,22 @@ abstract class Attribute extends \Magento\Eav\Model\ResourceModel\Entity\Attribu
      */
     public function getScopeValues(\Magento\Eav\Model\Attribute $object)
     {
-        $connection = $this->getConnection();
-        $bind = ['attribute_id' => (int)$object->getId(), 'website_id' => (int)$object->getWebsite()->getId()];
-        $select = $connection->select()->from(
-            $this->_getEavWebsiteTable()
-        )->where(
-            'attribute_id = :attribute_id'
-        )->where(
-            'website_id = :website_id'
-        )->limit(
-            1
-        );
-        $result = $connection->fetchRow($select, $bind);
+        if ($this->_getEavWebsiteTable()){
+            $connection = $this->getConnection();
+            $bind = ['attribute_id' => (int)$object->getId(), 'website_id' => (int)$object->getWebsite()->getId()];
+            $select = $connection->select()->from(
+                $this->_getEavWebsiteTable()
+            )->where(
+                'attribute_id = :attribute_id'
+            )->where(
+                'website_id = :website_id'
+            )->limit(
+                1
+            );
+            $result = $connection->fetchRow($select, $bind);
+        }
 
-        if (!$result) {
+        if (empty($result)) {
             $result = [];
         }
 

--- a/app/code/Magento/Eav/Model/ResourceModel/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Attribute/Collection.php
@@ -172,40 +172,42 @@ abstract class Collection extends \Magento\Eav\Model\ResourceModel\Entity\Attrib
 
         // scope values
 
-        $scopeDescribe = $connection->describeTable($this->_getEavWebsiteTable());
-        unset($scopeDescribe['attribute_id']);
-        $scopeColumns = [];
-        foreach (array_keys($scopeDescribe) as $columnName) {
-            if ($columnName == 'website_id') {
-                $scopeColumns['scope_website_id'] = $columnName;
-            } else {
-                if (isset($mainColumns[$columnName])) {
-                    $alias = 'scope_' . $columnName;
-                    $condition = 'main_table.' . $columnName . ' IS NULL';
-                    $true = 'scope_table.' . $columnName;
-                    $false = 'main_table.' . $columnName;
-                    $expression = $connection->getCheckSql($condition, $true, $false);
-                    $this->addFilterToMap($columnName, $expression);
-                    $scopeColumns[$alias] = $columnName;
-                } elseif (isset($extraColumns[$columnName])) {
-                    $alias = 'scope_' . $columnName;
-                    $condition = 'additional_table.' . $columnName . ' IS NULL';
-                    $true = 'scope_table.' . $columnName;
-                    $false = 'additional_table.' . $columnName;
-                    $expression = $connection->getCheckSql($condition, $true, $false);
-                    $this->addFilterToMap($columnName, $expression);
-                    $scopeColumns[$alias] = $columnName;
+        if ($this->_getEavWebsiteTable()){
+            $scopeDescribe = $connection->describeTable($this->_getEavWebsiteTable());
+            unset($scopeDescribe['attribute_id']);
+            $scopeColumns = [];
+            foreach (array_keys($scopeDescribe) as $columnName) {
+                if ($columnName == 'website_id') {
+                    $scopeColumns['scope_website_id'] = $columnName;
+                } else {
+                    if (isset($mainColumns[$columnName])) {
+                        $alias = 'scope_' . $columnName;
+                        $condition = 'main_table.' . $columnName . ' IS NULL';
+                        $true = 'scope_table.' . $columnName;
+                        $false = 'main_table.' . $columnName;
+                        $expression = $connection->getCheckSql($condition, $true, $false);
+                        $this->addFilterToMap($columnName, $expression);
+                        $scopeColumns[$alias] = $columnName;
+                    } elseif (isset($extraColumns[$columnName])) {
+                        $alias = 'scope_' . $columnName;
+                        $condition = 'additional_table.' . $columnName . ' IS NULL';
+                        $true = 'scope_table.' . $columnName;
+                        $false = 'additional_table.' . $columnName;
+                        $expression = $connection->getCheckSql($condition, $true, $false);
+                        $this->addFilterToMap($columnName, $expression);
+                        $scopeColumns[$alias] = $columnName;
+                    }
                 }
             }
-        }
 
-        $select->joinLeft(
-            ['scope_table' => $this->_getEavWebsiteTable()],
-            'scope_table.attribute_id = main_table.attribute_id AND scope_table.website_id = :scope_website_id',
-            $scopeColumns
-        );
-        $websiteId = $this->getWebsite() ? (int)$this->getWebsite()->getId() : 0;
-        $this->addBindParam('scope_website_id', $websiteId);
+            $select->joinLeft(
+                ['scope_table' => $this->_getEavWebsiteTable()],
+                'scope_table.attribute_id = main_table.attribute_id AND scope_table.website_id = :scope_website_id',
+                $scopeColumns
+            );
+            $websiteId = $this->getWebsite() ? (int)$this->getWebsite()->getId() : 0;
+            $this->addBindParam('scope_website_id', $websiteId);
+        }
 
         return $this;
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Returning null within _getEavWebsiteTable is intended to mean that the functionality is not required. Unfortunately there are a few places where SQL is generated using the eav website table and does not take into account that it can be null.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Wrapping the existing queries with conditional checks to see if the table name is null or not.  

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6043: Returning null on _getEavWebsiteTable results in describe table error.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a new eav entity without attribute_website table including attribute models (or to make it easier and quicker just return null on the customer one).
2. Retrieve the collection of attributes from your custom entity

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
