### PR TITLE
magneto/magento2#12362 Do not remove session instantly

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -543,11 +543,6 @@
                     <comment>Allows customers to stay logged in when switching between different stores.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="old_session_access_delta" translate="label comment" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Old session access delta</label>
-                    <comment>Time when access to old session is allowed. It uses to save session in unstable networks.</comment>
-                    <validate>validate-digits</validate>
-                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -543,6 +543,11 @@
                     <comment>Allows customers to stay logged in when switching between different stores.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="old_session_access_delta" translate="label comment" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Old session access delta</label>
+                    <comment>Time when access to old session is allowed. It uses to save session in unstable networks.</comment>
+                    <validate>validate-digits</validate>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -84,7 +84,7 @@
                 <use_http_x_forwarded_for>0</use_http_x_forwarded_for>
                 <use_http_user_agent>0</use_http_user_agent>
                 <use_frontend_sid>1</use_frontend_sid>
-                <old_session_access_delta>300</old_session_access_delta>
+                <old_session_access_delta>30</old_session_access_delta>
             </session>
             <browser_capabilities>
                 <cookies>1</cookies>

--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -84,6 +84,7 @@
                 <use_http_x_forwarded_for>0</use_http_x_forwarded_for>
                 <use_http_user_agent>0</use_http_user_agent>
                 <use_frontend_sid>1</use_frontend_sid>
+                <old_session_access_delta>300</old_session_access_delta>
             </session>
             <browser_capabilities>
                 <cookies>1</cookies>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -119,6 +119,7 @@
     <preference for="Magento\Framework\Filter\Encrypt\AdapterInterface" type="Magento\Framework\Filter\Encrypt\Basic" />
     <preference for="Magento\Framework\Cache\ConfigInterface" type="Magento\Framework\Cache\Config" />
     <preference for="Magento\Framework\View\Asset\MergeStrategyInterface" type="Magento\Framework\View\Asset\MergeStrategy\Direct" />
+    <preference for="Magento\Framework\Session\Actualization\StorageInterface" type="Magento\Framework\Session\Actualization\Storage"/>
     <preference for="Magento\Framework\App\ViewInterface" type="Magento\Framework\App\View" />
     <preference for="Magento\Framework\Data\Collection\EntityFactoryInterface" type="Magento\Framework\Data\Collection\EntityFactory" />
     <preference for="Magento\Framework\Translate\InlineInterface" type="Magento\Framework\Translate\Inline" />

--- a/lib/internal/Magento/Framework/Session/Actualization/Storage.php
+++ b/lib/internal/Magento/Framework/Session/Actualization/Storage.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Session Actualization Storage
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Session\Actualization;
+
+/**
+ * Actualization Storage
+ * Store required information for session actualization in conditions of unstable connection.
+ */
+class Storage extends \Magento\Framework\Session\Storage implements
+    \Magento\Framework\Session\Actualization\StorageInterface
+{
+    /**
+     * Storage constructor.
+     *
+     * @param string $namespace
+     * @param array $data
+     */
+    public function __construct($namespace = self::STORAGE_NAMESPACE, array $data = [])
+    {
+        parent::__construct($namespace, $data);
+    }
+
+    /**
+     * Get actual session id.
+     *
+     * @return string
+     */
+    public function getNewSessionId()
+    {
+        return $this->getData(self::NEW_SESSION_ID);
+    }
+
+    /**
+     * Set actual session id.
+     *
+     * @param string $sessionId
+     * @return $this
+     */
+    public function setNewSessionId($sessionId)
+    {
+        return $this->setData(self::NEW_SESSION_ID, $sessionId);
+    }
+
+    /**
+     * Check if session storage contains info about actual session.
+     *
+     * @return bool
+     */
+    public function hasNewSessionId()
+    {
+        return $this->hasData(self::NEW_SESSION_ID);
+    }
+
+    /**
+     * Get old session id.
+     *
+     * @return string
+     */
+    public function getOldSessionId()
+    {
+        return $this->getData(self::OLD_SESSION_ID);
+    }
+
+    /**
+     * Set old session id.
+     *
+     * @param string $sessionId
+     * @return $this
+     */
+    public function setOldSessionId($sessionId)
+    {
+        return $this->setData(self::OLD_SESSION_ID, $sessionId);
+    }
+
+    /**
+     * Check if actual session contains id of old session.
+     *
+     * @return bool
+     */
+    public function hasOldSessionId()
+    {
+        return $this->hasData(self::OLD_SESSION_ID);
+    }
+
+    /**
+     * Remove old session id.
+     *
+     * @return $this
+     */
+    public function unsOldSessionId()
+    {
+        return $this->unsetData(self::OLD_SESSION_ID);
+    }
+
+    /**
+     * Get timestamp when session become deprecated.
+     *
+     * @return int
+     */
+    public function getSessionOldTimestamp()
+    {
+        return $this->getData(self::SESSION_OLD_TIMESTAMP);
+    }
+
+    /**
+     * Set session as deprecated.
+     *
+     * @return $this
+     */
+    public function setSessionOldTimestamp()
+    {
+        return $this->setData(self::SESSION_OLD_TIMESTAMP, time());
+    }
+}

