### PR TITLE
[ForwardPort] Allow multiple tabs ui_components on a page

### DIFF
--- a/app/code/Magento/Ui/Component/Layout/Tabs.php
+++ b/app/code/Magento/Ui/Component/Layout/Tabs.php
@@ -350,15 +350,21 @@ class Tabs extends \Magento\Framework\View\Layout\Generic implements LayoutInter
     protected function addNavigationBlock()
     {
         $pageLayout = $this->component->getContext()->getPageLayout();
+
+        $navName = 'tabs_nav';
+        if ($pageLayout->hasElement($navName)) {
+            $navName = $this->component->getName() . '_tabs_nav';
+        }
+
         /** @var \Magento\Ui\Component\Layout\Tabs\Nav $navBlock */
         if (isset($this->navContainerName)) {
             $navBlock = $pageLayout->addBlock(
                 \Magento\Ui\Component\Layout\Tabs\Nav::class,
-                'tabs_nav',
+                $navName,
                 $this->navContainerName
             );
         } else {
-            $navBlock = $pageLayout->addBlock(\Magento\Ui\Component\Layout\Tabs\Nav::class, 'tabs_nav', 'content');
+            $navBlock = $pageLayout->addBlock(\Magento\Ui\Component\Layout\Tabs\Nav::class, $navName, 'content');
         }
         $navBlock->setTemplate('Magento_Ui::layout/tabs/nav/default.phtml');
         $navBlock->setData('data_scope', $this->namespace);


### PR DESCRIPTION
Original pull request: https://github.com/magento/magento2/pull/14742

### Description
When multiple UI Components are added on a page, with layout type 'tabs', this leads to an error, since both will try to add a navigation block with hardcoded name 'tabs_nav'.

### Manual testing scenarios
1. Create a page with multiple ui_components with layout type 'tabs' (e.g. 2 modals with forms in adminhtml page)

### Expected result
Both UI components will be rendered

### Actual result
The second UI component will fail to render with error message "Element with ID 'tabs_nav' already exists"