### PR TITLE
[Forwardport] Use index sitemap name as prefix in split sitemaps

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -646,7 +646,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
      */
     protected function _getCurrentSitemapFilename($index)
     {
-        return self::INDEX_FILE_PREFIX . '-' . $this->getStoreId() . '-' . $index . '.xml';
+        return str_replace('.xml', '', $this->getSitemapFilename()) . '-' . $this->getStoreId() . '-' . $index . '.xml';
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14836
### Description
When generating large sitemaps which result in a single index sitemap and several smaller split sitemap files, the split sitemap files do not use the same name prefix as the parent.

For example, if you have a sitemap called `products.xml` then the split sitemap files are named `sitemap-1-1.xml`, `sitemap-1-2.xml` etc. which does not make any sense.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Create sitemap in admin named `products.xml`
2. Set the URL limit for the sitemap to a small number to cause split files (Stores > Configuration > Catalog > XML Sitemap > Sitemap File Limits > Maximum No of URLs Per File)
3. Generate the sitemap
4. Should generate a single index sitemap file named `products.xml` and several split sitemap files prefixed with `products-`, e.g. `products-1-1.xml`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
