### PR TITLE
[FIX] Incorrect items count in the compare URL if product is our of stock

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/Compare.php
+++ b/app/code/Magento/Catalog/Helper/Product/Compare.php
@@ -295,7 +295,7 @@ class Compare extends \Magento\Framework\Url\Helper\Data
             $this->_itemCollection->addAttributeToSelect('name')->addUrlRewrite()->load();
 
             /* update compare items count */
-            $this->_catalogSession->setCatalogCompareItemsCount(count($this->_itemCollection));
+            $this->_catalogSession->setCatalogCompareItemsCount(count($this->_itemCollection->getItems()));
         }
 
         return $this->_itemCollection;
@@ -324,8 +324,7 @@ class Compare extends \Magento\Framework\Url\Helper\Data
         $collection->addPriceData()
             ->setVisibility($this->_catalogProductVisibility->getVisibleInSiteIds());
 
-        $count = $collection->getSize();
-        $this->_catalogSession->setCatalogCompareItemsCount($count);
+        $this->_catalogSession->setCatalogCompareItemsCount(count($collection->getItems()));
 
         return $this;
     }


### PR DESCRIPTION
### Description
Hello,

Worked on an internal issue I faced next problem. If you added a product to the compare list and then this product became out of stock it will be still counted into the compare product link.
I investigated this issue and found that the problem in this code (`Magento\Catalog\Helper\Product\Compare::calculate()`)
```
$count = $collection->getSize();
$this->_catalogSession->setCatalogCompareItemsCount($count);
```

As I understood this problem made by getSize() which just return a collection size ignoring stock availability and inventory settings (show or not out of stock products).

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Add product to the compare list
2. Change its stock status to out of stock
3. Open a new page of the site and check compare link. It will have 1 item in the link and if you will press it you will be redirected to the compare product page but bo products will be visible as expected be inventory settings.

**IMPORTANT!** To test this issue remember that links count values and other customer session data are stored in local storage. So just clean it when you will add any change to the code. :)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
