### PR TITLE
[Backport] Change 'Update'-button visibility on change qty event

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -86,6 +86,14 @@ define([
             events['keyup ' + this.options.item.qty] = function (event) {
                 self._showItemButton($(event.target));
             };
+
+            /**
+             * @param {jQuery.Event} event
+             */
+            events['change ' + this.options.item.qty] = function (event) {
+                self._showItemButton($(event.target));
+            };
+
             events['click ' + this.options.item.button] = function (event) {
                 event.stopPropagation();
                 self._updateItemQty($(event.currentTarget));


### PR DESCRIPTION
Original PR: #14935.

## Description
When qty value in minicat updated by js, Update-button should have the same behavior like when qty is manually edited.

## Manual testing scenarios
jQuery('.cart-item-qty:first').val(parseFloat(jQuery('.cart-item-qty:first').val()) - 1).change(); - Update button should be shown.
jQuery('.cart-item-qty:first').val(parseFloat(jQuery('.cart-item-qty:first').val()) - 1).change(); - Update button should be hidden.