### PR TITLE
[Forwardport] Fix typo in doc for updateSpecificCoupons

### DIFF
--- a/app/code/Magento/SalesRule/Model/ResourceModel/Coupon.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Coupon.php
@@ -106,7 +106,7 @@ class Coupon extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implem
     }
 
     /**
-     * Update auto generated Specific Coupon if it's rule changed
+     * Update auto generated Specific Coupon if its rule changed
      *
      * @param \Magento\SalesRule\Model\Rule $rule
      * @return $this


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14891
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Just a tiny typo correction in the `ResourceModel\Coupon.php:updateSpecificCoupons` doc,  as ["its" is the possessive form of "it" and "it's" is a contraction of "it" and "is".](http://grammarist.com/spelling/its-its/)


### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
