### PR TITLE
Add "min"/"max"/"step" attributes to add to cart qty.

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -218,6 +218,8 @@ class AbstractProduct extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Get product qty increments.
+     *
      * @return false|float
      */
     public function getQtyIncrements($product)

--- a/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -205,6 +205,29 @@ class AbstractProduct extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Gets maximal sales quantity
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     * @return int|null
+     */
+    public function getMaximalQty($product)
+    {
+        $stockItem = $this->stockRegistry->getStockItem($product->getId(), $product->getStore()->getWebsiteId());
+        $maxSaleQty = $stockItem->getMaxSaleQty();
+        return $maxSaleQty > 0 ? $maxSaleQty : null;
+    }
+
+    /**
+     * @return false|float
+     */
+    public function getQtyIncrements($product)
+    {
+        $stockItem = $this->stockRegistry->getStockItem($product->getId(), $product->getStore()->getWebsiteId());
+
+        return $stockItem->getQtyIncrements();
+    }
+
+    /**
      * Get product reviews summary
      *
      * @param \Magento\Catalog\Model\Product $product

--- a/app/code/Magento/Catalog/Block/Product/View.php
+++ b/app/code/Magento/Catalog/Block/Product/View.php
@@ -283,6 +283,12 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
         return $qty;
     }
 
+    /**
+     * Get minimal product sale qty.
+     *
+     * @param null $product
+     * @return int|null
+     */
     public function getProductMinQty($product = null)
     {
         if (!$product) {
@@ -292,6 +298,12 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
         return $this->getMinimalQty($product);;
     }
 
+    /**
+     * Get maximal produc sale qty.
+     *
+     * @param null $product
+     * @return int|null
+     */
     public function getProductMaxQty($product = null)
     {
         if (!$product) {
@@ -299,6 +311,21 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
         }
 
         return $this->getMaximalQty($product);
+    }
+
+    /**
+     * Get product qty
+     *
+     * @param null $product
+     * @return false|float
+     */
+    public function getProductQtyIncrements($product = null)
+    {
+        if (!$product) {
+            $product = $this->getProduct();
+        }
+
+        return $this->getQtyIncrements($product);
     }
 
     /**

--- a/app/code/Magento/Catalog/Block/Product/View.php
+++ b/app/code/Magento/Catalog/Block/Product/View.php
@@ -283,6 +283,24 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
         return $qty;
     }
 
+    public function getProductMinQty($product = null)
+    {
+        if (!$product) {
+            $product = $this->getProduct();
+        }
+
+        return $this->getMinimalQty($product);;
+    }
+
+    public function getProductMaxQty($product = null)
+    {
+        if (!$product) {
+            $product = $this->getProduct();
+        }
+
+        return $this->getMaximalQty($product);
+    }
+
     /**
      * Get container name, where product options should be displayed
      *

--- a/app/code/Magento/Catalog/Block/Product/View.php
+++ b/app/code/Magento/Catalog/Block/Product/View.php
@@ -295,7 +295,7 @@ class View extends AbstractProduct implements \Magento\Framework\DataObject\Iden
             $product = $this->getProduct();
         }
 
-        return $this->getMinimalQty($product);;
+        return $this->getMinimalQty($product);
     }
 
     /**

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -24,6 +24,9 @@
                        title="<?= /* @escapeNotVerified */ __('Qty') ?>"
                        class="input-text qty"
                        data-validate="<?= $block->escapeHtml(json_encode($block->getQuantityValidators())) ?>"
+                       <?php if ($minimalQty = $block->getProductMinQty()) { ?>min="<?= $minimalQty ?>" <?php } ?>
+                       <?php if ($maximalQty = $block->getProductMaxQty()) { ?>max="<?= $maximalQty ?>" <?php } ?>
+                       <?php if ($qtyIncrements = $block->getProductQtyIncrements()) { ?>step="<?= $qtyIncrements ?>" <?php } ?>
                        />
             </div>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Add attributes for qty input box related to min/max/step for input[type=number].

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
I was not looking for.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Admin > Catalog > Product and open any product for edit. Click "Advanced Inventory" link under " Quantity" field. In "Advanced Inventory" popup modal windows set values for:
 - Minimum Qty Allowed in Shopping Cart - any number
 - Maximum Qty Allowed in Shopping Cart - any number
 - Enable Qty Increments: "Yes"
 - Qty Increments: any number
 - Click "Done" button in molal and "Save" button to save product config.

2. Go to product frontend page and type some number in Qty input. Press Up/Down button, and check step for increment/decrement value, maximum and minimum values.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
Not tested,  sorry (no time).