### PR TITLE
Registry deprecation

### DIFF
--- a/lib/internal/Magento/Framework/Registry.php
+++ b/lib/internal/Magento/Framework/Registry.php
@@ -8,7 +8,11 @@ namespace Magento\Framework;
 /**
  * Registry model. Used to manage values in registry
  *
+ * Registry usage as a shared service introduces temporal, hard to detect coupling into system.
+ * It's usage should be avoid. Use service classes or data providers instead.
+ *
  * @api
+ * @deprecated
  */
 class Registry
 {
@@ -24,6 +28,8 @@ class Registry
      *
      * @param string $key
      * @return mixed
+     *
+     * @deprecated
      */
     public function registry($key)
     {
@@ -41,6 +47,8 @@ class Registry
      * @param bool $graceful
      * @return void
      * @throws \RuntimeException
+     *
+     * @deprecated
      */
     public function register($key, $value, $graceful = false)
     {
@@ -58,6 +66,8 @@ class Registry
      *
      * @param string $key
      * @return void
+     *
+     * @deprecated
      */
     public function unregister($key)
     {


### PR DESCRIPTION
`Magento\Framework\Registry` abused in Magento 2 and used to pass variables through the system. Such approach leads to an implicit temporal coupling which causes bugs and complicates system evolving. To explicitly communicate that Registry usage should be counted as bad practice this `Magento\Framework\Registry` will be deprecated since 2.3.0 release.