### PR TITLE
#14669 Css class "empty" is always present on minicart dropdown

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -25,7 +25,7 @@
         </span>
     </a>
     <?php if ($block->getIsNeedToDisplaySideBar()): ?>
-        <div class="block block-minicart empty"
+        <div class="block block-minicart"
              data-role="dropdownDialog"
              data-mage-init='{"dropdownDialog":{
                 "appendTo":"[data-block=minicart]",


### PR DESCRIPTION
### Description
Removed class "empty". It was shown even if there was products in cart. As there was nothing connected with it, i supose it can be removed. 

### Fixed Issues (if relevant)
1. magento/magento2#14669: Css class "empty" is always present on minicart dropdown



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
