### PR TITLE
Returning relative paths for validation.xml files

### DIFF
--- a/lib/internal/Magento/Framework/Validator/Factory.php
+++ b/lib/internal/Magento/Framework/Validator/Factory.php
@@ -11,11 +11,8 @@
 namespace Magento\Framework\Validator;
 
 use Magento\Framework\Cache\FrontendInterface;
-use Magento\Framework\Module\Dir\Reader;
-use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Config\FileIteratorFactory;
-use Magento\Framework\Phrase;
 
 class Factory
 {
@@ -23,7 +20,7 @@ class Factory
     const CACHE_KEY = __CLASS__;
 
     /**
-     * @var ObjectManagerInterface
+     * @var \Magento\Framework\ObjectManagerInterface
      */
     protected $_objectManager;
 
@@ -40,7 +37,7 @@ class Factory
     private $isDefaultTranslatorInitialized = false;
 
     /**
-     * @var Reader
+     * @var \Magento\Framework\Module\Dir\Reader
      */
     private $moduleReader;
 
@@ -60,8 +57,7 @@ class Factory
     private $fileIteratorFactory;
 
     /**
-     * Initialize dependencies
-     *
+     * Factory constructor.
      * @param ObjectManagerInterface $objectManager
      * @param Reader $moduleReader
      * @param FrontendInterface $cache
@@ -69,8 +65,8 @@ class Factory
      * @param FileIteratorFactory $fileIteratorFactory
      */
     public function __construct(
-        ObjectManagerInterface $objectManager,
-        Reader $moduleReader,
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        \Magento\Framework\Module\Dir\Reader $moduleReader,
         FrontendInterface $cache,
         DirectoryList $directoryList,
         FileIteratorFactory $fileIteratorFactory
@@ -117,12 +113,12 @@ class Factory
     /**
      * @return array
      */
-    protected function getRelativeFilePathsForConfigFiles()
+    private function getRelativeFilePathsForConfigFiles()
     {
         $relativeFilePaths = [];
-        $applicationRootLength = \strlen($this->applicationRoot);
+        $appRootLength = \strlen($this->applicationRoot);
         foreach ($this->_configFiles as $configFile => $fileContent) {
-            $relativeFilePaths[] = strpos($configFile, $this->applicationRoot) === 0 ? substr($configFile, $applicationRootLength) : $configFile;
+            $relativeFilePaths[] = strpos($configFile, $this->applicationRoot) === 0 ? substr($configFile, $appRootLength) : $configFile;
         }
         return $relativeFilePaths;
     }
@@ -132,18 +128,18 @@ class Factory
      *
      * @return void
      */
-    protected function _initializeDefaultTranslator()
+    private function _initializeDefaultTranslator()
     {
         if (!$this->isDefaultTranslatorInitialized) {
             // Pass translations to \Magento\Framework\TranslateInterface from validators
             $translatorCallback = function () {
                 $argc = func_get_args();
-                return (string)new Phrase(array_shift($argc), $argc);
+                return (string)new \Magento\Framework\Phrase(array_shift($argc), $argc);
             };
             /** @var \Magento\Framework\Translate\Adapter $translator */
             $translator = $this->_objectManager->create('Magento\Framework\Translate\Adapter');
             $translator->setOptions(['translator' => $translatorCallback]);
-            AbstractValidator::setDefaultTranslator($translator);
+            \Magento\Framework\Validator\AbstractValidator::setDefaultTranslator($translator);
             $this->isDefaultTranslatorInitialized = true;
         }
     }
@@ -169,7 +165,6 @@ class Factory
      * @param string $groupName
      * @param array|null $builderConfig
      * @return \Magento\Framework\Validator\Builder
-     * @throws \InvalidArgumentException
      */
     public function createValidatorBuilder($entityName, $groupName, array $builderConfig = null)
     {

--- a/lib/internal/Magento/Framework/Validator/Factory.php
+++ b/lib/internal/Magento/Framework/Validator/Factory.php
@@ -58,8 +58,7 @@ class Factory
 
     /**
      * Initialize dependencies
-     * 
-     * Factory constructor.
+     *
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\Module\Dir\Reader $moduleReader
      * @param FrontendInterface $cache

--- a/lib/internal/Magento/Framework/Validator/Factory.php
+++ b/lib/internal/Magento/Framework/Validator/Factory.php
@@ -57,9 +57,11 @@ class Factory
     private $fileIteratorFactory;
 
     /**
+     * Initialize dependencies
+     * 
      * Factory constructor.
-     * @param ObjectManagerInterface $objectManager
-     * @param Reader $moduleReader
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param \Magento\Framework\Module\Dir\Reader $moduleReader
      * @param FrontendInterface $cache
      * @param DirectoryList $directoryList
      * @param FileIteratorFactory $fileIteratorFactory

--- a/lib/internal/Magento/Framework/Validator/Factory.php
+++ b/lib/internal/Magento/Framework/Validator/Factory.php
@@ -100,7 +100,7 @@ class Factory
      * @param $serializedFilePaths
      * @return array
      */
-    protected function buildAbsolutePathsForConfigFiles($serializedFilePaths)
+    private function buildAbsolutePathsForConfigFiles($serializedFilePaths)
     {
         $absolutePaths = [];
         /** @var array $serializedFilePaths */
@@ -128,7 +128,7 @@ class Factory
      *
      * @return void
      */
-    private function _initializeDefaultTranslator()
+    protected function _initializeDefaultTranslator()
     {
         if (!$this->isDefaultTranslatorInitialized) {
             // Pass translations to \Magento\Framework\TranslateInterface from validators

--- a/lib/internal/Magento/Framework/Validator/Factory.php
+++ b/lib/internal/Magento/Framework/Validator/Factory.php
@@ -11,6 +11,11 @@
 namespace Magento\Framework\Validator;
 
 use Magento\Framework\Cache\FrontendInterface;
+use Magento\Framework\Module\Dir\Reader;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\FileIteratorFactory;
+use Magento\Framework\Phrase;
 
 class Factory
 {
@@ -18,7 +23,7 @@ class Factory
     const CACHE_KEY = __CLASS__;
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $_objectManager;
 
@@ -35,7 +40,7 @@ class Factory
     private $isDefaultTranslatorInitialized = false;
 
     /**
-     * @var \Magento\Framework\Module\Dir\Reader
+     * @var Reader
      */
     private $moduleReader;
 
@@ -45,20 +50,36 @@ class Factory
     private $cache;
 
     /**
+     * @var string
+     */
+    private $applicationRoot;
+
+    /**
+     * @var FileIteratorFactory
+     */
+    private $fileIteratorFactory;
+
+    /**
      * Initialize dependencies
      *
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
-     * @param \Magento\Framework\Module\Dir\Reader $moduleReader
+     * @param ObjectManagerInterface $objectManager
+     * @param Reader $moduleReader
      * @param FrontendInterface $cache
+     * @param DirectoryList $directoryList
+     * @param FileIteratorFactory $fileIteratorFactory
      */
     public function __construct(
-        \Magento\Framework\ObjectManagerInterface $objectManager,
-        \Magento\Framework\Module\Dir\Reader $moduleReader,
-        FrontendInterface $cache
+        ObjectManagerInterface $objectManager,
+        Reader $moduleReader,
+        FrontendInterface $cache,
+        DirectoryList $directoryList,
+        FileIteratorFactory $fileIteratorFactory
     ) {
         $this->_objectManager = $objectManager;
         $this->moduleReader = $moduleReader;
         $this->cache = $cache;
+        $this->applicationRoot = rtrim($directoryList->getRoot(), '/') . '/';
+        $this->fileIteratorFactory = $fileIteratorFactory;
     }
 
     /**
@@ -67,14 +88,43 @@ class Factory
     protected function _initializeConfigList()
     {
         if (!$this->_configFiles) {
-            $this->_configFiles = $this->cache->load(self::CACHE_KEY);
-            if (!$this->_configFiles) {
+            $serializedFilePaths = $this->cache->load(self::CACHE_KEY);
+            if (!$serializedFilePaths) {
                 $this->_configFiles = $this->moduleReader->getConfigurationFiles('validation.xml');
-                $this->cache->save(serialize($this->_configFiles), self::CACHE_KEY);
+                $relativeFilePaths = $this->getRelativeFilePathsForConfigFiles();
+                $this->cache->save(serialize($relativeFilePaths), self::CACHE_KEY);
             } else {
-                $this->_configFiles = unserialize($this->_configFiles);
+                $absolutePaths = $this->buildAbsolutePathsForConfigFiles($serializedFilePaths);
+                $this->_configFiles = $this->fileIteratorFactory->create($absolutePaths);
             }
         }
+    }
+
+    /**
+     * @param $serializedFilePaths
+     * @return array
+     */
+    protected function buildAbsolutePathsForConfigFiles($serializedFilePaths)
+    {
+        $absolutePaths = [];
+        /** @var array $serializedFilePaths */
+        foreach ($serializedFilePaths as $relativePath) {
+            $absolutePaths[] = $relativePath[0] === '/' ? $relativePath : $this->applicationRoot . $relativePath;
+        }
+        return $absolutePaths;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getRelativeFilePathsForConfigFiles()
+    {
+        $relativeFilePaths = [];
+        $applicationRootLength = \strlen($this->applicationRoot);
+        foreach ($this->_configFiles as $configFile => $fileContent) {
+            $relativeFilePaths[] = strpos($configFile, $this->applicationRoot) === 0 ? substr($configFile, $applicationRootLength) : $configFile;
+        }
+        return $relativeFilePaths;
     }
 
     /**
@@ -88,12 +138,12 @@ class Factory
             // Pass translations to \Magento\Framework\TranslateInterface from validators
             $translatorCallback = function () {
                 $argc = func_get_args();
-                return (string)new \Magento\Framework\Phrase(array_shift($argc), $argc);
+                return (string)new Phrase(array_shift($argc), $argc);
             };
             /** @var \Magento\Framework\Translate\Adapter $translator */
             $translator = $this->_objectManager->create('Magento\Framework\Translate\Adapter');
             $translator->setOptions(['translator' => $translatorCallback]);
-            \Magento\Framework\Validator\AbstractValidator::setDefaultTranslator($translator);
+            AbstractValidator::setDefaultTranslator($translator);
             $this->isDefaultTranslatorInitialized = true;
         }
     }
@@ -119,6 +169,7 @@ class Factory
      * @param string $groupName
      * @param array|null $builderConfig
      * @return \Magento\Framework\Validator\Builder
+     * @throws \InvalidArgumentException
      */
     public function createValidatorBuilder($entityName, $groupName, array $builderConfig = null)
     {

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
@@ -56,8 +56,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->_defaultTranslator = \Magento\Framework\Validator\AbstractValidator::getDefaultTranslator();
         $this->_objectManager = $this->getMock('Magento\Framework\ObjectManagerInterface');
         $this->_directoryList = new \Magento\Framework\App\Filesystem\DirectoryList(BP);
-        $this->_fileIterator = $this->iteratorFactory = $this->getMock('Magento\Framework\Config\FileIteratorFactory', [], [], '', false);
-        //$this->_fileIterator = $this->_objectManager->get('Magento\Framework\Config\FileIteratorFactory');
+        $this->_fileIterator = $this->iteratorFactory = $this->getMock(
+            'Magento\Framework\Config\FileIteratorFactory', [], [], '', false
+        );
         $this->_validatorConfig = $this->getMockBuilder(
             'Magento\Framework\Validator\Config'
         )->setMethods(

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
@@ -37,12 +37,24 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     protected $_defaultTranslator = null;
 
     /**
+     * @var \Magento\Framework\App\Filesystem\DirectoryList
+     */
+    protected $_directoryList;
+
+    /**
+     * @var \Magento\Framework\Config\FileIteratorFactory
+     */
+    protected $_fileIterator;
+
+    /**
      * Save default translator
      */
     protected function setUp()
     {
         $this->_defaultTranslator = \Magento\Framework\Validator\AbstractValidator::getDefaultTranslator();
         $this->_objectManager = $this->getMock('Magento\Framework\ObjectManagerInterface');
+        $this->_directoryList = $this->getMock('Magento\Framework\App\Filesystem\DirectoryList');
+        $this->_fileIterator = $this->getMock('Magento\Framework\Config\FileIteratorFactory');
         $this->_validatorConfig = $this->getMockBuilder(
             'Magento\Framework\Validator\Config'
         )->setMethods(
@@ -112,7 +124,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new \Magento\Framework\Validator\Factory(
             $this->_objectManager,
             $this->_config,
-            $this->cache
+            $this->cache,
+            $this->_directoryList,
+            $this->_fileIterator
         );
         $actualConfig = $factory->getValidatorConfig();
         $this->assertInstanceOf(
@@ -152,7 +166,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new \Magento\Framework\Validator\Factory(
             $this->_objectManager,
             $this->_config,
-            $this->cache
+            $this->cache,
+            $this->_directoryList,
+            $this->_fileIterator
         );
         $this->assertInstanceOf(
             'Magento\Framework\Validator\Builder',
@@ -179,7 +195,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new \Magento\Framework\Validator\Factory(
             $this->_objectManager,
             $this->_config,
-            $this->cache
+            $this->cache,
+            $this->_directoryList,
+            $this->_fileIterator
         );
         $this->assertInstanceOf('Magento\Framework\Validator', $factory->createValidator('test', 'class', []));
     }

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
@@ -7,6 +7,8 @@
  */
 namespace Magento\Framework\Validator\Test\Unit;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
+
 class FactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -53,8 +55,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->_defaultTranslator = \Magento\Framework\Validator\AbstractValidator::getDefaultTranslator();
         $this->_objectManager = $this->getMock('Magento\Framework\ObjectManagerInterface');
-        $this->_directoryList = $this->_objectManager->get('Magento\Framework\App\Filesystem\DirectoryList');
-        $this->_fileIterator = $this->_objectManager->get('Magento\Framework\Config\FileIteratorFactory');
+        $this->_directoryList = new \Magento\Framework\App\Filesystem\DirectoryList(BP);
+        $this->_fileIterator = $this->iteratorFactory = $this->getMock('Magento\Framework\Config\FileIteratorFactory', [], [], '', false);
+        //$this->_fileIterator = $this->_objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $this->_validatorConfig = $this->getMockBuilder(
             'Magento\Framework\Validator\Config'
         )->setMethods(

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
@@ -53,8 +53,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->_defaultTranslator = \Magento\Framework\Validator\AbstractValidator::getDefaultTranslator();
         $this->_objectManager = $this->getMock('Magento\Framework\ObjectManagerInterface');
-        $this->_directoryList = $this->getMock('Magento\Framework\App\Filesystem\DirectoryList');
-        $this->_fileIterator = $this->getMock('Magento\Framework\Config\FileIteratorFactory');
+        $this->_directoryList = $this->_objectManager->get('Magento\Framework\App\Filesystem\DirectoryList');
+        $this->_fileIterator = $this->_objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $this->_validatorConfig = $this->getMockBuilder(
             'Magento\Framework\Validator\Config'
         )->setMethods(


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
There is a bug in the `Magento\Framework\Validator` package which means that certain actions, for example saving a customer, will intermittently fail on multi-web server Magento environments which use different web roots per-web server but a single, shared cache instance. The bug is caused by Magento saving *absolute* paths to certain configuration files in the cache, as absolute paths will not be consistent between servers which have different web roots

With this change we now save the relative paths to Validation.xml configuration files. We recently faced an issue on a multi server setup where the paths to Magento were different.

|Server|Magento Root Path|
|------|-------------------------|
|Server 1|`/var/www/vhosts/server1/httpdocs/`|
|Server 2|`/var/www/vhosts/server2/httpdocs/`|
|Server 3|`/var/www/vhosts/server3/httpdocs/`|

By saving the paths relative to the Magento root in the cache we can prepend the Magento root path to the url to return the absolute urls without changing any functionality, the only thing we are changing is what is saved in the cache.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
Multi-server required with different web roots with a shared cache instance.
1. Log into the admin
2. Save a customer, this is when this method get's called
3. Saving should still work correctly without any exception being thrown

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
