### PR TITLE
[Forwardport] CSS load order incorrect using default_head_blocks.xml #1821

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/head.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/head.xsd
@@ -18,6 +18,7 @@
         <xs:attribute name="sizes" type="xs:string"/>
         <xs:attribute name="target" type="xs:string"/>
         <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="order" type="xs:integer"/>
         <xs:attribute name="src_type" type="xs:string"/>
     </xs:complexType>
 

--- a/lib/internal/Magento/Framework/View/Page/Config/Generator/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Generator/Head.php
@@ -42,6 +42,7 @@ class Head implements Layout\GeneratorInterface
      */
     protected $assetProperties = [
         'ie_condition',
+        'order'
     ];
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
@@ -71,38 +71,49 @@ class Head implements Layout\ReaderInterface
         Layout\Element $headElement
     ) {
         $pageConfigStructure = $readerContext->getPageConfigStructure();
-        /** @var \Magento\Framework\View\Layout\Element $node */
+
+        $orderedNodes = [];
+
         foreach ($headElement as $node) {
-            switch ($node->getName()) {
-                case self::HEAD_CSS:
-                case self::HEAD_SCRIPT:
-                case self::HEAD_LINK:
-                    $this->addContentTypeByNodeName($node);
-                    $pageConfigStructure->addAssets($node->getAttribute('src'), $this->getAttributes($node));
-                    break;
+            $nodeOrder = $node->getAttribute('order') ?: 0;
+            $orderedNodes[$nodeOrder][] = $node;
+        }
 
-                case self::HEAD_REMOVE:
-                    $pageConfigStructure->removeAssets($node->getAttribute('src'));
-                    break;
+        ksort($orderedNodes);
+        foreach ($orderedNodes as $nodes ) {
+            /** @var \Magento\Framework\View\Layout\Element $node */
+            foreach ($nodes as $node) {
+                switch ($node->getName()) {
+                    case self::HEAD_CSS:
+                    case self::HEAD_SCRIPT:
+                    case self::HEAD_LINK:
+                        $this->addContentTypeByNodeName($node);
+                        $pageConfigStructure->addAssets($node->getAttribute('src'), $this->getAttributes($node));
+                        break;
 
-                case self::HEAD_TITLE:
-                    $pageConfigStructure->setTitle(new \Magento\Framework\Phrase($node));
-                    break;
+                    case self::HEAD_REMOVE:
+                        $pageConfigStructure->removeAssets($node->getAttribute('src'));
+                        break;
 
-                case self::HEAD_META:
-                    $this->setMetadata($pageConfigStructure, $node);
-                    break;
+                    case self::HEAD_TITLE:
+                        $pageConfigStructure->setTitle(new \Magento\Framework\Phrase($node));
+                        break;
 
-                case self::HEAD_ATTRIBUTE:
-                    $pageConfigStructure->setElementAttribute(
-                        PageConfig::ELEMENT_TYPE_HEAD,
-                        $node->getAttribute('name'),
-                        $node->getAttribute('value')
-                    );
-                    break;
+                    case self::HEAD_META:
+                        $this->setMetadata($pageConfigStructure, $node);
+                        break;
 
-                default:
-                    break;
+                    case self::HEAD_ATTRIBUTE:
+                        $pageConfigStructure->setElementAttribute(
+                            PageConfig::ELEMENT_TYPE_HEAD,
+                            $node->getAttribute('name'),
+                            $node->getAttribute('value')
+                        );
+                        break;
+
+                    default:
+                        break;
+                }
             }
         }
         return $this;

--- a/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
@@ -71,51 +71,53 @@ class Head implements Layout\ReaderInterface
         Layout\Element $headElement
     ) {
         $pageConfigStructure = $readerContext->getPageConfigStructure();
-
-        $orderedNodes = [];
+        $nodes = [];
 
         foreach ($headElement as $node) {
-            $nodeOrder = $node->getAttribute('order') ?: 0;
-            $orderedNodes[$nodeOrder][] = $node;
+            $nodes[] = $node;
         }
 
-        ksort($orderedNodes);
-        foreach ($orderedNodes as $nodes ) {
-            /** @var \Magento\Framework\View\Layout\Element $node */
-            foreach ($nodes as $node) {
-                switch ($node->getName()) {
-                    case self::HEAD_CSS:
-                    case self::HEAD_SCRIPT:
-                    case self::HEAD_LINK:
-                        $this->addContentTypeByNodeName($node);
-                        $pageConfigStructure->addAssets($node->getAttribute('src'), $this->getAttributes($node));
-                        break;
+        usort(
+            $nodes,
+            function (Layout\Element $current, Layout\Element $next) {
+                return $current->getAttribute('order') > $next->getAttribute('order');
+            }
+        );
 
-                    case self::HEAD_REMOVE:
-                        $pageConfigStructure->removeAssets($node->getAttribute('src'));
-                        break;
+        foreach ($nodes as $node) {
+            switch ($node->getName()) {
+                case self::HEAD_CSS:
+                case self::HEAD_SCRIPT:
+                case self::HEAD_LINK:
+                    $this->addContentTypeByNodeName($node);
+                    $pageConfigStructure->addAssets($node->getAttribute('src'), $this->getAttributes($node));
+                    break;
 
-                    case self::HEAD_TITLE:
-                        $pageConfigStructure->setTitle(new \Magento\Framework\Phrase($node));
-                        break;
+                case self::HEAD_REMOVE:
+                    $pageConfigStructure->removeAssets($node->getAttribute('src'));
+                    break;
 
-                    case self::HEAD_META:
-                        $this->setMetadata($pageConfigStructure, $node);
-                        break;
+                case self::HEAD_TITLE:
+                    $pageConfigStructure->setTitle(new \Magento\Framework\Phrase($node));
+                    break;
 
-                    case self::HEAD_ATTRIBUTE:
-                        $pageConfigStructure->setElementAttribute(
-                            PageConfig::ELEMENT_TYPE_HEAD,
-                            $node->getAttribute('name'),
-                            $node->getAttribute('value')
-                        );
-                        break;
+                case self::HEAD_META:
+                    $this->setMetadata($pageConfigStructure, $node);
+                    break;
 
-                    default:
-                        break;
-                }
+                case self::HEAD_ATTRIBUTE:
+                    $pageConfigStructure->setElementAttribute(
+                        PageConfig::ELEMENT_TYPE_HEAD,
+                        $node->getAttribute('name'),
+                        $node->getAttribute('value')
+                    );
+                    break;
+
+                default:
+                    break;
             }
         }
+
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
@@ -71,16 +71,12 @@ class Head implements Layout\ReaderInterface
         Layout\Element $headElement
     ) {
         $pageConfigStructure = $readerContext->getPageConfigStructure();
-        $nodes = [];
-
-        foreach ($headElement as $node) {
-            $nodes[] = $node;
-        }
+        $nodes = iterator_to_array($headElement, false);
 
         usort(
             $nodes,
             function (Layout\Element $current, Layout\Element $next) {
-                return $current->getAttribute('order') > $next->getAttribute('order');
+                return $current->getAttribute('order') <=> $next->getAttribute('order');
             }
         );
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -82,6 +82,20 @@ class HeadTest extends \PHPUnit\Framework\TestCase
                 'content_type' => 'css',
                 'media' => 'all',
             ],
+            'remoteCssOrderedLast' => [
+                'src' => 'file-url-css-last',
+                'src_type' => 'url',
+                'content_type' => 'css',
+                'media' => 'all',
+                'order' => 30,
+            ],
+            'remoteCssOrderedFirst' => [
+                'src' => 'file-url-css-first',
+                'src_type' => 'url',
+                'content_type' => 'css',
+                'media' => 'all',
+                'order' => 10,
+            ],
             'remoteLink' => [
                 'src' => 'file-url-link',
                 'src_type' => 'url',
@@ -106,8 +120,14 @@ class HeadTest extends \PHPUnit\Framework\TestCase
             ->with('file-url-css', 'css', ['attributes' => ['media' => 'all']]);
         $this->pageConfigMock->expects($this->at(1))
             ->method('addRemotePageAsset')
-            ->with('file-url-link', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]);
+            ->with('file-url-css-last','css', ['attributes' => ['media' => 'all' ] , 'order' => 30]);
         $this->pageConfigMock->expects($this->at(2))
+            ->method('addRemotePageAsset')
+            ->with('file-url-css-first','css', ['attributes' => ['media' => 'all'] , 'order' => 10]);
+        $this->pageConfigMock->expects($this->at(3))
+            ->method('addRemotePageAsset')
+            ->with('file-url-link', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]);
+        $this->pageConfigMock->expects($this->at(4))
             ->method('addRemotePageAsset')
             ->with('http://magento.dev/customcss/render/css', 'css', ['attributes' => ['media' => 'all']]);
         $this->pageConfigMock->expects($this->once())

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -150,7 +150,7 @@ class HeadTest extends \PHPUnit\Framework\TestCase
                     'src_type' => 'url',
                     'content_type' => 'css',
                     'media' => 'all',
-                ],
+                    ],
                     'remoteCssOrderedLast' => [
                         'src' => 'file-url-css-last',
                         'src_type' => 'url',

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -120,10 +120,10 @@ class HeadTest extends \PHPUnit\Framework\TestCase
             ->with('file-url-css', 'css', ['attributes' => ['media' => 'all']]);
         $this->pageConfigMock->expects($this->at(1))
             ->method('addRemotePageAsset')
-            ->with('file-url-css-last','css', ['attributes' => ['media' => 'all' ] , 'order' => 30]);
+            ->with('file-url-css-last', 'css', ['attributes' => ['media' => 'all' ] , 'order' => 30]);
         $this->pageConfigMock->expects($this->at(2))
             ->method('addRemotePageAsset')
-            ->with('file-url-css-first','css', ['attributes' => ['media' => 'all'] , 'order' => 10]);
+            ->with('file-url-css-first', 'css', ['attributes' => ['media' => 'all'] , 'order' => 10]);
         $this->pageConfigMock->expects($this->at(3))
             ->method('addRemotePageAsset')
             ->with('file-url-link', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]);

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -60,7 +60,12 @@ class HeadTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testProcess()
+    /**
+     * @param array $assets
+     *
+     * @dataProvider testProcessAssetDataProvider
+     */
+    public function testProcess($assets)
     {
         $generatorContextMock = $this->createMock(Context::class);
         $this->title->expects($this->any())->method('set')->with()->will($this->returnSelf());
@@ -74,46 +79,6 @@ class HeadTest extends \PHPUnit\Framework\TestCase
             ->method('getUrl')
             ->with('customcss/render/css')
             ->willReturn('http://magento.dev/customcss/render/css');
-
-        $assets = [
-            'remoteCss' => [
-                'src' => 'file-url-css',
-                'src_type' => 'url',
-                'content_type' => 'css',
-                'media' => 'all',
-            ],
-            'remoteCssOrderedLast' => [
-                'src' => 'file-url-css-last',
-                'src_type' => 'url',
-                'content_type' => 'css',
-                'media' => 'all',
-                'order' => 30,
-            ],
-            'remoteCssOrderedFirst' => [
-                'src' => 'file-url-css-first',
-                'src_type' => 'url',
-                'content_type' => 'css',
-                'media' => 'all',
-                'order' => 10,
-            ],
-            'remoteLink' => [
-                'src' => 'file-url-link',
-                'src_type' => 'url',
-                'media' => 'all',
-            ],
-            'controllerCss' => [
-                'src' => 'customcss/render/css',
-                'src_type' => 'controller',
-                'content_type' => 'css',
-                'media' => 'all',
-            ],
-            'name' => [
-                'src' => 'file-path',
-                'ie_condition' => 'lt IE 7',
-                'content_type' => 'css',
-                'media' => 'print',
-            ],
-        ];
 
         $this->pageConfigMock->expects($this->at(0))
             ->method('addRemotePageAsset')
@@ -173,5 +138,52 @@ class HeadTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->headGenerator->process($readerContextMock, $generatorContextMock);
         $this->assertEquals($this->headGenerator, $result);
+    }
+
+    public function testProcessAssetDataProvider()
+    {
+        return [
+            [
+                'assets' => [
+                    'remoteCss' => [
+                    'src' => 'file-url-css',
+                    'src_type' => 'url',
+                    'content_type' => 'css',
+                    'media' => 'all',
+                ],
+                    'remoteCssOrderedLast' => [
+                        'src' => 'file-url-css-last',
+                        'src_type' => 'url',
+                        'content_type' => 'css',
+                        'media' => 'all',
+                        'order' => 30,
+                    ],
+                    'remoteCssOrderedFirst' => [
+                        'src' => 'file-url-css-first',
+                        'src_type' => 'url',
+                        'content_type' => 'css',
+                        'media' => 'all',
+                        'order' => 10,
+                    ],
+                    'remoteLink' => [
+                        'src' => 'file-url-link',
+                        'src_type' => 'url',
+                        'media' => 'all',
+                    ],
+                    'controllerCss' => [
+                        'src' => 'customcss/render/css',
+                        'src_type' => 'controller',
+                        'content_type' => 'css',
+                        'media' => 'all',
+                    ],
+                    'name' => [
+                        'src' => 'file-path',
+                        'ie_condition' => 'lt IE 7',
+                        'content_type' => 'css',
+                        'media' => 'print',
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
@@ -59,7 +59,7 @@ class HeadTest extends \PHPUnit\Framework\TestCase
 
         $structureMock->expects($this->at(4))
             ->method('addAssets')
-            ->with('path/file.css', ['src' => 'path/file.css', 'media' => 'all', 'content_type' => 'css'])
+            ->with('path/file-3.css', ['src' => 'path/file-3.css', 'media' => 'all', 'content_type' => 'css'])
             ->willReturnSelf();
 
         $structureMock->expects($this->at(5))
@@ -80,6 +80,16 @@ class HeadTest extends \PHPUnit\Framework\TestCase
         $structureMock->expects($this->at(8))
             ->method('setElementAttribute')
             ->with(Config::ELEMENT_TYPE_HEAD, 'head_attribute_name', 'head_attribute_value')
+            ->willReturnSelf();
+
+        $structureMock->expects($this->at(9))
+            ->method('addAssets')
+            ->with('path/file-1.css', ['src' => 'path/file-1.css', 'media' => 'all', 'content_type' => 'css', 'order' => 10])
+            ->willReturnSelf();
+
+        $structureMock->expects($this->at(10))
+            ->method('addAssets')
+            ->with('path/file-2.css', ['src' => 'path/file-2.css', 'media' => 'all', 'content_type' => 'css', 'order' => 30])
             ->willReturnSelf();
 
         $this->assertEquals($this->model, $this->model->interpret($readerContextMock, $element->children()[0]));

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
@@ -84,12 +84,22 @@ class HeadTest extends \PHPUnit\Framework\TestCase
 
         $structureMock->expects($this->at(9))
             ->method('addAssets')
-            ->with('path/file-1.css', ['src' => 'path/file-1.css', 'media' => 'all', 'content_type' => 'css', 'order' => 10])
+            ->with('path/file-1.css', [
+                'src' => 'path/file-1.css',
+                'media' => 'all',
+                'content_type' => 'css',
+                'order' => 10
+            ])
             ->willReturnSelf();
 
         $structureMock->expects($this->at(10))
             ->method('addAssets')
-            ->with('path/file-2.css', ['src' => 'path/file-2.css', 'media' => 'all', 'content_type' => 'css', 'order' => 30])
+            ->with('path/file-2.css', [
+                'src' => 'path/file-2.css',
+                'media' => 'all',
+                'content_type' => 'css',
+                'order' => 30
+            ])
             ->willReturnSelf();
 
         $this->assertEquals($this->model, $this->model->interpret($readerContextMock, $element->children()[0]));

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/_files/template_head.xml
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/_files/template_head.xml
@@ -11,7 +11,9 @@
         <meta name="meta_name" content="meta_content"/>
         <meta property="og:video:secure_url" content="https://secure.example.com/movie.swf" />
         <meta property="og:locale:alternate" content="uk_UA" />
-        <css src="path/file.css" media="all" />
+        <css src="path/file-1.css" order="10" media="all" />
+        <css src="path/file-2.css" order="30" media="all" />
+        <css src="path/file-3.css" media="all" />
         <script src="path/file.js" defer="defer"/>
         <link src="http://url.com" src_type="url"/>
         <remove src="path/remove/file.css"/>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14290
Added new attribute 'order' for set loading order .
Those attribute resolve issue about render files for some order.

### Fixed Issues (if relevant)
1. magento/magento2#1821: CSS load order incorrect using default_head_blocks.xml #1821

