### PR TITLE
[2.2] Fix - minicart label fixed size issue

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -239,7 +239,6 @@
         .product-item-pricing {
             .label {
                 display: inline-block;
-                width: 4.5rem;
             }
         }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -249,7 +249,6 @@
         .product-item-pricing {
             .label {
                 display: inline-block;
-                width: 4.5rem;
             }
         }
 


### PR DESCRIPTION
minicart qty label had fixed size and with longer translation phrases input field was covering label. 

### Description
Removed row with width attribute. 

### Manual testing scenarios
1.  Add product to cart
2.  change qty label text 
3.  Longer labels overflows and goes under input field. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
