### PR TITLE
[Forwardport] Pull 14336 Resolves adminhtml product grid issue #13338

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductDataProvider.php
@@ -67,6 +67,12 @@ class ProductDataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         $this->addFieldStrategies = $addFieldStrategies;
         $this->addFilterStrategies = $addFilterStrategies;
         $this->modifiersPool = $modifiersPool ?: ObjectManager::getInstance()->get(PoolInterface::class);
+
+        if (isset($data['config']['storageConfig']['default_store'])
+            && (bool) $data['config']['storageConfig']['default_store']
+        ) {
+            $this->collection->setStoreId($this->collection->getDefaultStoreId());
+        }
     }
 
     /**

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -21,6 +21,7 @@
         <settings>
             <storageConfig>
                 <param name="dataScope" xsi:type="string">filters.store_id</param>
+                <param name="default_store" xsi:type="string">1</param>
             </storageConfig>
             <updateUrl path="mui/index/render"/>
         </settings>


### PR DESCRIPTION
Added possibility to set store_id for ProductDataProvider in a data argument. This is also now set to zero (default store view) for the catalog/product/index product grid

### Description
By adding a store_id field to the data array, it is now possible to pass a store_id to the ProductDataProvider, this resolves an issue causing the default data values in the product grid in the adminhtml to be invalid and not the default store.

### Fixed Issues (if relevant)
1. magento/magento2#13338: Products grid in admin does not display default values?

### Manual testing scenarios
1. If needed, reproduce issue
2. Apply PR as patch
3. Clear cache, open product grid again
4. Issue resolved

### Contribution checklist
 - [✓] Pull request has a meaningful description of its purpose
 - [✓] All commits are accompanied by meaningful commit messages
 - [✓] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Original PR: https://github.com/magento/magento2/pull/14336