### PR TITLE
Preserve user group id when using /V1/customers/:customerId (PUT)

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
@@ -186,6 +186,13 @@ class CustomerRepository implements \Magento\Customer\Api\CustomerRepositoryInte
             $customerModel->setRpTokenCreatedAt(null);
         }
 
+        // Set group id to current stored id if no group id passed.
+        if (!($prevCustomerData === null) && $prevCustomerData->getGroupId() && $customer->getGroupId() === null) {
+            $customerModel->setGroupId(
+                $prevCustomerData->getGroupId()
+            );
+        }
+
         $this->setDefaultBilling($customerArr, $prevCustomerDataArr, $customerModel);
 
         $this->setDefaultShipping($customerArr, $prevCustomerDataArr, $customerModel);

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
@@ -160,7 +160,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
             false
         );
         $this->customer = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
-            ->setMethods(['__toArray'])
+            ->setMethods(['__toArray', 'setGroupId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->model = new \Magento\Customer\Model\ResourceModel\CustomerRepository(
@@ -187,6 +187,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $customerId = 1;
         $storeId = 2;
+        $groupId = 1;
 
         $region = $this->getMockForAbstractClass(\Magento\Customer\Api\Data\RegionInterface::class, [], '', false);
         $address = $this->getMockForAbstractClass(
@@ -222,6 +223,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
             [
                 'getId',
                 'setId',
+                'setGroupId',
                 'setStoreId',
                 'getStoreId',
                 'getAttributeSetId',
@@ -254,7 +256,8 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
                 'getEmail',
                 'getWebsiteId',
                 'getAddresses',
-                'setAddresses'
+                'setAddresses',
+                'getGroupId'
             ]
         );
         $customerSecureData = $this->getMock(
@@ -289,6 +292,17 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
             ->method('setCustomerId')
             ->with($customerId)
             ->willReturnSelf();
+
+        $this->customer->expects($this->exactly(2))
+            ->method('getGroupId')
+            ->willReturn($groupId);
+        $customerAttributesMetaData->expects($this->once())
+            ->method('getGroupId')
+            ->willReturn(null);
+        $customerModel->expects($this->once())
+            ->method('setGroupId')
+            ->with($groupId);
+
         $address->expects($this->once())
             ->method('getRegion')
             ->willReturn($region);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When you call /V1/customers/:customerId (PUT) and the customer has a group id already and you don't provide groupId in the request the customer group id is set to 1.
This fix preserves the group id.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. #14663

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
