### PR TITLE
Fix OptionsRepository API test to add option by attribute_id

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/OptionRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/OptionRepositoryTest.php
@@ -7,6 +7,9 @@
 
 namespace Magento\ConfigurableProduct\Api;
 
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+
 class OptionRepositoryTest extends \Magento\TestFramework\TestCase\WebapiAbstract
 {
     const SERVICE_NAME = 'configurableProductOptionRepositoryV1';
@@ -138,6 +141,12 @@ class OptionRepositoryTest extends \Magento\TestFramework\TestCase\WebapiAbstrac
      */
     public function testAdd()
     {
+        /** @var AttributeRepositoryInterface $attributeRepository */
+        $attributeRepository = Bootstrap::getObjectManager()->create(AttributeRepositoryInterface::class);
+
+        /** @var \Magento\Eav\Api\Data\AttributeInterface $attribute */
+        $attribute = $attributeRepository->get('catalog_product', 'test_configurable');
+
         $productSku = 'simple';
         $serviceInfo = [
             'rest' => [
@@ -151,7 +160,7 @@ class OptionRepositoryTest extends \Magento\TestFramework\TestCase\WebapiAbstrac
             ]
         ];
         $option = [
-            'attribute_id' => 'test_configurable',
+            'attribute_id' => $attribute->getAttributeId(),
             'label' => 'Test',
             'values' => [
                 [


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Users reported being unable to add multiple configurable product options via API. The solution is to use the attribute ID instead of attribute code in the request body. I've updated the API functional test to reflect correct usage. 

### Fixed Issues 
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5580: Cannot add multiple options to configurable product via REST API

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. See https://github.com/magento/magento2/issues/5580#issue-164875500

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
