### PR TITLE
[Forwardport] Fix infinite checkout loader when some script wasn't loaded correctly because of network error

### DIFF
--- a/lib/web/mage/requirejs/resolver.js
+++ b/lib/web/mage/requirejs/resolver.js
@@ -30,7 +30,7 @@ define([
     /**
      * Checks if provided module is rejected during load.
      *
-     * @param {Object} id - Module to be checked.
+     * @param {Object} module - Module to be checked.
      * @return {Boolean}
      */
     function isRejected(module) {

--- a/lib/web/mage/requirejs/resolver.js
+++ b/lib/web/mage/requirejs/resolver.js
@@ -34,7 +34,14 @@ define([
      * @returns {Boolean}
      */
     function isPending(module) {
-        return !!module.depCount;
+        if (!module.depCount) {
+            return false;
+        }
+
+        // Return `true` if some dependency doesn't errored yet
+        return _.some(module.depMaps, function (dependency) {
+            return !registry[dependency.id].error;
+        });
     }
 
     /**

--- a/lib/web/mage/requirejs/resolver.js
+++ b/lib/web/mage/requirejs/resolver.js
@@ -28,6 +28,16 @@ define([
     }
 
     /**
+     * Checks if provided module is rejected during load.
+     *
+     * @param {Object} id - Module to be checked.
+     * @return {Boolean}
+     */
+    function isRejected(module) {
+        return registry[module.id] && registry[module.id].error;
+    }
+
+    /**
      * Checks if provided module has unresolved dependencies.
      *
      * @param {Object} module - Module to be checked.
@@ -37,11 +47,7 @@ define([
         if (!module.depCount) {
             return false;
         }
-
-        // Return `true` if some dependency doesn't errored yet
-        return _.some(module.depMaps, function (dependency) {
-            return !registry[dependency.id].error;
-        });
+        return module.depCount > _.filter(module.depMaps, isRejected).length;
     }
 
     /**

--- a/lib/web/mage/requirejs/resolver.js
+++ b/lib/web/mage/requirejs/resolver.js
@@ -47,6 +47,7 @@ define([
         if (!module.depCount) {
             return false;
         }
+
         return module.depCount > _.filter(module.depMaps, isRejected).length;
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14874
### Description
Infinite checkout loader may appear when some module makes a `require` call but the dependency wasn't returned (Network error).

The patch changes how Magento treats `isPending` modules. If all dependencies are errored - treat it as loaded.

### Manual testing scenarios
1. Open `Magento/Checkout/view/frontend/web/js/model/quote.js`
2. Insert the following code: 

```js
require([
    'jquery',
    'https://some-site/tracking/api/js'
], function ($) {}, function () {});
``` 

right after

```js
define([
    'ko',
    'underscore'
], function (ko, _) {
    'use strict';

    // add code here
```

3. Navigate to checkout.
4. You can't purchase the product because the page is blocked by loader.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
