### PR TITLE
use "Module_Name::template/path" format instead of using template/path i…

### DIFF
--- a/app/code/Magento/Review/Block/Product/ReviewRenderer.php
+++ b/app/code/Magento/Review/Block/Product/ReviewRenderer.php
@@ -18,8 +18,8 @@ class ReviewRenderer extends \Magento\Framework\View\Element\Template implements
      * @var array
      */
     protected $_availableTemplates = [
-        self::FULL_VIEW => 'helper/summary.phtml',
-        self::SHORT_VIEW => 'helper/summary_short.phtml',
+        self::FULL_VIEW => 'Magento_Review::helper/summary.phtml',
+        self::SHORT_VIEW => 'Magento_Review::helper/summary_short.phtml',
     ];
 
     /**


### PR DESCRIPTION
…n Block class to ensure extensibility of the class. not doing so causes invalid template errors after extending the block class via preference

### Description
Often third party modules override core block classes. If the source block classes reference a template without specifying module name like "Vendor_Module::template_path" then block render fails with "nvalid template file: " error.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Overide the \Magento\Review\Block\Product\ReviewRenderer Block in your custom module via di preference. Leave your custom class empty.
2.  Product details should work.

### Contribution checklist
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
