### PR TITLE
[Forwardport] Refactor Code for Mass Order Unhold

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
@@ -21,7 +21,7 @@ class MassUnhold extends AbstractMassAction
     /**
      * @var OrderManagementInterface
      */
-    protected $orderManagement;
+    private $orderManagement;
 
     /**
      * @param Context $context
@@ -33,7 +33,7 @@ class MassUnhold extends AbstractMassAction
     {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
-        $this->orderManagement = $orderManagement;
+        $this->orderManagement = $orderManagement ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Sales\Api\OrderManagementInterface::class);
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
@@ -9,6 +9,7 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Backend\App\Action\Context;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Api\OrderManagementInterface;
 
 class MassUnhold extends AbstractMassAction
 {
@@ -16,16 +17,23 @@ class MassUnhold extends AbstractMassAction
      * Authorization level of a basic admin session
      */
     const ADMIN_RESOURCE = 'Magento_Sales::unhold';
+    
+    /**
+     * @var OrderManagementInterface
+     */
+    protected $orderManagement;
 
     /**
      * @param Context $context
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
+     * @param OrderManagementInterface $orderManagement
      */
-    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory)
+    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory, OrderManagementInterface $orderManagement)
     {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
+        $this->orderManagement = $orderManagement;
     }
 
     /**
@@ -40,12 +48,10 @@ class MassUnhold extends AbstractMassAction
 
         /** @var \Magento\Sales\Model\Order $order */
         foreach ($collection->getItems() as $order) {
-            $order->load($order->getId());
             if (!$order->canUnhold()) {
                 continue;
             }
-            $order->unhold();
-            $order->save();
+            $this->orderManagement->unHold($order->getEntityId());
             $countUnHoldOrder++;
         }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
@@ -27,13 +27,19 @@ class MassUnhold extends AbstractMassAction
      * @param Context $context
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
-     * @param OrderManagementInterface $orderManagement
+     * @param OrderManagementInterface|null $orderManagement
      */
-    public function __construct(Context $context, Filter $filter, CollectionFactory $collectionFactory, OrderManagementInterface $orderManagement)
-    {
+    public function __construct(
+        Context $context,
+        Filter $filter,
+        CollectionFactory $collectionFactory,
+        OrderManagementInterface $orderManagement = null
+    ) {
         parent::__construct($context, $filter);
         $this->collectionFactory = $collectionFactory;
-        $this->orderManagement = $orderManagement ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Sales\Api\OrderManagementInterface::class);
+        $this->orderManagement = $orderManagement ?: \Magento\Framework\App\ObjectManager::getInstance()->get(
+            \Magento\Sales\Api\OrderManagementInterface::class
+        );
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassUnholdTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassUnholdTest.php
@@ -85,6 +85,11 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
      */
     protected $filterMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $orderManagementMock;
+
     protected function setUp()
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
@@ -146,12 +151,15 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($this->orderCollectionMock);
 
+        $this->orderManagementMock = $this->createMock(\Magento\Sales\Api\OrderManagementInterface::class);
+
         $this->massAction = $objectManagerHelper->getObject(
             \Magento\Sales\Controller\Adminhtml\Order\MassUnhold::class,
             [
                 'context' => $this->contextMock,
                 'filter' => $this->filterMock,
-                'collectionFactory' => $this->orderCollectionFactoryMock
+                'collectionFactory' => $this->orderCollectionFactoryMock,
+                'orderManagement' => $this->orderManagementMock
             ]
         );
     }
@@ -175,9 +183,7 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
             ->method('canUnhold')
             ->willReturn(true);
         $order1->expects($this->once())
-            ->method('unhold');
-        $order1->expects($this->once())
-            ->method('save');
+            ->method('getEntityId');
 
         $this->orderCollectionMock->expects($this->once())
             ->method('count')
@@ -186,6 +192,8 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
         $order2->expects($this->once())
             ->method('canUnhold')
             ->willReturn(false);
+
+        $this->orderManagementMock->expects($this->atLeastOnce())->method('unHold')->willReturn(true);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addError')


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14629
### Description
I have observed that MassAction Unhold is using the collection to release order from hold, whereas MassAction Hold is using Interface to put the order on hold.
So, I have refactor code in app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php same as in app/code/Magento/Sales/Controller/Adminhtml/Order/MassHold.php

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Sales -> Order
2. Select any number of orders (orders which are on hold.) 
3. Select Unhold Action from the Action dropdown.
