### PR TITLE
Fix for Issue #14404

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -121,6 +121,7 @@ class Gallery extends \Magento\Catalog\Block\Product\View\AbstractView
                 'isMain' => $this->isMainImage($image),
                 'type' => str_replace('external-', '', $image->getMediaType()),
                 'videoUrl' => $image->getVideoUrl(),
+                'video' => $image->getVideoUrl(),
             ];
         }
         if (empty($imagesItems)) {
@@ -133,6 +134,7 @@ class Gallery extends \Magento\Catalog\Block\Product\View\AbstractView
                 'isMain' => true,
                 'type' => 'image',
                 'videoUrl' => null,
+				'video' => null,
             ];
         }
         return json_encode($imagesItems);

--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -134,7 +134,7 @@ class Gallery extends \Magento\Catalog\Block\Product\View\AbstractView
                 'isMain' => true,
                 'type' => 'image',
                 'videoUrl' => null,
-				'video' => null,
+                'video' => null,
             ];
         }
         return json_encode($imagesItems);

--- a/app/code/Magento/ConfigurableProduct/Block/Plugin/Product/Media/Gallery.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Plugin/Product/Media/Gallery.php
@@ -64,7 +64,7 @@ class Gallery
             $result[] = [
                 'mediaType' => $image->getMediaType(),
                 'videoUrl' => $image->getVideoUrl(),
-				'video' => $image->getVideoUrl(),
+                'video' => $image->getVideoUrl(),
                 'isBase' => $product->getImage() == $image->getFile(),
             ];
         }

--- a/app/code/Magento/ConfigurableProduct/Block/Plugin/Product/Media/Gallery.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Plugin/Product/Media/Gallery.php
@@ -64,6 +64,7 @@ class Gallery
             $result[] = [
                 'mediaType' => $image->getMediaType(),
                 'videoUrl' => $image->getVideoUrl(),
+				'video' => $image->getVideoUrl(),
                 'isBase' => $product->getImage() == $image->getFile(),
             ];
         }

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -269,6 +269,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
                         'isMain' => $image->getFile() == $product->getImage(),
                         'type' => str_replace('external-', '', $image->getMediaType()),
                         'videoUrl' => $image->getVideoUrl(),
+						'video' => $image->getVideoUrl(),
                     ];
             }
         }

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -269,7 +269,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
                         'isMain' => $image->getFile() == $product->getImage(),
                         'type' => str_replace('external-', '', $image->getMediaType()),
                         'videoUrl' => $image->getVideoUrl(),
-						'video' => $image->getVideoUrl(),
+                        'video' => $image->getVideoUrl(),
                     ];
             }
         }

--- a/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
@@ -283,6 +283,7 @@ define([
                     tmpVideoData.id = dataUrl.id;
                     tmpVideoData.provider = dataUrl.type;
                     tmpVideoData.videoUrl = tmpInputData.videoUrl;
+					tmpVideoData.video = tmpInputData.videoUrl;
                 }
 
                 videoData.push(tmpVideoData);

--- a/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
@@ -283,7 +283,7 @@ define([
                     tmpVideoData.id = dataUrl.id;
                     tmpVideoData.provider = dataUrl.type;
                     tmpVideoData.videoUrl = tmpInputData.videoUrl;
-					tmpVideoData.video = tmpInputData.videoUrl;
+                    tmpVideoData.video = tmpInputData.videoUrl;
                 }
 
                 videoData.push(tmpVideoData);


### PR DESCRIPTION
Added video to configuration to compensate for changes in Fotorama.  Please note that I've only added 'video' and not replaced 'videoUrl'.  I expect it to be entirely possible that cached versions of Fotorama will still want the old structure and it's relatively inexpensive to simply add the field.

### Description
Added 'video' field for Fotorama video data.  Fotorama is not checking for videoUrl

### Fixed Issues (if relevant)
1. magento/magento2#14404: With Fotorama, product gallery videos not pulling in
Currently only has changes for 2.2.  Looks like these changes would apply to 2.1 and 2.3 as well.

### Manual testing scenarios
1. Completely clear cache
2. Attempt to look at a product detail page with a video in the gallery (I was able to reproduce this issue on an unaltered product detail page)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
