### PR TITLE
Change 'Update'-button visibility on change qty event.

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -108,6 +108,13 @@ define([
             /**
              * @param {jQuery.Event} event
              */
+            events['change ' + this.options.item.qty] = function (event) {
+                self._showItemButton($(event.target));
+            };
+
+            /**
+             * @param {jQuery.Event} event
+             */
             events['click ' + this.options.item.button] = function (event) {
                 event.stopPropagation();
                 self._updateItemQty($(event.currentTarget));


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
When qty value in minicat updated by js, Update-button should have the same behavior like when qty is manually edited. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. `jQuery('.cart-item-qty:first').val(parseFloat(jQuery('.cart-item-qty:first').val()) - 1).change();` - Update button should be shown.
2. `jQuery('.cart-item-qty:first').val(parseFloat(jQuery('.cart-item-qty:first').val()) - 1).change();` - Update button should be hidden. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
