### PR TITLE
Remove foreach and break statements

### DIFF
--- a/app/code/Magento/Rule/Model/Condition/AbstractCondition.php
+++ b/app/code/Magento/Rule/Model/Condition/AbstractCondition.php
@@ -83,18 +83,14 @@ abstract class AbstractCondition extends \Magento\Framework\DataObject implement
         $this->loadAttributeOptions()->loadOperatorOptions()->loadValueOptions();
 
         $options = $this->getAttributeOptions();
-        if ($options) {
-            foreach (array_keys($options) as $attr) {
-                $this->setAttribute($attr);
-                break;
-            }
+        if (!empty($options)) {
+            $attrs = array_keys($options);
+            $this->setAttribute($attrs[0]);
         }
         $options = $this->getOperatorOptions();
-        if ($options) {
-            foreach (array_keys($options) as $operator) {
-                $this->setOperator($operator);
-                break;
-            }
+        if (!empty($options)) {
+            $operators = array_keys($options);
+            $this->setOperator($operators[0]);
         }
     }
 
@@ -520,9 +516,10 @@ abstract class AbstractCondition extends \Magento\Framework\DataObject implement
     public function getAttributeElement()
     {
         if (null === $this->getAttribute()) {
-            foreach (array_keys($this->getAttributeOption()) as $option) {
-                $this->setAttribute($option);
-                break;
+            $options = $this->getAttributeOptions();
+            if (!empty($options)) {
+                $attrs = array_keys($options);
+                $this->setAttribute($attrs[0]);
             }
         }
         return $this->getForm()->addField(

--- a/app/code/Magento/Rule/Model/Condition/AbstractCondition.php
+++ b/app/code/Magento/Rule/Model/Condition/AbstractCondition.php
@@ -83,14 +83,14 @@ abstract class AbstractCondition extends \Magento\Framework\DataObject implement
         $this->loadAttributeOptions()->loadOperatorOptions()->loadValueOptions();
 
         $options = $this->getAttributeOptions();
-        if (!empty($options)) {
-            $attrs = array_keys($options);
-            $this->setAttribute($attrs[0]);
+        if ($options) {
+            reset($options);
+            $this->setAttribute(key($attrs));
         }
         $options = $this->getOperatorOptions();
-        if (!empty($options)) {
-            $operators = array_keys($options);
-            $this->setOperator($operators[0]);
+        if ($options) {
+            reset($options);
+            $this->setOperator(key($operator));
         }
     }
 
@@ -517,9 +517,9 @@ abstract class AbstractCondition extends \Magento\Framework\DataObject implement
     {
         if (null === $this->getAttribute()) {
             $options = $this->getAttributeOptions();
-            if (!empty($options)) {
-                $attrs = array_keys($options);
-                $this->setAttribute($attrs[0]);
+            if ($options) {
+                reset($options);
+                $this->setAttribute(key($attrs));
             }
         }
         return $this->getForm()->addField(


### PR DESCRIPTION
Retrieves the first element key of the options.

### Description

I was reading some piece of code when I see te "foreach" and "break" statements. I know that the "break" should be avoided, so here my suggestion to retrieve the key of the first element of the array.

Is there a goal to do it via a foreach and break?

