### PR TITLE
Removal of deprecated escape function escapeJsQuote.

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -7,6 +7,7 @@
 namespace Magento\GoogleAnalytics\Block;
 
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Escaper;
 
 /**
  * GoogleAnalytics Page Block
@@ -34,22 +35,30 @@ class Ga extends \Magento\Framework\View\Element\Template
     private $cookieHelper;
 
     /**
+     * @var Escaper
+     */
+    private $escaper;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $salesOrderCollection
      * @param \Magento\GoogleAnalytics\Helper\Data $googleAnalyticsData
      * @param array $data
      * @param \Magento\Cookie\Helper\Cookie|null $cookieHelper
+     * @param Escaper $escaper
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $salesOrderCollection,
         \Magento\GoogleAnalytics\Helper\Data $googleAnalyticsData,
         array $data = [],
-        \Magento\Cookie\Helper\Cookie $cookieHelper = null
+        \Magento\Cookie\Helper\Cookie $cookieHelper = null,
+        Escaper $escaper = null
     ) {
         $this->_googleAnalyticsData = $googleAnalyticsData;
         $this->_salesOrderCollection = $salesOrderCollection;
         $this->cookieHelper = $cookieHelper ?: ObjectManager::getInstance()->get(\Magento\Cookie\Helper\Cookie::class);
+        $this->escaper = $escaper ?: ObjectManager::getInstance()->get(Escaper);
         parent::__construct($context, $data);
     }
 
@@ -128,8 +137,8 @@ class Ga extends \Magento\Framework\View\Element\Template
                         'price': '%s',
                         'quantity': %s
                     });",
-                    $this->escapeJsQuote($item->getSku()),
-                    $this->escapeJsQuote($item->getName()),
+                    $this->escaper->escapeJs($item->getSku()),
+                    $this->escaper->escapeJs($item->getName()),
                     $item->getPrice(),
                     $item->getQtyOrdered()
                 );
@@ -144,7 +153,7 @@ class Ga extends \Magento\Framework\View\Element\Template
                     'shipping': '%s'
                 });",
                 $order->getIncrementId(),
-                $this->escapeJsQuote($this->_storeManager->getStore()->getFrontendName()),
+                $this->escaper->escapeJs($this->_storeManager->getStore()->getFrontendName()),
                 $order->getGrandTotal(),
                 $order->getTaxAmount(),
                 $order->getShippingAmount()
