### PR TITLE
CSV files: added possibility to select PHP input file mode

### DIFF
--- a/lib/internal/Magento/Framework/File/Csv.php
+++ b/lib/internal/Magento/Framework/File/Csv.php
@@ -126,13 +126,17 @@ class Csv
     /**
      * Saving data row array into file
      *
-     * @param   string $file
-     * @param   array $data
-     * @return  $this
+     * @param string $file
+     * @param array $data
+     * @param string $mode
+     *
+     * @return $this
+     *
+     * @throws \Magento\Framework\Exception\FileSystemException
      */
-    public function saveData($file, $data)
+    public function saveData($file, $data, $mode = 'w')
     {
-        $fh = fopen($file, 'w');
+        $fh = fopen($file, $mode);
         foreach ($data as $dataRow) {
             $this->file->filePutCsv($fh, $dataRow, $this->_delimiter, $this->_enclosure);
         }

--- a/lib/internal/Magento/Framework/File/Csv.php
+++ b/lib/internal/Magento/Framework/File/Csv.php
@@ -126,29 +126,23 @@ class Csv
     /**
      * Saving data row array into file
      *
-     * @param   string $file
-     * @param   array $data
-     * @return  $this
+     * @param string $file
+     * @param array $data
+     * @return $this
      * @throws \Magento\Framework\Exception\FileSystemException
      * @deprecated
      * @see appendData
      */
     public function saveData($file, $data)
     {
-        $fh = fopen($file, 'w');
-        foreach ($data as $dataRow) {
-            $this->file->filePutCsv($fh, $dataRow, $this->_delimiter, $this->_enclosure);
-        }
-        fclose($fh);
-        return $this;
+        return $this->appendData($file, $data, 'w');
     }
 
     /**
-     * Replace the saveData method by
-     * allowing to select the input mode
+     * Replace the saveData method by allowing to select the input mode
      *
-     * @param $file
-     * @param $data
+     * @param string $file
+     * @param array $data
      * @param string $mode
      *
      * @return $this

--- a/lib/internal/Magento/Framework/File/Csv.php
+++ b/lib/internal/Magento/Framework/File/Csv.php
@@ -126,21 +126,43 @@ class Csv
     /**
      * Saving data row array into file
      *
-     * @param string $file
-     * @param array $data
+     * @param   string $file
+     * @param   array $data
+     * @return  $this
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @deprecated
+     * @see appendData
+     */
+    public function saveData($file, $data)
+    {
+        $fh = fopen($file, 'w');
+        foreach ($data as $dataRow) {
+            $this->file->filePutCsv($fh, $dataRow, $this->_delimiter, $this->_enclosure);
+        }
+        fclose($fh);
+        return $this;
+    }
+
+    /**
+     * Replace the saveData method by
+     * allowing to select the input mode
+     *
+     * @param $file
+     * @param $data
      * @param string $mode
      *
      * @return $this
      *
      * @throws \Magento\Framework\Exception\FileSystemException
      */
-    public function saveData($file, $data, $mode = 'w')
+    public function appendData($file, $data, $mode = 'w')
     {
-        $fh = fopen($file, $mode);
+        $fileHandler = fopen($file, $mode);
         foreach ($data as $dataRow) {
-            $this->file->filePutCsv($fh, $dataRow, $this->_delimiter, $this->_enclosure);
+            $this->file->filePutCsv($fileHandler, $dataRow, $this->_delimiter, $this->_enclosure);
         }
-        fclose($fh);
+        fclose($fileHandler);
+
         return $this;
     }
 }


### PR DESCRIPTION
### Description

A small modification to the CSV processor of the framework. This processeur is juste a layer
over native PHP functions. However it forces the input mode when writing into a file which is very unpleasant and lacks of flexibility. 

For instance, if you want to progressively save the data in to the file, you can't: you have to save it at once. It could lead to have big amount of data stored in memory while it could be saved progressively in the file.

This small modification allows to developer to choose the input mode while not breaking the backward compatibility.


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Use the Magento CSV file processor to save data in to a file, and use different input mode (w, w+...)


### Contribution checklist
 - [x ] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
