### PR TITLE
Low stock report is showing empty grid #9408

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Lowstock/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Lowstock/Collection.php
@@ -303,7 +303,9 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Product\Collection
             (int)$this->stockConfiguration->getNotifyStockQty($storeId),
             $this->_getInventoryItemField('notify_stock_qty')
         );
-        $this->getSelect()->where($this->_getInventoryItemField('qty') . ' < ?', $notifyStockExpr);
+        $this->getSelect()
+            ->where($this->_getInventoryItemField('qty') . ' < ?', $notifyStockExpr)
+            ->orWhere($this->_getInventoryItemField('qty') . ' IS NULL');
         return $this;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Fixed Report Low Stock Products

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9408: Low stock report is showing empty grid


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1.  Login to admin panel
2. Create product with qty as 0 (Product >> Catalog >> Create new Product)
3. Check the low stock report ("Report >> Products >> Low stock)
Expected result:
It will show the grid with value.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