--- a/lib/internal/Magento/Framework/Session/Actualization/StorageInterface.php
+++ b/lib/internal/Magento/Framework/Session/Actualization/StorageInterface.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Session Actualization Storage interface
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Session\Actualization;
+
+/**
+ * Session Actualization Storage interface
+ */
+interface StorageInterface extends \Magento\Framework\Session\StorageInterface
+{
+    const STORAGE_NAMESPACE = 'actualization';
+
+    const SESSION_OLD_TIMESTAMP = 'destroyed';
+
+    const NEW_SESSION_ID = 'new_session_id';
+
+    const OLD_SESSION_ID = 'old_session_id';
+
+    /**
+     * Get actual session id.
+     *
+     * @return string
+     */
+    public function getNewSessionId();
+
+    /**
+     * Set actual session id.
+     *
+     * @param string $sessionId
+     * @return $this
+     */
+    public function setNewSessionId($sessionId);
+
+    /**
+     * Check if session storage contains info about actual session.
+     *
+     * @return bool
+     */
+    public function hasNewSessionId();
+
+    /**
+     * Get old session id.
+     *
+     * @return string
+     */
+    public function getOldSessionId();
+
+    /**
+     * Set old session id.
+     *
+     * @param string $sessionId
+     * @return $this
+     */
+    public function setOldSessionId($sessionId);
+
+    /**
+     * Check if actual session contains id of old session.
+     *
+     * @return bool
+     */
+    public function hasOldSessionId();
+
+    /**
+     * Remove old session id.
+     *
+     * @return $this
+     */
+    public function unsOldSessionId();
+
+    /**
+     * Get timestamp when session become deprecated.
+     *
+     * @return int
+     */
+    public function getSessionOldTimestamp();
+
+    /**
+     * Set session as deprecated.
+     *
+     * @return $this
+     */
+    public function setSessionOldTimestamp();
+}

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -209,6 +209,8 @@ class SessionManager implements SessionManagerInterface
      * Start session.
      *
      * @throws \Magento\Framework\Exception\SessionException
