### PR TITLE
[Backport] Removed extra spaces from language file

### DIFF
--- a/app/code/Magento/CatalogInventory/i18n/en_US.csv
+++ b/app/code/Magento/CatalogInventory/i18n/en_US.csv
@@ -48,11 +48,7 @@ Inventory,Inventory
 "Only X left Threshold","Only X left Threshold"
 "Display Products Availability in Stock on Storefront","Display Products Availability in Stock on Storefront"
 "Product Stock Options","Product Stock Options"
-"
-                    Please note that these settings apply to individual items in the cart, not to the entire cart.
-                ","
-                    Please note that these settings apply to individual items in the cart, not to the entire cart.
-                "
+"Please note that these settings apply to individual items in the cart, not to the entire cart.","Please note that these settings apply to individual items in the cart, not to the entire cart."
 "Manage Stock","Manage Stock"
 Backorders,Backorders
 "Maximum Qty Allowed in Shopping Cart","Maximum Qty Allowed in Shopping Cart"


### PR DESCRIPTION
Original PR: #14896.

### Description
Removed extra spaces from a key-value in en_US.csv file. Because of this extra spaces, it's not translated properly.