### PR TITLE
Fixed issue products grid operations in admin cart price rule edit page for user which has no access to CatalogRule module

### DIFF
--- a/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Widget/Chooser/Sku.php
+++ b/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Widget/Chooser/Sku.php
@@ -207,7 +207,7 @@ class Sku extends \Magento\Backend\Block\Widget\Grid\Extended
     public function getGridUrl()
     {
         return $this->getUrl(
-            'catalog_rule/*/chooser',
+            '*/*/chooser',
             ['_current' => true, 'current_grid_id' => $this->getId(), 'collapse' => null]
         );
     }


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->

<!--- Provide a description of the changes proposed in the pull request -->
## Preconditions
Magento 2.2 have multiple admin user roles with access restrictions to some resources. Role has access to cart price rules, but it restricted to catalog rules rules.

## Problem
When admin user with role mentioned above tried in edit/new cart price rule, in conditions settings add “SKU” condition, and then select products from loaded product grid – all grid navigation, sorting and  filtering operations will lead to “403” redirect.  Reason
When magento loaded products grid for selecting product sku for cart price rules it use controller action which is inherited from similar one  form CatalogRule module, this controller render its block Magento\CatalogRule\Block\Adminhtml\Promo\Widget\Chooser\Sku (which generate product grid HTML and JavaScript). This block method “getGridUrl” generates urls with route 'catalog_rule/*/chooser', so all requests for updating products grid data will lead to  CatalogRule module controller. But current user has no access to  CatalogRule routes so it get 403 response.  

## Solution 
Modify method Magento\CatalogRule\Block\Adminhtml\Promo\Widget\Chooser\Sku::getGridUrl() method. Change route parameter which it pass in “getUrl” method from “catalog_rule/*/chooser” to “*/*/chooser”.  