### PR TITLE
Refactor Mass Order Cancel code to use Interface

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
@@ -9,6 +9,7 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Api\OrderManagementInterface;
 
 class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
@@ -16,16 +17,23 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
      * Authorization level of a basic admin session
      */
     const ADMIN_RESOURCE = 'Magento_Sales::cancel';
+    
+    /**
+     * @var OrderManagementInterface
+     */
+    protected $orderManagement;
 
     /**
      * @param Context $context
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
+     * @param OrderManagementInterface $orderManagement
      */
-    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory)
+    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory, OrderManagementInterface $orderManagement)
     {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
+        $this->orderManagement = $orderManagement;
     }
 
     /**
@@ -41,8 +49,7 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
             if (!$order->canCancel()) {
                 continue;
             }
-            $order->cancel();
-            $order->save();
+            $this->orderManagement->cancel($order->getEntityId());
             $countCancelOrder++;
         }
         $countNonCancelOrder = $collection->count() - $countCancelOrder;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
@@ -27,13 +27,19 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
      * @param Context $context
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
-     * @param OrderManagementInterface $orderManagement
+     * @param OrderManagementInterface|null $orderManagement
      */
-    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory, OrderManagementInterface $orderManagement)
-    {
+    public function __construct(
+        Context $context,
+        Filter $filter,
+        CollectionFactory $collectionFactory,
+        OrderManagementInterface $orderManagement = null
+    ) {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
-        $this->orderManagement = $orderManagement ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Sales\Api\OrderManagementInterface::class);
+        $this->orderManagement = $orderManagement ?: \Magento\Framework\App\ObjectManager::getInstance()->get(
+            \Magento\Sales\Api\OrderManagementInterface::class
+        );
     }
 
     /**
@@ -46,10 +52,10 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
     {
         $countCancelOrder = 0;
         foreach ($collection->getItems() as $order) {
-            if (!$order->canCancel()) {
+            $isCanceled = $this->orderManagement->cancel($order->getEntityId());
+            if ($isCanceled === false) {
                 continue;
             }
-            $this->orderManagement->cancel($order->getEntityId());
             $countCancelOrder++;
         }
         $countNonCancelOrder = $collection->count() - $countCancelOrder;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
@@ -21,7 +21,7 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
     /**
      * @var OrderManagementInterface
      */
-    protected $orderManagement;
+    private $orderManagement;
 
     /**
      * @param Context $context
@@ -33,7 +33,7 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
     {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
-        $this->orderManagement = $orderManagement;
+        $this->orderManagement = $orderManagement ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Sales\Api\OrderManagementInterface::class);
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassCancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassCancelTest.php
@@ -85,6 +85,11 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
      */
     protected $filterMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $orderManagementMock;
+
     protected function setUp()
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
@@ -145,12 +150,15 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
         $this->orderCollectionFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($this->orderCollectionMock);
+        $this->orderManagementMock = $this->createMock(\Magento\Sales\Api\OrderManagementInterface::class);
+
         $this->massAction = $objectManagerHelper->getObject(
             \Magento\Sales\Controller\Adminhtml\Order\MassCancel::class,
             [
                 'context' => $this->contextMock,
                 'filter' => $this->filterMock,
-                'collectionFactory' => $this->orderCollectionFactoryMock
+                'collectionFactory' => $this->orderCollectionFactoryMock,
+                'orderManagement' => $this->orderManagementMock
             ]
         );
     }
@@ -161,6 +169,9 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecuteCanCancelOneOrder()
     {
+        $order1id = 100;
+        $order2id = 200;
+
         $order1 = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -175,20 +186,19 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
             ->willReturn($orders);
 
         $order1->expects($this->once())
-            ->method('canCancel')
-            ->willReturn(true);
-        $order1->expects($this->once())
-            ->method('cancel');
-        $order1->expects($this->once())
-            ->method('save');
+            ->method('getEntityId')
+            ->willReturn($order1id);
+
+        $order2->expects($this->once())
+            ->method('getEntityId')
+            ->willReturn($order2id);
 
         $this->orderCollectionMock->expects($this->once())
             ->method('count')
             ->willReturn($countOrders);
 
-        $order2->expects($this->once())
-            ->method('canCancel')
-            ->willReturn(false);
+        $this->orderManagementMock->expects($this->at(0))->method('cancel')->with($order1id)->willReturn(true);
+        $this->orderManagementMock->expects($this->at(1))->method('cancel')->with($order2id)->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addError')
@@ -222,21 +232,23 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
         $orders = [$order1, $order2];
         $countOrders = count($orders);
 
+        $order1->expects($this->once())
+            ->method('getEntityId')
+            ->willReturn(100);
+
+        $order2->expects($this->once())
+            ->method('getEntityId')
+            ->willReturn(200);
+
         $this->orderCollectionMock->expects($this->any())
             ->method('getItems')
             ->willReturn([$order1, $order2]);
-
-        $order1->expects($this->once())
-            ->method('canCancel')
-            ->willReturn(false);
 
         $this->orderCollectionMock->expects($this->once())
             ->method('count')
             ->willReturn($countOrders);
 
-        $order2->expects($this->once())
-            ->method('canCancel')
-            ->willReturn(false);
+        $this->orderManagementMock->expects($this->atLeastOnce())->method('cancel')->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addError')
@@ -265,11 +277,10 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
             ->willReturn([$order1]);
 
         $order1->expects($this->once())
-            ->method('canCancel')
-            ->willReturn(true);
-        $order1->expects($this->once())
-            ->method('cancel')
-            ->willThrowException($exception);
+            ->method('getEntityId')
+            ->willReturn(100);
+
+        $this->orderManagementMock->expects($this->atLeastOnce())->method('cancel')->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addError')


### PR DESCRIPTION
### Description
I have observed that MassAction Cancel is using the collection for orders cancel, whereas Order Cancel (order cancel from order edit section) is using Interface to put the order on hold.
So, I have refactor the Mass Order Cancel code to use Sales Order Interface.

### Manual testing scenarios
1. Go to Sales Order Grid
2. Select any number of orders to cancel
3. Select Cancel from Action Dropdown
