### PR TITLE
#7816: Customer_account.xml file abused (2.2)

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/Index.php
+++ b/app/code/Magento/Customer/Controller/Account/Index.php
@@ -35,9 +35,6 @@ class Index extends \Magento\Customer\Controller\AbstractAccount
      */
     public function execute()
     {
-        /** @var \Magento\Framework\View\Result\Page $resultPage */
-        $resultPage = $this->resultPageFactory->create();
-        $resultPage->getConfig()->getTitle()->set(__('My Account'));
-        return $resultPage;
+        return $this->resultPageFactory->create();
     }
 }

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -6,6 +6,9 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Customer My Account (All Pages)" design_abstraction="custom">
+    <head>
+        <title>My Account</title>
+    </head>
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="sidebar.main">

--- a/app/code/Magento/Paypal/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/customer_account.xml
@@ -6,9 +6,6 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <head>
-        <title>Billing Agreements</title>
-    </head>
     <body>
         <referenceBlock name="customer_account_navigation">
             <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-billing-agreements-link">


### PR DESCRIPTION
### Description

The initial problem was that the paypal module was setting the customer dashbaord page to "Billing Agreements", a previous commit of 36cac17 fixed that which I have cherry picked, however there is a related issue - the customer account dashboard title was being set in the controller which was not good, so I've fixed that too.

### Fixed Issues (if relevant)

1. magento/magento2#7816
2. magento/magento2#12852

### Manual testing scenarios

1. Log in
2. Ensure the page title on the dashboard is "My Account"

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
