### PR TITLE
Add ability to set custom product option with negative price

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -461,6 +461,7 @@ class Helper
             }
 
             $customOption = $this->customOptionFactory->create(['data' => $customOptionData]);
+            $customOption->setProduct($product);
             $customOption->setProductSku($product->getSku());
             $customOptions[] = $customOption;
         }

--- a/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Catalog\Model\Product\Option\Validator;
 
+use Magento\Catalog\Model\Config\Source\ProductPriceOptionsInterface;
 use Magento\Catalog\Model\Product\Option;
 use Zend_Validate_Exception;
 
@@ -132,7 +133,15 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
      */
     protected function validateOptionValue(Option $option)
     {
-        return $this->isInRange($option->getPriceType(), $this->priceTypes) && !$this->isNegative($option->getPrice());
+        $productPrice = 0.0;
+        if ($option->getPriceType() === ProductPriceOptionsInterface::VALUE_PERCENT) {
+            $productPrice = 100.0;
+        } elseif ($option->getProduct()) {
+            $productPrice = $option->getProduct()->getSpecialPrice() ?: $option->getProduct()->getPrice();
+        }
+
+        return $this->isInRange($option->getPriceType(), $this->priceTypes)
+            && !$this->isNegative($productPrice + $option->getPrice());
     }
 
     /**

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
@@ -923,7 +923,7 @@ class CustomOptions extends AbstractModifier
                         'addbeforePool' => $this->productOptionsPrice->prefixesToOptionArray(),
                         'sortOrder' => $sortOrder,
                         'validation' => [
-                            'validate-zero-or-greater' => true
+                            'validate-number' => true
                         ],
                     ],
                 ],

--- a/app/code/Magento/Catalog/view/base/web/js/price-options.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-options.js
@@ -20,8 +20,10 @@ define([
         optionConfig: {},
         optionHandlers: {},
         optionTemplate: '<%= data.label %>' +
-        '<% if (data.finalPrice.value) { %>' +
+        '<% if (data.finalPrice.value > 0) { %>' +
         ' +<%- data.finalPrice.formatted %>' +
+        '<% } else if (data.finalPrice.value) { %>' +
+        ' <%- data.finalPrice.formatted %>' +
         '<% } %>',
         controlContainer: 'dd'
     };


### PR DESCRIPTION
### Description
Enabled ability to set negative prices for custom product options.

### Fixed Issues
1. magento/magento2#7333: Unable to set negative custom option fixed price in admin view

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create product.
2. Add custom option and set negative value.
3. Save product. For fixed price absolute value of option's price cannot exceed product's special/regular price and if it does - 'Invalid option value' message is shown. For percentage the value of 100 cannot be exceeded.
4. If negative value is in proper range product saves correctly and option is displayed in storefront with proper + or - sign
