### PR TITLE
Move customer.account.dashboard.info.extra block to contact information

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml
@@ -20,6 +20,7 @@
                     <?= $block->escapeHtml($block->getName()) ?><br>
                     <?= $block->escapeHtml($block->getCustomer()->getEmail()) ?><br>
                 </p>
+                <?= $block->getChildHtml('customer.account.dashboard.info.extra'); ?>
             </div>
             <div class="box-actions">
                 <a class="action edit" href="<?= $block->escapeUrl($block->getUrl('customer/account/edit')) ?>">
@@ -43,8 +44,6 @@
                             <?= $block->escapeHtml(__('You aren\'t subscribed to our newsletter.')) ?>
                         <?php endif; ?>
                     </p>
-                    <?php /* Extensions placeholder */ ?>
-                    <?= $block->getChildHtml('customer.account.dashboard.info.extra') ?>
                 </div>
                 <div class="box-actions">
                     <a class="action edit" href="<?= $block->escapeUrl($block->getUrl('newsletter/manage')) ?>"><span><?= $block->escapeHtml(__('Edit')) ?></span></a>


### PR DESCRIPTION
Port of https://github.com/magento/magento2/pull/14923

### Description
Move extension block to contact information. Seems not logic to add this to the newsletter section.

### Fixed Issues (if relevant)
1. None.

### Manual testing scenarios
1. Add custom block in reference `customer_account_dashboard_info` with name `customer.account.dashboard.info.extra` to display additional data in customers dashboard.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)