### PR TITLE
[2.3-develop][Forwardport] Transport variable can not be altered in email_invoice_set_template_vars_before Event

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -131,14 +131,17 @@ class OrderSender extends Sender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
-        $transport = new DataObject($transport);
+        $transportObject = new DataObject($transport);
 
+        /**
+         * Event argument `transport` is @deprecated. Use `transportObject` instead.
+         */
         $this->eventManager->dispatch(
             'email_order_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transport]
+            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
         );
 
-        $this->templateContainer->setTemplateVars($transport->getData());
+        $this->templateContainer->setTemplateVars($transportObject->getData());
 
         parent::prepareTemplate($order);
     }


### PR DESCRIPTION
Fix missing commits from #10210 Transport variable can not be altered in email_invoice_set_template_vars_before Event

### Description
Original commit in #10210 missed updates to the /app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php file

### Fixed Issues (if relevant)
1. magento/magento2#10210

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
