### PR TITLE
Store Address Renderer - Remove commas for empty fields

### DIFF
--- a/app/code/Magento/Store/Model/Address/Renderer.php
+++ b/app/code/Magento/Store/Model/Address/Renderer.php
@@ -51,7 +51,7 @@ class Renderer
         $this->eventManager->dispatch('store_address_format', ['type' => $type, 'store_info' => $storeInfo]);
         $address = $this->filterManager->template(
             "{{var name}}\n{{var street_line1}}\n{{depend street_line2}}{{var street_line2}}\n{{/depend}}"
-            . "{{var city}}, {{var region}} {{var postcode}},\n{{var country}}",
+            . "{{depend city}}{{var city}},{{/depend}} {{var region}} {{depend postcode}}{{var postcode}},{{/depend}}\n{{var country}}",
             ['variables' => $storeInfo->getData()]
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
If in Stores->Settings->Configuration->General->Store Information  
Next fields are empty:  
* ZIP/Postal Code  
* City  

Email notifications has commas in [footer](https://github.com/nans/MagentoBug/blob/master/doc/email-template.png)

This fix removed commas for empty fields.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Stores->Settings->Configuration->General->Store Information
2. Set ZIP/Postal Code  or/and City as empty
3. Save, Cashe cleen.
4. Create new customer
5. Open email box end letter
6. Commas in footer

After fix in 6 step no commas in bootom.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
