### PR TITLE
Add getShippingAddress and setShippingAddress functions to Order interface

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -1538,6 +1538,21 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     public function setBillingAddress(\Magento\Sales\Api\Data\OrderAddressInterface $billingAddress = null);
 
     /**
+     * Gets the shipping address, if any, for the order.
+     *
+     * @return \Magento\Sales\Api\Data\OrderAddressInterface|null Shipping address. Otherwise, null.
+     */
+    public function getShippingAddress();
+
+    /**
+     * Sets the shipping address, if any, for the order.
+     *
+     * @param \Magento\Sales\Api\Data\OrderAddressInterface $shippingAddress
+     * @return $this
+     */
+    public function setShippingAddress(\Magento\Sales\Api\Data\OrderAddressInterface $shippingAddress = null);
+
+    /**
      * Gets order payment
      *
      * @return \Magento\Sales\Api\Data\OrderPaymentInterface|null


### PR DESCRIPTION
Hello,

### Description
I just noticed functions `getShippingAddress()` and `setShippingAddress()` are missing from the Order interface (class `Magento\Sales\Api\Data\OrderInterface`).

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
