### PR TITLE
[Forwardport] Check if store id is not null instead of empty

### DIFF
--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -111,7 +111,7 @@ class PageRepository implements PageRepositoryInterface
      */
     public function save(\Magento\Cms\Api\Data\PageInterface $page)
     {
-        if (empty($page->getStoreId())) {
+        if ($page->getStoreId() === null) {
             $storeId = $this->storeManager->getStore()->getId();
             $page->setStoreId($storeId);
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14504
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Store id 0 `is_empty` returns true so a cms page for all store views can’t be created

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
