### PR TITLE
Issue-5077: Store View (language) switch leads to 404

### DIFF
--- a/app/code/Magento/Cms/Controller/Router.php
+++ b/app/code/Magento/Cms/Controller/Router.php
@@ -112,6 +112,12 @@ class Router implements \Magento\Framework\App\RouterInterface
         $page = $this->_pageFactory->create();
         $pageId = $page->checkIdentifier($identifier, $this->_storeManager->getStore()->getId());
         if (!$pageId) {
+            $pageId = $page->checkIdentifier($identifier, $this->_storeManager->getDefaultStoreView()->getId());
+            if($pageId) {
+                $this->_response->setRedirect('/');
+                $request->setDispatched(true);
+                return $this->actionFactory->create(\Magento\Framework\App\Action\Redirect::class);
+            }
             return null;
         }
 


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#5077: Store View (language) switch leads to 404

## Steps to reproduce
1. Install Magento 2.0.7
2. Add several store views e.g. "English", "French", "German"
3. Create a CMS page for "English" store view - e.g. "About Us" with Url Key `about-s`
4. Now create the same CMS page for "French" store view e.g. "À propos de nous" with Url Key `a-propos-de-nous`
## Expected result
1. I can open "About Us" page
2. I am redirected to homepage when I switch store view (language) as CMS pages are not linked n any way
## Actual result
1. I can open "About Us" page
2. 404 page is show when I switch store view (language)

Product categories are general with possibility to translate them in each store view but CMS pages does not work like that. For CMS pages I would expect that user is redirected to homepage as Magento2 can't know which pages represent the same content in different store view.

One way to resolve this would be to use the same Url Key in all store views for the same page but that's a hack rather then a solution (also SEO suffers).

Is there at least a way how to fix this for now?


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
