### PR TITLE
Add support to associative arrays as output at REST API

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
@@ -9,7 +9,6 @@ use Magento\Framework\Api\AbstractExtensibleObject;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Framework\Reflection\MethodsMap;
-use Magento\Framework\Webapi\ServicePayloadConverterInterface;
 
 /**
  * Data object converter
@@ -86,7 +85,7 @@ class ServiceOutputProcessor implements ServicePayloadConverterInterface
     /**
      * Convert associative array into proper data object.
      *
-     * @param array $data
+     * @param mixed $data
      * @param string $type
      * @return array|object
      */

--- a/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
@@ -95,13 +95,13 @@ class ServiceOutputProcessor implements ServicePayloadConverterInterface
         if (is_array($data)) {
             $result = [];
             $arrayElementType = substr($type, 0, -2);
-            foreach ($data as $datum) {
+            foreach ($data as $index => $datum) {
                 if (is_object($datum)) {
                     $datum = $this->processDataObject(
                         $this->dataObjectProcessor->buildOutputDataArray($datum, $arrayElementType)
                     );
                 }
-                $result[] = $datum;
+                $result[$index] = $datum;
             }
             return $result;
         } elseif (is_object($data)) {

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceOutputProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceOutputProcessorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Magento\Framework\Webapi\Test\Unit;
+
+use Magento\Framework\Reflection\DataObjectProcessor;
+use Magento\Framework\Reflection\MethodsMap;
+use Magento\Framework\Webapi\ServiceOutputProcessor;
+use PHPUnit\Framework\TestCase;
+
+class ServiceOutputProcessorTest extends TestCase
+{
+    /**
+     * @dataProvider providerForConvertSimpleValue
+     */
+    public function testConvertSimpleValue($input, $expected)
+    {
+        $dataObjectProcessor = $this->createMock(DataObjectProcessor::class);
+        $methodsMap = $this->createMock(MethodsMap::class);
+        $processor = new ServiceOutputProcessor($dataObjectProcessor, $methodsMap);
+        $result = $processor->convertValue($input, '');
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function providerForConvertSimpleValue()
+    {
+        return [
+            'array' => [
+                [1,2,3],
+                [1,2,3]
+            ],
+            'associatve array' => [
+                [
+                    'A' => 'B',
+                    'X' => 'Y',
+                ],
+                [
+                    'A' => 'B',
+                    'X' => 'Y',
+                ],
+            ],
+            'null' => [
+                null,
+                [],
+            ],
+            'string' => [
+                'a',
+                'a',
+            ]
+        ];
+    }
+
+    public function testConvertObject()
+    {
+        $dataObjectProcessor = $this->createMock(DataObjectProcessor::class);
+        $dataObjectProcessor->expects($this->once())
+            ->method('buildOutputDataArray')
+            ->with(new \stdClass(), \stdClass::class)
+            ->willReturn(['A' => 'B', 'C' => 'D']);
+        $methodsMap = $this->createMock(MethodsMap::class);
+        $processor = new ServiceOutputProcessor($dataObjectProcessor, $methodsMap);
+        $result = $processor->convertValue(new \stdClass(), \stdClass::class);
+
+        $this->assertEquals(['A' => 'B', 'C' => 'D'], $result);
+    }
+}


### PR DESCRIPTION
At REST API the associative arrays are not supported.

### Description
In class ServiceOutputProcessor I am using the index of the arrays to build the output, before they were ignored.

### Fixed Issues (if relevant)

- The index of associative arrays were ignored. Now they are being ussed

1. magento/magento2#5659: REST API Associative Array Not Supporting

### Manual testing scenarios
Tried the following output with the resulting json responses:

| Output array | JSON Response |
|--------------|-----------------|
|['X' => 1, 'Y' => 3] | {"X":1,"Y":3}|
|['X','Y']|["X","Y"]|
|['X' => 1, 'Y' => 3, 'J' => ['K' => 4]]|{"X":1,"Y":3,"J":{"K":4}}|
|['X' => 1, 'Y' => 3, 'J' => ['K' => 4, 'H' => [1,3,4]]]|{"X":1,"Y":3,"J":{"K":4,"H":[1,3,4]}}|
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
