### PR TITLE
[Backport] Fix aggregations use statements and return values

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
@@ -6,7 +6,7 @@
 namespace Magento\Cms\Model\ResourceModel\Block\Grid;
 
 use Magento\Framework\Api\Search\SearchResultInterface;
-use Magento\Framework\Search\AggregationInterface;
+use Magento\Framework\Api\Search\AggregationInterface;
 use Magento\Cms\Model\ResourceModel\Block\Collection as BlockCollection;
 
 /**
@@ -82,6 +82,7 @@ class Collection extends BlockCollection implements SearchResultInterface
     public function setAggregations($aggregations)
     {
         $this->aggregations = $aggregations;
+        return $this;
     }
 
     /**

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Grid/Collection.php
@@ -83,6 +83,7 @@ class Collection extends PageCollection implements SearchResultInterface
     public function setAggregations($aggregations)
     {
         $this->aggregations = $aggregations;
+        return $this;
     }
 
     /**

--- a/app/code/Magento/Sales/Model/ResourceModel/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Grid/Collection.php
@@ -6,7 +6,7 @@
 namespace Magento\Sales\Model\ResourceModel\Grid;
 
 use Magento\Framework\Api\Search\SearchResultInterface;
-use Magento\Framework\Search\AggregationInterface;
+use Magento\Framework\Api\Search\AggregationInterface;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 /**
@@ -78,6 +78,7 @@ class Collection extends AbstractCollection implements SearchResultInterface
     public function setAggregations($aggregations)
     {
         $this->aggregations = $aggregations;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
### Description
Several classes have wrong use statements for AggregationInterface (`Magento\Framework\Search\AggregationInterface` instead of `Magento\Framework\Api\Search\AggregationInterface`).
Also, `setAggregations` methods don't return a correct value (incompatible with interface annotation).

Original PR: https://github.com/magento/magento2/pull/14482