+     *
+     * @return void
      */
     private function sessionStart()
     {
@@ -551,6 +553,8 @@ class SessionManager implements SessionManagerInterface
 
     /**
      * Regenerate session id, with saving relation between two sessions.
+     *
+     * @return void
      */
     protected function regenerateSessionId()
     {
@@ -569,7 +573,9 @@ class SessionManager implements SessionManagerInterface
     /**
      * Restart the session with new ID.
      *
-     * @param $sid
+     * @param string $sid
+     *
+     * @return void
      */
     protected function restartSession($sid)
     {

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -7,6 +7,7 @@
  */
 namespace Magento\Framework\Session;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Session\Config\ConfigInterface;
 
 /**
@@ -15,12 +16,6 @@ use Magento\Framework\Session\Config\ConfigInterface;
  */
 class SessionManager implements SessionManagerInterface
 {
-    const SESSION_OLD_TIMESTAMP = 'destroyed';
-
-    const NEW_SESSION_ID = 'new_session_id';
-
-    const OLD_SESSION_ID = 'old_session_id';
-
     /**
      * Default options when a call destroy()
      *
@@ -99,6 +94,11 @@ class SessionManager implements SessionManagerInterface
     private $appState;
 
     /**
+     * @var \Magento\Framework\Session\Actualization\StorageInterface
+     */
+    private $actualizationStorage;
+
+    /**
      * @param \Magento\Framework\App\Request\Http $request
      * @param SidResolverInterface $sidResolver
      * @param ConfigInterface $sessionConfig
@@ -108,7 +108,9 @@ class SessionManager implements SessionManagerInterface
      * @param \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager
      * @param \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory
      * @param \Magento\Framework\App\State $appState
+     * @param \Magento\Framework\Session\Actualization\StorageInterface $actualizationStorage
      * @throws \Magento\Framework\Exception\SessionException
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         \Magento\Framework\App\Request\Http $request,
@@ -119,7 +121,8 @@ class SessionManager implements SessionManagerInterface
         StorageInterface $storage,
         \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager,
         \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory,
-        \Magento\Framework\App\State $appState
+        \Magento\Framework\App\State $appState,
+        \Magento\Framework\Session\Actualization\StorageInterface $actualizationStorage = null
     ) {
         $this->request = $request;
         $this->sidResolver = $sidResolver;
@@ -130,7 +133,8 @@ class SessionManager implements SessionManagerInterface
         $this->cookieManager = $cookieManager;
         $this->cookieMetadataFactory = $cookieMetadataFactory;
         $this->appState = $appState;
-
+        $this->actualizationStorage = $actualizationStorage ?:
+            ObjectManager::getInstance()->get('Magento\Framework\Session\Actualization\StorageInterface');
         // Enable session.use_only_cookies
         ini_set('session.use_only_cookies', '1');
         $this->start();
@@ -208,26 +212,27 @@ class SessionManager implements SessionManagerInterface
     /**
      * Start session.
      *
-     * @throws \Magento\Framework\Exception\SessionException
-     *
      * @return void
+     * @throws \Magento\Framework\Exception\SessionException
+     * @SuppressWarnings(PHPMD.Superglobals)
      */
     private function sessionStart()
     {
         session_start();
         $this->validator->validate($this);
+        $this->actualizationStorage->init(isset($_SESSION) ? $_SESSION : []);
 
-        if (isset($_SESSION[self::NEW_SESSION_ID])) {
+        if ($this->actualizationStorage->hasNewSessionId()) {
             // Looks like we work with unstable network. Start actual session.
-            $this->restartSession($_SESSION[self::NEW_SESSION_ID]);
+            $this->restartSession($this->actualizationStorage->getNewSessionId());
             $this->validator->validate($this);
-        } elseif (isset($_SESSION[self::OLD_SESSION_ID])) {
+        } elseif ($this->actualizationStorage->hasOldSessionId()) {
             // New cookie was received. Proceed with old session delete.
             $currentSessionId = $this->getSessionId();
-            $oldSessionId = $_SESSION[self::OLD_SESSION_ID];
-            unset($_SESSION[self::OLD_SESSION_ID]);
+            $oldSessionId = $this->actualizationStorage->getOldSessionId();
+            $this->actualizationStorage->unsOldSessionId();
             $this->restartSession($oldSessionId);
-            if ($currentSessionId == $_SESSION[self::NEW_SESSION_ID]) {
+            if ($currentSessionId == $this->actualizationStorage->getNewSessionId()) {
                 session_destroy();
             }
             $this->restartSession($currentSessionId);
@@ -560,12 +565,12 @@ class SessionManager implements SessionManagerInterface
     {
         $oldSessionId = session_id();
         session_regenerate_id();
-        $_SESSION[self::OLD_SESSION_ID] = $oldSessionId;
+        $this->actualizationStorage->setOldSessionId($oldSessionId);
 
         $newSessionId = session_id();
         $this->restartSession($oldSessionId);
-        $_SESSION[self::SESSION_OLD_TIMESTAMP] = time();
-        $_SESSION[self::NEW_SESSION_ID] = $newSessionId;
+        $this->actualizationStorage->setSessionOldTimestamp();
+        $this->actualizationStorage->setNewSessionId($newSessionId);
 
         $this->restartSession($newSessionId);
     }
@@ -574,8 +579,8 @@ class SessionManager implements SessionManagerInterface
      * Restart the session with new ID.
      *
      * @param string $sid
-     *
      * @return void
+     * @SuppressWarnings(PHPMD.Superglobals)
      */
     protected function restartSession($sid)
     {
@@ -584,6 +589,7 @@ class SessionManager implements SessionManagerInterface
         $this->setSessionId($sid);
         session_start();
         ini_restore('session.use_strict_mode');
+        $this->actualizationStorage->init(isset($_SESSION) ? $_SESSION : []);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -222,21 +222,35 @@ class SessionManager implements SessionManagerInterface
         $this->validator->validate($this);
         $this->actualizationStorage->init(isset($_SESSION) ? $_SESSION : []);
 
-        if ($this->actualizationStorage->hasNewSessionId()) {
-            // Looks like we work with unstable network. Start actual session.
+        $forwarded = false;
+        while ($this->actualizationStorage->hasNewSessionId()) {
+            // Looks like we work with unstable network. Start more actual session.
             $this->restartSession($this->actualizationStorage->getNewSessionId());
             $this->validator->validate($this);
-        } elseif ($this->actualizationStorage->hasOldSessionId()) {
-            // New cookie was received. Proceed with old session delete.
-            $currentSessionId = $this->getSessionId();
-            $oldSessionId = $this->actualizationStorage->getOldSessionId();
-            $this->actualizationStorage->unsOldSessionId();
-            $this->restartSession($oldSessionId);
-            if ($currentSessionId == $this->actualizationStorage->getNewSessionId()) {
-                session_destroy();
-            }
-            $this->restartSession($currentSessionId);
+            $forwarded = true;
         }
+
+        if ($forwarded == false && $this->actualizationStorage->hasOldSessionId()) {
+            // New cookie was received. Proceed with old session delete.
+            $this->destroyOldSession();
+        }
+    }
+
+    /**
+     * Destroy old session.
+     *
+     * @return void
+     */
+    private function destroyOldSession()
+    {
+        $currentSessionId = $this->getSessionId();
+        $oldSessionId = $this->actualizationStorage->getOldSessionId();
+        $this->actualizationStorage->unsOldSessionId();
+        $this->restartSession($oldSessionId);
+        if ($currentSessionId == $this->actualizationStorage->getNewSessionId()) {
+            session_destroy();
+        }
+        $this->restartSession($currentSessionId);
     }
 
     /**
@@ -585,10 +599,8 @@ class SessionManager implements SessionManagerInterface
     protected function restartSession($sid)
     {
         session_commit();
-        ini_set('session.use_strict_mode', 0);
         $this->setSessionId($sid);
         session_start();
-        ini_restore('session.use_strict_mode');
         $this->actualizationStorage->init(isset($_SESSION) ? $_SESSION : []);
     }
 

--- a/lib/internal/Magento/Framework/Session/Validator.php
+++ b/lib/internal/Magento/Framework/Session/Validator.php
@@ -31,6 +31,8 @@ class Validator implements ValidatorInterface
 
     const XML_PATH_USE_USER_AGENT = 'web/session/use_http_user_agent';
 
+    const XML_PATH_OLD_SESSION_ACCESS_DELTA = 'web/session/old_session_access_delta';
+
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -102,6 +104,17 @@ class Validator implements ValidatorInterface
     {
         $sessionData = $_SESSION[self::VALIDATOR_KEY];
         $validatorData = $this->_getSessionEnvironment();
+
+        if (isset($_SESSION[SessionManager::SESSION_OLD_TIMESTAMP]) &&
+            (time() - $_SESSION[SessionManager::SESSION_OLD_TIMESTAMP])  >  $this->_scopeConfig->getValue(
+                self::XML_PATH_OLD_SESSION_ACCESS_DELTA,
+                $this->_scopeType
+            )
+        ) {
+            throw new SessionException(
+                new Phrase('Detected attempt to access an old session.')
+            );
+        }
 
         if ($this->_scopeConfig->getValue(
             self::XML_PATH_USE_REMOTE_ADDR,


### PR DESCRIPTION
Give configurable time delay to capture session id.
Remove old sessions only after new session id cookie was received.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Current pull request contains fix for the issue #12362.
Problem related to specific case of session work in PHP.
In case of call function 'session_regenerate_id(true)' there is required to be sure that renewed cookie will be successfully delivered to the browser.
Current PR provide functionality to keep old session till customer will not receive cookie.

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12362: Concurrent (quick reload) requests on checkout cause cart to empty - related to session_regenerate_id
2.  magento/magento2#13427: [2.1.11] Add to cart, try to checkout, cart is empty but mini-cart has items.
3. magento/magento2#4301: Hit fast twice F5 on checout page, customer loggs out automatically

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
#### Pre-Conditions
1. Magento 2.2.0
2. PHP7
#### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Add product to cart
2. Navigate to checkout
3. Reload the page as quick as possible (F5 multiple times)
#### Expected result
<!--- Tell us what should happen -->
1. Reload the checkout as usual
2. Cart contains session items
#### Actual result
<!--- Tell us what happens instead -->
1. Redirects to empty cart

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
