### PR TITLE
Issue #5992 fix - adding proper attribute class to category attribute…

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Attribute/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Attribute/Collection.php
@@ -74,4 +74,21 @@ class Collection extends \Magento\Eav\Model\ResourceModel\Entity\Attribute\Colle
     {
         return $this;
     }
+
+    /**
+     * Process loaded collection data
+     *
+     * @return $this
+     */
+    protected function _afterLoadData()
+    {
+        // Set attribute model
+        foreach ($this->_data as $key => $item) {
+            if(!isset($item['attribute_model'])) {
+                $this->_data[$key]['attribute_model'] = \Magento\Catalog\Model\Category\Attribute::class;
+            }
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Fix for the issue #5992 https://github.com/magento/magento2/issues/5992

### Description
Category attribute model is added to collection items.

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/5992

### Manual testing scenarios
1. Write an integration test case as follows: 

```
public function testCategoryAttributeExists($attributeCode)
{
    $categoryAttributesRepository = \Magento\TestFramework\ObjectManager::getInstance()->get(
        \Magento\Catalog\Api\CategoryAttributeRepositoryInterface::class
    );
    $this->assertInstanceOf(
        \Magento\Catalog\Api\Data\CategoryAttributeInterface::class,
        $categoryAttributesRepository->get($attributeCode)
    );
}
```
1.  Pass an existing attribute code via data provider
2.  Run the test
### Expected result
1.  The test passes, because the contract of `Magento\Catalog\Api\CategoryAttributeRepositoryInterface` states:

```
    /**
     * Retrieve specific attribute
     *
     * @param string $attributeCode
     * @return \Magento\Catalog\Api\Data\CategoryAttributeInterface
     */
    public function get($attributeCode);
```
### Actual result
1. The test fails with a message like this

> Failed asserting that Magento\Catalog\Model\ResourceModel\Eav\Attribute\Interceptor Object (...) is an instance of interface "Magento\Catalog\Api\Data\CategoryAttributeInterface".

