### PR TITLE
[Forwardport] FR#7428 - Multiline fields in forms have no visible label

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -279,7 +279,7 @@
     //  Hide group legend and show first field label instead
     legend {
         &.admin__field-label {
-            opacity: 0;
+            opacity: 1;
         }
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14317
Change css to label multifields 

### Description
admin__field-label has opacity 0, change to 1

### Fixed Issues (if relevant)
1. magento/magento2#7428: Multiline fields in forms have no visible label

### Manual testing scenarios
1. Create a <field>
2. Set it's formElement to multiline
3. Load the form in the browser

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
