### PR TITLE
[Forwardport] Add argument on app:config:dump to skip dumping all system settings.

### DIFF
--- a/app/code/Magento/Deploy/Console/Command/App/ApplicationDumpCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/App/ApplicationDumpCommand.php
@@ -76,8 +76,7 @@ class ApplicationDumpCommand extends Command
         $this->addArgument(
             self::INPUT_CONFIG_TYPES,
             InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            sprintf('Space-separated list of config types or omit to dump all [%s]',
-                implode(', ', $this->configTypes))
+            sprintf('Space-separated list of config types or omit to dump all [%s]', implode(', ', $this->configTypes))
         );
         parent::configure();
     }

--- a/app/code/Magento/Deploy/Console/Command/App/ApplicationDumpCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/App/ApplicationDumpCommand.php
@@ -24,16 +24,6 @@ class ApplicationDumpCommand extends Command
     const INPUT_CONFIG_TYPES = 'config-types';
 
     /**
-     * @var array
-     */
-    private $configTypes = [
-        \Magento\Store\App\Config\Type\Scopes::CONFIG_TYPE,
-        \Magento\Deploy\Source\Themes::TYPE,
-        \Magento\Translation\App\Config\Type\Translation::CONFIG_TYPE,
-        \Magento\Config\App\Config\Type\System::CONFIG_TYPE,
-    ];
-
-    /**
      * @var Writer
      */
     private $writer;
@@ -60,10 +50,10 @@ class ApplicationDumpCommand extends Command
         array $sources,
         Hash $configHash = null
     ) {
-        parent::__construct();
         $this->writer = $writer;
         $this->sources = $sources;
         $this->configHash = $configHash ?: ObjectManager::getInstance()->get(Hash::class);
+        parent::__construct();
     }
 
     /**
@@ -73,10 +63,12 @@ class ApplicationDumpCommand extends Command
     {
         $this->setName('app:config:dump');
         $this->setDescription('Create dump of application');
+
+        $configTypes = array_unique(array_column($this->sources, 'namespace'));
         $this->addArgument(
             self::INPUT_CONFIG_TYPES,
             InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            sprintf('Space-separated list of config types or omit to dump all [%s]', implode(', ', $this->configTypes))
+            sprintf('Space-separated list of config types or omit to dump all [%s]', implode(', ', $configTypes))
         );
         parent::configure();
     }

--- a/app/code/Magento/Deploy/Console/Command/App/ApplicationDumpCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/App/ApplicationDumpCommand.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -20,6 +21,18 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ApplicationDumpCommand extends Command
 {
+    const INPUT_CONFIG_TYPES = 'config-types';
+
+    /**
+     * @var array
+     */
+    private $configTypes = [
+        \Magento\Store\App\Config\Type\Scopes::CONFIG_TYPE,
+        \Magento\Deploy\Source\Themes::TYPE,
+        \Magento\Translation\App\Config\Type\Translation::CONFIG_TYPE,
+        \Magento\Config\App\Config\Type\System::CONFIG_TYPE,
+    ];
+
     /**
      * @var Writer
      */
@@ -60,6 +73,12 @@ class ApplicationDumpCommand extends Command
     {
         $this->setName('app:config:dump');
         $this->setDescription('Create dump of application');
+        $this->addArgument(
+            self::INPUT_CONFIG_TYPES,
+            InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+            sprintf('Space-separated list of config types or omit to dump all [%s]',
+                implode(', ', $this->configTypes))
+        );
         parent::configure();
     }
 
@@ -74,11 +93,14 @@ class ApplicationDumpCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->groupSourcesByPool();
-
+        $dumpedTypes = [];
         foreach ($this->sources as $pool => $sources) {
             $dump = [];
             $comments = [];
             foreach ($sources as $sourceData) {
+                if ($this->skipDump($input, $sourceData)) {
+                    continue;
+                }
                 /** @var ConfigSourceInterface $source */
                 $source = $sourceData['source'];
                 $namespace = $sourceData['namespace'];
@@ -95,15 +117,21 @@ class ApplicationDumpCommand extends Command
                 null,
                 $comments
             );
+            $dumpedTypes = array_unique($dumpedTypes + array_keys($dump));
             if (!empty($comments)) {
                 $output->writeln($comments);
             }
         }
 
+        if (!$dumpedTypes) {
+            $output->writeln('<error>Nothing dumped. Check the config types specified and try again');
+            return Cli::RETURN_FAILURE;
+        }
+
         // Generate and save new hash of deployment configuration.
         $this->configHash->regenerate();
 
