### PR TITLE
[Forwardport] Renamed "Add Block Names to Hints" config setting to represent what it actually does

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -136,7 +136,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="template_hints_blocks" translate="label" type="select" sortOrder="21" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Add Block Names to Hints</label>
+                    <label>Add Block Class Type to Hints</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14939
This config name is notoriously misleading as it does not show the block name at all, instead it shows the block class type. Worse still there is a question about this in the Magento2 certification exam which is utterly confusing due to the poor naming of the config setting.

### Description
I have updated the label of this config setting to state what it actually does when enabled, displaying the block class type on the hints.

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios
- Login to admin, view updated configuration label.
- Set config to "Yes", confirm block class types are still being shown on template hints.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
