### PR TITLE
[Forwardport] FIX for issue#14855 - Adding an * to do a customer search

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/UiComponent/DataProvider/FulltextFilter.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/DataProvider/FulltextFilter.php
@@ -63,6 +63,16 @@ class FulltextFilter implements FilterApplierInterface
     }
 
     /**
+     * Escape against value
+     * @param string $value
+     * @return string
+     */
+    private function escapeAgainstValue(string $value): string
+    {
+        return preg_replace('/([+\-><\(\)~*\"@]+)/', ' ', $value);
+    }
+
+    /**
      * Apply fulltext filters
      *
      * @param Collection $collection
@@ -86,7 +96,7 @@ class FulltextFilter implements FilterApplierInterface
         $collection->getSelect()
             ->where(
                 'MATCH(' . implode(',', $columns) . ') AGAINST(?)',
-                $filter->getValue()
+                $this->escapeAgainstValue($filter->getValue())
             );
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14905
According to MySQL fulltext documentation, AGAINST values shoud be stripped of special chars if they are not intended to be used.
https://dev.mysql.com/doc/refman/5.5/en/fulltext-search.html
Searching "*" in any grid list causes a 400 error because of no filtering is applied.

### Fixed Issues (if relevant)
1. magento/magento2#14855: Adding an * to do a customer search

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
