### PR TITLE
Fix DI default arguments replacing

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Factory/Dynamic/Developer.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/Dynamic/Developer.php
@@ -25,7 +25,7 @@ class Developer extends \Magento\Framework\ObjectManager\Factory\AbstractFactory
         $defaultArguments = $this->config->getArguments($requestedType);
         if (is_array($defaultArguments)) {
             if (count($arguments)) {
-                $arguments = array_replace($defaultArguments, $arguments);
+                $arguments = array_replace_recursive($defaultArguments, $arguments);
             } else {
                 $arguments = $defaultArguments;
             }


### PR DESCRIPTION
### Description
Currently Magento will replace **$defaultArguments** by values passed as **$arguments** (if it is not empty).

I noted the issue with blocks - while generation we always have "**data**" argument in scope of **$arguments** variable. Even if I didn't added any arguments to the block via layout, "**data**" argument exists as empty array.

So, if I will want to specify some "data" attributes directly from **di.xml** - it will not work. Since it will be always replaced with "data" array (empty or with data generated by layout arguments).

**Example:**
Try to add some data-argument to block via di.xml like this:
```
<type name="Magento\Catalog\Block\Product\View\Description">
        <arguments>
            <argument name="data" xsi:type="array">
                <item name="my_code" xsi:type="string">Hello</item>
            </argument>
        </arguments>
</type>
```
Here you will see what is happening:
1.  Before replacing arguments: http://prntscr.com/jf0m1q
2. After: http://prntscr.com/jf0mug

So, our default argument attribute with key "my_code" was not added to result arguments array.

**What I suggesting:**

It would be nice to do **array_replace_recursive**, so array arguments will be not just replaced by another array. Instead we can replace only duplicate keys.
So, result with such fix will looks like this; http://prntscr.com/jf0upy

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