@@ -234,15 +243,15 @@ class Ga extends \Magento\Framework\View\Element\Template
         foreach ($collection as $order) {
             foreach ($order->getAllVisibleItems() as $item) {
                 $result['products'][] = [
-                    'id' => $this->escapeJsQuote($item->getSku()),
-                    'name' =>  $this->escapeJsQuote($item->getName()),
+                    'id' => $this->escaper->escapeJs($item->getSku()),
+                    'name' =>  $this->escaper->escapeJs($item->getName()),
                     'price' => $item->getPrice(),
                     'quantity' => $item->getQtyOrdered(),
                 ];
             }
             $result['orders'][] = [
                 'id' =>  $order->getIncrementId(),
-                'affiliation' => $this->escapeJsQuote($this->_storeManager->getStore()->getFrontendName()),
+                'affiliation' => $this->escaper->escapeJs($this->_storeManager->getStore()->getFrontendName()),
                 'revenue' => $order->getGrandTotal(),
                 'tax' => $order->getTaxAmount(),
                 'shipping' => $order->getShippingAmount(),

--- a/app/code/Magento/Translation/Block/Js.php
+++ b/app/code/Magento/Translation/Block/Js.php
@@ -8,6 +8,8 @@ namespace Magento\Translation\Block;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Translation\Model\Js\Config;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Escaper;
 
 /**
  * @api
@@ -26,20 +28,28 @@ class Js extends Template
     private $fileManager;
 
     /**
+     * @var Escaper
+     */
+    private $escaper;
+
+    /**
      * @param Template\Context $context
      * @param Config $config
      * @param \Magento\Translation\Model\FileManager $fileManager
      * @param array $data
+     * @param Escaper $escaper
      */
     public function __construct(
         Template\Context $context,
         Config $config,
         \Magento\Translation\Model\FileManager $fileManager,
-        array $data = []
+        array $data = [],
+        Escaper $escaper = null
     ) {
         parent::__construct($context, $data);
         $this->config = $config;
         $this->fileManager = $fileManager;
+        $this->escaper = $escaper ?: ObjectManager::getInstance()->get(Escaper);
     }
 
     /**

--- a/app/code/Magento/Translation/view/base/templates/translate.phtml
+++ b/app/code/Magento/Translation/view/base/templates/translate.phtml
@@ -28,7 +28,7 @@
 
                 <?php $version = $block->getTranslationFileVersion(); ?>
 
-                if (versionObj.version !== '<?php $block->escapeJsQuote($version) ?>') {
+                if (versionObj.version !== '<?php $block->escaper->escapeJs($version) ?>') {
                     dependencies.push(
                         'text!<?= /* @noEscape */ Magento\Translation\Model\Js\Config::DICTIONARY_FILE_NAME ?>'
                     );
@@ -44,7 +44,7 @@
                             $.localStorage.set(
                                 'mage-translation-file-version',
                                 {
-                                    version: '<?php $block->escapeJsQuote($version) ?>'
+                                    version: '<?php $block->escaper->escapeJs($version) ?>'
                                 }
                             );
                         } else {

--- a/app/code/Magento/Widget/Model/Widget.php
+++ b/app/code/Magento/Widget/Model/Widget.php
@@ -315,7 +315,7 @@ class Widget
                 }
             }
             if (isset($value)) {
-                $directive .= sprintf(' %s="%s"', $name, $this->escaper->escapeQuote($value));
+                $directive .= sprintf(' %s="%s"', $name, $this->escaper->escapeHtml($value));
             }
         }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Element/AbstractBlockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Element/AbstractBlockTest.php
@@ -528,12 +528,6 @@ class AbstractBlockTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($url, $this->_block->escapeUrl($url));
     }
 
