### PR TITLE
[2.3-develop] [ForwardPort] Port of #12285 The option <var name="allowfullscreen">false</var> for mobile device don't work in product view page gallery

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.

--- a/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Config;
+
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * Tests Magento\Framework\Config\Convert
+ */
+class ConverterTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var Converter
+     */
+    private $converter;
+
+    /**
+     * Tests config value "false" is not interpreted as true.
+     *
+     * @param string $sourceString
+     * @param array $expected
+     * @dataProvider parseVarElementDataProvider
+     */
+    public function testParseVarElement($sourceString, $expected)
+    {
+        $document = new \DOMDocument();
+        $document->loadXML($sourceString);
+        $actual = $this->converter->convert($document);
+
+        self::assertEquals(
+            $expected,
+            $actual
+        );
+    }
+
+    /**
+     * Data provider for testParseVarElement.
+     *
+     * @return array
+     */
+    public function parseVarElementDataProvider()
+    {
+        $sourceString = <<<'XML'
+<?xml version="1.0"?>
+<view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
+    <vars module="Magento_Test">    
+        <var name="str">some string</var>  
+        <var name="int-1">1</var>        
+        <var name="int-0">0</var>        
+        <var name="bool-true">true</var> 
+        <var name="bool-false">false</var> 
+    </vars>
+ </view>
+XML;
+        $expectedResult = [
+            'vars' => [
+                'Magento_Test' => [
+                    'str' => 'some string',
+                    'int-1' => '1',
+                    'int-0' => '0',
+                    'bool-true' => true,
+                    'bool-false' => false
+                ]
+            ]
+        ];
+
+        return [
+            [
+                $sourceString,
+                $expectedResult
+            ],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->converter = $this->objectManager->get(Converter::class);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
@@ -6,18 +6,11 @@
 
 namespace Magento\Framework\Config;
 
-use Magento\Framework\ObjectManagerInterface;
-
 /**
  * Tests Magento\Framework\Config\Convert
  */
 class ConverterTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var ObjectManagerInterface
-     */
-    private $objectManager;
-
     /**
      * @var Converter
      */
@@ -87,7 +80,6 @@ XML;
      */
     protected function setUp()
     {
-        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->converter = $this->objectManager->get(Converter::class);
+        $this->converter = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Framework\Config\Converter::class);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
@@ -80,6 +80,7 @@ XML;
      */
     protected function setUp()
     {
-        $this->converter = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Framework\Config\Converter::class);
+        $this->converter = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+              ->create(\Magento\Framework\Config\Converter::class);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Config/ConverterTest.php
@@ -51,7 +51,8 @@ class ConverterTest extends \PHPUnit\Framework\TestCase
     {
         $sourceString = <<<'XML'
 <?xml version="1.0"?>
-<view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
+<view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
     <vars module="Magento_Test">    
         <var name="str">some string</var>  
         <var name="int-1">1</var>        

--- a/lib/internal/Magento/Framework/Config/Converter.php
+++ b/lib/internal/Magento/Framework/Config/Converter.php
@@ -103,7 +103,9 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             }
         }
         if (!count($result)) {
-            $result = $node->nodeValue;
+            $result = (strtolower($node->nodeValue) !== 'true' &&  strtolower($node->nodeValue) !== 'false')
+                ? $node->nodeValue
+                : filter_var($node->nodeValue, FILTER_VALIDATE_BOOLEAN);        
         }
         return $result;
     }

--- a/lib/internal/Magento/Framework/Config/Converter.php
+++ b/lib/internal/Magento/Framework/Config/Converter.php
@@ -103,9 +103,9 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             }
         }
         if (!count($result)) {
-            $result = (strtolower($node->nodeValue) !== 'true' &&  strtolower($node->nodeValue) !== 'false')
+            $result = (strtolower($node->nodeValue) !== 'true' && strtolower($node->nodeValue) !== 'false')
                 ? $node->nodeValue
-                : filter_var($node->nodeValue, FILTER_VALIDATE_BOOLEAN);        
+                : filter_var($node->nodeValue, FILTER_VALIDATE_BOOLEAN);
         }
         return $result;
     }


### PR DESCRIPTION
### Description
Change the type of config variables of values "true" and "false" to type boolean, instead of string.

### Fixed Issues (if relevant)
1. magento/magento2#12285: The option <var name="allowfullscreen">false</var> for mobile device don't work in product view page gallery

Whilst the original bug was not reported against 2.3, this needs applying to be consistent across releases. We cant have 2.2 changing from strings to booleans, and 2.3 remaining as strings.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
