### PR TITLE
Fix aggregations use statements and return values

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
@@ -6,7 +6,7 @@
 namespace Magento\Cms\Model\ResourceModel\Block\Grid;
 
 use Magento\Framework\Api\Search\SearchResultInterface;
-use Magento\Framework\Search\AggregationInterface;
+use Magento\Framework\Api\Search\AggregationInterface;
 use Magento\Cms\Model\ResourceModel\Block\Collection as BlockCollection;
 
 /**

--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
@@ -82,6 +82,7 @@ class Collection extends BlockCollection implements SearchResultInterface
     public function setAggregations($aggregations)
     {
         $this->aggregations = $aggregations;
+        return $this;
     }
 
     /**

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Grid/Collection.php
@@ -83,6 +83,7 @@ class Collection extends PageCollection implements SearchResultInterface
     public function setAggregations($aggregations)
     {
         $this->aggregations = $aggregations;
+        return $this;
     }
 
     /**

--- a/app/code/Magento/Sales/Model/ResourceModel/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Grid/Collection.php
@@ -6,7 +6,7 @@
 namespace Magento\Sales\Model\ResourceModel\Grid;
 
 use Magento\Framework\Api\Search\SearchResultInterface;
-use Magento\Framework\Search\AggregationInterface;
+use Magento\Framework\Api\Search\AggregationInterface;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 /**

--- a/app/code/Magento/Sales/Model/ResourceModel/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Grid/Collection.php
@@ -78,6 +78,7 @@ class Collection extends AbstractCollection implements SearchResultInterface
     public function setAggregations($aggregations)
     {
         $this->aggregations = $aggregations;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
### Description
Several classes have wrong use statements for AggregationInterface (`Magento\Framework\Search\AggregationInterface` instead of `Magento\Framework\Api\Search\AggregationInterface`).
Also I have found that some `setAggregations` methods doesn't return value (incompatible with interface annotation).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
