### PR TITLE
[Forwardport] Fix HTML tags in meta description

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/View.php
+++ b/app/code/Magento/Catalog/Helper/Product/View.php
@@ -131,7 +131,7 @@ class View extends \Magento\Framework\App\Helper\AbstractHelper
         if ($description) {
             $pageConfig->setDescription($description);
         } else {
-            $pageConfig->setDescription($this->string->substr($product->getDescription(), 0, 255));
+            $pageConfig->setDescription($this->string->substr(strip_tags($product->getDescription()), 0, 255));
         }
 
         if ($this->_catalogProduct->canUseCanonicalTag()) {


### PR DESCRIPTION
### Description
Port fix #14436 from 2.1 to 2.3, fixes issue with HTML tags in meta description if no meta description is provided.

### Fixed Issues
1. HTML tags in meta description

### Manual testing scenarios
1. Ensure a product has no meta description but does have a product description with HTML in it
2. Visit product on front-end and view page source