### PR TITLE
Fix unstable session manager

### DIFF
--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -183,10 +183,21 @@ class SessionManager implements SessionManagerInterface
             // Need to apply the config options so they can be ready by session_start
             $this->initIniOptions();
             $this->registerSaveHandler();
+            if (isset($_SESSION['new_session_id'])) {
+                // Not fully expired yet. Could be lost cookie by unstable network.
+                session_commit();
+                session_id($_SESSION['new_session_id']);
+            }
             $sid = $this->sidResolver->getSid($this);
             // potential custom logic for session id (ex. switching between hosts)
             $this->setSessionId($sid);
             session_start();
+            if (isset($_SESSION['destroyed'])) {
+                if ($_SESSION['destroyed'] < time() - 300) {
+                    $this->destroy(['clear_storage' => true]);
+
+                }
+            }
             $this->validator->validate($this);
             $this->renewCookie($sid);
 
@@ -501,7 +512,31 @@ class SessionManager implements SessionManagerInterface
             return $this;
         }
 
-        $this->isSessionExists() ? session_regenerate_id(true) : session_start();
+        if ($this->isSessionExists()) {
+            //regenerate the session
+            session_regenerate_id();
+            $new_session_id = session_id();
+
+            $_SESSION['new_session_id'] = $new_session_id;
+
+            // Set destroy timestamp
+            $_SESSION['destroyed'] = time();
+
+            // Write and close current session;
+            session_commit();
+            $oldSession = $_SESSION;   //called after destroy - see destroy!
+            // Start session with new session ID
+            session_id($new_session_id);
+            ini_set('session.use_strict_mode', 0);
+            session_start();
+            ini_set('session.use_strict_mode', 1);
+            $_SESSION = $oldSession;
+            // New session does not need them
+            unset($_SESSION['destroyed']);
+            unset($_SESSION['new_session_id']);
+        } else {
+            session_start();
+        }
         $this->storage->init(isset($_SESSION) ? $_SESSION : []);
 
         if ($this->sessionConfig->getUseCookies()) {

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -195,7 +195,6 @@ class SessionManager implements SessionManagerInterface
             if (isset($_SESSION['destroyed'])) {
                 if ($_SESSION['destroyed'] < time() - 300) {
                     $this->destroy(['clear_storage' => true]);
-
                 }
             }
             $this->validator->validate($this);

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -514,18 +514,20 @@ class SessionManager implements SessionManagerInterface
         if ($this->isSessionExists()) {
             //regenerate the session
             session_regenerate_id();
-            $new_session_id = session_id();
+            $newSessionId = session_id();
 
-            $_SESSION['new_session_id'] = $new_session_id;
+            $_SESSION['new_session_id'] = $newSessionId;
 
             // Set destroy timestamp
             $_SESSION['destroyed'] = time();
 
             // Write and close current session;
             session_commit();
-            $oldSession = $_SESSION;   //called after destroy - see destroy!
+            
+            //called after destroy()
+            $oldSession = $_SESSION;
             // Start session with new session ID
-            session_id($new_session_id);
+            session_id($newSessionId);
             ini_set('session.use_strict_mode', 0);
             session_start();
             ini_set('session.use_strict_mode', 1);

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -5,6 +5,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+// @codingStandardsIgnoreFile
+
 namespace Magento\Framework\Session;
 
 use Magento\Framework\Session\Config\ConfigInterface;
@@ -512,7 +515,7 @@ class SessionManager implements SessionManagerInterface
         }
 
         if ($this->isSessionExists()) {
-            //regenerate the session
+            // Regenerate the session
             session_regenerate_id();
             $newSessionId = session_id();
 
@@ -523,8 +526,7 @@ class SessionManager implements SessionManagerInterface
 
             // Write and close current session;
             session_commit();
-            
-            //called after destroy()
+            // Called after destroy()
             $oldSession = $_SESSION;
             // Start session with new session ID
             session_id($newSessionId);

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -513,7 +513,6 @@ class SessionManager implements SessionManagerInterface
         }
 
         if ($this->isSessionExists()) {
-
             // Regenerate the session
             session_regenerate_id();
             $newSessionId = session_id();


### PR DESCRIPTION
### Description

Fix of the unstable behaviour of the session management with high volume of concurrent sessions.

### Fixed Issues
1. magento/magento2#12362: Concurrent (quick reload) requests on checkout cause cart to empty - related to session_regenerate_id

### Manual testing scenarios

1. Reach the checkout page with products in the cart
2. Press CMD+R or ALT+F5 multiple times to refresh the page, after the fix the user is not being logged out and redirected to the empty cart page.

We already deployed the fix on our high traffic website and the issue is fixed.