### PR TITLE
#13685: Upgrading compatibility jQuery with 3.3.1

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/product/storage/data-storage.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/storage/data-storage.js
@@ -228,7 +228,7 @@ define([
             this.updateRequestConfig.data = queryBuilder.buildQuery(prepareAjaxParams);
             this.updateRequestConfig.data['store_id'] = store;
             this.updateRequestConfig.data['currency_code'] = currency;
-            $.ajax(this.updateRequestConfig).success(function (data) {
+            $.ajax(this.updateRequestConfig).done(function (data) {
                 this.request = {};
                 this.providerHandler(getParsedDataFromServer(data));
             }.bind(this));

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/js.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/js.phtml
@@ -89,7 +89,7 @@
                             showLoader: true,
                             context: $form
                         })
-                            .success(function (data) {
+                            .done(function (data) {
                                 if (!data.error) {
                                     setAttributeSetId(data.id);
                                     closeDialogAndProcessForm($form);

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/product-grid.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/product-grid.js
@@ -95,7 +95,7 @@ define([
                 type: 'GET',
                 url: this._buildGridUrl(filterData),
                 context: $('body')
-            }).success(function (data) {
+            }).done(function (data) {
                 bootstrap(JSON.parse(data));
             });
         },

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
@@ -492,7 +492,7 @@ define([
                 dataType: 'json',
                 showLoader: true,
                 context: this
-            }).success(function (data) {
+            }).done(function (data) {
                 if (!data.error) {
                     this.set(
                         'skeletonAttributeSet',
@@ -507,7 +507,7 @@ define([
                 }
 
                 return false;
-            }).error(function (xhr) {
+            }).fail(function (xhr) {
                 if (xhr.statusText === 'abort') {
                     return;
                 }

--- a/dev/tests/js/jasmine/tests/lib/mage/backend/suggest.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/backend/suggest.test.js
@@ -101,8 +101,8 @@ define([
 
             expect(suggestInstance.dropdown.hasClass('wrapper-test')).toBe(true);
             expect(suggestInstance.dropdown.is(':hidden')).toBe(true);
-            expect(suggestInstance.element.closest('.test-input-wrapper').size()).toBeGreaterThan(0);
-            expect(suggestInstance.element.closest('.' + options.className).size()).toBeGreaterThan(0);
+            expect(suggestInstance.element.closest('.test-input-wrapper').length).toBeGreaterThan(0);
+            expect(suggestInstance.element.closest('.' + options.className).length).toBeGreaterThan(0);
             expect(suggestInstance.element.attr('autocomplete')).toBe('off');
 
             options.appendMethod = 'before';

--- a/lib/web/mage/collapsible.js
+++ b/lib/web/mage/collapsible.js
@@ -531,12 +531,12 @@ define([
                     that.element.addClass(that.options.loadingClass);
                 }
                 that.content.attr('aria-busy', 'true');
-                that.xhr.success(function (response) {
+                that.xhr.done(function (response) {
                     setTimeout(function () {
                         that.content.html(response);
                     }, 1);
                 });
-                that.xhr.complete(function (jqXHR, status) {
+                that.xhr.always(function (jqXHR, status) {
                     setTimeout(function () {
                         if (status === 'abort') {
                             that.content.stop(false, true);


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Cherry-picked changes for jQuery 3 compatibility from https://github.com/magento/magento2/pull/14556
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13685: Incompatibilies with jQuery 3
2. ...

### Manual testing scenarios
1. I can checkout without any problems
2. I can use admin without any problems

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
