### PR TITLE
magento/magento2#14465 Fix empty changelog tables after MySQL restart.

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -121,7 +121,7 @@ class Changelog implements ChangelogInterface
             throw new ChangelogTableNotExistsException(new Phrase("Table %1 does not exist", [$changelogTableName]));
         }
 
-        $this->connection->delete($changelogTableName, ['version_id <= ?' => (int)$versionId]);
+        $this->connection->delete($changelogTableName, ['version_id < ?' => (int)$versionId]);
 
         return true;
     }


### PR DESCRIPTION
Leave at least one record after tebles cleanup.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This pull request is related to the issue #14465.
The idea of the fix - leave at least one record in changelog tables.
So after restart of MySQL, tables will never by empty.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14465: Indexes] Product 'version_id' lost last 'auro_increment' value after MySQL restart.

### Manual testing scenarios
The test scenario is well described in the issue.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
