### PR TITLE
#14958: Add missing foreign key

### DIFF
--- a/app/code/Magento/SalesSequence/Setup/UpgradeSchema.php
+++ b/app/code/Magento/SalesSequence/Setup/UpgradeSchema.php
@@ -10,7 +10,7 @@ use Magento\Framework\Setup\UpgradeSchemaInterface;
 
 class UpgradeSchema implements UpgradeSchemaInterface
 {
-    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context): void
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
         $setup->startSetup();
 
@@ -21,7 +21,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         $setup->endSetup();
     }
 
-    private function addSequenceMetaStoreIdForeignKey(SchemaSetupInterface $setup): void
+    private function addSequenceMetaStoreIdForeignKey(SchemaSetupInterface $setup)
     {
         $setup->getConnection()->addForeignKey(
             $setup->getFkName('sales_sequence_meta', 'store_id', 'store', 'store_id'),

--- a/app/code/Magento/SalesSequence/Setup/UpgradeSchema.php
+++ b/app/code/Magento/SalesSequence/Setup/UpgradeSchema.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magento\SalesSequence\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context): void
+    {
+        $setup->startSetup();
+
+        if (version_compare($context->getVersion(), '2.0.1', '<')) {
+            $this->addSequenceMetaStoreIdForeignKey($setup);
+        }
+
+        $setup->endSetup();
+    }
+
+    private function addSequenceMetaStoreIdForeignKey(SchemaSetupInterface $setup): void
+    {
+        $setup->getConnection()->addForeignKey(
+            $setup->getFkName('sales_sequence_meta', 'store_id', 'store', 'store_id'),
+            $setup->getTable('sales_sequence_meta'),
+            'store_id',
+            $setup->getTable('store'),
+            'store_id'
+        );
+    }
+}

--- a/app/code/Magento/SalesSequence/composer.json
+++ b/app/code/Magento/SalesSequence/composer.json
@@ -3,6 +3,7 @@
     "description": "N/A",
     "require": {
         "php": "~7.0.13|~7.1.0",
+        "magento/module-store": "100.2.*",
         "magento/framework": "101.0.*"
     },
     "type": "magento2-module",

--- a/app/code/Magento/SalesSequence/etc/module.xml
+++ b/app/code/Magento/SalesSequence/etc/module.xml
@@ -7,5 +7,8 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Magento_SalesSequence" setup_version="2.0.1">
+        <sequence>
+            <module name="Magento_Store"/>
+        </sequence>
     </module>
 </config>

--- a/app/code/Magento/SalesSequence/etc/module.xml
+++ b/app/code/Magento/SalesSequence/etc/module.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_SalesSequence" setup_version="2.0.0">
+    <module name="Magento_SalesSequence" setup_version="2.0.1">
     </module>
 </config>


### PR DESCRIPTION
`sale_sequence_meta` and `sales_sequence_profile` records are now removed upon store deletion.

### Description
Adds missing foreign key 

### Fixed Issues (if relevant)
1. magento/magento2#14958: sale_sequence_* records are not removed on store deletion

### Manual testing scenarios
1. Delete a store view
2. Check that records with deleted store view ID are deleted from `sale_sequence_meta` table

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)