### PR TITLE
Fix issue with saving untouched attributes data

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/UpdateHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/UpdateHandler.php
@@ -172,8 +172,8 @@ class UpdateHandler implements AttributeInterface
                     }
                 } else {
                     if (array_key_exists($code, $fallbackSnapshot)) {
-                        $fallbackSnapshotValue = $fallbackSnapshot[$code];
-                        if ($fallbackSnapshotValue === (string) $newValue) {
+                        $fallbackValue = $fallbackSnapshot[$code];
+                        if ($fallbackValue === (string) $newValue) {
                             continue;
                         }
                     }


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#8897: Saving product with non-default store scope causes untouched attributes to become store scoped if loaded using ProductRepository

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
