### PR TITLE
[Backport] use "Module_Name::template/path" format instead of using template/path

### DIFF
--- a/app/code/Magento/Review/Block/Product/ReviewRenderer.php
+++ b/app/code/Magento/Review/Block/Product/ReviewRenderer.php
@@ -18,8 +18,8 @@ class ReviewRenderer extends \Magento\Framework\View\Element\Template implements
      * @var array
      */
     protected $_availableTemplates = [
-        self::FULL_VIEW => 'helper/summary.phtml',
-        self::SHORT_VIEW => 'helper/summary_short.phtml',
+        self::FULL_VIEW => 'Magento_Review::helper/summary.phtml',
+        self::SHORT_VIEW => 'Magento_Review::helper/summary_short.phtml',
     ];
 
     /**


### PR DESCRIPTION
in Block class to ensure extensibility of the class. not doing so causes invalid template errors after extending the block class via preference

Original PR: #14946.

## Description
Often third party modules override core block classes. If the source block classes reference a template without specifying module name like "Vendor_Module::template_path" then block render fails with "nvalid template file: " error.

## Manual testing scenarios
Overide the \Magento\Review\Block\Product\ReviewRenderer Block in your custom module via di preference. Leave your custom class empty.
Product details should work.