### PR TITLE
Fix bug with retry connect and custom db port

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -549,6 +549,14 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                     $retry = true;
                     $triesCount++;
                     $this->closeConnection();
+
+                    /**
+                     * _connect() function does not allow port parameter, so put the port back with the host
+                     */
+                    if (!empty($this->_config['port'])) {
+                        $this->_config['host'] = implode(':', [$this->_config['host'], $this->_config['port']]);
+                    }
+
                     $this->_connect();
                 }
 

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -555,6 +555,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                      */
                     if (!empty($this->_config['port'])) {
                         $this->_config['host'] = implode(':', [$this->_config['host'], $this->_config['port']]);
+                        unset($this->_config['port']);
                     }
 
                     $this->_connect();


### PR DESCRIPTION
Fix a bug in the MySQL adapter when using non standard port

### Manual testing scenarios
1. Use a database config with port, e.g. localhost:3307
2. On first call to _connect(), the config['host'] parameter is split into config['host'] and config['port']
3. In the _query() function, a situation happens that is suitable for a retry (e.g. a "MySQL has gone away" error)
4. _connect() is called again

### Expected result
Connection is reestablished and query tried again

### Actual result
"Port must be configured within host parameter" exception