### PR TITLE
[Backport 2.1] Issue 14351: Product import doesn't change `Enable Qty Increments` field

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -8,6 +8,7 @@
 
 namespace Magento\CatalogImportExport\Model\Import;
 
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface as ValidatorInterface;
 use Magento\Framework\Model\ResourceModel\Db\TransactionManagerInterface;
@@ -2549,8 +2550,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $useConfigFields = array();
         foreach ($rowData as $key => $value) {
-            $useConfigName = $key === 'enable_qty_increments'
-                ? 'use_config_enable_qty_inc'
+            $useConfigName = $key === StockItemInterface::ENABLE_QTY_INCREMENTS
+                ? StockItemInterface::USE_CONFIG_ENABLE_QTY_INC
                 : self::INVENTORY_USE_CONFIG_PREFIX . $key;
 
             if (isset($this->defaultStockData[$key])

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2549,7 +2549,10 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $useConfigFields = array();
         foreach ($rowData as $key => $value) {
-            $useConfigName = self::INVENTORY_USE_CONFIG_PREFIX . $key;
+            $useConfigName = $key === 'enable_qty_increments'
+                ? 'use_config_enable_qty_inc'
+                : self::INVENTORY_USE_CONFIG_PREFIX . $key;
+
             if (isset($this->defaultStockData[$key])
                 && isset($this->defaultStockData[$useConfigName])
                 && !empty($value)


### PR DESCRIPTION
Backported pull request #14352

### Description
`\Magento\CatalogImportExport\Model\Import\Product::_setStockUseConfigFieldsValues` method rely on **Use Config Settings** property name will be with `use_config_` prefix, but for `enable_qty_increments` filed it is named as `use_config_enable_qty_inc`.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14351: Product import doesn't change `Enable Qty Increments` field 

### Manual testing scenarios
As explained in #14352