### PR TITLE
[Backport 2.2] Issue 14351: Product import doesn't change `Enable Qty Increments` field

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -9,6 +9,7 @@ use Magento\Catalog\Model\Config as CatalogConfig;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\CatalogImportExport\Model\Import\Product\MediaGalleryProcessor;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface as ValidatorInterface;
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
@@ -2580,8 +2581,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $useConfigFields = [];
         foreach ($rowData as $key => $value) {
-            $useConfigName = $key === 'enable_qty_increments'
-                ? 'use_config_enable_qty_inc'
+            $useConfigName = $key === StockItemInterface::ENABLE_QTY_INCREMENTS
+                ? StockItemInterface::USE_CONFIG_ENABLE_QTY_INC
                 : self::INVENTORY_USE_CONFIG_PREFIX . $key;
 
             if (isset($this->defaultStockData[$key])

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2580,7 +2580,10 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $useConfigFields = [];
         foreach ($rowData as $key => $value) {
-            $useConfigName = self::INVENTORY_USE_CONFIG_PREFIX . $key;
+            $useConfigName = $key === 'enable_qty_increments'
+                ? 'use_config_enable_qty_inc'
+                : self::INVENTORY_USE_CONFIG_PREFIX . $key;
+
             if (isset($this->defaultStockData[$key])
                 && isset($this->defaultStockData[$useConfigName])
                 && !empty($value)


### PR DESCRIPTION
Backported pull request https://github.com/magento/magento2/pull/14352

### Description
`\Magento\CatalogImportExport\Model\Import\Product::_setStockUseConfigFieldsValues` method rely on **Use Config Settings** property name will be with `use_config_` prefix, but for `enable_qty_increments` filed it is named as `use_config_enable_qty_inc`.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14351: Product import doesn't change `Enable Qty Increments` field 

### Manual testing scenarios
As explained in #14352