### PR TITLE
[Forwardport] magento/magento2#13765 Excess requests 'customer data' on checkout cart page were fixed

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
@@ -14,17 +14,19 @@ define([
     'use strict';
 
     var quoteItems = ko.observable(quote.totals().items),
-        cartData = customerData.get('cart'),
-        quoteSubtotal = parseFloat(quote.totals().subtotal),
-        subtotalAmount = parseFloat(cartData().subtotalAmount);
+        cartData = customerData.get('cart');
 
     quote.totals.subscribe(function (newValue) {
         quoteItems(newValue.items);
     });
 
-    if (quoteSubtotal !== subtotalAmount) {
-        customerData.reload(['cart'], false);
-    }
+    cartData.subscribe(function () {
+        var quoteSubtotal = parseFloat(quote.totals().subtotal),
+            subtotalAmount = parseFloat(cartData().subtotalAmount);
+        if (quoteSubtotal !== subtotalAmount) {
+            customerData.reload(['cart'], false);
+        }
+    }, this);
 
     return {
         totals: quote.totals,

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
@@ -23,6 +23,7 @@ define([
     cartData.subscribe(function () {
         var quoteSubtotal = parseFloat(quote.totals().subtotal),
             subtotalAmount = parseFloat(cartData().subtotalAmount);
+
         if (quoteSubtotal !== subtotalAmount) {
             customerData.reload(['cart'], false);
         }

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
@@ -94,6 +94,7 @@ define([
                 this.isLoading(addToCartCalls > 0);
                 sidebarInitialized = false;
                 this.update(updatedCart);
+
                 if (cartData()['website_id'] !== window.checkout.websiteId) {
                     customerData.reload(['cart'], false);
                 }

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
@@ -94,16 +94,15 @@ define([
                 this.isLoading(addToCartCalls > 0);
                 sidebarInitialized = false;
                 this.update(updatedCart);
+                if (cartData()['website_id'] !== window.checkout.websiteId) {
+                    customerData.reload(['cart'], false);
+                }
                 initSidebar();
             }, this);
             $('[data-block="minicart"]').on('contentLoading', function () {
                 addToCartCalls++;
                 self.isLoading(true);
             });
-
-            if (cartData()['website_id'] !== window.checkout.websiteId) {
-                customerData.reload(['cart'], false);
-            }
 
             return this._super();
         },

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -232,9 +232,11 @@ define([
             if (!_.isEmpty(privateContent)) {
                 countryData = this.get('directory-data');
 
-                if (_.isEmpty(countryData())) {
-                    customerData.reload(['directory-data'], false);
-                }
+                countryData.subscribe(function () {
+                    if (_.isEmpty(countryData())) {
+                        customerData.reload(['directory-data'], false);
+                    }
+                }, this);
             }
         },
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14314
### Description
The customer/section/load gets called 4 times when loading the cart for the first time. 3 of those times, cart data gets returned. On Magento 2.1, I believe only two calls are made to customer/section/load.

### Fixed Issues (if relevant)
1. magento/magento2#13765: "cart" section data gets loaded 3 times on cart page (2.2.2)

### Steps to reproduce
1. Add any product to cart
2. Go to cart page `/checkout/cart` with the "Network" panel open in DevTools.
### Expected result
1. The `/customer/section/load` url should only get called twice. For example, these are the two urls that get called on a Magento 2.1 install:
```
https://magento22.dev/customer/section/load/?sections=&update_section_id=false&_=1519190370042
https://magento22.dev/customer/section/load/?sections=directory-data&update_section_id=false&_=1519190370043
```

### Actual result
1. The `/customer/section/load` url will get called four times:
```
https://magento22.dev/customer/section/load/?sections=&update_section_id=false&_=1519190370042
https://magento22.dev/customer/section/load/?sections=directory-data&update_section_id=false&_=1519190370043
https://magento22.dev/customer/section/load/?sections=cart&update_section_id=false&_=1519190370045
https://magento22.dev/customer/section/load/?sections=cart&update_section_id=false&_=1519190370046
```

Note: if you refresh the cart, there will only be two calls made to `/customer/section/load`.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)