### PR TITLE
Update validation.js

### DIFF
--- a/lib/web/mage/validation/validation.js
+++ b/lib/web/mage/validation/validation.js
@@ -30,7 +30,7 @@
 
                     if (val && val.length > 0) {
                         result = true;
-                        valInt = parseInt(val, 10) || 0;
+                        valInt = parseFloat(val) || 0;
 
                         if (valInt >= 0) {
                             total += valInt;


### PR DESCRIPTION
Fix to allow use decimals less then 1 in subproducts qty.
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
There is impossible to place order from grouped product where subproducts qty less then one.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14692: 'validate-grouped-qty' validation is meaningless

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set "Qty Uses Decimals" = Yes and Minimum Qty Allowed in Shopping Cart" = 0.01 for all products on any grouped product.
2. Go to groped product page on frontend.
3. Put for all suproducts qty less than 1.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