-    public function testEscapeJsQuote()
-    {
-        $script = "var s = 'text';";
-        $this->assertEquals('var s = \\\'text\\\';', $this->_block->escapeJsQuote($script));
-    }
-
     public function testGetCacheKeyInfo()
     {
         $name = uniqid('block.');

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
@@ -1043,8 +1043,6 @@ return [
     ['getHash', '\Magento\Core\Helper\Data'],
     ['escapeHtml', '\Magento\Framework\App\Helper\AbstractHelper', '\Magento\Framework\Escaper::escapeHtml'],
     ['escapeUrl', '\Magento\Framework\App\Helper\AbstractHelper', '\Magento\Framework\Escaper::escapeUrl'],
-    ['jsQuoteEscape', '\Magento\Framework\App\Helper\AbstractHelper', '\Magento\Framework\Escaper::escapeJsQuote'],
-    ['quoteEscape', '\Magento\Framework\App\Helper\AbstractHelper', '\Magento\Framework\Escaper::escapeQuote'],
     ['removeTags', '\Magento\Framework\App\Helper\AbstractHelper', '\Magento\Framework\Filter\FilterManager'],
     ['removeAccents', '\Magento\Core\Helper\Data', '\Magento\Framework\Filter\FilterManager'],
     ['splitWords', '\Magento\Core\Helper\String', '\Magento\Framework\Filter\FilterManager'],

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -263,27 +263,6 @@ class Escaper
     }
 
     /**
-     * Escape quotes in java script
-     *
-     * @param string|array $data
-     * @param string $quote
-     * @return string|array
-     * @deprecated 100.2.0
-     */
-    public function escapeJsQuote($data, $quote = '\'')
-    {
-        if (is_array($data)) {
-            $result = [];
-            foreach ($data as $item) {
-                $result[] = $this->escapeJsQuote($item, $quote);
-            }
-        } else {
-            $result = str_replace($quote, '\\' . $quote, $data);
-        }
-        return $result;
-    }
-
-    /**
      * Escape xss in urls
      * Remove `javascript:`, `vbscript:`, `data:` words from url
      *
@@ -298,23 +277,6 @@ class Escaper
             . '(\\\\x64\\\\x61\\\\x74\\\\x61(\\\\x3a|:|%3A)))/i';
         $result = preg_replace($pattern, ':', $data);
         return htmlspecialchars($result, ENT_COMPAT | ENT_HTML5 | ENT_HTML401, 'UTF-8', false);
-    }
-
-    /**
-     * Escape quotes inside html attributes
-     * Use $addSlashes = false for escaping js that inside html attribute (onClick, onSubmit etc)
-     *
-     * @param string $data
-     * @param bool $addSlashes
-     * @return string
-     * @deprecated 100.2.0
-     */
-    public function escapeQuote($data, $addSlashes = false)
-    {
-        if ($addSlashes === true) {
-            $data = addslashes($data);
-        }
-        return htmlspecialchars($data, ENT_QUOTES, null, false);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -267,31 +267,6 @@ class EscaperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \Magento\Framework\Escaper::escapeJsQuote
-     */
-    public function testEscapeJsQuote()
-    {
-        $data = ["Don't do that.", 'lost_key' => "Can't do that."];
-        $expected = ["Don\\'t do that.", "Can\\'t do that."];
-        $this->assertEquals($expected, $this->escaper->escapeJsQuote($data));
-        $this->assertEquals($expected[0], $this->escaper->escapeJsQuote($data[0]));
-    }
-
-    /**
-     * @covers \Magento\Framework\Escaper::escapeQuote
-     */
-    public function testEscapeQuote()
-    {
-        $data = "Text with 'single' and \"double\" quotes";
-        $expected = [
-            "Text with &#039;single&#039; and &quot;double&quot; quotes",
-            "Text with \\&#039;single\\&#039; and \\&quot;double\\&quot; quotes",
-        ];
-        $this->assertEquals($expected[0], $this->escaper->escapeQuote($data));
-        $this->assertEquals($expected[1], $this->escaper->escapeQuote($data, true));
-    }
-
-    /**
      * @covers \Magento\Framework\Escaper::escapeXssInUrl
      * @param string $input
      * @param string $expected

--- a/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
+++ b/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
@@ -892,18 +892,6 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
     }
 
     /**
-     * Escape string for the JavaScript context
-     *
-     * @param string $string
-     * @return string
-     * @since 100.2.0
-     */
-    public function escapeJs($string)
-    {
-        return $this->_escaper->escapeJs($string);
-    }
-
-    /**
      * Escape a string for the HTML attribute context
      *
      * @param string $string
@@ -965,34 +953,6 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
     public function escapeXssInUrl($data)
     {
         return $this->_escaper->escapeXssInUrl($data);
-    }
-
-    /**
-     * Escape quotes inside html attributes
-     *
-     * Use $addSlashes = false for escaping js that inside html attribute (onClick, onSubmit etc)
-     *
-     * @param  string $data
-     * @param  bool $addSlashes
-     * @return string
-     * @deprecated 100.2.0
-     */
-    public function escapeQuote($data, $addSlashes = false)
-    {
-        return $this->_escaper->escapeQuote($data, $addSlashes);
-    }
-
-    /**
-     * Escape quotes in java scripts
-     *
-     * @param string|array $data
-     * @param string $quote
-     * @return string|array
-     * @deprecated 100.2.0
-     */
-    public function escapeJsQuote($data, $quote = '\'')
-    {
-        return $this->_escaper->escapeJsQuote($data, $quote);
     }
 
     /**


### PR DESCRIPTION
### Description
`escapeJsQuote` is marked as deprecated and `escapeJs` replaces it just fine. `escapeQuote` is only used once and it appears html escaping is fine here.
Clearing away these unused escaping methods simplifies auditing and also developers wishing to fix escaping.

### Fixed Issues
1. Removal of two unused deprecated escape functions

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Ensure widgets are working
2. Ensure Google analytics is tracking

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
