### PR TITLE
[Forwardport] Checkout page - Fix tooltip position on mobile devices

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -1233,7 +1233,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = (@screen__m + 1)) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .abs-checkout-tooltip-content-position-top-mobile {
         @abs-checkout-tooltip-content-position-top();
     }

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1681,7 +1681,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = (@screen__m + 1)) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .abs-checkout-tooltip-content-position-top-mobile {
         @abs-checkout-tooltip-content-position-top();
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14678
### Description
Fix tooltip position on mobile devices on checkout page

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Go to checkout page on mobile device
2. Click to "?" icon near "email" or "phone" inputs

### Expected result
Tooltip should be visible, additional scroll should not be added

### Actual result
Tooltip should is visible, but additional scroll is added
![1](https://user-images.githubusercontent.com/1873745/38728725-5173dbcc-3f19-11e8-8d21-a010db0be020.png)
![2](https://user-images.githubusercontent.com/1873745/38728726-52caa3d4-3f19-11e8-83a6-1eab580b93f4.png)
![3](https://user-images.githubusercontent.com/1873745/38728728-545c8d0c-3f19-11e8-8d40-556bd57ad5d1.png)


### Notes
1 . Fixes were split into two commits to be able apply patch while fix is not released yet.
2. Issue is caused by usage different `@brake` variables in https://github.com/magento/magento2/blob/12247954d9343da4abda8bf65aa149f637b12b5d/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less#L141-L147 and https://github.com/magento/magento2/blob/1224795/app/design/frontend/Magento/blank/web/css/source/_extends.less#L1236-L1240


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
