### PR TITLE
[Forwardport] Disable "Back" button on the first step of the setup

### DIFF
--- a/setup/pub/magento/setup/main.js
+++ b/setup/pub/magento/setup/main.js
@@ -93,10 +93,6 @@ main.controller('navigationController',
             return str.indexOf(suffix, str.length - suffix.length) !== -1;
         };
 
-        $scope.goToStart = function() {
-            $scope.goToAction($state.current.type);
-        };
-
         $scope.goToBackup = function() {
             $state.go('root.create-backup-uninstall');
         };

--- a/setup/view/magento/setup/readiness-check.phtml
+++ b/setup/view/magento/setup/readiness-check.phtml
@@ -18,7 +18,7 @@
             <button
                 type="button"
                 class="btn"
-                ng-click="goToStart()"
+                disabled="disabled"
                 >Back</button>
         </div>
         <div class="btn-wrap btn-wrap-try-again"


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14309
### Description
When you enter the setup of Magento, the "Back" button is enabled
on the first step. When you click this, you go straight to the
final step of the installation, without entering any data in the
steps, so you can't install Magento at all.

With this commit the back button on the first step of the setup
is always disabled, since there's no previous step, except for the
page where you agree with the terms and conditions, which is not
part of the wizard.

### Fixed Issues
1. magento/magento2#14307: Possible to press the "Previous" button while in the first step of the installation

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a fresh Magento 2 environment
2. Go to the setup wizard in your browser
3. When on the first step, try to use the "Back" button. This is now disabled with this fix.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
