### PR TITLE
Remove unused namespace from Ui Export model

### DIFF
--- a/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
@@ -8,7 +8,6 @@ namespace Magento\Ui\Model\Export;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Ui\Component\MassAction\Filter;
 
 /**
@@ -17,7 +16,7 @@ use Magento\Ui\Component\MassAction\Filter;
 class ConvertToCsv
 {
     /**
-     * @var WriteInterface
+     * @var DirectoryList
      */
     protected $directory;
 

--- a/app/code/Magento/Ui/Model/Export/ConvertToXml.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToXml.php
@@ -12,7 +12,6 @@ use Magento\Framework\Convert\Excel;
 use Magento\Framework\Convert\ExcelFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Ui\Component\MassAction\Filter;
 
 /**
@@ -21,7 +20,7 @@ use Magento\Ui\Component\MassAction\Filter;
 class ConvertToXml
 {
     /**
-     * @var WriteInterface
+     * @var DirectoryList
      */
     protected $directory;
 


### PR DESCRIPTION
### Description
The Export model have some unused namespaces: `Magento\Framework\Filesystem\Directory\WriteInterface`.
Just removing it and update description

### Manual testing scenarios
1. For example, go to orders list;
2. Export list of order by XML or CSV;
3. All should export as expected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
