### PR TITLE
fixed documentation about viewModels. The key in xml should be view_m…

### DIFF
--- a/app/code/Magento/Backend/Block/Template.php
+++ b/app/code/Magento/Backend/Block/Template.php
@@ -17,9 +17,11 @@ namespace Magento\Backend\Block;
  * Example:
  * <block name="my.block" class="Magento\Backend\Block\Template" template="My_Module::template.phtml" >
  *      <arguments>
- *          <argument name="viewModel" xsi:type="object">My\Module\ViewModel\Custom</argument>
+ *          <argument name="view_model" xsi:type="object">My\Module\ViewModel\Custom</argument>
  *      </arguments>
  * </block>
+ *
+ * Your class object can then be accessed by doing $block->getViewModel()
  *
  * @api
  * @SuppressWarnings(PHPMD.NumberOfChildren)


### PR DESCRIPTION
…odel instead of viewModel

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
`\Magento\Backend\Block\Template` documents view models and how to use them in blocks. The key used in arguments was **viewModel** which is wrong. Changed it to **view_model** and added an extra line about how to call these view models


### Manual testing scenarios
Changed comments. Hence not applicable

### Contribution checklist
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds on Travis CI are green)
