### PR TITLE
#10382 - Fix no change to product image for default conigurable from URL

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -286,6 +286,7 @@ define([
 
             if (!galleryObject) {
                 gallery.on('gallery:loaded', this._changeGalleryImage.bind(this, gallery));
+                
                 return;
             }
 

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -286,7 +286,7 @@ define([
 
             if (!galleryObject) {
                 gallery.on('gallery:loaded', this._changeGalleryImage.bind(this, gallery));
-                
+
                 return;
             }
 

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -275,18 +275,32 @@ define([
         },
 
         /**
-         * Change displayed product image according to chosen options of configurable product
+         * When approrpriate, trigger change to displayed product image according to chosen
+         * options of configurable product
          *
          * @private
          */
         _changeProductImage: function () {
-            var images,
-                initialImages = this.options.mediaGalleryInitial,
-                galleryObject = $(this.options.mediaGallerySelector).data('gallery');
+            var gallery = $(this.options.mediaGallerySelector),
+                galleryObject = gallery.data('gallery');
 
             if (!galleryObject) {
+                gallery.on('gallery:loaded', this._changeGalleryImage.bind(this, gallery));
                 return;
             }
+
+            this._changeGalleryImage.call(this, gallery);
+        },
+
+        /**
+         * Change displayed product image according to chosen options of configurable product
+         *
+         * @private
+         */
+        _changeGalleryImage: function (element) {
+            var images,
+                initialImages = this.options.mediaGalleryInitial,
+                galleryObject = element.data('gallery');
 
             images = this.options.spConfig.images[this.simpleProduct];
 


### PR DESCRIPTION
Fix issue https://github.com/magento/magento2/issues/10382 to allow default configured values (gathered from the URL, but could be from anywhere setting default configurable options theoretically) to successfully change the gallery. Previously, the change to the gallery in this default configured scenario would try to happen, but most of the time the gallery wouldn't be ready yet.

### Description
Trigger the actual gallery image change when the product image gallery component is ready: When the gallery is not ready yet, listen to an event that calls back. When the gallery is ready straight away, change the image straight away.

### Fixed Issues (if relevant)
1. magento/magento2#10382: select default options of configurable product by URL query string does not update gallery

### Manual testing scenarios
1. Create a configurable product (with or without a gallery of images) with simples that have their own gallery of images
2. Navigate to the URL of the product, with an additional hash in the URL to populate a default configuration (i.e. http://magento.test/my-product/#93=6 where 93 is the ID of the attribute the product is configured by and 6 is an available option of the configurable)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
