### PR TITLE
magento/magento2#10057

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator.php
@@ -103,8 +103,7 @@ class QuantityValidator
         $quoteItem = $observer->getEvent()->getItem();
         if (!$quoteItem ||
             !$quoteItem->getProductId() ||
-            !$quoteItem->getQuote() ||
-            $quoteItem->getQuote()->getIsSuperMode()
+            !$quoteItem->getQuote()
         ) {
             return;
         }
@@ -115,6 +114,18 @@ class QuantityValidator
         $stockItem = $this->stockRegistry->getStockItem($product->getId(), $product->getStore()->getWebsiteId());
         if (!$stockItem instanceof StockItemInterface) {
             throw new LocalizedException(__('The stock item for Product is not valid.'));
+        }
+
+        if (($options = $quoteItem->getQtyOptions()) && $qty > 0) {
+            foreach ($options as $option) {
+                $this->optionInitializer->initialize($option, $quoteItem, $qty);
+            }
+        } else {
+            $this->stockItemInitializer->initialize($stockItem, $quoteItem, $qty);
+        }
+
+        if ($quoteItem->getQuote()->getIsSuperMode()) {
+            return;
         }
 
         /* @var \Magento\CatalogInventory\Api\Data\StockStatusInterface $stockStatus */
@@ -159,7 +170,7 @@ class QuantityValidator
         /**
          * Check item for options
          */
