### PR TITLE
[Forwardport] Missing ext-bcmath dependency added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "ext-spl": "*",
         "ext-xsl": "*",
         "ext-zip": "*",
+        "ext-bcmath": "*",
         "lib-libxml": "*",
         "braintree/braintree_php": "3.28.0",
         "colinmollenhour/cache-backend-file": "~1.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6206f691f045589bbf11b8417f01ef69",
+    "content-hash": "418e2abd4b2a874feeac73395c125bb6",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -837,13 +837,6 @@
                 "reference": "68522e5768edc8e829d1f64b620a3de3753f1141",
                 "shasum": ""
             },
-            "archive": {
-                "exclude": [
-                    "/demos",
-                    "/documentation",
-                    "/tests"
-                ]
-            },
             "require": {
                 "php": ">=5.2.11"
             },
@@ -862,6 +855,7 @@
                     "Zend_": "library/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "include-path": [
                 "library/"
             ],
@@ -871,14 +865,10 @@
             "description": "Magento Zend Framework 1",
             "homepage": "http://framework.zend.com/",
             "keywords": [
-                "framework",
-                "zf1"
+                "ZF1",
+                "framework"
             ],
-            "support": {
-                "source": "https://github.com/magento-engcom/zf1-php-7.2-support/tree/master",
-                "issues": "https://github.com/magento-engcom/zf1-php-7.2-support/issues"
-            },
-            "time": "2018-04-06T17:12:22+00:00"
+            "time": "2018-04-06T18:49:03+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -6604,6 +6594,7 @@
         "ext-spl": "*",
         "ext-xsl": "*",
         "ext-zip": "*",
+        "ext-bcmath": "*",
         "lib-libxml": "*"
     },
     "platform-dev": []

--- a/lib/internal/Magento/Framework/composer.json
+++ b/lib/internal/Magento/Framework/composer.json
@@ -20,6 +20,7 @@
         "ext-simplexml": "*",
         "ext-spl": "*",
         "ext-xsl": "*",
+        "ext-bcmath": "*",
         "lib-libxml": "*",
         "colinmollenhour/php-redis-session-abstract": "~1.3.8",
         "composer/composer": "^1.6",


### PR DESCRIPTION
Composer does not check availability of the "bcmath" php module. But Magento framework uses "bccomp" function in getBatchSize method of the Magento\Framework\DB\FieldDataConverter class.

### Description
This request proposes to change the composer.json file by adding requirement for the "bcmath" module.

### Fixed Issues (if relevant)
No issues exist.

### Manual testing scenarios
1. remove bcmath php module if installed.
2. run "composer update"
3. run phpunit tests: "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist"
4. error will appear about missing "bccomp" method.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
