### PR TITLE
Add @api annotation to the ScopeConfig WriterInterface

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/Storage/WriterInterface.php
+++ b/lib/internal/Magento/Framework/App/Config/Storage/WriterInterface.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * Interface \Magento\Framework\App\Config\Storage\WriterInterface
- *
+ * @api
  */
 interface WriterInterface
 {


### PR DESCRIPTION
### Description

I would like a more official way of writing config that's part of the API.

Currently, You should use `Magento\Config\Model\ResourceModel\Config::saveConfig` - which is @api annotated.

That class implements `Magento\Framework\App\Config\ConfigResource\ConfigInterface` (which is not annotated) - and that class is used by `Magento\Framework\App\Config\Storage\WriterInterface` (which is not annotated - but I propose to do so here)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
