### PR TITLE
Refactor Mass Order UnHold code to use Interface

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
@@ -9,6 +9,7 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Api\OrderManagementInterface;
 
 class MassUnhold extends AbstractMassAction
 {
@@ -16,16 +17,23 @@ class MassUnhold extends AbstractMassAction
      * Authorization level of a basic admin session
      */
     const ADMIN_RESOURCE = 'Magento_Sales::unhold';
+    
+    /**
+     * @var OrderManagementInterface
+     */
+    protected $orderManagement;
 
     /**
      * @param Context $context
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
+     * @param OrderManagementInterface $orderManagement
      */
-    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory)
+    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory, OrderManagementInterface $orderManagement)
     {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
+        $this->orderManagement = $orderManagement;
     }
 
     /**
@@ -40,12 +48,10 @@ class MassUnhold extends AbstractMassAction
 
         /** @var \Magento\Sales\Model\Order $order */
         foreach ($collection->getItems() as $order) {
-            $order->load($order->getId());
             if (!$order->canUnhold()) {
                 continue;
             }
-            $order->unhold();
-            $order->save();
+            $this->orderManagement->unHold($order->getEntityId());
             $countUnHoldOrder++;
         }
 


### PR DESCRIPTION
### Description
I have observed that MassAction Unhold is using the collection to release order from hold, whereas MassAction Hold is using Interface to put the order on hold.
So, I have refactor the Mass Order Unhold code to use Sales Order Interface as it is used or Mass Order Hold.

### Manual testing scenarios
1. Go to Sales Order Grid
2. Select any number of holded orders to release hold
3. Select Unhold from Action Dropdown