### PR TITLE
[Forwardport] Fix issue #13010. Check if product is assigned to current website.

### DIFF
--- a/app/code/Magento/Review/Controller/Product.php
+++ b/app/code/Magento/Review/Controller/Product.php
@@ -219,6 +219,11 @@ abstract class Product extends \Magento\Framework\App\Action\Action
 
         try {
             $product = $this->productRepository->getById($productId);
+
+            if (!in_array($this->storeManager->getStore()->getWebsiteId(), $product->getWebsiteIds())) {
+                throw new NoSuchEntityException();
+            }
+
             if (!$product->isVisibleInCatalog() || !$product->isVisibleInSiteVisibility()) {
                 throw new NoSuchEntityException();
             }

--- a/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
+++ b/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
@@ -147,7 +147,11 @@ class PostTest extends \PHPUnit\Framework\TestCase
         $ratingFactory->expects($this->once())->method('create')->willReturn($this->rating);
         $this->messageManager = $this->createMock(\Magento\Framework\Message\ManagerInterface::class);
 
-        $this->store = $this->createPartialMock(\Magento\Store\Model\Store::class, ['getId']);
+        $this->store = $this->createPartialMock(
+            \Magento\Store\Model\Store::class,
+            ['getId', 'getWebsiteId']
+        );
+
         $storeManager = $this->getMockForAbstractClass(\Magento\Store\Model\StoreManagerInterface::class);
         $storeManager->expects($this->any())->method('getStore')->willReturn($this->store);
 
@@ -219,7 +223,7 @@ class PostTest extends \PHPUnit\Framework\TestCase
             ->willReturn(1);
         $product = $this->createPartialMock(
             \Magento\Catalog\Model\Product::class,
-            ['__wakeup', 'isVisibleInCatalog', 'isVisibleInSiteVisibility', 'getId']
+            ['__wakeup', 'isVisibleInCatalog', 'isVisibleInSiteVisibility', 'getId', 'getWebsiteIds']
         );
         $product->expects($this->once())
             ->method('isVisibleInCatalog')
@@ -227,6 +231,15 @@ class PostTest extends \PHPUnit\Framework\TestCase
         $product->expects($this->once())
             ->method('isVisibleInSiteVisibility')
             ->willReturn(true);
+
+        $product->expects($this->once())
+            ->method('getWebsiteIds')
+            ->willReturn([1]);
+
+        $this->store->expects($this->once())
+            ->method('getWebsiteId')
+            ->willReturn(1);
+
         $this->productRepository->expects($this->any())->method('getById')
             ->with(1)
             ->willReturn($product);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14360
### Description
Checking if product is assigne to current website, before displaying "Write a review page". 

### Fixed Issues (if relevant)
1. magento/magento2#13010: Write a Review page works on multistore for products that are not assigned to that store

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Create an additional Website and Storefront e.g. http://www.store1.com/ and http://www.store2.com/
2. Create a product that is assigned to website 1 only
3. Ensure http://www.store1.com/catalog/product/view/id/1 shows up correctly and http://www.store2.com/catalog/product/view/id/1 throws a 404.
4. Navigate directly to the /review/product/list/id/1 page on store 2 (http://www.store2.com/review/product/list/id/1)
5. Page 404 should be displayed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)