### PR TITLE
[Forwardport] Fix for Issue #13950 - Cache issue with configurable products related to currency-conversions

### DIFF
--- a/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
@@ -160,7 +160,7 @@ class ProductsList extends \Magento\Catalog\Block\Product\AbstractProduct implem
 
         return [
             'CATALOG_PRODUCTS_LIST_WIDGET',
-            $this->getPriceCurrency()->getCurrencySymbol(),
+            $this->getPriceCurrency()->getCurrency()->getCode(),
             $this->_storeManager->getStore()->getId(),
             $this->_design->getDesignTheme()->getId(),
             $this->httpContext->getValue(\Magento\Customer\Model\Context::CONTEXT_GROUP),

--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
@@ -147,7 +147,9 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
         $this->request->expects($this->once())->method('getParam')->with('page_number')->willReturn(1);
 
         $this->request->expects($this->once())->method('getParams')->willReturn('request_params');
-        $this->priceCurrency->expects($this->once())->method('getCurrencySymbol')->willReturn('$');
+        $currency = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $currency->expects($this->once())->method('getCode')->willReturn('USD');
+        $this->priceCurrency->expects($this->once())->method('getCurrency')->willReturn($currency);
 
         $this->serializer->expects($this->any())
             ->method('serialize')
@@ -157,7 +159,7 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
 
         $cacheKey = [
             'CATALOG_PRODUCTS_LIST_WIDGET',
-            '$',
+            'USD',
             1,
             'blank',
             'context_group',


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14559
Its a new Pull request for https://github.com/magento/magento2/pull/14017
Old one can be closed

### Preconditions.
Magento website with configured multiple currencies, for some of currencies not configured currency symbol.

### Problem.
Two  Magento block classes used in generating  cache key (in method getCacheKeyInfo()) current currency symbol. It leads to problem that these blocks has same cache for different currencies which has no symbol configured.

### Solution.
Use currency code instead currency symbol in cache key generating to get unique cache of these block for different currencies.