### PR TITLE
Use `LEFT JOIN` When Checking for `null` Attributes

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1498,6 +1498,10 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
                 $condition
             );
         } else {
+            if (isset($condition['null'])) {
+                $joinType = 'left';
+            }
+
             $this->_addAttributeJoin($attribute, $joinType);
             if (isset($this->_joinAttributes[$attribute]['condition_alias'])) {
                 $field = $this->_joinAttributes[$attribute]['condition_alias'];

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CollectionTest.php
@@ -149,4 +149,20 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
         self::assertContains($expected, str_replace(PHP_EOL, '', $sql));
     }
+
+    /**
+     * Checks that a collection uses the correct join when filtering by null.
+     *
+     * This actually affects AbstractCollection, but inheritance yada yada.
+     *
+     * @magentoDataFixture Magento/Catalog/Model/ResourceModel/_files/product_simple.php
+     * @magentoDbIsolation enabled
+     */
+    public function testFilterByNull()
+    {
+        $this->collection->addAttributeToFilter([['attribute' => 'special_price', 'null' => true]]);
+        $productCount = $this->collection->count();
+
+        $this->assertEquals(1, $productCount, 'Product with null special_price not found');
+    }
 }


### PR DESCRIPTION


### Description

It is not possible to filter an EAV collection by an attribute being `null`.

### Fixed Issues (if relevant)

* magento/magento2#14355: Impossible to Filter Collection by `null` Attribute Value

Also addresses:

* magento/magento2#14312: GraphQL `ProductFilterInput` Requires Field to be a String

### Manual testing scenarios

As addressed by the integration test, load a product collection and try to `addAttributeToFilter` and select an attribute to be `null`. This is a correct usage of the API, and the `where` clause is generated correctly, as `... WHERE ((at_special_price.value IS NULL))`.

However, without this diff, the join is an `INNER JOIN`, which automatically excludes `null` values.

### Discussion

I have chosen to add a little complexity here, by checking for a null comparison and only then selecting a `LEFT JOIN`. It would work fine to use a `LEFT JOIN` for this all the time, but I suspect that `INNER JOIN` was chosen for a reason, perhaps performance. I decided it was best to respect this decision and change as little as possible.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
