### PR TITLE
magento/magento2#12250: View.xml is inheriting image sizes from paren…

### DIFF
--- a/app/code/Magento/Catalog/Model/ImageExtractor.php
+++ b/app/code/Magento/Catalog/Model/ImageExtractor.php
@@ -32,16 +32,16 @@ class ImageExtractor implements TypeDataExtractorInterface
                     continue;
                 }
                 $attributeTagName = $attribute->tagName;
-                if ($attributeTagName === 'background') {
-                    $nodeValue = $this->processImageBackground($attribute->nodeValue);
-                } elseif ($attributeTagName === 'width' || $attributeTagName === 'height') {
-                    if ((bool)$attribute->getAttribute('xsi:nil') !== true) {
-                        $nodeValue = intval($attribute->nodeValue);
+                if ((bool)$attribute->getAttribute('xsi:nil') !== true) {
+                    if ($attributeTagName === 'background') {
+                        $nodeValue = $this->processImageBackground($attribute->nodeValue);
+                    } elseif ($attributeTagName === 'width' || $attributeTagName === 'height') {
+                            $nodeValue = intval($attribute->nodeValue);
                     } else {
-                        $nodeValue = null;
+                        $nodeValue = $attribute->nodeValue;
                     }
                 } else {
-                    $nodeValue = $attribute->nodeValue;
+                    $nodeValue = null;
                 }
                 $result[$mediaParentTag][$moduleNameImage][Image::MEDIA_TYPE_CONFIG_NODE][$imageId][$attribute->tagName]
                     = $nodeValue;

--- a/app/code/Magento/Catalog/Model/ImageExtractor.php
+++ b/app/code/Magento/Catalog/Model/ImageExtractor.php
@@ -35,7 +35,11 @@ class ImageExtractor implements TypeDataExtractorInterface
                 if ($attributeTagName === 'background') {
                     $nodeValue = $this->processImageBackground($attribute->nodeValue);
                 } elseif ($attributeTagName === 'width' || $attributeTagName === 'height') {
-                    $nodeValue = intval($attribute->nodeValue);
+                    if ((bool)$attribute->getAttribute('xsi:nil') !== true) {
+                        $nodeValue = intval($attribute->nodeValue);
+                    } else {
+                        $nodeValue = null;
+                    }
                 } else {
                     $nodeValue = $attribute->nodeValue;
                 }

--- a/lib/internal/Magento/Framework/Config/etc/view.xsd
+++ b/lib/internal/Magento/Framework/Config/etc/view.xsd
@@ -55,7 +55,7 @@
                         <xs:element name="aspect_ratio" type="xs:boolean" minOccurs="0" nillable="true"/>
                         <xs:element name="frame" type="xs:boolean" minOccurs="0" nillable="true"/>
                         <xs:element name="transparency" type="xs:boolean" minOccurs="0" nillable="true"/>
-                        <xs:element name="background" minOccurs="0">
+                        <xs:element name="background" minOccurs="0" nillable="true">
                             <xs:simpleType>
                                 <xs:restriction base="xs:string">
                                     <xs:pattern value="\[(\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\]"/>

--- a/lib/internal/Magento/Framework/Config/etc/view.xsd
+++ b/lib/internal/Magento/Framework/Config/etc/view.xsd
@@ -49,12 +49,12 @@
             <xs:element name="image" minOccurs="1" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="width" type="xs:positiveInteger" minOccurs="0"/>
-                        <xs:element name="height" type="xs:positiveInteger" minOccurs="0"/>
-                        <xs:element name="constrain" type="xs:boolean" minOccurs="0"/>
-                        <xs:element name="aspect_ratio" type="xs:boolean" minOccurs="0"/>
-                        <xs:element name="frame" type="xs:boolean" minOccurs="0"/>
-                        <xs:element name="transparency" type="xs:boolean" minOccurs="0"/>
+                        <xs:element name="width" type="xs:positiveInteger" minOccurs="0" nillable="true"/>
+                        <xs:element name="height" type="xs:positiveInteger" minOccurs="0" nillable="true"/>
+                        <xs:element name="constrain" type="xs:boolean" minOccurs="0" nillable="true"/>
+                        <xs:element name="aspect_ratio" type="xs:boolean" minOccurs="0" nillable="true"/>
+                        <xs:element name="frame" type="xs:boolean" minOccurs="0" nillable="true"/>
+                        <xs:element name="transparency" type="xs:boolean" minOccurs="0" nillable="true"/>
                         <xs:element name="background" minOccurs="0">
                             <xs:simpleType>
                                 <xs:restriction base="xs:string">


### PR DESCRIPTION
View.xml is inheriting image sizes from parent (so an optional field is replaced by the value of parent)

- Made media attributes nullable and parse them correct

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12250: View.xml is inheriting image sizes from parent (so an optional field is replaced by the value of parent)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
