### PR TITLE
Fix HTML tags in meta description

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View.php
+++ b/app/code/Magento/Catalog/Block/Product/View.php
@@ -145,7 +145,7 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
         if ($description) {
             $this->pageConfig->setDescription($description);
         } else {
-            $this->pageConfig->setDescription($this->string->substr($product->getDescription(), 0, 255));
+            $this->pageConfig->setDescription($this->string->substr(strip_tags($product->getDescription()), 0, 255));
         }
         if ($this->_productHelper->canUseCanonicalTag()) {
             $this->pageConfig->addRemotePageAsset(


### PR DESCRIPTION
### Description
Fixes issue with HTML tags in meta description if no meta description is provided.

### Fixed Issues (if relevant)
1. HTML tags in meta description

### Manual testing scenarios
1. Ensure a product has no meta description
2. Visit product on frontend and view page source
