### PR TITLE
[Backport] "Add Block Names to Hints" config setting to represent what it actually does

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -116,7 +116,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="template_hints_blocks" translate="label" type="select" sortOrder="21" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Add Block Names to Hints</label>
+                    <label>Add Block Class Type to Hints</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>

--- a/app/code/Magento/Backend/i18n/en_US.csv
+++ b/app/code/Magento/Backend/i18n/en_US.csv
@@ -324,7 +324,7 @@ Developer,Developer
 Debug,Debug
 "Enabled Template Path Hints for Storefront","Enabled Template Path Hints for Storefront"
 "Enabled Template Path Hints for Admin","Enabled Template Path Hints for Admin"
-"Add Block Names to Hints","Add Block Names to Hints"
+"Add Block Class Type to Hints","Add Block Class Type to Hints"
 "Template Settings","Template Settings"
 "Allow Symlinks","Allow Symlinks"
 "Warning! Enabling this feature is not recommended on production environments because it represents a potential security risk.","Warning! Enabling this feature is not recommended on production environments because it represents a potential security risk."


### PR DESCRIPTION
Original PR: #14939.

This config name is notoriously misleading as it does not show the block name at all, instead it shows the block class type. Worse still there is a question about this in the Magento2 certification exam which is utterly confusing due to the poor naming of the config setting.

## Description
I have updated the label of this config setting to state what it actually does when enabled, displaying the block class type on the hints.

## Fixed Issues (if relevant)
n/a

## Manual testing scenarios
Login to admin, view updated configuration label.
Set config to "Yes", confirm block class types are still being shown on template hints.