### PR TITLE
precision for price overriding by js

### DIFF
--- a/app/code/Magento/Catalog/view/base/web/js/price-utils.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-utils.js
@@ -79,7 +79,7 @@ define([
         am = Number(Math.round(Math.abs(amount - i) + 'e+' + precision) + ('e-' + precision));
         r = (j ? i.substr(0, j) + groupSymbol : '') +
             i.substr(j).replace(re, '$1' + groupSymbol) +
-            (precision ? decimalSymbol + am.toFixed(2).replace(/-/, 0).slice(2) : '');
+            (precision ? decimalSymbol + am.toFixed(precision).replace(/-/, 0).slice(2) : '');
 
         return pattern.replace('%s', r).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
     }


### PR DESCRIPTION
When using more then 2 digits ex(9.4880 will be displayed as 9.49) for the price the js will override this value and it will format using the round for 2 digits.
### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. magento 2.2.0
2. php 7.0
3. mysql 5.7.21

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Create a plugin to use more then 2 digits for the price 
2. The price should be saved in database as 9.4880
3. category page will display the price based on database value, but when accessing the prodcut page the price will be overrided with value 9.49

### Expected result

1. Price = 9.488 

### Actual result

1. Price = 9.49

Going deeer found the issue in price-utils.js on this line 

```
        // replace(/-/, 0) is only for fixing Safari bug which appears
        // when Math.abs(0).toFixed() executed on '0' number.
        // Result is '0.-0' :(

        am = Number(Math.round(Math.abs(amount - i) + 'e+' + precision) + ('e-' + precision));
        r = (j ? i.substr(0, j) + groupSymbol : '') +
            i.substr(j).replace(re, '$1' + groupSymbol) +
            (precision ? decimalSymbol + am.toFixed(2).replace(/-/, 0).slice(2) : '');
```
am.toFixed(2) <--- is using the hardcoded precision and the price will be overrided with 2 digits value !!!

done a quick check and changing this to 
```
am.toFixed(precision)
```
seems to do the job.

### Fixed Issues (if relevant)

1. magento/magento2#14249: Priduct page price is using the hardcoded digits in js


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
