### PR TITLE
Parameter update for post method in http client interface

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/ClientInterface.php
+++ b/lib/internal/Magento/Framework/HTTP/ClientInterface.php
@@ -99,7 +99,7 @@ interface ClientInterface
      * Make POST request
      *
      * @param string $uri full uri
-     * @param array $params POST fields array
+     * @param array|string $params POST fields array or string in case of JSON or XML data
      * @return void
      */
     public function post($uri, $params);


### PR DESCRIPTION
Updated `$params` parameter for post method of `\Magento\Framework\HTTP\ClientInterface` interface.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Currently all classes that implement  `\Magento\Framework\HTTP\ClientInterface` interface already have (or will have soon in all branches) support of string in post method. So current PR populate that useful ability to the interface.

### Related issue and PRs

- CURL Json POST #3489
- Socket Json POST #14169

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)