### PR TITLE
Backport of PR-10445 for Magento 2.1: Fix JS translation search

### DIFF
--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -124,12 +124,13 @@ class DataProvider implements DataProviderInterface
     {
         $phrases = [];
         foreach ($this->config->getPatterns() as $pattern) {
-            $result = preg_match_all($pattern, $content, $matches);
+            $concatenatedContent = preg_replace('~(["\'])\s*?\+\s*?\1~', '', $content);
+            $result = preg_match_all($pattern, $concatenatedContent, $matches);
 
             if ($result) {
                 if (isset($matches[2])) {
                     foreach ($matches[2] as $match) {
-                        $phrases[] = str_replace('\\\'', '\'', $match);
+                        $phrases[] = str_replace(["\'", '\"'], ["'", '"'], $match);
                     }
                 }
             }

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -59,8 +59,8 @@
             <argument name="patterns" xsi:type="array">
                 <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
-                <item name="mage_translation_widget" xsi:type="string">~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)\1(?s).*?\)~</item>
-                <item name="mage_translation_static" xsi:type="string">~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~</item>
+                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~(?:\$|jQuery)\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
+                <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Don't only replace \' but also \" with ' and "

(cherry picked from commit a150d2485ec17687b83a444fa7ba4cac528e55f2)

Concatenate JS translations before translating them

This enables support for $.mage.__("concatenating" + "strings");

(cherry picked from commit c79b583422d994433f613355cf2e2ffb22c8d4e1)

+: put all regexes in cdata tags

(cherry picked from commit f9304714d9ba0959150c09be3eeb7670a776d342)

Prevent translation string lookup from breaking on \' or \" with a negative lookbehind

(cherry picked from commit 87d4ba475f46c86ab4473f2d66a6c9c5ccf4456c)

Support $.mage.__('') as well as jQuery.mage.__('')

(cherry picked from commit 5ae47df31fc186b60053e7318a1bcb5091902239)

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This is a backport of https://github.com/magento/magento2/pull/10445 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/7403: JS Translation Regex leads to unexpected results and untranslatable strings

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
