### PR TITLE
Don't throw shipping method exception when creating quote with only virtual products in API

### DIFF
--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -177,7 +177,9 @@ class ShippingInformationManagement implements \Magento\Checkout\Api\ShippingInf
 
         $shippingAddress = $quote->getShippingAddress();
 
-        if (!$quote->getIsVirtual() && !$shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod())) {
+        if (!$quote->getIsVirtual()
+            && !$shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod())
+        ) {
             throw new NoSuchEntityException(
                 __('Carrier with such method not found: %1, %2', $carrierCode, $methodCode)
             );

--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -177,7 +177,7 @@ class ShippingInformationManagement implements \Magento\Checkout\Api\ShippingInf
 
         $shippingAddress = $quote->getShippingAddress();
 
-        if (!$shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod())) {
+        if (!$shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod()) && !$quote->getIsVirtual()) {
             throw new NoSuchEntityException(
                 __('Carrier with such method not found: %1, %2', $carrierCode, $methodCode)
             );

--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -177,7 +177,7 @@ class ShippingInformationManagement implements \Magento\Checkout\Api\ShippingInf
 
         $shippingAddress = $quote->getShippingAddress();
 
-        if (!$shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod()) && !$quote->getIsVirtual()) {
+        if (!$quote->getIsVirtual() && !$shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod())) {
             throw new NoSuchEntityException(
                 __('Carrier with such method not found: %1, %2', $carrierCode, $methodCode)
             );

--- a/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementTest.php
@@ -19,6 +19,9 @@ use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Quote\Api\ShipmentEstimationInterface;
 use Magento\Sales\Api\InvoiceOrderInterface;
 
+/**
+ * Shipping information managment test.
+ */
 class ShippingInformationManagementTest extends \PHPUnit\Framework\TestCase
 {
     /** @var CartManagementInterface */

--- a/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Checkout\Model;
 
+use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Checkout\Api\Data\ShippingInformationInterface;
 use Magento\Checkout\Api\PaymentInformationManagementInterface;
 use Magento\Checkout\Api\ShippingInformationManagementInterface;
@@ -55,7 +56,7 @@ class ShippingInformationManagementTest extends \PHPUnit\Framework\TestCase
 
     public function setUp()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager = Bootstrap::getObjectManager();
 
         $this->cartManagement = $objectManager->create(CartManagementInterface::class);
         $this->cartItemRepository = $objectManager->create(CartItemRepositoryInterface::class);

--- a/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Checkout\Model;
+
+use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Checkout\Api\PaymentInformationManagementInterface;
+use Magento\Checkout\Api\ShippingInformationManagementInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Quote\Api\CartItemRepositoryInterface;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Api\Data\AddressInterfaceFactory;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Api\ShipmentEstimationInterface;
+use Magento\Sales\Api\InvoiceOrderInterface;
+
+class ShippingInformationManagementTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var CartManagementInterface */
+    private $cartManagement;
+
+    /** @var CartItemRepositoryInterface */
+    private $cartItemRepository;
+
+    /** @var CartItemInterface */
+    private $cartItem;
+
+    /** @var ShippingInformationManagementInterface */
+    private $shippingInformationManagement;
+
+    /** @var ShippingInformationInterface */
+    private $shippingInformation;
+
+    /** @var CustomerRepositoryInterface */
+    private $customerRepository;
+
+    /** @var AddressInterfaceFactory */
+    private $apiAddressFactory;
+
+    /** @var ShipmentEstimationInterface */
+    private $shipmentEstimation;
+
+    /** @var PaymentInformationManagementInterface */
+    private $paymentInformationManagement;
+
+    /** @var PaymentInterface */
+    private $payment;
+
+    /** @var InvoiceOrderInterface */
+    private $invoiceOrder;
+
+    public function setUp()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+        $this->cartManagement = $objectManager->create(CartManagementInterface::class);
+        $this->cartItemRepository = $objectManager->create(CartItemRepositoryInterface::class);
+        $this->cartItem = $objectManager->create(CartItemInterface::class);
+        $this->shippingInformationManagement = $objectManager->create(ShippingInformationManagementInterface::class);
+        $this->shippingInformation = $objectManager->create(ShippingInformationInterface::class);
+        $this->customerRepository = $objectManager->create(CustomerRepositoryInterface::class);
+        $this->apiAddressFactory = $objectManager->create(AddressInterfaceFactory::class);
+        $this->shipmentEstimation = $objectManager->create(ShipmentEstimationInterface::class);
+        $this->paymentInformationManagement = $objectManager->create(PaymentInformationManagementInterface::class);
+        $this->payment = $objectManager->create(PaymentInterface::class);
+        $this->invoiceOrder = $objectManager->create(InvoiceOrderInterface::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Customer/_files/customer.php
+     * @magentoDataFixture Magento/Customer/_files/customer_address.php
+     * @magentoDataFixture Magento/Catalog/_files/product_virtual_in_stock.php
+     */
+    public function testQuoteApiWithOnlyVirtualProducts()
+    {
+        $customer = $this->customerRepository->getById(1);
+
+        // Create empty quote
+        $quoteId = $this->cartManagement->createEmptyCartForCustomer($customer->getId());
+
+        $cartItem = $this->cartItem
+            ->setSku('virtual-product')
+            ->setQty(1)
+            ->setQuoteId($quoteId);
+
+        // Add item to cart
+        $this->cartItemRepository->save($cartItem);
+
+        $billingAddress = $shippingAddress = null;
+        foreach ($customer->getAddresses() as $address) {
+            $billingAddress = $address;
+            $shippingAddress = $address;
+            break;
+        }
+
+        /** @var \Magento\Quote\Model\Quote\Address $apiBillingAddress */
+        $apiBillingAddress = $this->apiAddressFactory->create();
+        $apiBillingAddress->setRegion($billingAddress->getRegion())
+            ->setRegionId($billingAddress->getRegionId())
+            ->setCountryId($billingAddress->getCountryId())
+            ->setStreet($billingAddress->getStreet())
+            ->setPostcode($billingAddress->getPostcode())
+            ->setCity($billingAddress->getCity())
+            ->setFirstname($billingAddress->getFirstname())
+            ->setLastname($billingAddress->getLastname())
+            ->setEmail($customer->getEmail())
+            ->setTelephone($billingAddress->getTelephone());
+
+        /** @var \Magento\Quote\Model\Quote\Address $apiShippingAddress */
+        $apiShippingAddress = $this->apiAddressFactory->create();
+        $apiShippingAddress->setRegion($shippingAddress->getRegion())
+            ->setRegionId($shippingAddress->getRegionId())
+            ->setCountryId($shippingAddress->getCountryId())
+            ->setStreet($shippingAddress->getStreet())
+            ->setPostcode($shippingAddress->getPostcode())
+            ->setCity($shippingAddress->getCity())
+            ->setFirstname($shippingAddress->getFirstname())
+            ->setLastname($shippingAddress->getLastname())
+            ->setEmail($customer->getEmail())
+            ->setTelephone($shippingAddress->getTelephone());
+
+        // Estimate shipping
+        $this->shipmentEstimation->estimateByExtendedAddress($quoteId, $apiShippingAddress);
+
+        $addressInformation = $this->shippingInformation
+            ->setBillingAddress($apiBillingAddress)
+            ->setShippingAddress($apiShippingAddress)
+            ->setShippingCarrierCode('flatrate')
+            ->setShippingMethodCode('flatrate');
+
+        // Set address information on quote
+        $this->shippingInformationManagement->saveAddressInformation($quoteId, $addressInformation);
+    }
+}


### PR DESCRIPTION
### Description
When creating a quote (and order) via the API with only virtual products, the following error is thrown:

> Carrier with such method not found: <carrier_code>, <method_code>

Because there are no shipping rates available, since they're not necessary.

### Fixed Issues (if relevant)
When creating a quote with only virtual products (`$quote->getIsVirtual() === true`), it skips the check for available shipping method when saving address information.

### Manual testing scenarios
Follow the steps listed here:
http://devdocs.magento.com/guides/v2.2/get-started/order-tutorial/order-intro.html
Only add the `Magento/Catalog/_files/product_virtual_in_stock.php` fixture product to the quote, and save the address information (http://devdocs.magento.com/guides/v2.2/get-started/order-tutorial/order-prepare-checkout.html#set-addresses)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
