### PR TITLE
fix: set message-success in setup if we already have the latest version

### DIFF
--- a/setup/pub/magento/setup/select-version.js
+++ b/setup/pub/magento/setup/select-version.js
@@ -13,6 +13,7 @@ angular.module('select-version', ['ngStorage'])
         $scope.upgradeReadyForNext = false;
         $scope.upgradeProcessed = false;
         $scope.upgradeProcessError = false;
+        $scope.upgradeAlreadyLatestVersion = false;
         $scope.upgradeProcessErrorMessage = '';
         $scope.componentsReadyForNext = true;
         $scope.componentsProcessed = false;
@@ -39,6 +40,7 @@ angular.module('select-version', ['ngStorage'])
 
                     if ($scope.upgradeProcessError) {
                         $scope.upgradeProcessErrorMessage = "You're already using the latest version, there's nothing for us to do.";
+                        $scope.upgradeAlreadyLatestVersion = true;
                     } else {
                         $scope.selectedOption = [];
                         $scope.versions = [];

--- a/setup/view/magento/setup/select-version.phtml
+++ b/setup/view/magento/setup/select-version.phtml
@@ -38,7 +38,7 @@
         </span>
         <span class="message-text">Checking for a new version...</span>
     </div>
-    <div class="message message-error" ng-show="upgradeProcessError">
+    <div class="message" ng-class="upgradeAlreadyLatestVersion ? 'message-success' : 'message-error'" ng-show="upgradeProcessError">
             <span class="message-text" ng-bind-html="upgradeProcessErrorMessage"></span>
     </div>
     <div class="message" ng-show="upgradeProcessed && !upgradeProcessError && currentVersion">

--- a/setup/view/magento/setup/select-version.phtml
+++ b/setup/view/magento/setup/select-version.phtml
@@ -38,7 +38,10 @@
         </span>
         <span class="message-text">Checking for a new version...</span>
     </div>
-    <div class="message" ng-class="upgradeAlreadyLatestVersion ? 'message-success' : 'message-error'" ng-show="upgradeProcessError">
+    <div
+        class="message"
+        ng-class="upgradeAlreadyLatestVersion ? 'message-success' : 'message-error'"
+        ng-show="upgradeProcessError">
             <span class="message-text" ng-bind-html="upgradeProcessErrorMessage"></span>
     </div>
     <div class="message" ng-show="upgradeProcessed && !upgradeProcessError && currentVersion">


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Currently the upgrade check in the setup uses `message-error` even if we already have the latest version.

how it currently is:
![magento daniel-ruf de_setup_ 1](https://user-images.githubusercontent.com/827205/39666689-344c1c62-50a8-11e8-8683-64c88bfd78f2.png)

how it should be:
![magento daniel-ruf de_setup_ 2](https://user-images.githubusercontent.com/827205/39666711-7a00ee86-50a8-11e8-8fcb-41df9a7abacf.png)

Logic wise it should be message-success in this case instead of message-error as this is not an error and is not what we expect from the UX perspective.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. update Magento 2 to the latest version
2.open the upgrade check in the setup

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
