### PR TITLE
modified nginx and httpd default config to leverage cache-control max…

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -103,7 +103,7 @@ location /static/ {
         rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
     }
 
-    location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2)$ {
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";
         expires +1y;

--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -67,7 +67,7 @@ AddType application/xml xml
 
 <IfModule mod_headers.c>
 
-    <FilesMatch .*\.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2)$>
+    <FilesMatch .*\.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$>
         Header append Cache-Control public
     </FilesMatch>
 
@@ -91,7 +91,7 @@ AddType application/xml xml
     </FilesMatch>
     ExpiresByType text/xml "access plus 0 seconds"
     ExpiresByType text/csv "access plus 0 seconds"
-    ExpiresByType application/json "access plus 0 seconds"
+    ExpiresByType application/json "access plus 1 year"
     ExpiresByType application/zip "access plus 0 seconds"
     ExpiresByType application/x-gzip "access plus 0 seconds"
     ExpiresByType application/x-bzip2 "access plus 0 seconds"


### PR DESCRIPTION
Actually nginx and httpd doesn't leverage browser's cache for .json files. On webpagetest.org you will get the warning:
```
FAILED - (No max-age or expires) - https://www.website.com/pub/static/version1523427334/frontend/MODULENAME/it_IT/js-translation.json
```
This will make the files "js-translation.json" newly downloaded on every client's request.
This commit will change the default nginx and httpd configuration to make json browser's cache working better on /static/ files.