### PR TITLE
Add checkPasswordStrength() to API

### DIFF
--- a/app/code/Magento/Customer/Api/AccountManagementInterface.php
+++ b/app/code/Magento/Customer/Api/AccountManagementInterface.php
@@ -153,6 +153,15 @@ interface AccountManagementInterface
     public function resetPassword($email, $resetToken, $newPassword);
 
     /**
+     * Make sure that password complies with minimum security requirements.
+     *
+     * @param string $password
+     * @return void
+     * @throws \Magento\Framework\Exception\InputException
+     */
+    public function checkPasswordStrength($password);
+
+    /**
      * Check if password reset token is valid.
      *
      * @param int $customerId

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -632,13 +632,9 @@ class AccountManagement implements AccountManagementInterface
     }
 
     /**
-     * Make sure that password complies with minimum security requirements.
-     *
-     * @param string $password
-     * @return void
-     * @throws InputException
+     * {@inheritdoc}
      */
-    protected function checkPasswordStrength($password)
+    public function checkPasswordStrength($password)
     {
         $length = $this->stringHelper->strlen($password);
         if ($length > self::MAX_PASSWORD_LENGTH) {
@@ -649,7 +645,7 @@ class AccountManagement implements AccountManagementInterface
                 )
             );
         }
-        $configMinPasswordLength = $this->getMinPasswordLength();
+        $configMinPasswordLength = $this->scopeConfig->getValue(self::XML_PATH_MINIMUM_PASSWORD_LENGTH);
         if ($length < $configMinPasswordLength) {
             throw new InputException(
                 __(
@@ -712,6 +708,7 @@ class AccountManagement implements AccountManagementInterface
      * Retrieve minimum password length
      *
      * @return int
+     * @deprecated
      */
     protected function getMinPasswordLength()
     {


### PR DESCRIPTION
### Description
Add `checkPasswordStrength()` to API so we can extend it without making a preference. With that, I also deprecated `getMinPasswordLength()` since it isn't used anywhere else in the code.

An alternative is to move the strength check to a `PasswordStrengthValidator`. That way no update to the API is needed. Please let me know what is prefered.

### Fixed Issues (if relevant)
1. None.

### Manual testing scenarios
1. None.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
