### PR TITLE
Eiminate never user variable in AdminNotification\Model\ResourceModel

### DIFF
--- a/app/code/Magento/AdminNotification/Model/Inbox.php
+++ b/app/code/Magento/AdminNotification/Model/Inbox.php
@@ -77,7 +77,7 @@ class Inbox extends \Magento\Framework\Model\AbstractModel implements NotifierIn
      */
     public function getNoticeStatus()
     {
-        return $this->getResource()->getNoticeStatus($this);
+        return $this->getResource()->getNoticeStatus();
     }
 
     /**

--- a/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox.php
+++ b/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox.php
@@ -55,11 +55,9 @@ class Inbox extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     /**
      * Get notifications grouped by severity
      *
-     * @param \Magento\AdminNotification\Model\Inbox $object
      * @return array
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getNoticeStatus(\Magento\AdminNotification\Model\Inbox $object)
+    public function getNoticeStatus()
     {
         $connection = $this->getConnection();
         $select = $connection->select()->from(


### PR DESCRIPTION
### Description
This fix removes not user parameter of method (detected it during development).
Magento\AdminNotification\Model\ResourceModel::getNoticeStatus();

Not sure why it was added there, but its not defined in Interface and not used in this method body.

Also Magento Standards test causer and Warning: 
62 | WARNING | The method parameter $object is never used

### Fixed Issues (if relevant)
No fixed issues, code improving 

### Manual testing scenarios
No fixed issues, code improving 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
