### PR TITLE
[2.3-develop][Forwardport] #7822 Empty Checkout Agreement Edit Form when Single Store Mode is enabled

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
@@ -353,8 +353,13 @@ abstract class AbstractElement extends AbstractForm
             $html .= '<label class="addbefore" for="' . $htmlId . '">' . $beforeElementHtml . '</label>';
         }
 
-        $html .= '<input id="' . $htmlId . '" name="' . $this->getName() . '" ' . $this->_getUiId() . ' value="' .
-            $this->getEscapedValue() . '" ' . $this->serialize($this->getHtmlAttributes()) . '/>';
+        if (is_array($this->getValue())) {
+            foreach ($this->getValue() as $value) {
+                $html .= $this->getHtmlForInputByValue($this->_escape($value));
+            }
+        } else {
+            $html .= $this->getHtmlForInputByValue($this->getEscapedValue());
+        }
 
         $afterElementJs = $this->getAfterElementJs();
         if ($afterElementJs) {
@@ -573,5 +578,18 @@ abstract class AbstractElement extends AbstractForm
     public function isLocked()
     {
         return $this->getData($this->lockHtmlAttribute) == 1;
+    }
+
+    /**
+     * Get input html by sting value.
+     *
+     * @param string|null $value
+     *
+     * @return string
+     */
+    private function getHtmlForInputByValue($value)
+    {
+        return '<input id="' . $this->getHtmlId() . '" name="' . $this->getName() . '" ' . $this->_getUiId()
+            . ' value="' . $value . '" ' . $this->serialize($this->getHtmlAttributes()) . '/>';
     }
 }

--- a/lib/internal/Magento/Framework/Test/Unit/Data/Form/Element/HiddenTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Data/Form/Element/HiddenTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Test\Unit\Data\Form\Element;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * Test for \Magento\Framework\Data\Form\Element\Hidden.
+ */
+class HiddenTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\Data\Form\Element\Hidden
+     */
+    private $element;
+
+    protected function setUp()
+    {
+        $objectManager = new ObjectManager($this);
+        $this->element = $objectManager->getObject(\Magento\Framework\Data\Form\Element\Hidden::class);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @dataProvider getElementHtmlDataProvider
+     */
+    public function testGetElementHtml($value)
+    {
+        $form = $this->createMock(\Magento\Framework\Data\Form::class);
+        $this->element->setForm($form);
+        $this->element->setValue($value);
+        $html = $this->element->getElementHtml();
+
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                $this->assertContains($item, $html);
+            }
+        } else {
+            $this->assertContains($value, $html);
+        }
+    }
+
+    public function getElementHtmlDataProvider()
+    {
+        return [
+            ['some_value'],
+            ['store_ids[]' => ['1', '2']],
+        ];
+    }
+}

--- a/lib/internal/Magento/Framework/Test/Unit/Data/Form/Element/HiddenTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Data/Form/Element/HiddenTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.

--- a/lib/internal/Magento/Framework/Test/Unit/Data/Form/Element/HiddenTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Data/Form/Element/HiddenTest.php
@@ -40,9 +40,9 @@ class HiddenTest extends \PHPUnit\Framework\TestCase
             foreach ($value as $item) {
                 $this->assertContains($item, $html);
             }
-        } else {
-            $this->assertContains($value, $html);
+            return;
         }
+        $this->assertContains($value, $html);
     }
 
     public function getElementHtmlDataProvider()


### PR DESCRIPTION
#7822 Empty Checkout Agreement Edit Form when Single Store Mode is enabled

### Fixed Issues (if relevant)
1. magento/magento2#7822: Empty Checkout Agreement Edit Form when Single Store Mode is enabled

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
