### PR TITLE
[Forwardport] chore: upgrade Node.js to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   global:
     - COMPOSER_BIN_DIR=~/bin
     - INTEGRATION_SETS=3
-    - NODE_JS_VERSION=6
+    - NODE_JS_VERSION=8
     - MAGENTO_HOST_NAME="magento2.travis"
   matrix:
     - TEST_SUITE=unit


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15018
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Node.s 6 a bit old (4 is EOL since last month), 8 is the current LTS release and 10 is the current stable. So we should check the current Node.js LTS release which will also bring a better performance (and also automatic npm 5 with automatic package-lock.json generation).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
