### PR TITLE
Fixed decimal handling in order quantities

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -233,7 +233,7 @@ class Item extends AbstractModel implements OrderItemInterface
     public function getSimpleQtyToShip()
     {
         $qty = $this->getQtyOrdered() - $this->getQtyShipped() - $this->getQtyRefunded() - $this->getQtyCanceled();
-        return max($qty, 0);
+        return max(round($qty, 8), 0);
     }
 
     /**
@@ -248,7 +248,7 @@ class Item extends AbstractModel implements OrderItemInterface
         }
 
         $qty = $this->getQtyOrdered() - $this->getQtyInvoiced() - $this->getQtyCanceled();
-        return max($qty, 0);
+        return max(round($qty, 8), 0);
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -235,4 +235,201 @@ class ItemTest extends \PHPUnit\Framework\TestCase
             ]
         ];
     }
+
+    /**
+     * Test different combinations of item qty setups
+     *
+     * @param array $options
+     * @param float $expectedResult
+     *
+     * @dataProvider getItemQtyVariants
+     */
+    public function testGetSimpleQtyToShip(array $options, $expectedResult)
+    {
+        $this->model->setData($options);
+        $this->assertSame($this->model->getSimpleQtyToShip(), $expectedResult['to_ship']);
+    }
+
+    /**
+     * Test different combinations of item qty setups
+     *
+     * @param array $options
+     * @param float $expectedResult
+     *
+     * @dataProvider getItemQtyVariants
+     */
+    public function testGetQtyToInvoice(array $options, $expectedResult)
+    {
+        $this->model->setData($options);
+        $this->assertSame($this->model->getQtyToInvoice(), $expectedResult['to_invoice']);
+    }
+
+    /**
+     * Provides different combinations of qty options for an item and the
+     * expected qtys pending shipment and invoice
+     *
+     * @return array
+     */
+    public function getItemQtyVariants()
+    {
+        return [
+            'empty_item' => [
+                'options' => [
+                    'qty_ordered' => 0,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'ordered_item' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 12.0,
+                    'to_invoice' => 12.0
+                ]
+            ],
+            'partially_invoiced' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 4,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 12.0,
+                    'to_invoice' => 8.0
+                ]
+            ],
+            'completely_invoiced' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 12.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'partially_invoiced_refunded' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 5,
+                    'qty_refunded' => 5,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 7.0,
+                    'to_invoice' => 7.0
+                ]
+            ],
+            'partially_refunded' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 5,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 7.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'partially_shipped' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 8.0,
+                    'to_invoice' => 12.0
+                ]
+            ],
+            'partially_refunded_partially_shipped' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 5,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 3.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'complete' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 12,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'canceled' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 12,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'completely_shipped_using_decimals' => [
+                'options' => [
+                    'qty_ordered' => 4.4,
+                    'qty_invoiced' => 0.4,
+                    'qty_refunded' => 0.4,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 4.0
+                ]
+            ],
+            'completely_invoiced_using_decimals' => [
+                'options' => [
+                    'qty_ordered' => 4.4,
+                    'qty_invoiced' => 4,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0.4,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ]
+        ];
+    }
+
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -275,161 +275,87 @@ class ItemTest extends \PHPUnit\Framework\TestCase
         return [
             'empty_item' => [
                 'options' => [
-                    'qty_ordered' => 0,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 0, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 0,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ],
             'ordered_item' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 0,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 12.0,
-                    'to_invoice' => 12.0
-                ]
+                'expectedResult' => ['to_ship' => 12.0, 'to_invoice' => 12.0]
             ],
             'partially_invoiced' => [
-                'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 4,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
+                'options' => ['qty_ordered' => 12, 'qty_invoiced' => 4, 'qty_refunded' => 0, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 12.0,
-                    'to_invoice' => 8.0
-                ]
+                'expectedResult' => ['to_ship' => 12.0, 'to_invoice' => 8.0]
             ],
             'completely_invoiced' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 0, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 12.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 12.0, 'to_invoice' => 0.0]
             ],
             'partially_invoiced_refunded' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 5,
-                    'qty_refunded' => 5,
-                    'qty_shipped' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 5, 'qty_refunded' => 5, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 7.0,
-                    'to_invoice' => 7.0
-                ]
+                'expectedResult' => ['to_ship' => 7.0, 'to_invoice' => 7.0]
             ],
             'partially_refunded' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 5,
-                    'qty_shipped' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 5, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 7.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 7.0, 'to_invoice' => 0.0]
             ],
             'partially_shipped' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 4,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 4,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 8.0,
-                    'to_invoice' => 12.0
-                ]
+                'expectedResult' => ['to_ship' => 8.0, 'to_invoice' => 12.0]
             ],
             'partially_refunded_partially_shipped' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 5,
-                    'qty_shipped' => 4,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 5, 'qty_shipped' => 4,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 3.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 3.0, 'to_invoice' => 0.0]
             ],
             'complete' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 12,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 0, 'qty_shipped' => 12,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ],
             'canceled' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
-                    'qty_canceled' => 12,
+                    'qty_ordered' => 12, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 0,
+                    'qty_canceled' => 12
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ],
             'completely_shipped_using_decimals' => [
                 'options' => [
-                    'qty_ordered' => 4.4,
-                    'qty_invoiced' => 0.4,
-                    'qty_refunded' => 0.4,
-                    'qty_shipped' => 4,
+                    'qty_ordered' => 4.4, 'qty_invoiced' => 0.4, 'qty_refunded' => 0.4, 'qty_shipped' => 4,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 4.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 4.0]
             ],
             'completely_invoiced_using_decimals' => [
                 'options' => [
-                    'qty_ordered' => 4.4,
-                    'qty_invoiced' => 4,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 4,
-                    'qty_canceled' => 0.4,
+                    'qty_ordered' => 4.4, 'qty_invoiced' => 4, 'qty_refunded' => 0, 'qty_shipped' => 4,
+                    'qty_canceled' => 0.4
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ]
         ];
     }
-
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -244,23 +244,10 @@ class ItemTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider getItemQtyVariants
      */
-    public function testGetSimpleQtyToShip(array $options, $expectedResult)
+    public function testGetSimpleQtyToMethods(array $options, $expectedResult)
     {
         $this->model->setData($options);
         $this->assertSame($this->model->getSimpleQtyToShip(), $expectedResult['to_ship']);
-    }
-
-    /**
-     * Test different combinations of item qty setups
-     *
-     * @param array $options
-     * @param float $expectedResult
-     *
-     * @dataProvider getItemQtyVariants
-     */
-    public function testGetQtyToInvoice(array $options, $expectedResult)
-    {
-        $this->model->setData($options);
         $this->assertSame($this->model->getQtyToInvoice(), $expectedResult['to_invoice']);
     }
 


### PR DESCRIPTION
Also added test coverage to getSimpleQtyToShip and getQtyToInvoice

### Description
I am using rounding to a large number of decimals (8) to orders that cannot be completed due to strict equal to zero comparisons on item qty

### Fixed Issues (if relevant)

Fixes #14328 

### Manual testing scenarios

1. Complete an order with a product using qty = 4.4
2. Create an invoice for qty = 0.4
3. Refund the invoice
4. Create an invoice for qty = 4
5. Create a shipment for qty = 4
6. Order should be complete

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
