### PR TITLE
[backport] fix for button color in email template 

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_email-base.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_email-base.less
@@ -238,7 +238,7 @@ body {
         a:visited {
             //  Undo general link hover state
             border: 1px solid @button-primary__hover__background;
-            color: @button-primary__color !important;
+            color: @button-primary__hover__color !important;
             text-decoration: none !important;
         }
     }


### PR DESCRIPTION
Original PR #14455 

### Description
On hover button should use @button-primary__hover__color not @button-primary__color

### Fixed Issues (if relevant)


### Manual testing scenarios

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
