### PR TITLE
Backport: Fix for broken navigation menu on IE11 #14230

### DIFF
--- a/lib/web/css/source/lib/_navigation.less
+++ b/lib/web/css/source/lib/_navigation.less
@@ -324,6 +324,7 @@
                 .lib-css(text-decoration, @_nav-level0-item-text-decoration);
                 box-sizing: border-box;
                 position: relative;
+                display: inline-block;
 
                 &:hover, &.ui-state-focus {
                     .lib-css(background, @_nav-level0-item-background-color-hover);


### PR DESCRIPTION
### Description
The navigation without the "display: inline-block" sometimes gets broken on Internet Explorer 11. This happens after some refreshes of the page, both on Luma and Blank theme. The problem is that the A element has no display: inline-block or block but also has padding. IE11 understands that differently sometimes without giving any of the inline block properties to the element like width or padding.

### Manual testing scenarios
1. Go to any 2.2-develop branch, blank or luma theme using ie11
2. Start refreshing the homepage
3. At some point the menu will break causing elements floating on top of each other

Backport for https://github.com/magento/magento2/pull/14230