### PR TITLE
[Forwardport] Allow to configure min and max dates for date picker component

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Date.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Date.php
@@ -167,6 +167,8 @@ class Date extends AbstractElement
                         'buttonImage' => $this->getImage(),
                         'buttonText' => 'Select Date',
                         'disabled' => $this->getDisabled(),
+                        'minDate' => $this->getMinDate(),
+                        'maxDate' => $this->getMaxDate(),
                     ],
                 ]
             )


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14552
### Description
Currently it is not possible to pass over the min and max dates for the datepicker component. This issue is fixed in this PR.

e.g. after this the date field can be used like this:
```
       $fieldset->addField(
            'my_date',
            'date',
            [
                'name' => 'my_date',
                'label' => __('Date'),
                'title' => __('Date'),
                'format' => 'yyyy-mm-dd',
                'min_date' => (new DateTimeImmutable('today+1 day'))->format('Y-m-d'),
                'max_date' => (new DateTimeImmutable('today+1 week'))->format('Y-m-d'),
                'required' => true
            ]
        );
```