### PR TITLE
[Forwardport] [FIX]: Recent orders are not filtered per store at the customer account page

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Recent.php
+++ b/app/code/Magento/Sales/Block/Order/Recent.php
@@ -10,6 +10,7 @@ use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Magento\Customer\Model\Session;
 use Magento\Sales\Model\Order\Config;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Sales order history block
@@ -57,15 +58,16 @@ class Recent extends \Magento\Framework\View\Element\Template
         CollectionFactory $orderCollectionFactory,
         Session $customerSession,
         Config $orderConfig,
-        StoreManagerInterface $storeManager,
-        array $data = []
+        array $data = [],
+        StoreManagerInterface $storeManager = null
     ) {
         $this->_orderCollectionFactory = $orderCollectionFactory;
         $this->_customerSession = $customerSession;
         $this->_orderConfig = $orderConfig;
-        $this->storeManager = $storeManager;
-        parent::__construct($context, $data);
         $this->_isScopePrivate = true;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()
+            ->get(StoreManagerInterface::class);
+        parent::__construct($context, $data);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Order/Recent.php
+++ b/app/code/Magento/Sales/Block/Order/Recent.php
@@ -50,8 +50,8 @@ class Recent extends \Magento\Framework\View\Element\Template
      * @param \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Sales\Model\Order\Config $orderConfig
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param array $data
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
     public function __construct(
         Context $context,
@@ -65,9 +65,9 @@ class Recent extends \Magento\Framework\View\Element\Template
         $this->_customerSession = $customerSession;
         $this->_orderConfig = $orderConfig;
         $this->_isScopePrivate = true;
+        parent::__construct($context, $data);
         $this->storeManager = $storeManager ?: ObjectManager::getInstance()
             ->get(StoreManagerInterface::class);
-        parent::__construct($context, $data);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Order/Recent.php
+++ b/app/code/Magento/Sales/Block/Order/Recent.php
@@ -65,9 +65,9 @@ class Recent extends \Magento\Framework\View\Element\Template
         $this->_customerSession = $customerSession;
         $this->_orderConfig = $orderConfig;
         $this->_isScopePrivate = true;
-        parent::__construct($context, $data);
         $this->storeManager = $storeManager ?: ObjectManager::getInstance()
             ->get(StoreManagerInterface::class);
+        parent::__construct($context, $data);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Order/Recent.php
+++ b/app/code/Magento/Sales/Block/Order/Recent.php
@@ -82,7 +82,7 @@ class Recent extends \Magento\Framework\View\Element\Template
     /**
      * Get recently placed orders. By default they will be limited by 5.
      */
-    protected function getRecentOrders()
+    private function getRecentOrders()
     {
         $orders = $this->_orderCollectionFactory->create()->addAttributeToSelect(
             '*'

--- a/app/code/Magento/Sales/Test/Unit/Block/Order/RecentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Order/RecentTest.php
@@ -5,6 +5,15 @@
  */
 namespace Magento\Sales\Test\Unit\Block\Order;
 
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Customer\Model\Session;
+use Magento\Sales\Model\Order\Config;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\View\Layout;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Sales\Model\ResourceModel\Order\Collection;
+
 class RecentTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -32,26 +41,34 @@ class RecentTest extends \PHPUnit\Framework\TestCase
      */
     protected $orderConfig;
 
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $storeManagerMock;
+
     protected function setUp()
     {
-        $this->context = $this->createMock(\Magento\Framework\View\Element\Template\Context::class);
+        $this->context = $this->createMock(Context::class);
         $this->orderCollectionFactory = $this->createPartialMock(
-            \Magento\Sales\Model\ResourceModel\Order\CollectionFactory::class,
+            CollectionFactory::class,
             ['create']
         );
-        $this->customerSession = $this->createPartialMock(\Magento\Customer\Model\Session::class, ['getCustomerId']);
+        $this->customerSession = $this->createPartialMock(Session::class, ['getCustomerId']);
         $this->orderConfig = $this->createPartialMock(
-            \Magento\Sales\Model\Order\Config::class,
+            Config::class,
             ['getVisibleOnFrontStatuses']
         );
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->getMockForAbstractClass();
     }
 
     public function testConstructMethod()
     {
         $data = [];
-        $attribute = ['customer_id', 'status'];
+        $attribute = ['customer_id', 'store_id', 'status'];
         $customerId = 25;
-        $layout = $this->createPartialMock(\Magento\Framework\View\Layout::class, ['getBlock']);
+        $storeId = 4;
+        $layout = $this->createPartialMock(Layout::class, ['getBlock']);
         $this->context->expects($this->once())
             ->method('getLayout')
             ->will($this->returnValue($layout));
@@ -64,14 +81,20 @@ class RecentTest extends \PHPUnit\Framework\TestCase
             ->method('getVisibleOnFrontStatuses')
             ->will($this->returnValue($statuses));
 
-        $orderCollection = $this->createPartialMock(\Magento\Sales\Model\ResourceModel\Order\Collection::class, [
-                'addAttributeToSelect',
-                'addFieldToFilter',
-                'addAttributeToFilter',
-                'addAttributeToSort',
-                'setPageSize',
-                'load'
-            ]);
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->getMockForAbstractClass();
+        $storeMock = $this->getMockBuilder(StoreInterface::class)->getMockForAbstractClass();
+        $this->storeManagerMock->expects($this->once())->method('getStore')->willReturn($storeMock);
+        $storeMock->expects($this->any())->method('getId')->willReturn($storeId);
+
+        $orderCollection = $this->createPartialMock(Collection::class, [
+            'addAttributeToSelect',
+            'addFieldToFilter',
+            'addAttributeToFilter',
+            'addAttributeToSort',
+            'setPageSize',
+            'load'
+        ]);
         $this->orderCollectionFactory->expects($this->once())
             ->method('create')
             ->will($this->returnValue($orderCollection));
@@ -85,17 +108,21 @@ class RecentTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $orderCollection->expects($this->at(2))
             ->method('addAttributeToFilter')
-            ->with($attribute[1], $this->equalTo(['in' => $statuses]))
-            ->will($this->returnSelf());
+            ->with($attribute[1], $this->equalTo($storeId))
+            ->willReturnSelf();
         $orderCollection->expects($this->at(3))
+            ->method('addAttributeToFilter')
+            ->with($attribute[2], $this->equalTo(['in' => $statuses]))
+            ->will($this->returnSelf());
+        $orderCollection->expects($this->at(4))
             ->method('addAttributeToSort')
             ->with('created_at', 'desc')
             ->will($this->returnSelf());
-        $orderCollection->expects($this->at(4))
+        $orderCollection->expects($this->at(5))
             ->method('setPageSize')
             ->with('5')
             ->will($this->returnSelf());
-        $orderCollection->expects($this->at(5))
+        $orderCollection->expects($this->at(6))
             ->method('load')
             ->will($this->returnSelf());
         $this->block = new \Magento\Sales\Block\Order\Recent(
@@ -103,6 +130,7 @@ class RecentTest extends \PHPUnit\Framework\TestCase
             $this->orderCollectionFactory,
             $this->customerSession,
             $this->orderConfig,
+            $this->storeManagerMock,
             $data
         );
         $this->assertEquals($orderCollection, $this->block->getOrders());

--- a/app/code/Magento/Sales/Test/Unit/Block/Order/RecentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Order/RecentTest.php
@@ -64,7 +64,6 @@ class RecentTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructMethod()
     {
-        $data = [];
         $attribute = ['customer_id', 'store_id', 'status'];
         $customerId = 25;
         $storeId = 4;
@@ -130,8 +129,8 @@ class RecentTest extends \PHPUnit\Framework\TestCase
             $this->orderCollectionFactory,
             $this->customerSession,
             $this->orderConfig,
-            $this->storeManagerMock,
-            $data
+            [],
+            $this->storeManagerMock
         );
         $this->assertEquals($orderCollection, $this->block->getOrders());
     }

--- a/app/code/Magento/Sales/view/frontend/templates/order/recent.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/recent.phtml
@@ -8,10 +8,13 @@
 
 ?>
 <div class="block block-dashboard-orders">
-<?php $_orders = $block->getOrders(); ?>
+<?php
+    $_orders = $block->getOrders();
+    $count = count($_orders);
+?>
     <div class="block-title order">
         <strong><?= /* @escapeNotVerified */ __('Recent Orders') ?></strong>
-        <?php if (sizeof($_orders->getItems()) > 0): ?>
+        <?php if ($count > 0): ?>
             <a class="action view" href="<?= /* @escapeNotVerified */ $block->getUrl('sales/order/history') ?>">
                 <span><?= /* @escapeNotVerified */ __('View All') ?></span>
             </a>
@@ -19,7 +22,7 @@
     </div>
     <div class="block-content">
     <?= $block->getChildHtml() ?>
-    <?php if (sizeof($_orders->getItems()) > 0): ?>
+    <?php if ($count > 0): ?>
         <div class="table-wrapper orders-recent">
             <table class="data table table-order-items recent" id="my-orders-table">
                 <caption class="table-caption"><?= /* @escapeNotVerified */ __('Recent Orders') ?></caption>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13257
### Description
Hello,

In this PR I provide fix for filtering recent orders block where previously orders were not filtered by store. You can have account and orders from two different stores and when you logged-in to one of those stores you will see  recent orders but it is possible to see orders from all stores belong to a website.

**Main changes:**

1. `Magento\Sales\Block\Order\Recent`

- Move recent orders select to separate method
- Filter selected collection by current store

2. `Magento\Sales\Test\Unit\Block\Order\RecentTest`

- Change test according to the class method changes

3. `app/code/Magento/Sales/view/frontend/templates/order/recent.phtml`

- Change `sizeof()` to `count()` and execute it only once instead of double call

Best regards,
Alex

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios

1. Create 2 stores on one website
2. Create account.
3. Place orders for two different store
4. Log In to previously created account for which you created orders and check `Recent Orders` section. It will show orders for all stores

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
