### PR TITLE
Resolves adminhtml product grid issue #13338

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
@@ -58,6 +58,10 @@ class ProductDataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         $this->collection = $collectionFactory->create();
         $this->addFieldStrategies = $addFieldStrategies;
         $this->addFilterStrategies = $addFilterStrategies;
+
+        if (isset($data['store_id'])) {
+            $this->collection->setStoreId($data['store_id']);
+        }
     }
 
     /**

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
@@ -62,7 +62,6 @@ class ProductDataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         if (isset($data['config']['storageConfig']['default_store'])
             && (bool) $data['config']['storageConfig']['default_store']
         ) {
-            print_r("Oh damn");exit;
             $this->collection->setStoreId($this->collection->getDefaultStoreId());
         }
     }

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
@@ -59,8 +59,11 @@ class ProductDataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         $this->addFieldStrategies = $addFieldStrategies;
         $this->addFilterStrategies = $addFilterStrategies;
 
-        if (isset($data['store_id'])) {
-            $this->collection->setStoreId($data['store_id']);
+        if (isset($data['config']['storageConfig']['default_store'])
+            && (bool) $data['config']['storageConfig']['default_store']
+        ) {
+            print_r("Oh damn");exit;
+            $this->collection->setStoreId($this->collection->getDefaultStoreId());
         }
     }
 

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -21,21 +21,18 @@
         <settings>
             <storageConfig>
                 <param name="dataScope" xsi:type="string">filters.store_id</param>
+                <param name="default_store" xsi:type="string">1</param>
             </storageConfig>
             <updateUrl path="mui/index/render"/>
         </settings>
         <aclResource>Magento_Catalog::products</aclResource>
         <dataProvider class="Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider" name="product_listing_data_source">
+            <storeId>1000</storeId>
             <settings>
                 <requestFieldName>id</requestFieldName>
                 <primaryFieldName>entity_id</primaryFieldName>
             </settings>
         </dataProvider>
-        <argument name="dataProvider" xsi:type="configurableObject">
-            <argument name="data" xsi:type="array">
-                <item name="store_id" xsi:type="number">0</item>
-            </argument>
-        </argument>
     </dataSource>
     <listingToolbar name="listing_top">
         <settings>

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -27,7 +27,6 @@
         </settings>
         <aclResource>Magento_Catalog::products</aclResource>
         <dataProvider class="Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider" name="product_listing_data_source">
-            <storeId>1000</storeId>
             <settings>
                 <requestFieldName>id</requestFieldName>
                 <primaryFieldName>entity_id</primaryFieldName>

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -25,7 +25,6 @@
             <updateUrl path="mui/index/render"/>
         </settings>
         <aclResource>Magento_Catalog::products</aclResource>
-        <storeId>0</storeId>
         <dataProvider class="Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider" name="product_listing_data_source">
             <settings>
                 <requestFieldName>id</requestFieldName>

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -25,12 +25,18 @@
             <updateUrl path="mui/index/render"/>
         </settings>
         <aclResource>Magento_Catalog::products</aclResource>
+        <storeId>0</storeId>
         <dataProvider class="Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider" name="product_listing_data_source">
             <settings>
                 <requestFieldName>id</requestFieldName>
                 <primaryFieldName>entity_id</primaryFieldName>
             </settings>
         </dataProvider>
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="data" xsi:type="array">
+                <item name="store_id" xsi:type="number">0</item>
+            </argument>
+        </argument>
     </dataSource>
     <listingToolbar name="listing_top">
         <settings>


### PR DESCRIPTION
Added possibility to set store_id for ProductDataProvider in a data argument. This is also now set to zero (default store view) for the catalog/product/index product grid

### Description
By adding a store_id field to the data array, it is now possible to pass a store_id to the ProductDataProvider, this resolves an issue causing the default data values in the product grid in the adminhtml to be invalid and not the default store.

### Fixed Issues (if relevant)
1. magento/magento2#13338: Products grid in admin does not display default values?

### Manual testing scenarios
1. If needed, reproduce issue
2. Apply PR as patch
3. Clear cache, open product grid again
4. Issue resolved

### Contribution checklist
 - [✓] Pull request has a meaningful description of its purpose
 - [✓] All commits are accompanied by meaningful commit messages
 - [✓] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
