### PR TITLE
Catalog price rule save is too slow #13378

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -21,6 +21,7 @@ use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\DataObject;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Data\FormFactory;
 use Magento\Framework\DataObject\IdentityInterface;
@@ -161,7 +162,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     /**
      * @var RuleResourceModel
      */
-    protected $ruleResourceModel;
+    private $ruleResourceModel;
 
     /**
      * Rule constructor
@@ -188,7 +189,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      * @param ExtensionAttributesFactory|null $extensionFactory
      * @param AttributeValueFactory|null $customAttributeFactory
      * @param \Magento\Framework\Serialize\Serializer\Json $serializer
-     * @param \Magento\CatalogRule\Model\ResourceModel\RuleResourceModel $ruleResourceModel
+     * @param \Magento\CatalogRule\Model\ResourceModel\RuleResourceModel|null $ruleResourceModel
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -228,9 +229,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
         $this->_relatedCacheTypes = $relatedCacheTypes;
         $this->dateTime = $dateTime;
         $this->_ruleProductProcessor = $ruleProductProcessor;
-        $this->ruleResourceModel = $ruleResourceModel ? $ruleResourceModel :
-            ObjectManager::getInstance()
-                ->get(RuleResourceModel::class);
+        $this->ruleResourceModel = $ruleResourceModel ?: ObjectManager::getInstance()->get(RuleResourceModel::class);
 
         parent::__construct(
             $context,

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -8,8 +8,10 @@ namespace Magento\CatalogRule\Model;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductFactory;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\CatalogRule\Api\Data\RuleExtensionInterface;
 use Magento\CatalogRule\Api\Data\RuleInterface;
 use Magento\CatalogRule\Helper\Data;
+use Magento\CatalogRule\Model\Data\Condition\Converter;
 use Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor;
 use Magento\CatalogRule\Model\ResourceModel\Rule as RuleResourceModel;
 use Magento\CatalogRule\Model\Rule\Action\CollectionFactory as RuleCollectionFactory;
@@ -18,6 +20,7 @@ use Magento\Customer\Model\Session;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Data\FormFactory;
 use Magento\Framework\DataObject\IdentityInterface;
@@ -226,7 +229,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
         $this->dateTime = $dateTime;
         $this->_ruleProductProcessor = $ruleProductProcessor;
         $this->ruleResourceModel = $ruleResourceModel ? $ruleResourceModel :
-            \Magento\Framework\App\ObjectManager::getInstance()
+            ObjectManager::getInstance()
                 ->get(RuleResourceModel::class);
 
         parent::__construct(
@@ -391,7 +394,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     /**
      * {@inheritdoc}
      */
-    public function validateData(\Magento\Framework\DataObject $dataObject)
+    public function validateData(DataObject $dataObject)
     {
         $result = parent::validateData($dataObject);
         if ($result === true) {
@@ -796,7 +799,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     /**
      * {@inheritdoc}
      *
-     * @return \Magento\CatalogRule\Api\Data\RuleExtensionInterface|null
+     * @return RuleExtensionInterface|null
      */
     public function getExtensionAttributes()
     {
@@ -806,10 +809,10 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     /**
      * {@inheritdoc}
      *
-     * @param \Magento\CatalogRule\Api\Data\RuleExtensionInterface $extensionAttributes
+     * @param RuleExtensionInterface $extensionAttributes
      * @return $this
      */
-    public function setExtensionAttributes(\Magento\CatalogRule\Api\Data\RuleExtensionInterface $extensionAttributes)
+    public function setExtensionAttributes(RuleExtensionInterface $extensionAttributes)
     {
         return $this->_setExtensionAttributes($extensionAttributes);
     }
@@ -821,8 +824,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     private function getRuleConditionConverter()
     {
         if (null === $this->ruleConditionConverter) {
-            $this->ruleConditionConverter = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\CatalogRule\Model\Data\Condition\Converter::class);
+            $this->ruleConditionConverter = ObjectManager::getInstance()
+                ->get(Converter::class);
         }
         return $this->ruleConditionConverter;
     }

--- a/dev/tests/integration/testsuite/Magento/CatalogRule/Model/RuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogRule/Model/RuleTest.php
@@ -33,7 +33,7 @@ class RuleTest extends \PHPUnit\Framework\TestCase
 
         $this->_object = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\CatalogRule\Model\Rule::class,
-            ['resource' => $resourceMock]
+            ['ruleResourceModel' => $resourceMock]
         );
     }
 


### PR DESCRIPTION
Backport for https://github.com/magento/magento2/pull/14704
**Preconditions**
Have a large enough data set
Set indexing mode to Reindex on schedule
**Steps to reproduce**
Go to admin and create new catalog price rule that has condition based on category
Hit save
**Expected result**
New catalog price rule should be saved within reasonable time
**Actual result**
Request times out
**Details**
There are actually more than one thing wrong here:

1. Function after save of Magento\CatalogRule\Model\Rule walks through collection of products and triggers the reindex, regardless of indexing setting. It may do nothing, but the fact that it does go over the data set makes this action really slow. Plus, depending on third party integrations, it may trigger unwanted sync at this point. And I know that what third party extensions do is not under your control, just pointing out that something is triggered and that is not supposed to happen at this time.
3. They way it fetches the affected products is wrong. Function [getMatchingProductIds](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/CatalogRule/Model/Rule.php#L289-L321) will not scope the collection by category. And if that is your only condition, you will get whole catalog, even though the rule will affect only two products in that category. With the large enough set, code will end up checking potentially hundreds of thousands of products instead of just one category.

Combining these two, you get additional actions triggered where not necessary, on a data set that is too large in the first place hence the transaction timing out. I have observed this on just 140k products in the catalog.