### PR TITLE
Deprecate startSetup() and endSetup()

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -687,15 +687,51 @@ interface AdapterInterface
      * Run additional environment before setup
      *
      * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     *
+     * @deprecated Call individual methods only if required
+     * @see disableAutoValueOnZero()
+     * @see disableForeignKeyChecks()
      */
     public function startSetup();
+
+    /**
+     * Set no auto value on zero
+     *
+     * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    public function disableAutoValueOnZero();
+
+    /**
+     * Disable foreign key checks
+     *
+     * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    public function disableForeignKeyChecks();
 
     /**
      * Run additional environment after setup
      *
      * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     *
+     * @deprecated Call individual methods only if required
+     * @see resetAutoValueOnZero()
+     * @see resetForeignKeyChecks()
      */
     public function endSetup();
+
+    /**
+     * Reset mode back to what it was previously
+     *
+     * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    public function resetAutoValueOnZero();
+
+    /**
+     * Reset foreign key checks back to what they were previously
+     *
+     * @return \Magento\Framework\DB\Adapter\AdapterInterface
+     */
+    public function resetForeignKeyChecks();
 
     /**
      * Set cache adapter

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -2812,12 +2812,40 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Run additional environment before setup
      *
      * @return $this
+     *
+     * @deprecated Call individual methods only if required
+     * @see disableAutoValueOnZero()
+     * @see disableForeignKeyChecks()
      */
     public function startSetup()
     {
         $this->rawQuery("SET SQL_MODE=''");
-        $this->rawQuery("SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0");
+        $this->disableForeignKeyChecks();
+        $this->disableAutoValueOnZero();
+
+        return $this;
+    }
+
+    /**
+     * Set no auto value on zero
+     *
+     * @return $this
+     */
+    public function disableAutoValueOnZero()
+    {
         $this->rawQuery("SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO'");
+
+        return $this;
+    }
+
+    /**
+     * Disable foreign key checks
+     *
+     * @return $this
+     */
+    public function disableForeignKeyChecks()
+    {
+        $this->rawQuery("SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0");
 
         return $this;
     }
@@ -2826,10 +2854,38 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Run additional environment after setup
      *
      * @return $this
+     *
+     * @deprecated Call individual methods only if required
+     * @see resetAutoValueOnZero()
+     * @see resetForeignKeyChecks()
      */
     public function endSetup()
     {
+        $this->resetAutoValueOnZero();
+        $this->resetForeignKeyChecks();
+
+        return $this;
+    }
+
+    /**
+     * Reset mode back to what it was previously
+     *
+     * @return $this
+     */
+    public function resetAutoValueOnZero()
+    {
         $this->rawQuery("SET SQL_MODE=IFNULL(@OLD_SQL_MODE,'')");
+
+        return $this;
+    }
+
+    /**
+     * Reset foreign key checks back to what they were previously
+     *
+     * @return $this
+     */
+    public function resetForeignKeyChecks()
+    {
         $this->rawQuery("SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS=0, 0, 1)");
 
         return $this;

--- a/lib/internal/Magento/Framework/Module/Setup.php
+++ b/lib/internal/Magento/Framework/Module/Setup.php
@@ -169,6 +169,10 @@ class Setup implements SetupInterface
      * Prepare database before install/upgrade
      *
      * @return $this
+     *
+     * @deprecated Call individual methods only if required
+     * @see disableAutoValueOnZero()
+     * @see disableForeignKeyChecks()
      */
     public function startSetup()
     {
@@ -177,13 +181,61 @@ class Setup implements SetupInterface
     }
 
     /**
+     * Set no auto value on zero
+     *
+     * @return $this
+     */
+    public function disableAutoValueOnZero()
+    {
+        $this->getConnection()->disableAutoValueOnZero();
+        return $this;
+    }
+
+    /**
+     * Disable foreign key checks
+     *
+     * @return $this
+     */
+    public function disableForeignKeyChecks()
+    {
+        $this->getConnection()->disableForeignKeyChecks();
+        return $this;
+    }
+
+    /**
      * Prepare database after install/upgrade
      *
      * @return $this
+     *
+     * @deprecated Call individual methods only if required
+     * @see resetAutoValueOnZero()
+     * @see resetForeignKeyChecks()
      */
     public function endSetup()
     {
         $this->getConnection()->endSetup();
+        return $this;
+    }
+
+    /**
+     * Reset mode back to what it was previously
+     *
+     * @return $this
+     */
+    public function resetAutoValueOnZero()
+    {
+        $this->getConnection()->resetAutoValueOnZero();
+        return $this;
+    }
+
+    /**
+     * Reset foreign key checks back to what they were previously
+     *
+     * @return $this
+     */
+    public function resetForeignKeyChecks()
+    {
+        $this->getConnection()->resetForeignKeyChecks();
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Setup/SetupInterface.php
+++ b/lib/internal/Magento/Framework/Setup/SetupInterface.php
@@ -65,13 +65,49 @@ interface SetupInterface
      * Prepares database before install/upgrade
      *
      * @return $this
+     *
+     * @deprecated Call individual methods only if required
+     * @see disableAutoValueOnZero()
+     * @see disableForeignKeyChecks()
      */
     public function startSetup();
+
+    /**
+     * Set no auto value on zero
+     *
+     * @return $this
+     */
+    public function disableAutoValueOnZero();
+
+    /**
+     * Disable foreign key checks
+     *
+     * @return $this
+     */
+    public function disableForeignKeyChecks();
 
     /**
      * Prepares database after install/upgrade
      *
      * @return $this
+     *
+     * @deprecated Call individual methods only if required
+     * @see resetAutoValueOnZero()
+     * @see resetForeignKeyChecks()
      */
     public function endSetup();
+
+    /**
+     * Reset mode back to what it was previously
+     *
+     * @return $this
+     */
+    public function resetAutoValueOnZero();
+
+    /**
+     * Reset foreign key checks back to what they were previously
+     *
+     * @return $this
+     */
+    public function resetForeignKeyChecks();
 }


### PR DESCRIPTION
Deprecated startSetup() and endSetup(), and add new methods to toggle auto value on zero and foreign key checks.

### Description
Deprecation and separation of individual actions within `startSetup()` and `endSetup()` methods to prevent developers from automatically including these calls in their setup scripts, when they are usually not required.

### Fixed Issues (if relevant)
1. magento/magento2#9694

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
