### PR TITLE
Fix for not working LESS extends 

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -8,7 +8,6 @@
 //  _____________________________________________
 
 @checkout-tooltip__hover__z-index: @tooltip__z-index;
-@checkout-tooltip-breakpoint__screen-m: @modal-popup-breakpoint-screen__m;
 
 @checkout-tooltip-icon-arrow__font-size: 10px;
 @checkout-tooltip-icon-arrow__left: -( @checkout-tooltip-content__padding + @checkout-tooltip-icon-arrow__font-size - @checkout-tooltip-content__border-width);
@@ -138,7 +137,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @checkout-tooltip-breakpoint__screen-m) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .field-tooltip {
         .field-tooltip-content {
             &:extend(.abs-checkout-tooltip-content-position-top-mobile all);

--- a/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
@@ -262,7 +262,7 @@
         }
 
         .toolbar {
-            &:extend(.abs-add-clearfix-desktop all);
+            &:extend(.abs-add-clearfix-mobile all);
 
             .pages {
                 float: right;

--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -1233,7 +1233,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = (@screen__m + 1)) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .abs-checkout-tooltip-content-position-top-mobile {
         @abs-checkout-tooltip-content-position-top();
     }

--- a/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
@@ -16,7 +16,6 @@
 
 @modal-popup-title__font-size: 26px;
 @modal-popup-title-mobile__font-size: @font-size__base;
-@modal-popup-breakpoint-screen__m: @screen__m;
 
 @modal-slide__first__indent-left: 44px;
 @modal-slide-mobile__background-color: @color-gray-light01;
@@ -149,7 +148,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @modal-popup-breakpoint-screen__m) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .modal-popup {
         &.modal-slide {
             .modal-inner-wrap[class] {
@@ -180,7 +179,7 @@
 //  Desktop
 //  _____________________________________________
 
-.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @modal-popup-breakpoint-screen__m) {
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .modal-popup {
         &.modal-slide {
             .modal-footer {

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1681,7 +1681,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = (@screen__m + 1)) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .abs-checkout-tooltip-content-position-top-mobile {
         @abs-checkout-tooltip-content-position-top();
     }

--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -16,7 +16,6 @@
 
 @modal-popup-title__font-size: 26px;
 @modal-popup-title-mobile__font-size: @font-size__base;
-@modal-popup-breakpoint-screen__m: @screen__m;
 
 @modal-slide__first__indent-left: 44px;
 @modal-slide-mobile__background-color: @color-gray-light01;
@@ -148,7 +147,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @modal-popup-breakpoint-screen__m) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .modal-popup {
         &.modal-slide {
             .modal-inner-wrap[class] {
@@ -179,7 +178,7 @@
 //  Desktop
 //  _____________________________________________
 
-.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @modal-popup-breakpoint-screen__m) {
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .modal-popup {
         &.modal-slide {
             .modal-footer {


### PR DESCRIPTION
### Description
LESS compile code even when it's written against rules, without throwing any errors.
In this case was trying to extend selectors form different MQ, which is prohibited by design.

I fixed all wrong extends and removed some variables, which were just assignments of other variables, making code unnecessarily complex to debug.