### PR TITLE
Catalog price rule save is too slow, ignore on demand reindex

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -8,8 +8,10 @@ namespace Magento\CatalogRule\Model;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductFactory;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\CatalogRule\Api\Data\RuleExtensionInterface;
 use Magento\CatalogRule\Api\Data\RuleInterface;
 use Magento\CatalogRule\Helper\Data;
+use Magento\CatalogRule\Model\Data\Condition\Converter;
 use Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor;
 use Magento\CatalogRule\Model\ResourceModel\Rule as RuleResourceModel;
 use Magento\CatalogRule\Model\Rule\Action\CollectionFactory as RuleCollectionFactory;
@@ -18,8 +20,10 @@ use Magento\Customer\Model\Session;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Data\FormFactory;
+use Magento\Framework\DataObject;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
@@ -226,7 +230,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
         $this->dateTime = $dateTime;
         $this->_ruleProductProcessor = $ruleProductProcessor;
         $this->ruleResourceModel = $ruleResourceModel ? $ruleResourceModel :
-            \Magento\Framework\App\ObjectManager::getInstance()
+            ObjectManager::getInstance()
                 ->get(RuleResourceModel::class);
 
         parent::__construct(
@@ -391,7 +395,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     /**
      * {@inheritdoc}
      */
-    public function validateData(\Magento\Framework\DataObject $dataObject)
+    public function validateData(DataObject $dataObject)
     {
         $result = parent::validateData($dataObject);
         if ($result === true) {
@@ -806,7 +810,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      * @param \Magento\CatalogRule\Api\Data\RuleExtensionInterface $extensionAttributes
      * @return $this
      */
-    public function setExtensionAttributes(\Magento\CatalogRule\Api\Data\RuleExtensionInterface $extensionAttributes)
+    public function setExtensionAttributes(RuleExtensionInterface $extensionAttributes)
     {
         return $this->_setExtensionAttributes($extensionAttributes);
     }
@@ -818,8 +822,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     private function getRuleConditionConverter()
     {
         if (null === $this->ruleConditionConverter) {
-            $this->ruleConditionConverter = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\CatalogRule\Model\Data\Condition\Converter::class);
+            $this->ruleConditionConverter = ObjectManager::getInstance()
+                ->get(Converter::class);
         }
         return $this->ruleConditionConverter;
     }

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -18,6 +18,7 @@ use Magento\Customer\Model\Session;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Data\FormFactory;
 use Magento\Framework\DataObject\IdentityInterface;
@@ -158,7 +159,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     /**
      * @var RuleResourceModel
      */
-    protected $ruleResourceModel;
+    private $ruleResourceModel;
 
     /**
      * Rule constructor
@@ -185,7 +186,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      * @param ExtensionAttributesFactory|null $extensionFactory
      * @param AttributeValueFactory|null $customAttributeFactory
      * @param \Magento\Framework\Serialize\Serializer\Json $serializer
-     * @param \Magento\CatalogRule\Model\ResourceModel\RuleResourceModel $ruleResourceModel
+     * @param \Magento\CatalogRule\Model\ResourceModel\RuleResourceModel|null $ruleResourceModel
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -225,9 +226,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
         $this->_relatedCacheTypes = $relatedCacheTypes;
         $this->dateTime = $dateTime;
         $this->_ruleProductProcessor = $ruleProductProcessor;
-        $this->ruleResourceModel = $ruleResourceModel ? $ruleResourceModel :
-            \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(RuleResourceModel::class);
+        $this->ruleResourceModel = $ruleResourceModel ?: ObjectManager::getInstance()->get(RuleResourceModel::class);
 
         parent::__construct(
             $context,

--- a/dev/tests/integration/testsuite/Magento/CatalogRule/Model/RuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogRule/Model/RuleTest.php
@@ -33,7 +33,7 @@ class RuleTest extends \PHPUnit\Framework\TestCase
 
         $this->_object = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\CatalogRule\Model\Rule::class,
-            ['resource' => $resourceMock]
+            ['ruleResourceModel' => $resourceMock]
         );
     }
 


### PR DESCRIPTION
**Preconditions**
Have a large enough data set
Set indexing mode to Reindex on schedule
**Steps to reproduce**
Go to admin and create new catalog price rule that has condition based on category
Hit save
**Expected result**
New catalog price rule should be saved within reasonable time
**Actual result**
Request times out
**Details**
There are actually more than one thing wrong here:

1. Function after save of Magento\CatalogRule\Model\Rule walks through collection of products and triggers the reindex, regardless of indexing setting. It may do nothing, but the fact that it does go over the data set makes this action really slow. Plus, depending on third party integrations, it may trigger unwanted sync at this point. And I know that what third party extensions do is not under your control, just pointing out that something is triggered and that is not supposed to happen at this time.
3. They way it fetches the affected products is wrong. Function [getMatchingProductIds](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/CatalogRule/Model/Rule.php#L289-L321) will not scope the collection by category. And if that is your only condition, you will get whole catalog, even though the rule will affect only two products in that category. With the large enough set, code will end up checking potentially hundreds of thousands of products instead of just one category.

Combining these two, you get additional actions triggered where not necessary, on a data set that is too large in the first place hence the transaction timing out. I have observed this on just 140k products in the catalog.