### PR TITLE
Prevent not category links in breadcrumbs at product page

### DIFF
--- a/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
+++ b/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
@@ -162,6 +162,7 @@ class Topmenu
             'url' => $this->catalogCategory->getCategoryUrl($category),
             'has_active' => in_array((string)$category->getId(), explode('/', $currentCategory->getPath()), true),
             'is_active' => $category->getId() == $currentCategory->getId(),
+            'is_category' => true,
             'is_parent_active' => $isParentActive
         ];
     }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
@@ -9,7 +9,6 @@ $viewModel = $block->getData('viewModel');
 ?>
 <div class="breadcrumbs" data-mage-init='{
     "breadcrumbs": {
-        "baseUrl": "<?= $block->getBaseUrl(); ?>",
         "categoryUrlSuffix": "<?= $block->escapeHtml($viewModel->getCategoryUrlSuffix()); ?>",
         "useCategoryPathInUrl": <?= (int)$viewModel->isCategoryUsedInProductUrl(); ?>,
         "product": "<?= $block->escapeHtml($viewModel->getProductName()); ?>"

--- a/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
@@ -9,6 +9,7 @@ $viewModel = $block->getData('viewModel');
 ?>
 <div class="breadcrumbs" data-mage-init='{
     "breadcrumbs": {
+        "baseUrl": "<?= $block->getBaseUrl(); ?>",
         "categoryUrlSuffix": "<?= $block->escapeHtml($viewModel->getCategoryUrlSuffix()); ?>",
         "useCategoryPathInUrl": <?= (int)$viewModel->isCategoryUsedInProductUrl(); ?>,
         "product": "<?= $block->escapeHtml($viewModel->getProductName()); ?>"

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
@@ -13,10 +13,10 @@ define([
 
         $.widget('mage.breadcrumbs', widget, {
             options: {
-                categoryPathRegex: /(nav\-)[0-9]+(\-[0-9]+)+/gi,
                 categoryUrlSuffix: '',
                 useCategoryPathInUrl: false,
                 product: '',
+                categoryItemSelector: '.category-item',
                 menuContainer: '[data-action="navigation"] > ul'
             },
 
@@ -137,7 +137,7 @@ define([
                 }
 
                 classes = menuItem.parent().attr('class');
-                classNav = classes.match(this.options.categoryPathRegex);
+                classNav = classes.match(/(nav\-)[0-9]+(\-[0-9]+)+/gi);
 
                 if (classNav) {
                     classNav = classNav[0];
@@ -164,20 +164,13 @@ define([
             _resolveCategoryMenuItem: function () {
                 var categoryUrl = this._resolveCategoryUrl(),
                     menu = $(this.options.menuContainer),
-                    categoryMenuItem = null,
-                    isCategoryMenuItem;
+                    categoryMenuItem = null;
 
                 if (categoryUrl && menu.length) {
-                    categoryMenuItem = menu.find('a[href="' + categoryUrl + '"]');
-
-                    // Check if this is a category (Not a link to contacts, homepage, etc)
-                    isCategoryMenuItem = categoryMenuItem.parent('li')
-                        .attr('class')
-                        .match(this.options.categoryPathRegex);
-
-                    if (!isCategoryMenuItem) {
-                        categoryMenuItem = null;
-                    }
+                    categoryMenuItem = menu.find(
+                        this.options.categoryItemSelector +
+                        ' > a[href="' + categoryUrl + '"]'
+                    );
                 }
 
                 return categoryMenuItem;

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
@@ -13,7 +13,7 @@ define([
 
         $.widget('mage.breadcrumbs', widget, {
             options: {
-                baseUrl: '',
+                categoryPathRegex: /(nav\-)[0-9]+(\-[0-9]+)+/gi,
                 categoryUrlSuffix: '',
                 useCategoryPathInUrl: false,
                 product: '',
@@ -137,7 +137,7 @@ define([
                 }
 
                 classes = menuItem.parent().attr('class');
-                classNav = classes.match(/(nav\-)[0-9]+(\-[0-9]+)+/gi);
+                classNav = classes.match(this.options.categoryPathRegex);
 
                 if (classNav) {
                     classNav = classNav[0];
@@ -164,10 +164,20 @@ define([
             _resolveCategoryMenuItem: function () {
                 var categoryUrl = this._resolveCategoryUrl(),
                     menu = $(this.options.menuContainer),
-                    categoryMenuItem = null;
+                    categoryMenuItem = null,
+                    isCategoryMenuItem;
 
                 if (categoryUrl && menu.length) {
                     categoryMenuItem = menu.find('a[href="' + categoryUrl + '"]');
+
+                    // Check if this is a category (Not a link to contacts, homepage, etc)
+                    isCategoryMenuItem = categoryMenuItem.parent('li')
+                        .attr('class')
+                        .match(this.options.categoryPathRegex);
+
+                    if (!isCategoryMenuItem) {
+                        categoryMenuItem = null;
+                    }
                 }
 
                 return categoryMenuItem;
@@ -193,11 +203,6 @@ define([
 
                     if (categoryUrl.indexOf('?') > 0) {
                         categoryUrl = categoryUrl.substr(0, categoryUrl.indexOf('?'));
-                    }
-
-                    // prevent double home link, when menu has link to the home
-                    if (categoryUrl === this.options.baseUrl) {
-                        categoryUrl = '';
                     }
                 }
 

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
@@ -193,6 +193,11 @@ define([
                     if (categoryUrl.indexOf('?') > 0) {
                         categoryUrl = categoryUrl.substr(0, categoryUrl.indexOf('?'));
                     }
+
+                    // prevent double home link, when menu has link to the home
+                    if (categoryUrl === BASE_URL) {
+                        categoryUrl = '';
+                    }
                 }
 
                 return categoryUrl;

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
@@ -13,6 +13,7 @@ define([
 
         $.widget('mage.breadcrumbs', widget, {
             options: {
+                baseUrl: '',
                 categoryUrlSuffix: '',
                 useCategoryPathInUrl: false,
                 product: '',
@@ -195,7 +196,7 @@ define([
                     }
 
                     // prevent double home link, when menu has link to the home
-                    if (categoryUrl === BASE_URL) {
+                    if (categoryUrl === this.options.baseUrl) {
                         categoryUrl = '';
                     }
                 }

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -309,6 +309,10 @@ class Topmenu extends Template implements IdentityInterface
         $classes[] = 'level' . $item->getLevel();
         $classes[] = $item->getPositionClass();
 
+        if ($item->getIsCategory()) {
+            $classes[] = 'category-item';
+        }
+
         if ($item->getIsFirst()) {
             $classes[] = 'first';
         }

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
@@ -20,7 +20,11 @@ define([
         },
         defaultContext = require.s.contexts._,
         menuSelector = '[data-action="navigation"] > ul',
-        menuItem = $('<li class="level0 category-item"><a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a></li>')[0],
+        menuItem = $(
+            '<li class="level0 category-item">' +
+            '<a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a>' +
+            '</li>'
+        )[0],
 
         /**
          * Create context object.

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
@@ -20,7 +20,7 @@ define([
         },
         defaultContext = require.s.contexts._,
         menuSelector = '[data-action="navigation"] > ul',
-        menuItem = $('<li class="level0"><a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a></li>')[0],
+        menuItem = $('<li class="level0 category-item"><a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a></li>')[0],
 
         /**
          * Create context object.


### PR DESCRIPTION
### Description
Magento 2.2.4 only.
When a product is opened from a homepage and menu has a link to the homepage,
two home links will be inserted into breadcrumbs.

**Update: Added the case with "Contacts" link in the navigation.**

### Manual testing scenarios
1. Open `app/code/Magento/Theme/view/frontend/templates/html/topmenu.phtml`
2. Insert the following code:

```php
<li class="level0 level-top" role="presentation">
    <a href="<?php echo $block->getUrl() ?>" class="level-top" tabindex="-1" role="menuitem"><span>Home</span></a>
</li>
<li class="level0 level-top" role="presentation">
    <a href="<?php echo $block->getUrl('contact') ?>" class="level-top" tabindex="-1" role="menuitem"><span>Contacts</span></a>
</li>
```

Right before 

```php
<?= /* @escapeNotVerified */ $_menu ?>
```

3. Open homepage or contacts page
4. Click on any product to navigate to its page (It may be a product in cart)
5. Breadcrumbs will have two "Home" links, or Contacts page will be added into breadcrumbs.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
