### PR TITLE
Fix generating product URL rewrites for anchor categories

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
@@ -61,7 +61,7 @@ class AnchorUrlRewriteGenerator
             $anchorCategoryIds = $category->getAnchorsAbove();
             if ($anchorCategoryIds) {
                 foreach ($anchorCategoryIds as $anchorCategoryId) {
-                    $anchorCategory = $this->categoryRepository->get($anchorCategoryId);
+                    $anchorCategory = $this->categoryRepository->get($anchorCategoryId, $storeId);
                     $urls[] = $this->urlRewriteFactory->create()
                         ->setEntityType(ProductUrlRewriteGenerator::ENTITY_TYPE)
                         ->setEntityId($product->getId())


### PR DESCRIPTION
2.3-develop PR https://github.com/magento/magento2/pull/20826

### Description
During product URL rewrite generation anchor categories were loaded with no store ID specified resulting with default url key being read from the DB.

### Fixed Issues
1. magento/magento2#11615: URL Rewrites vs multiple storeviews - a never ending battle

### Manual testing scenarios
Test scenario is well described in the linked issue

The same fix for 2.3-develop: https://github.com/magento/magento2/pull/20826