### PR TITLE
[2.3-develop] [ForwardPort] Port of #15020 Update Gallery Template to handle boolean config Variables

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -47,21 +47,11 @@
                 "data": <?= /* @escapeNotVerified */ $block->getGalleryImagesJson() ?>,
                 "options": {
                     "nav": "<?= /* @escapeNotVerified */ $block->getVar("gallery/nav") ?>",
-                    <?php if (($block->getVar("gallery/loop"))): ?>
-                        "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/loop") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/keyboard"))): ?>
-                        "keyboard": <?= /* @escapeNotVerified */ $block->getVar("gallery/keyboard") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/arrows"))): ?>
-                        "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/arrows") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/allowfullscreen"))): ?>
-                        "allowfullscreen": <?= /* @escapeNotVerified */ $block->getVar("gallery/allowfullscreen") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/caption"))): ?>
-                        "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
-                    <?php endif; ?>
+                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/loop") ? 'true' : 'false' ?>,
+                    "keyboard": <?= /* @escapeNotVerified */ $block->getVar("gallery/keyboard") ? 'true' : 'false' ?>,
+                    "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/arrows") ? 'true' : 'false' ?>,
+                    "allowfullscreen": <?= /* @escapeNotVerified */ $block->getVar("gallery/allowfullscreen") ? 'true' : 'false' ?>,
+                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ? 'true' : 'false' ?>,
                     "width": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'width') ?>",
                     "thumbwidth": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_small', 'width') ?>",
                     <?php if ($block->getImageAttribute('product_page_image_small', 'height') || $block->getImageAttribute('product_page_image_small', 'width')): ?>
@@ -76,28 +66,18 @@
                         "transitionduration": <?= /* @escapeNotVerified */ $block->getVar("gallery/transition/duration") ?>,
                     <?php endif; ?>
                     "transition": "<?= /* @escapeNotVerified */ $block->getVar("gallery/transition/effect") ?>",
-                    <?php if (($block->getVar("gallery/navarrows"))): ?>
-                        "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/navarrows") ?>,
-                    <?php endif; ?>
+                    "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/navarrows") ? 'true' : 'false' ?>,
                     "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navtype") ?>",
                     "navdir": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navdir") ?>"
                 },
                 "fullscreen": {
                     "nav": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/nav") ?>",
-                    <?php if ($block->getVar("gallery/fullscreen/loop")): ?>
-                        "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/loop") ?>,
-                    <?php endif; ?>
+                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/loop") ? 'true' : 'false' ?>,
                     "navdir": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navdir") ?>",
-                    <?php if ($block->getVar("gallery/transition/navarrows")): ?>
-                        "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navarrows") ?>,
-                    <?php endif; ?>
+                    "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navarrows") ? 'true' : 'false' ?>,
                     "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navtype") ?>",
-                    <?php if ($block->getVar("gallery/fullscreen/arrows")): ?>
-                        "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/arrows") ?>,
-                    <?php endif; ?>
-                    <?php if ($block->getVar("gallery/fullscreen/caption")): ?>
-                        "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/caption") ?>,
-                    <?php endif; ?>
+                    "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/arrows") ? 'true' : 'false' ?>,
+                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/caption") ? 'true' : 'false' ?>,
                     <?php if ($block->getVar("gallery/fullscreen/transition/duration")): ?>
                         "transitionduration": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/transition/duration") ?>,
                     <?php endif; ?>


### PR DESCRIPTION
### Description
Changes implemented in the resolution to #12285, boolean configuration variables are now properly typed booleans, instead of the strings "true" and "false". This fix was applied to 2.2-develop only. Pull request #15021 applies the fix to 2.3-develop, hence this is now required in 2.3-develop aswell.

If we don't apply PR #15021 and this PR to 2.3-develop, then 2.2 and 2.3 will become horribly out of sync.

### Fixed Issues (if relevant)
1. magento/magento2#15009: 2.2.4 Gallery theme variables being ignored

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
