### PR TITLE
Add support to associative arrays as output at REST API

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
@@ -95,13 +95,13 @@ class ServiceOutputProcessor implements ServicePayloadConverterInterface
         if (is_array($data)) {
             $result = [];
             $arrayElementType = substr($type, 0, -2);
-            foreach ($data as $datum) {
+            foreach ($data as $index => $datum) {
                 if (is_object($datum)) {
                     $datum = $this->processDataObject(
                         $this->dataObjectProcessor->buildOutputDataArray($datum, $arrayElementType)
                     );
                 }
-                $result[] = $datum;
+                $result[$index] = $datum;
             }
             return $result;
         } elseif (is_object($data)) {


### PR DESCRIPTION
At REST API the associative arrays are not supported.

### Description
In class ServiceOutputProcessor I am using the index of the arrays to build the output, before they were ignored.

### Fixed Issues (if relevant)

- The index of associative arrays were ignored. Now they are being ussed

1. magento/magento2#5659: REST API Associative Array Not Supporting

### Manual testing scenarios
Tried the following output with the resulting json responses:

| Output array | JSON Response |
|--------------|-----------------|
|['X' => 1, 'Y' => 3] | {"X":1,"Y":3}|
|['X','Y']|["X","Y"]|
|['X' => 1, 'Y' => 3, 'J' => ['K' => 4]]|{"X":1,"Y":3,"J":{"K":4}}|
|['X' => 1, 'Y' => 3, 'J' => ['K' => 4, 'H' => [1,3,4]]]|{"X":1,"Y":3,"J":{"K":4,"H":[1,3,4]}}|
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
