### PR TITLE
[Forwardport] Display Wrong Data On Cart Update Page

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
@@ -22,6 +22,7 @@
         <input type="hidden" name="product" value="<?= /* @escapeNotVerified */ $_product->getId() ?>" />
         <input type="hidden" name="selected_configurable_option" value="" />
         <input type="hidden" name="related_product" id="related-products-field" value="" />
+        <input type="hidden" name="item"  value="<?= $block->getRequest()->getParam('id') ?>" />
         <?= $block->getBlockHtml('formkey') ?>
         <?= $block->getChildHtml('form_top') ?>
         <?php if (!$block->hasOptions()):?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
@@ -22,7 +22,7 @@
         <input type="hidden" name="product" value="<?= /* @escapeNotVerified */ $_product->getId() ?>" />
         <input type="hidden" name="selected_configurable_option" value="" />
         <input type="hidden" name="related_product" id="related-products-field" value="" />
-        <input type="hidden" name="item"  value="<?= $block->getRequest()->getParam('id') ?>" />
+        <input type="hidden" name="item"  value="<?= /* @noEscape */ $block->getRequest()->getParam('id') ?>" />
         <?= $block->getBlockHtml('formkey') ?>
         <?= $block->getChildHtml('form_top') ?>
         <?php if (!$block->hasOptions()):?>

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/configure/product-customer-data.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/configure/product-customer-data.js
@@ -7,10 +7,12 @@ require([
 
     var selectors = {
         qtySelector: '#product_addtocart_form [name="qty"]',
-        productIdSelector: '#product_addtocart_form [name="product"]'
+        productIdSelector: '#product_addtocart_form [name="product"]',
+        itemIdSelector: '#product_addtocart_form [name="item"]'
     },
     cartData = customerData.get('cart'),
     productId = $(selectors.productIdSelector).val(),
+    itemId = $(selectors.itemIdSelector).val(),
     productQty,
     productQtyInput,
 
@@ -40,8 +42,10 @@ require([
             return;
         }
         product = data.items.find(function (item) {
-            return item['product_id'] === productId ||
-                item['item_id'] === productId;
+            if (item['item_id'] == itemId) {
+                return item['product_id'] === productId ||
+                    item['item_id'] === productId;
+            }
         });
 
         if (!product) {

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/configure/product-customer-data.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/configure/product-customer-data.js
@@ -42,7 +42,7 @@ require([
             return;
         }
         product = data.items.find(function (item) {
-            if (item['item_id'] == itemId) {
+            if (item['item_id'] === itemId) {
                 return item['product_id'] === productId ||
                     item['item_id'] === productId;
             }

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
@@ -7,10 +7,12 @@ define([
 
     var selectors = {
         formSelector: '#product_addtocart_form',
-        productIdSelector: '#product_addtocart_form [name="product"]'
+        productIdSelector: '#product_addtocart_form [name="product"]',
+        itemIdSelector:'#product_addtocart_form [name="item"]'
     },
     cartData = customerData.get('cart'),
     productId = $(selectors.productIdSelector).val(),
+    itemId= $(selectors.itemIdSelector).val(),
 
     /**
     * set productOptions according to cart data from customer-data
@@ -24,8 +26,10 @@ define([
         if (!(data && data.items && data.items.length && productId)) {
             return false;
         }
-        changedProductOptions = _.find(data.items, function (item) {
-            return item['product_id'] === productId;
+        changedProductOptions = data.items.find(function (item) {
+            if (item['item_id'] == itemId) {
+                return item['product_id'] === productId;
+            }
         });
         changedProductOptions = changedProductOptions && changedProductOptions.options &&
             changedProductOptions.options.reduce(function (obj, val) {

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
@@ -8,11 +8,11 @@ define([
     var selectors = {
         formSelector: '#product_addtocart_form',
         productIdSelector: '#product_addtocart_form [name="product"]',
-        itemIdSelector:'#product_addtocart_form [name="item"]'
+        itemIdSelector: '#product_addtocart_form [name="item"]'
     },
     cartData = customerData.get('cart'),
     productId = $(selectors.productIdSelector).val(),
-    itemId= $(selectors.itemIdSelector).val(),
+    itemId = $(selectors.itemIdSelector).val(),
 
     /**
     * set productOptions according to cart data from customer-data
@@ -27,7 +27,7 @@ define([
             return false;
         }
         changedProductOptions = data.items.find(function (item) {
-            if (item['item_id'] == itemId) {
+            if (item['item_id'] === itemId) {
                 return item['product_id'] === productId;
             }
         });


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14765
If we add configurable product in cart with different options And We need to update 1st item from the cart. So we click edit icon and open Update Cart Page But Quantity and Options display wrong on this page.

### Description
This request proposes to set Product options and quantity by checking Item Id.

### Fixed Issues (if relevant)
1.
2. ...

### Manual testing scenarios
1. Create Configurable product.
2. Add that product in cart with Different options and Quantity.
3. Now Update 1st item.So click on update item icon.
4. Update Cart page open .
5. Quantity and selected option display wrong on this page.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
