### PR TITLE
MSI-814: php bin/magento setup:upgrade command throw exception.

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Constraints/ForeignKey.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Constraints/ForeignKey.php
@@ -72,7 +72,7 @@ class ForeignKey implements DbDefinitionProcessorInterface
      */
     public function fromDefinition(array $data)
     {
-        $createMySQL = $data['Create Table'];
+        $createMySQL = $data['Create Table'] ?? $data['Create View'];
         $ddl = [];
         $regExp  = '#,\s*CONSTRAINT\s*`([^`]*)`\s*FOREIGN KEY\s*?\(`([^`]*)`\)\s*'
             . 'REFERENCES\s*(`([^`]*)`\.)?`([^`]*)`\s*\(`([^`]*)`\)\s*'

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/Db/MySQL/Definition/Constraints/ForeignKeyTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/Db/MySQL/Definition/Constraints/ForeignKeyTest.php
@@ -122,6 +122,14 @@ class ForeignKeyTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test creating SQL View does not throw any exception.
+     */
+    public function testCreateView()
+    {
+        $this->foreignKey->fromDefinition(['Create View' => '']);
+    }
+
+    /**
      * @return array
      */
     public function definitionDataProvider()


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
This PR is needed to MSI project.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
bin/magento setup:upgrade command fails when we are using some SQL View in Magento database because \Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Constraints\ForeignKey expects only Table creation. This PR fixes that issue.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/msi#814: php bin/magento setup:upgrade command throw exception.