### PR TITLE
Add Parent Item to order item in repository

### DIFF
--- a/app/code/Magento/Sales/Model/Order/ItemRepository.php
+++ b/app/code/Magento/Sales/Model/Order/ItemRepository.php
@@ -114,6 +114,7 @@ class ItemRepository implements OrderItemRepositoryInterface
             }
 
             $this->addProductOption($orderItem);
+            $this->addParentItem($orderItem);
             $this->registry[$id] = $orderItem;
         }
         return $this->registry[$id];
@@ -211,6 +212,20 @@ class ItemRepository implements OrderItemRepositoryInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Set parent item.
+     *
+     * @param OrderItemInterface $orderItem
+     * @throws InputException
+     * @throws NoSuchEntityException
+     */
+    private function addParentItem(OrderItemInterface $orderItem)
+    {
+        if ($parentId = $orderItem->getParentItemId()) {
+            $orderItem->setParentItem($this->get($parentId));
+        }
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ItemRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ItemRepositoryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\Order;
+
+class ItemRepositoryTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var \Magento\Sales\Model\Order */
+    private $order;
+
+    /** @var \Magento\Sales\Api\OrderItemRepositoryInterface */
+    private $orderItemRepository;
+
+    /** @var \Magento\Framework\Api\SearchCriteriaBuilder */
+    private $searchCriteriaBuilder;
+
+    protected function setUp()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+        $this->order = $objectManager->create(\Magento\Sales\Model\Order::class);
+        $this->orderItemRepository = $objectManager->create(\Magento\Sales\Api\OrderItemRepositoryInterface::class);
+        $this->searchCriteriaBuilder = $objectManager->create(\Magento\Framework\Api\SearchCriteriaBuilder::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_configurable_product.php
+     */
+    public function testAddOrderItemParent()
+    {
+        $this->order->load('100000001', 'increment_id');
+
+        foreach ($this->order->getItems() as $item) {
+            if ($item->getProductType() === \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE) {
+                $orderItem = $this->orderItemRepository->get($item->getItemId());
+                $this->assertInstanceOf(\Magento\Sales\Api\Data\OrderItemInterface::class, $orderItem->getParentItem());
+            }
+        }
+
+        $itemList = $this->orderItemRepository->getList(
+            $this->searchCriteriaBuilder->addFilter('order_id', $this->order->getId())->create()
+        );
+
+        foreach ($itemList->getItems() as $item) {
+            if ($item->getProductType() === \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE) {
+                $this->assertInstanceOf(\Magento\Sales\Api\Data\OrderItemInterface::class, $item->getParentItem());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
When using `GET /V1/orders/items/{id}` the parent item isn't set. This PR will add the parent item if the `parent_item_id` is set.

### Fixed Issues (if relevant)
1. None

### Manual testing scenarios
1. Order a configurable product.
2. Fetch the ordered simple product using `GET /V1/orders/items/{id}`.
3. `parent_item_id` is set but `parent_item` isn't.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
