### PR TITLE
[Backport] Fix issue #13010. Check if product is assigned to current website

### DIFF
--- a/app/code/Magento/Review/Controller/Product.php
+++ b/app/code/Magento/Review/Controller/Product.php
@@ -219,6 +219,11 @@ abstract class Product extends \Magento\Framework\App\Action\Action
 
         try {
             $product = $this->productRepository->getById($productId);
+
+            if (!in_array($this->storeManager->getStore()->getWebsiteId(), $product->getWebsiteIds())) {
+                throw new NoSuchEntityException();
+            }
+
             if (!$product->isVisibleInCatalog() || !$product->isVisibleInSiteVisibility()) {
                 throw new NoSuchEntityException();
             }

--- a/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
+++ b/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
@@ -170,7 +170,13 @@ class PostTest extends \PHPUnit_Framework_TestCase
         $ratingFactory->expects($this->once())->method('create')->willReturn($this->rating);
         $this->messageManager = $this->getMock('\Magento\Framework\Message\ManagerInterface');
 
-        $this->store = $this->getMock('\Magento\Store\Model\Store', ['getId'], [], '', false);
+        $this->store = $this->getMock(
+            '\Magento\Store\Model\Store',
+            ['getId', 'getWebsiteId'],
+            [],
+            '',
+            false
+        );
         $storeManager = $this->getMockForAbstractClass('\Magento\Store\Model\StoreManagerInterface');
         $storeManager->expects($this->any())->method('getStore')->willReturn($this->store);
 
@@ -242,7 +248,7 @@ class PostTest extends \PHPUnit_Framework_TestCase
             ->willReturn(1);
         $product = $this->getMock(
             'Magento\Catalog\Model\Product',
-            ['__wakeup', 'isVisibleInCatalog', 'isVisibleInSiteVisibility', 'getId'],
+            ['__wakeup', 'isVisibleInCatalog', 'isVisibleInSiteVisibility', 'getId', 'getWebsiteIds'],
             [],
             '',
             false
@@ -253,6 +259,10 @@ class PostTest extends \PHPUnit_Framework_TestCase
         $product->expects($this->once())
             ->method('isVisibleInSiteVisibility')
             ->willReturn(true);
+        $product->expects($this->once())
+            ->method('getWebsiteIds')
+            ->willReturn([1]);
+
         $this->productRepository->expects($this->any())->method('getById')
             ->with(1)
             ->willReturn($product);
@@ -288,6 +298,8 @@ class PostTest extends \PHPUnit_Framework_TestCase
         $this->review->expects($this->once())->method('setCustomerId')->with($customerId)->willReturnSelf();
         $this->store->expects($this->exactly(2))->method('getId')
             ->willReturn($storeId);
+        $this->store->expects($this->once())->method('getWebsiteId')
+            ->willReturn(1);
         $this->review->expects($this->once())->method('setStoreId')
             ->with($storeId)
             ->willReturnSelf();


### PR DESCRIPTION
Original Pull Request
#14360

### Description
Checking if product is assigne to current website, before displaying "Write a review page". 

### Fixed Issues (if relevant)
1. magento/magento2#13010: Write a Review page works on multistore for products that are not assigned to that store

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Create an additional Website and Storefront e.g. http://www.store1.com/ and http://www.store2.com/
2. Create a product that is assigned to website 1 only
3. Ensure http://www.store1.com/catalog/product/view/id/1 shows up correctly and http://www.store2.com/catalog/product/view/id/1 throws a 404.
4. Navigate directly to the /review/product/list/id/1 page on store 2 (http://www.store2.com/review/product/list/id/1)
5. Page 404 should be displayed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)