### PR TITLE
Fix for issue 911 found on MSI project - Cannot read property source_…

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows-grid.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows-grid.js
@@ -109,9 +109,8 @@ define([
          * @param {String|Number} recordId
          */
         deleteRecord: function (index, recordId) {
-            this._super();
-
             this.updateInsertData(recordId);
+            this._super();
         },
 
         /**


### PR DESCRIPTION
…code of undefined

Dynamic data rows were failing due to a read after delete condition
Rows were removed just before the information update. An undefined javascript error was triggered.

This issue has ben found in MSI, but it comes from core implementation.

### Fixed Issues (if relevant)
1. magento-engcom/msi#911: Cannot read property source_code of undefined

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
