### PR TITLE
Set hasDataChanges to true when instantiating a model with data using a factory

### DIFF
--- a/lib/internal/Magento/Framework/Model/AbstractModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractModel.php
@@ -190,6 +190,10 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
             $this->_idFieldName = $this->_getResource()->getIdFieldName();
         }
 
+        if (!empty($data)) {
+            $this->_hasDataChanges = true;
+        }
+
         parent::__construct($data);
         $this->_construct();
     }


### PR DESCRIPTION
### Description
When instantiating a model the following:
```php
$inquiry = $this->inquiryFactory->create(['data' => $data]);
$this->inquiryResource->save($inquiry);
```

The model won't be saved, because when instantiating a model with data using a factory, `_hasDataChanges` won't be set to true. That's because currently, it's the responsibility of `AbstractModel::setData()`. For now, I work around the problem the following:

```php
$inquiry = $this->inquiryFactory->create();
$inquiry->setData($data);
$this->inquiryResource->save($inquiry);
```

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a model using a factory, provided with data
2. Save the model

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
