### PR TITLE
Fix product url model to not include category in url if 'Use Categories Path for Product URLs' config is not enabled

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Url.php
+++ b/app/code/Magento/Catalog/Model/Product/Url.php
@@ -5,6 +5,12 @@
  */
 namespace Magento\Catalog\Model\Product;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Filter\FilterManager;
+use Magento\Framework\Session\SidResolverInterface;
+use Magento\Framework\UrlFactory;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 
@@ -19,46 +25,53 @@ class Url extends \Magento\Framework\DataObject
     /**
      * URL instance
      *
-     * @var \Magento\Framework\UrlFactory
+     * @var UrlFactory
      */
     protected $urlFactory;
 
     /**
-     * @var \Magento\Framework\Filter\FilterManager
+     * @var FilterManager
      */
     protected $filter;
 
     /**
      * Store manager
      *
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     protected $storeManager;
 
     /**
-     * @var \Magento\Framework\Session\SidResolverInterface
+     * @var SidResolverInterface
      */
     protected $sidResolver;
 
     /**
-     * @var \Magento\UrlRewrite\Model\UrlFinderInterface
+     * @var UrlFinderInterface
      */
     protected $urlFinder;
 
     /**
-     * @param \Magento\Framework\UrlFactory $urlFactory
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param \Magento\Framework\Filter\FilterManager $filter
-     * @param \Magento\Framework\Session\SidResolverInterface $sidResolver
-     * @param UrlFinderInterface $urlFinder
-     * @param array $data
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @param UrlFactory            $urlFactory
+     * @param StoreManagerInterface $storeManager
+     * @param FilterManager         $filter
+     * @param SidResolverInterface  $sidResolver
+     * @param UrlFinderInterface    $urlFinder
+     * @param ScopeConfigInterface  $scopeConfig
+     * @param array                 $data
      */
     public function __construct(
-        \Magento\Framework\UrlFactory $urlFactory,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\Filter\FilterManager $filter,
-        \Magento\Framework\Session\SidResolverInterface $sidResolver,
+        UrlFactory $urlFactory,
+        StoreManagerInterface $storeManager,
+        FilterManager $filter,
+        SidResolverInterface $sidResolver,
         UrlFinderInterface $urlFinder,
+        ScopeConfigInterface $scopeConfig,
         array $data = []
     ) {
         parent::__construct($data);
@@ -67,6 +80,7 @@ class Url extends \Magento\Framework\DataObject
         $this->filter = $filter;
         $this->sidResolver = $sidResolver;
         $this->urlFinder = $urlFinder;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -142,7 +156,16 @@ class Url extends \Magento\Framework\DataObject
 
         $categoryId = null;
 
-        if (!isset($params['_ignore_category']) && $product->getCategoryId() && !$product->getDoNotUseCategoryId()) {
+        $useCategoryInUrl = $this->scopeConfig->getValue(
+            \Magento\Catalog\Helper\Product::XML_PATH_PRODUCT_URL_USE_CATEGORY,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        if (!isset($params['_ignore_category'])
+            && !$product->getDoNotUseCategoryId()
+            && $product->getCategoryId()
+            && $useCategoryInUrl) {
             $categoryId = $product->getCategoryId();
         }
 

--- a/app/code/Magento/Catalog/Model/Product/Url.php
+++ b/app/code/Magento/Catalog/Model/Product/Url.php
@@ -54,7 +54,7 @@ class Url extends \Magento\Framework\DataObject
     /**
      * @var ScopeConfigInterface
      */
-    protected $scopeConfig;
+    private $scopeConfig;
 
     /**
      * @param UrlFactory            $urlFactory
@@ -62,8 +62,8 @@ class Url extends \Magento\Framework\DataObject
      * @param FilterManager         $filter
      * @param SidResolverInterface  $sidResolver
      * @param UrlFinderInterface    $urlFinder
-     * @param ScopeConfigInterface  $scopeConfig
      * @param array                 $data
+     * @param ScopeConfigInterface  $scopeConfig
      */
     public function __construct(
         UrlFactory $urlFactory,
@@ -71,8 +71,8 @@ class Url extends \Magento\Framework\DataObject
         FilterManager $filter,
         SidResolverInterface $sidResolver,
         UrlFinderInterface $urlFinder,
-        ScopeConfigInterface $scopeConfig,
-        array $data = []
+        array $data = [],
+        ScopeConfigInterface $scopeConfig = null
     ) {
         parent::__construct($data);
         $this->urlFactory = $urlFactory;
@@ -80,7 +80,8 @@ class Url extends \Magento\Framework\DataObject
         $this->filter = $filter;
         $this->sidResolver = $sidResolver;
         $this->urlFinder = $urlFinder;
-        $this->scopeConfig = $scopeConfig;
+        $this->scopeConfig = $scopeConfig
+            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(ScopeConfigInterface::class);
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Url.php
+++ b/app/code/Magento/Catalog/Model/Product/Url.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Catalog\Model\Product;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Catalog\Model\Product\UrlConfig\UrlConfigInterface;
 use Magento\Framework\Filter\FilterManager;
 use Magento\Framework\Session\SidResolverInterface;
 use Magento\Framework\UrlFactory;
@@ -52,9 +52,9 @@ class Url extends \Magento\Framework\DataObject
     protected $urlFinder;
 
     /**
-     * @var ScopeConfigInterface
+     * @var UrlConfigInterface
      */
-    private $scopeConfig;
+    private $urlConfig;
 
     /**
      * @param UrlFactory            $urlFactory
@@ -63,7 +63,7 @@ class Url extends \Magento\Framework\DataObject
      * @param SidResolverInterface  $sidResolver
      * @param UrlFinderInterface    $urlFinder
      * @param array                 $data
-     * @param ScopeConfigInterface  $scopeConfig
+     * @param UrlConfigInterface    $urlConfig
      */
     public function __construct(
         UrlFactory $urlFactory,
@@ -72,7 +72,7 @@ class Url extends \Magento\Framework\DataObject
         SidResolverInterface $sidResolver,
         UrlFinderInterface $urlFinder,
         array $data = [],
-        ScopeConfigInterface $scopeConfig = null
+        UrlConfigInterface $urlConfig = null
     ) {
         parent::__construct($data);
         $this->urlFactory = $urlFactory;
@@ -80,8 +80,8 @@ class Url extends \Magento\Framework\DataObject
         $this->filter = $filter;
         $this->sidResolver = $sidResolver;
         $this->urlFinder = $urlFinder;
-        $this->scopeConfig = $scopeConfig
-            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(ScopeConfigInterface::class);
+        $this->urlConfig = $urlConfig
+            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(UrlConfigInterface::class);
     }
 
     /**
@@ -157,16 +157,10 @@ class Url extends \Magento\Framework\DataObject
 
         $categoryId = null;
 
-        $useCategoryInUrl = $this->scopeConfig->getValue(
-            \Magento\Catalog\Helper\Product::XML_PATH_PRODUCT_URL_USE_CATEGORY,
-            ScopeInterface::SCOPE_STORES,
-            $storeId
-        );
-
         if (!isset($params['_ignore_category'])
             && !$product->getDoNotUseCategoryId()
             && $product->getCategoryId()
-            && $useCategoryInUrl) {
+            && $this->urlConfig->useCategoryInUrl($storeId)) {
             $categoryId = $product->getCategoryId();
         }
 

--- a/app/code/Magento/Catalog/Model/Product/UrlConfig.php
+++ b/app/code/Magento/Catalog/Model/Product/UrlConfig.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Magento\Catalog\Model\Product;
+
+use Magento\Catalog\Helper\Product as ProductHelper;
+use Magento\Catalog\Model\Product\UrlConfig\UrlConfigInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class UrlConfig implements UrlConfigInterface
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+    
+    /**
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+    
+    /**
+     * @param int $storeId
+     *
+     * @return bool
+     */
+    public function useCategoryInUrl($storeId)
+    {
+        return $this->scopeConfig->getValue(
+            ProductHelper::XML_PATH_PRODUCT_URL_USE_CATEGORY,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+    }
+}

--- a/app/code/Magento/Catalog/Model/Product/UrlConfig/UrlConfigInterface.php
+++ b/app/code/Magento/Catalog/Model/Product/UrlConfig/UrlConfigInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Magento\Catalog\Model\Product\UrlConfig;
+
+interface UrlConfigInterface
+{
+    /**
+     * @param int $storeId
+     *
+     * @return bool
+     */
+    public function useCategoryInUrl($storeId);
+}

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/UrlTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/UrlTest.php
@@ -40,9 +40,9 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     protected $sidResolver;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Catalog\Model\Product\UrlConfig\UrlConfigInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $scopeConfig;
+    protected $urlConfig;
 
     protected function setUp()
     {
@@ -63,7 +63,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         )->getMock();
 
         $this->sidResolver = $this->createMock(\Magento\Framework\Session\SidResolverInterface::class);
-        $this->scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $this->urlConfig = $this->createMock(\Magento\Catalog\Model\Product\UrlConfig\UrlConfigInterface::class);
 
         $store = $this->createPartialMock(\Magento\Store\Model\Store::class, ['getId', '__wakeup']);
         $store->expects($this->any())->method('getId')->will($this->returnValue(1));
@@ -86,7 +86,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
                 'urlFactory' => $urlFactory,
                 'sidResolver' => $this->sidResolver,
                 'urlFinder' => $this->urlFinder,
-                'scopeConfig' => $this->scopeConfig
+                'urlConfig' => $this->urlConfig
             ]
         );
     }
@@ -160,9 +160,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
             ->with($routePath, $routeParamsUrl)
             ->will($this->returnValue($requestPathProduct));
         $this->urlFinder->expects($this->any())->method('findOneByData')->will($this->returnValue(false));
-        $this->scopeConfig->expects($this->any())->method('getValue')->with(
-            'catalog/seo/product_use_categories',
-            'stores',
+        $this->urlConfig->expects($this->any())->method('useCategoryInUrl')->with(
             1
         )->will($this->returnValue($categoryInUrlAllowed ? 1 : 0));
 

--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -70,6 +70,7 @@
     <preference for="Magento\Catalog\Api\Data\ProductRender\FormattedPriceInfoInterface" type="Magento\Catalog\Model\ProductRender\FormattedPriceInfo" />
     <preference for="Magento\Framework\Indexer\BatchProviderInterface" type="Magento\Framework\Indexer\BatchProvider" />
     <preference for="Magento\Catalog\Model\Indexer\Product\Price\UpdateIndexInterface" type="Magento\Catalog\Model\Indexer\Product\Price\InvalidateIndex" />
+    <preference for="Magento\Catalog\Model\Product\UrlConfig\UrlConfigInterface" type="Magento\Catalog\Model\Product\UrlConfig" />
     <type name="Magento\Customer\Model\ResourceModel\Visitor">
         <plugin name="catalogLog" type="Magento\Catalog\Model\Plugin\Log" />
     </type>


### PR DESCRIPTION
Fix product url model to not include category in url if 'Use Categories Path for Product URLs' config is not enabled

### Description
If the "Use Categories Path for Product URLs" config is not enabled the Product Url model still generates a product url which includes category id. So the fix for the issue to respect this config setting.

Note that the Product Collection already uses this config setting in (magento/module-catalog/Model/ResourceModel/Product/Collection.php -> addUrlRewrite method) which means it is working properly for collections already.