-        $output->writeln('<info>Done.</info>');
+        $output->writeln(sprintf('<info>Done. Config types dumped: %s</info>', implode(', ', $dumpedTypes)));
         return Cli::RETURN_SUCCESS;
     }
 
@@ -126,5 +154,21 @@ class ApplicationDumpCommand extends Command
         }
 
         $this->sources = $sources;
+    }
+
+    /**
+     * Check whether the dump source should be skipped
+     *
+     * @param InputInterface $input
+     * @param array $sourceData
+     * @return bool
+     */
+    private function skipDump(InputInterface $input, array $sourceData): bool
+    {
+        $allowedTypes = $input->getArgument(self::INPUT_CONFIG_TYPES);
+        if ($allowedTypes && !in_array($sourceData['namespace'], $allowedTypes)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/ApplicationDumpCommandTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/ApplicationDumpCommandTest.php
@@ -130,7 +130,7 @@ class ApplicationDumpCommandTest extends \PHPUnit\Framework\TestCase
             ->method('writeln')
             ->withConsecutive(
                 [['system' => 'Some comment message']],
-                ['<info>Done.</info>']
+                ['<info>Done. Config types dumped: system</info>']
             );
 
         $method = new \ReflectionMethod(ApplicationDumpCommand::class, 'execute');

--- a/dev/tests/integration/testsuite/Magento/Deploy/Console/Command/App/ApplicationDumpCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/Console/Command/App/ApplicationDumpCommandTest.php
@@ -176,7 +176,7 @@ class ApplicationDumpCommandTest extends \PHPUnit\Framework\TestCase
             ->with(['system' => $comment]);
         $outputMock->expects($this->at(1))
             ->method('writeln')
-            ->with('<info>Done.</info>');
+            ->with('<info>Done. Config types dumped: scopes, themes, system, i18n</info>');
 
         /** @var ApplicationDumpCommand command */
         $command = $this->objectManager->create(ApplicationDumpCommand::class);

--- a/dev/tests/integration/testsuite/Magento/Deploy/Console/Command/App/ApplicationDumpCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/Console/Command/App/ApplicationDumpCommandTest.php
@@ -176,7 +176,7 @@ class ApplicationDumpCommandTest extends \PHPUnit\Framework\TestCase
             ->with(['system' => $comment]);
         $outputMock->expects($this->at(1))
             ->method('writeln')
-            ->with('<info>Done. Config types dumped: scopes, themes, system, i18n</info>');
+            ->with('<info>Done. Config types dumped: scopes, system, themes, i18n</info>');
 
         /** @var ApplicationDumpCommand command */
         $command = $this->objectManager->create(ApplicationDumpCommand::class);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/12410
### Description
Add option `config-types` on `app:config:dump` to skip dumping all system settings. That allows to dump only `scope`, `theme` for easier maintainability.

### Fixed Issues
When using `app:config:dump` in real projects, we normally do not want to dump all thousands `core_config_data` settings into config files. That makes the files difficult to read and maintain. Imho dumping `scopes` and `themes` makes a lot of sense. However, the system settings should be kept small and simple. They must be progressively added according to project needs.

On the other hand, the main purpose of `config.php` is to propagate configuration that must be same in all environments, specially for `PRD` and `Build` systems. These settings should be just a few, like for example `css` and `js` configuration needed for `setup:static-content:deploy`. Of course others settings might be needed depending on the project but all the others are better managed into `core_config_data` table or by using setup scripts.

This new option `config-types` makes possible to dump `scopes` and `themes` automatically (needed for build system) while managing system settings manually using `config:set --lock-config` as requested in PR:

* #12178

It also fixes this issue:

* https://github.com/magento/magento2/issues/11396

### Manual testing scenarios

Example of workflow on a real project:

0. When creating the project we dump all settings with `app:config:dump scopes themes`
0. That creates the needed settings for `scopes` and `themes` but skips `system` core config data
0. We also add shared settings needed for `PRD` and `Build` environments

    ```
    bin/magento config:set --lock-config dev/js/merge_files 1
    bin/magento config:set --lock-config dev/css/merge_css_files 1
    bin/magento config:set --lock-config dev/static/sign 1
    ```

0. As project evolves, we add a new stores and themes, so we need to update our `config.php` settings.

    ```
    bin/magento app:config:dump  scopes themes
    ```

0. At the same time, if we ever need to `share` system settings on all environments, we can use the command `bin/magento config:set --lock-config` without needing to dump all hundreds of settings into the `config.php`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
