### PR TITLE
MAGETWO-82524: Add meta assets #5023

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -475,6 +475,23 @@ class Config
         );
         return $this;
     }
+    
+    /**
+     * Adjust metadata content url
+     *
+     * @param string $content
+     * @return string $content
+     */
+    public function getMetaUrl($content)
+    {
+        $parsed = parse_url($content);
+
+        if (empty($parsed['scheme'])) {
+            return $this->assetRepo->getUrl($content);
+        }
+
+        return $content;
+    }
 
     /**
      * Set additional element attribute

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -19,6 +19,11 @@ class Renderer implements RendererInterface
      * @var array
      */
     protected $assetTypeOrder = ['css', 'ico', 'js'];
+    
+    /**
+     * @var array
+     */
+    protected $metaAssets = ['msapplication-TileImage'];
 
     /**
      * @var \Magento\Framework\View\Page\Config
@@ -139,6 +144,11 @@ class Renderer implements RendererInterface
         if (method_exists($this->pageConfig, $method)) {
             $content = $this->pageConfig->$method();
         }
+        
+        if ($content && in_array($name, $this->metaAssets)) {
+            $content = $this->pageConfig->getMetaUrl($content);
+        }
+
         return $content;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Support assets urls in selected meta tags

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5023: It is not possible to add MS tile image meta via default_head_blocks.xml

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open default_head_blocks.xml
2. Add ```<meta name="msapplication-TileImage" content="images/favicons/default/mstile-144x144.png"/>``` to the head
3. Expect localized theme path being respected in meta content url

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
