### PR TITLE
[BACKPORT 2.1] Removed cache backend option which explicitly set file permissions

### DIFF
--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -68,7 +68,6 @@ class Factory
      */
     protected $_backendOptions = [
         'hashed_directory_level' => 1,
-        'hashed_directory_umask' => 0777,
         'file_name_prefix' => 'mage',
     ];
 


### PR DESCRIPTION
 - Removed hashed_directory_umask option because it caused Cm_Cache_Backend_File class to explicitly set permissions using chmod, ignoring umask and setgid bit.
 - Zend_Cache_Backend_File class deprecated and removed hashed_directory_umask option from Zend Framework v1.12+
 - Magento Framework does not explicitly set file & directory permissions as of v2.0.6+
<!--- Provide a general summary of the Pull Request in the Title above -->
[https://github.com/magento/magento2/pull/14361](https://github.com/magento/magento2/pull/14361)

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This fix will allow the Magento Framework to no longer explicitly set file/directory permissions from the default cache backend by removing use of the hashed_directory_umask option 
`'hashed_directory_umask' => 0777,`
from code within the file
`lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php`.

This option was deprecated and removed from the Zend Framework as of version 1.12, but has remained in the Magento Framework.

Cm_Cache_Backend_File class still supports "hashed_directory_umask" option, with additional class code providing backwards compatibility with ZF 1.11.

However, setting this option was causing Cm_Cache_Backend_File to use PHP's chmod function recursively on the hashed directory structure during file and directory creation.  Simply removing this option allows permissions to be inherited properly from the file system, and respects SETGID bit and Magento umask.


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
<!--- 1. magento/magento2#<issue_number>: Issue title -->
1. magento/magento2#11930: setup:di:compile's generated cache files inaccessible by the web-server user
2. magento/magento2#10700: Magento 2 Admin panel show loading on each page

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install any version of Magento2
2. Check file & directory permissions from `var/cache` and `var/page_cache` and up
3. Notice that file & directory permissions are inherited from parent directories, and obey SETGID bit & umask.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
