### PR TITLE
Unused variable removed

### DIFF
--- a/lib/web/css/source/lib/variables/_typography.less
+++ b/lib/web/css/source/lib/variables/_typography.less
@@ -12,7 +12,6 @@
 //  ---------------------------------------------
 
 //  Path
-@font-path: "../../fonts/";
 @icons__font-path: "@{baseDir}fonts/Blank-Theme-Icons/Blank-Theme-Icons";
 
 //  Names


### PR DESCRIPTION
### Description
Removal of unused `@font-path` LESS variable.

I didn't edit docs (`lib/web/css/docs`) on purpose, b/c it seems like no one edit a single line in these files for last 4 years.

Related to https://github.com/SnowdogApps/magento2-theme-blank-sass/pull/177