### PR TITLE
MAGETWO-84709 - Respect Magento document root in CLI

### DIFF
--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -60,6 +60,11 @@ class Cli extends Console\Application
     private $objectManager;
 
     /**
+     * @var array
+     */
+    private $configuration;
+    
+    /**
      * @param string $name the application name
      * @param string $version the application version
      * @SuppressWarnings(PHPMD.ExitExpression)
@@ -67,9 +72,9 @@ class Cli extends Console\Application
     public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
     {
         try {
-            $configuration = require BP . '/setup/config/application.config.php';
+            $this->configuration = require BP . '/setup/config/application.config.php';
             $bootstrapApplication = new Application();
-            $application = $bootstrapApplication->bootstrap($configuration);
+            $application = $bootstrapApplication->bootstrap($this->configuration);
             $this->serviceManager = $application->getServiceManager();
 
             $this->assertCompilerPreparation();
@@ -158,6 +163,21 @@ class Cli extends Console\Application
     {
         $params = (new ComplexParameter(self::INPUT_KEY_BOOTSTRAP))->mergeFromArgv($_SERVER, $_SERVER);
         $params[Bootstrap::PARAM_REQUIRE_MAINTENANCE] = null;
+
+        /**
+         * Workaround for CLI not respecting pub document root described in MAGETWO-84709
+         */
+        if (isset($this->configuration['document_root']) 
+            && $this->configuration['document_root'] === \Magento\Framework\App\Filesystem\DirectoryList::PUB) {
+
+            $params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
+                DirectoryList::PUB => [DirectoryList::URL_PATH => ''],
+                DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],
+                DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
+                DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
+            ];
+            
+        }
 
         $this->objectManager = Bootstrap::create(BP, $params)->getObjectManager();
 

--- a/setup/config/application.config.php
+++ b/setup/config/application.config.php
@@ -32,5 +32,6 @@ return [
     // list of Magento specific required services, like default abstract factory
     'required_services' => [
         DiAbstractServiceFactory::class
-    ]
+    ],
+    'document_root' => ''
 ];


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

Due to Magento 2 architecture and hardcoded url paths in ```\Magento\Framework\App\Filesystem\DirectoryList``` command line interface returns wrong path to media files when document root is mounted in pub folder.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8868: [2.x.x] Production mode is not detected in CLI => the uri for media and static are not good and contain pub
2. magento/magento2#9111: Cron gets wrong base media URL

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set server document root to pub directory
2. Run console command that returns base media url.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