-        if (($options = $quoteItem->getQtyOptions()) && $qty > 0) {
+        if ($options) {
             $qty = $product->getTypeInstance()->prepareQuoteItemQty($qty, $product);
             $quoteItem->setData('qty', $qty);
             if ($stockStatus) {
@@ -193,7 +204,7 @@ class QuantityValidator
             $removeError = true;
 
             foreach ($options as $option) {
-                $result = $this->optionInitializer->initialize($option, $quoteItem, $qty);
+                $result = $option->getStockStateResult();
                 if ($result->getHasError()) {
                     $option->setHasError(true);
                     //Setting this to false, so no error statuses are cleared
@@ -206,7 +217,7 @@ class QuantityValidator
             }
         } else {
             if ($quoteItem->getParentItem() === null) {
-                $result = $this->stockItemInitializer->initialize($stockItem, $quoteItem, $qty);
+                $result = $quoteItem->getStockStateResult();
                 if ($result->getHasError()) {
                     $this->addErrorInfoToQuote($result, $quoteItem);
                 } else {

--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/Initializer/Option.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/Initializer/Option.php
@@ -133,6 +133,8 @@ class Option
 
         $stockItem->unsIsChildItem();
 
+        $option->setStockStateResult($result);
+
         return $result;
     }
 }

--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/Initializer/StockItem.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/Initializer/StockItem.php
@@ -135,6 +135,8 @@ class StockItem
             $quoteItem->setBackorders($result->getItemBackorders());
         }
 
+        $quoteItem->setStockStateResult($result);
+
         return $result;
     }
 }

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/Initializer/QuantityValidatorTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/Initializer/QuantityValidatorTest.php
@@ -278,8 +278,11 @@ class QuantityValidatorTest extends \PHPUnit\Framework\TestCase
     {
         $optionMock = $this->getMockBuilder(OptionItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHasError'])
+            ->setMethods(['setHasError', 'getStockStateResult'])
             ->getMock();
+        $optionMock->expects($this->once())
+            ->method('getStockStateResult')
+            ->willReturn($this->resultMock);
         $this->stockRegistryMock->expects($this->at(0))
             ->method('getStockItem')
             ->willReturn($this->stockItemMock);
@@ -316,7 +319,7 @@ class QuantityValidatorTest extends \PHPUnit\Framework\TestCase
     {
         $optionMock = $this->getMockBuilder(OptionItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHasError'])
+            ->setMethods(['setHasError', 'getStockStateResult'])
             ->getMock();
         $this->stockRegistryMock->expects($this->at(0))
             ->method('getStockItem')
@@ -324,6 +327,9 @@ class QuantityValidatorTest extends \PHPUnit\Framework\TestCase
         $this->stockRegistryMock->expects($this->at(1))
             ->method('getStockStatus')
             ->willReturn($this->stockStatusMock);
+        $optionMock->expects($this->once())
+            ->method('getStockStateResult')
+            ->willReturn($this->resultMock);
         $options = [$optionMock];
         $this->createInitialStub(1);
         $this->setUpStubForQuantity(1, true);
@@ -354,12 +360,15 @@ class QuantityValidatorTest extends \PHPUnit\Framework\TestCase
     {
         $optionMock = $this->getMockBuilder(OptionItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHasError'])
+            ->setMethods(['setHasError', 'getStockStateResult'])
             ->getMock();
         $quoteItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
             ->setMethods(['getItemId', 'getErrorInfos'])
             ->getMock();
+        $optionMock->expects($this->once())
+            ->method('getStockStateResult')
+            ->willReturn($this->resultMock);
         $this->stockRegistryMock->expects($this->at(0))
             ->method('getStockItem')
             ->willReturn($this->stockItemMock);

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/Initializer/StockItemTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/Initializer/StockItemTest.php
@@ -84,6 +84,7 @@ class StockItemTest extends \PHPUnit\Framework\TestCase
                     'setMessage',
                     'setBackorders',
                     '__wakeup',
+                    'setStockStateResult'
                 ]
             )
             ->disableOriginalConstructor()
@@ -178,6 +179,7 @@ class StockItemTest extends \PHPUnit\Framework\TestCase
         $quoteItem->expects($this->once())->method('setMessage')->with('message')->will($this->returnSelf());
         $result->expects($this->exactly(2))->method('getItemBackorders')->will($this->returnValue('backorders'));
         $quoteItem->expects($this->once())->method('setBackorders')->with('backorders')->will($this->returnSelf());
+        $quoteItem->expects($this->once())->method('setStockStateResult')->with($result)->will($this->returnSelf());
 
         $this->model->initialize($stockItem, $quoteItem, $qty);
     }

--- a/dev/tests/integration/testsuite/Magento/CatalogInventory/Model/Quote/Item/QuantityValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogInventory/Model/Quote/Item/QuantityValidatorTest.php
@@ -130,8 +130,29 @@ class QuantityValidatorTest extends \PHPUnit\Framework\TestCase
         $this->stockState->expects($this->any())->method('checkQtyIncrements')->willReturn($resultMock);
         $this->optionInitializer->expects($this->any())->method('initialize')->willReturn($resultMock);
         $resultMock->expects($this->any())->method('getHasError')->willReturn(true);
+        $this->setMockStockStateResultToQuoteItemOptions($quoteItem, $resultMock);
         $this->observer->execute($this->observerMock);
         $this->assertCount(2, $quoteItem->getErrorInfos(), 'Expected 2 errors in QuoteItem');
+    }
+
+    /**
+     * Set mock of Stock State Result to Quote Item Options.
+     *
+     *
+     * @param \Magento\Quote\Model\Quote\Item $quoteItem
+     * @param \PHPUnit_Framework_MockObject_MockObject $resultMock
+     */
+    private function setMockStockStateResultToQuoteItemOptions($quoteItem, $resultMock)
+    {
+        if ($options = $quoteItem->getQtyOptions()) {
+            foreach ($options as $option) {
+                $option->setStockStateResult($resultMock);
+            }
+
+            return;
+        }
+
+        $this->fail('Test failed since Quote Item does not have Qty options.');
     }
 
     /**


### PR DESCRIPTION
### Description
Current Pull Request contains fix for issue #10057 .
Problem related to products with configured backorder.
If you place order with backorder product from frontend - everything work properly: backorder order items will have status 'Backordered'.
But when you try to place order/edit/reorder from backoffice, backorder products will not have 'Backorder' status.

### Fixed Issue
1. magento/magento2#10057: Editing order with backordered items results in new order not correctly marking order items as backordered.

### Manual testing scenarios
#### Steps to reproduce
1. Set a product up as backorderable - 0 quantity stock, "allow orders below 0", in stock, enabled.
2. Go to BO -> Sales -> Operations -> Orders -> Create New Order 
3. Create new order with backorderable product.
4. Check order item details which was created from backorderable product.
#### Expected result
1. Order item has status 'Backordered'.
#### Actual result
1. Order item has status 'Ordered'.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
