### PR TITLE
Fix unnecessary recalculation of product list pricing

### DIFF
--- a/app/code/Magento/Tax/Model/Config.php
+++ b/app/code/Magento/Tax/Model/Config.php
@@ -832,12 +832,12 @@ class Config
      * If it necessary will be returned conversion type (minus or plus)
      *
      * @param null|int|string|Store $store
-     * @return bool
+     * @return bool|int
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function needPriceConversion($store = null)
     {
-        $res = false;
+        $res = 0;
         $priceIncludesTax = $this->priceIncludesTax($store) || $this->getNeedUseShippingExcludeTax();
         if ($priceIncludesTax) {
             switch ($this->getPriceDisplayType($store)) {
@@ -845,7 +845,7 @@ class Config
                 case self::DISPLAY_TYPE_BOTH:
                     return self::PRICE_CONVERSION_MINUS;
                 case self::DISPLAY_TYPE_INCLUDING_TAX:
-                    $res = true;
+                    $res = false;
                     break;
                 default:
                     break;


### PR DESCRIPTION
### Description
Unnecessary recalculation of large product list pricing causes huge slowdowns.

### Fixed Issues (if relevant)
1. magento/magento2#14941: Unnecessary recalculation of product list pricing causes huge slowdowns

### Manual testing scenarios
1. Create a catalog where prices are including tax + prices are shown including tax.
2. Go to a category page and show 100 products per page.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
