### PR TITLE
Remove json helper data usage in AdminNotification

### DIFF
--- a/app/code/Magento/AdminNotification/Block/System/Messages.php
+++ b/app/code/Magento/AdminNotification/Block/System/Messages.php
@@ -16,24 +16,34 @@ class Messages extends \Magento\Backend\Block\Template
 
     /**
      * @var \Magento\Framework\Json\Helper\Data
+     * @deprecated
      */
     protected $jsonHelper;
+
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized $messages
      * @param \Magento\Framework\Json\Helper\Data $jsonHelper
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized $messages,
         \Magento\Framework\Json\Helper\Data $jsonHelper,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->jsonHelper = $jsonHelper;
         parent::__construct($context, $data);
         $this->_messages = $messages;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -117,7 +127,7 @@ class Messages extends \Magento\Backend\Block\Template
      */
     public function getSystemMessageDialogJson()
     {
-        return $this->jsonHelper->jsonEncode(
+        return $this->serializer->serialize(
             [
                 'systemMessageDialog' => [
                     'buttons' => [],

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
@@ -6,6 +6,8 @@
  */
 namespace Magento\AdminNotification\Controller\Adminhtml\System\Message;
 
+use Magento\Framework\Controller\ResultFactory;
+
 class ListAction extends \Magento\Backend\App\AbstractAction
 {
     /**
@@ -15,6 +17,7 @@ class ListAction extends \Magento\Backend\App\AbstractAction
 
     /**
      * @var \Magento\Framework\Json\Helper\Data
+     * @deprecated
      */
     protected $jsonHelper;
 
@@ -41,7 +44,7 @@ class ListAction extends \Magento\Backend\App\AbstractAction
     }
 
     /**
-     * @return void
+     * @return \Magento\Framework\Controller\Result\Json
      */
     public function execute()
     {
@@ -63,6 +66,9 @@ class ListAction extends \Magento\Backend\App\AbstractAction
                     . 'Please refresh the web page to clear the notice alert.',
             ];
         }
-        $this->getResponse()->representJson($this->jsonHelper->jsonEncode($result));
+        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+        $resultJson->setData($result);
+        return $resultJson;
     }
 }


### PR DESCRIPTION
### Description
The class `Magento\Framework\Json\Helper\Data` is deprecated. In this PR I remove the usage of this class in the module `Magento\AdminNotification`

### Fixed Issues (if relevant)
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Manual testing scenarios
1. Setup some admin notifications and check that they are still working as desired,

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
