### PR TITLE
Fix \Magento\Checkout\Controller\Index\Index::isSecureRequest method to take care of current request being secure and also from referer, as stated in phpdoc block

### DIFF
--- a/app/code/Magento/Checkout/Controller/Index/Index.php
+++ b/app/code/Magento/Checkout/Controller/Index/Index.php
@@ -51,18 +51,16 @@ class Index extends \Magento\Checkout\Controller\Onepage
      */
     private function isSecureRequest(): bool
     {
-        $secure = false;
         $request = $this->getRequest();
 
-        if ($request->isSecure()) {
-            $secure = true;
-        }
+        $referrer = $request->getHeader('referer');
+        $secure = false;
 
-        if ($request->getHeader('referer')) {
-            $scheme = parse_url($request->getHeader('referer'), PHP_URL_SCHEME);
+        if ($referrer) {
+            $scheme = parse_url($referrer, PHP_URL_SCHEME);
             $secure = $scheme === 'https';
         }
 
-        return $secure;
+        return $secure && $request->isSecure();
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Index/IndexTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Index/IndexTest.php
@@ -237,25 +237,26 @@ class IndexTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
-                'secure' => true,
-                'referer' => false,
-                'expectedCall' => self::never()
-            ],
-            [
-                'secure' => true,
-                'referer' => 'https://test.domain.com/',
-                'expectedCall' => self::never()
-            ],
-            [
                 'secure' => false,
                 'referer' => 'https://test.domain.com/',
-                'expectedCall' => self::never()
+                'expectedCall' => self::once()
+            ],
+            [
+                'secure' => true,
+                'referer' => false,
+                'expectedCall' => self::once()
             ],
             [
                 'secure' => true,
                 'referer' => 'http://test.domain.com/',
                 'expectedCall' => self::once()
-            ]
+            ],
+            // This is the only case in which session regeneration can be skipped
+            [
+                'secure' => true,
+                'referer' => 'https://test.domain.com/',
+                'expectedCall' => self::never()
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description
Fix \Magento\Checkout\Controller\Index\Index::isSecureRequest method to take care of current request being secure and also from referer, as stated in phpdoc block.

After last try to implement a solution for session loss in checkout, this private method did behaviour as expected. Updated as agreed with @sidolov .

### Fixed Issues (if relevant)
1. magento/magento2#4301: Hit fast twice F5 on checout page, customer loggs out automatically
2. magento/magento2#12362: Concurrent (quick reload) requests on checkout cause cart to empty - related to session_regenerate_id
3. magento/magento2#13427: Add to cart, try to checkout, cart is empty but mini-cart has items.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
