### PR TITLE
Changed the length of the remote_ip field to store ipv6 addresses

### DIFF
--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -26,7 +26,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
         $setup->startSetup();
-
         if (version_compare($context->getVersion(), '2.0.1', '<')) {
             $setup->getConnection(self::$connectionName)->addIndex(
                 $setup->getTable('quote_id_mask', self::$connectionName),
@@ -34,7 +33,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ['masked_id']
             );
         }
-
         if (version_compare($context->getVersion(), '2.0.2', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
@@ -101,34 +99,51 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '2.0.7', '<')) {
-            $connection = $setup->getConnection(self::$connectionName);
-            $connection->modifyColumn(
-                $setup->getTable('quote_address', self::$connectionName),
-                'telephone',
-                ['type' => Table::TYPE_TEXT, 'length' => 255]
-            )->modifyColumn(
-                $setup->getTable('quote_address', self::$connectionName),
-                'fax',
-                ['type' => Table::TYPE_TEXT, 'length' => 255]
-            )->modifyColumn(
-                $setup->getTable('quote_address', self::$connectionName),
-                'region',
-                ['type' => Table::TYPE_TEXT, 'length' => 255]
-            )->modifyColumn(
-                $setup->getTable('quote_address', self::$connectionName),
-                'city',
-                ['type' => Table::TYPE_TEXT, 'length' => 255]
-            );
+            $this->expandQuoteAddressFields($setup);
         }
         if (version_compare($context->getVersion(), '2.0.8', '<')) {
-            $connection = $setup->getConnection(self::$connectionName);
-            $connection->modifyColumn(
-                $setup->getTable('quote', self::$connectionName),
-                'remote_ip',
-                ['type' => Table::TYPE_TEXT, 'length' => 45]
-            );
+            $this->expandRemoteIpField($setup);
         }
-
         $setup->endSetup();
+    }
+
+    /**
+     * @param SchemaSetupInterface $setup
+     * @return void
+     */
+    private function expandRemoteIpField(SchemaSetupInterface $setup)
+    {
+        $connection = $setup->getConnection(self::$connectionName);
+        $connection->modifyColumn(
+            $setup->getTable('quote', self::$connectionName),
+            'remote_ip',
+            ['type' => Table::TYPE_TEXT, 'length' => 45]
+        );
+    }
+
+    /**
+     * @param SchemaSetupInterface $setup
+     * @return void
+     */
+    private function expandQuoteAddressFields(SchemaSetupInterface $setup)
+    {
+        $connection = $setup->getConnection(self::$connectionName);
+        $connection->modifyColumn(
+            $setup->getTable('quote_address', self::$connectionName),
+            'telephone',
+            ['type' => Table::TYPE_TEXT, 'length' => 255]
+        )->modifyColumn(
+            $setup->getTable('quote_address', self::$connectionName),
+            'fax',
+            ['type' => Table::TYPE_TEXT, 'length' => 255]
+        )->modifyColumn(
+            $setup->getTable('quote_address', self::$connectionName),
+            'region',
+            ['type' => Table::TYPE_TEXT, 'length' => 255]
+        )->modifyColumn(
+            $setup->getTable('quote_address', self::$connectionName),
+            'city',
+            ['type' => Table::TYPE_TEXT, 'length' => 255]
+        );
     }
 }

--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -120,6 +120,15 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ['type' => Table::TYPE_TEXT, 'length' => 255]
             );
         }
+        if (version_compare($context->getVersion(), '2.0.8', '<')) {
+            $connection = $setup->getConnection(self::$connectionName);
+            $connection->modifyColumn(
+                $setup->getTable('quote', self::$connectionName),
+                'remote_ip',
+                ['type' => Table::TYPE_TEXT, 'length' => 45]
+            );
+        }
+
         $setup->endSetup();
     }
 }

--- a/app/code/Magento/Quote/etc/module.xml
+++ b/app/code/Magento/Quote/etc/module.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Quote" setup_version="2.0.7">
+    <module name="Magento_Quote" setup_version="2.0.8">
     </module>
 </config>

--- a/app/code/Magento/Sales/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Sales/Setup/UpgradeSchema.php
@@ -107,15 +107,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '2.0.10', '<')) {
-            $connection = $installer->getConnection(self::$connectionName);
-            $connection->modifyColumn(
-                $installer->getTable('sales_order', self::$connectionName),
-                'remote_ip',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    'length' => 45
-                ]
-            );
+            $this->expandRemoteIpField($installer);
         }
     }
 
@@ -150,6 +142,23 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $installer->getTable('sales_invoice_grid', self::$connectionName),
             $installer->getIdxName('sales_invoice_grid', ['base_grand_total'], '', self::$connectionName),
             ['base_grand_total']
+        );
+    }
+
+    /**
+     * @param SchemaSetupInterface $installer
+     * @return void
+     */
+    private function expandRemoteIpField(SchemaSetupInterface $installer)
+    {
+        $connection = $installer->getConnection(self::$connectionName);
+        $connection->modifyColumn(
+            $installer->getTable('sales_order', self::$connectionName),
+            'remote_ip',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'length' => 45
+            ]
         );
     }
 }

--- a/app/code/Magento/Sales/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Sales/Setup/UpgradeSchema.php
@@ -106,6 +106,17 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
+        if (version_compare($context->getVersion(), '2.0.10', '<')) {
+            $connection = $installer->getConnection(self::$connectionName);
+            $connection->modifyColumn(
+                $installer->getTable('sales_order', self::$connectionName),
+                'remote_ip',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 45
+                ]
+            );
+        }
     }
 
     /**

--- a/app/code/Magento/Sales/etc/module.xml
+++ b/app/code/Magento/Sales/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Sales" setup_version="2.0.9">
+    <module name="Magento_Sales" setup_version="2.0.10">
         <sequence>
             <module name="Magento_Rule"/>
             <module name="Magento_Catalog"/>


### PR DESCRIPTION
Expands the `remote_ip` field to 45 characters in both the `sales_order` and `quote` tables, to cope with the ipv6 addresses, otherwise they get truncated.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10395 : REMOTE_IP gets saved partially when using IPV6

### Manual testing scenarios
1. trigger a `bin/magento setup:upgrade` and check both tables mentioned to check for the changes; also, check the versions of the modules in `setup_module`


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
