### PR TITLE
Removed unused translation for comment tag

### DIFF
--- a/app/code/Magento/Analytics/etc/adminhtml/system.xml
+++ b/app/code/Magento/Analytics/etc/adminhtml/system.xml
@@ -17,14 +17,14 @@
                 Your reports can be accessed securely on a personalized dashboard outside of the admin panel by clicking on the
                 "Go to Advanced Reporting" link. </br> For more information, see our <a href="https://magento.com/legal/terms/cloud-terms">
                 terms and conditions</a>.]]></comment>
-                <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Advanced Reporting Service</label>
                     <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
                     <backend_model>Magento\Analytics\Model\Config\Backend\Enabled</backend_model>
                     <frontend_model>Magento\Analytics\Block\Adminhtml\System\Config\SubscriptionStatusLabel</frontend_model>
                     <config_path>analytics/subscription/enabled</config_path>
                 </field>
-                <field id="collection_time" translate="label comment" type="time" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="collection_time" translate="label" type="time" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Time of day to send data</label>
                     <frontend_model>Magento\Analytics\Block\Adminhtml\System\Config\CollectionTimeLabel</frontend_model>
                     <backend_model>Magento\Analytics\Model\Config\Backend\CollectionTime</backend_model>

--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -36,10 +36,10 @@
             </group>
             <group id="recently_products" translate="label" type="text" sortOrder="350" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Recently Viewed/Compared Products</label>
-                <field id="recently_viewed_lifetime" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="recently_viewed_lifetime" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Lifetime of products in Recently Viewed Widget</label>
                 </field>
-                <field id="recently_compared_lifetime" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="recently_compared_lifetime" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Lifetime of products in Recently Compared Widget</label>
                 </field>
                 <field id="synchronize_with_backend" translate="label" type="select" showInDefault="1" canRestore="1">
@@ -83,7 +83,7 @@
                     <backend_model>Magento\Catalog\Model\Indexer\Product\Flat\System\Config\Mode</backend_model>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="default_sort_by" translate="label comment" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="default_sort_by" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Product Listing Sort by</label>
                     <source_model>Magento\Catalog\Model\Config\Source\ListSort</source_model>
                 </field>

--- a/app/code/Magento/InstantPurchase/CustomerData/InstantPurchase.php
+++ b/app/code/Magento/InstantPurchase/CustomerData/InstantPurchase.php
@@ -30,7 +30,7 @@ class InstantPurchase implements SectionSourceInterface
     private $customerSession;
 
     /**
-     * @var StoreManagerInterface\
+     * @var StoreManagerInterface
      */
     private $storeManager;
 

--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -106,15 +106,15 @@
                     <comment>We'll use the default error above if you leave this empty.</comment>
                 </field>
             </group>
-            <group id="dashboard" translate="label comment" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
+            <group id="dashboard" translate="label" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Dashboard</label>
-                <field id="use_aggregated_data" translate="label" sortOrder="10" type="select" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="use_aggregated_data" translate="label comment" sortOrder="10" type="select" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Use Aggregated Data</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Improves dashboard performance but provides non-realtime data.</comment>
                 </field>
             </group>
-            <group id="orders" translate="label comment" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+            <group id="orders" translate="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Orders Cron Settings</label>
                 <field id="delete_pending_after" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Pending Payment Order Lifetime (minutes)</label>

--- a/app/code/Magento/Swatches/etc/adminhtml/system.xml
+++ b/app/code/Magento/Swatches/etc/adminhtml/system.xml
@@ -9,10 +9,10 @@
     <system>
         <section id="catalog" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="frontend" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
-                <field id="swatches_per_product" translate="label comment" type="text" sortOrder="300" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="swatches_per_product" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Swatches per Product</label>
                 </field>
-                <field id="show_swatches_in_product_list" translate="label comment" type="select" sortOrder="310" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                <field id="show_swatches_in_product_list" translate="label" type="select" sortOrder="310" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Show Swatches in Product List</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>

--- a/app/code/Magento/Ups/etc/adminhtml/system.xml
+++ b/app/code/Magento/Ups/etc/adminhtml/system.xml
@@ -106,7 +106,7 @@
                     <label>Live Account</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="unit_of_measure" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="unit_of_measure" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Weight Unit</label>
                     <source_model>Magento\Ups\Model\Config\Source\Unitofmeasure</source_model>
                 </field>


### PR DESCRIPTION
Removed unused translation for `<comment>` tag, because `<comment>` not found as a child for the node.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
