### PR TITLE
Add Parent Item to order item in repository

### DIFF
--- a/app/code/Magento/Sales/Model/Order/ItemRepository.php
+++ b/app/code/Magento/Sales/Model/Order/ItemRepository.php
@@ -114,6 +114,7 @@ class ItemRepository implements OrderItemRepositoryInterface
             }
 
             $this->addProductOption($orderItem);
+            $this->addParentItem($orderItem);
             $this->registry[$id] = $orderItem;
         }
         return $this->registry[$id];
@@ -134,6 +135,7 @@ class ItemRepository implements OrderItemRepositoryInterface
         /** @var OrderItemInterface $orderItem */
         foreach ($searchResult->getItems() as $orderItem) {
             $this->addProductOption($orderItem);
+            $this->addParentItem($orderItem);
         }
 
         return $searchResult;
@@ -211,6 +213,20 @@ class ItemRepository implements OrderItemRepositoryInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Set parent item.
+     *
+     * @param OrderItemInterface $orderItem
+     * @throws InputException
+     * @throws NoSuchEntityException
+     */
+    private function addParentItem(OrderItemInterface $orderItem)
+    {
+        if ($parentId = $orderItem->getParentItemId()) {
+            $orderItem->setParentItem($this->get($parentId));
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
When using `GET /V1/orders/items/{id}` the parent item isn't set. This PR will add the parent item if the `parent_item_id` is set.

### Fixed Issues (if relevant)
1. None

### Manual testing scenarios
1. Order a configurable product.
2. Fetch the ordered simple product using `GET /V1/orders/items/{id}`.
3. `parent_item_id` is set but `parent_item` isn't.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
