### PR TITLE
FIX for issue#14869 - Wrong price at backend after update

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
@@ -46,6 +46,11 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
     protected $_quoteConfig;
 
     /**
+     * @var \Magento\Store\Model\StoreManagerInterface|null
+     */
+    private $storeManager;
+
+    /**
      * @param \Magento\Framework\Data\Collection\EntityFactory $entityFactory
      * @param \Psr\Log\LoggerInterface $logger
      * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy
@@ -54,6 +59,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
      * @param Option\CollectionFactory $itemOptionCollectionFactory
      * @param \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory
      * @param \Magento\Quote\Model\Quote\Config $quoteConfig
+     * @param \Magento\Store\Model\StoreManagerInterface|null $storeManager
      * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
      * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -67,6 +73,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
         \Magento\Quote\Model\ResourceModel\Quote\Item\Option\CollectionFactory $itemOptionCollectionFactory,
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory,
         \Magento\Quote\Model\Quote\Config $quoteConfig,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null,
         \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
         \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
@@ -82,6 +89,10 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
         $this->_itemOptionCollectionFactory = $itemOptionCollectionFactory;
         $this->_productCollectionFactory = $productCollectionFactory;
         $this->_quoteConfig = $quoteConfig;
+
+        // Backward compatibility constructor parameters
+        $this->storeManager = $storeManager ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Store\Model\StoreManagerInterface::class);
     }
 
     /**
@@ -101,7 +112,10 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
      */
     public function getStoreId()
     {
-        return (int)$this->_productCollectionFactory->create()->getStoreId();
+        // Fallback to current storeId if no quote is provided
+        // (see https://github.com/magento/magento2/commit/9d3be732a88884a66d667b443b3dc1655ddd0721)
+        return $this->_quote === null ?
+            (int) $this->storeManager->getStore()->getId() : (int) $this->_quote->getStoreId();
     }
 
     /**


### PR DESCRIPTION
A previous commit 9d3be732a88884a66d667b443b3dc1655ddd0721 (cc @neeta-wagento) changed the default behaviour of
`\Magento\Quote\Model\ResourceModel\Quote\Item\Collection::getStoreId()` using the store coming from the current session
instead of using the one from quote. The previous commit was made to fix an error while using `getItems()` without setting a quote.
The implemetation is correctly working in the frontend because the quote storeId is and the session storeId are matchnig, but it breaks the admin implementation because they can be different.

The current fix restore the previous behaviour and adds a check if the quote is not specified.

### Fixed Issues (if relevant)
1. magento/magento2#14869: Wrong price at backend after update

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
