### PR TITLE
[backport] fix translation issue with rating stars

### DIFF
--- a/app/code/Magento/Review/i18n/en_US.csv
+++ b/app/code/Magento/Review/i18n/en_US.csv
@@ -131,3 +131,5 @@ Summary,Summary
 "Allow Guests to Write Reviews","Allow Guests to Write Reviews"
 Active,Active
 Inactive,Inactive
+star,star
+stars,stars

--- a/app/code/Magento/Review/view/frontend/templates/form.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/form.phtml
@@ -42,9 +42,9 @@
                                 <label
                                     class="rating-<?php /* @escapeNotVerified */ echo $iterator; ?>"
                                     for="<?php echo $block->escapeHtml($_rating->getRatingCode()) ?>_<?php /* @escapeNotVerified */ echo $_option->getValue() ?>"
-                                    title="<?php /* @escapeNotVerified */ echo __('%1 %2', $iterator, $iterator > 1 ? 'stars' : 'star') ?>"
+                                    title="<?php /* @escapeNotVerified */ echo __('%1 %2', $iterator, $iterator > 1 ? __('stars') : __('star')) ?>"
                                     id="<?php echo $block->escapeHtml($_rating->getRatingCode()) ?>_<?php /* @escapeNotVerified */ echo $_option->getValue() ?>_label">
-                                    <span><?php /* @escapeNotVerified */ echo __('%1 %2', $iterator, $iterator > 1 ? 'stars' : 'star') ?></span>
+                                    <span><?php /* @escapeNotVerified */ echo __('%1 %2', $iterator, $iterator > 1 ? __('stars') : __('star')) ?></span>
                                 </label>
                             <?php $iterator++; ?>
                             <?php endforeach; ?>


### PR DESCRIPTION
Original PR https://github.com/magento/magento2/pull/14498
### Description
Added possibility to translate "stars" phrase in product reviews

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
