### PR TITLE
[Forwardport] [TASK] Fix overriding of payment methods in getPaymentMethodList

### DIFF
--- a/app/code/Magento/Payment/Helper/Data.php
+++ b/app/code/Magento/Payment/Helper/Data.php
@@ -293,7 +293,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             foreach ($methods as $code => $title) {
                 if (isset($groups[$code])) {
                     $labelValues[$code]['label'] = $title;
-                    $labelValues[$code]['value'] = null;
+                    if (!isset($labelValues[$code]['value'])) {
+                        $labelValues[$code]['value'] = null;
+                    }
                 } elseif (isset($groupRelations[$code])) {
                     unset($labelValues[$code]);
                     $labelValues[$groupRelations[$code]]['value'][$code] = ['value' => $code, 'label' => $title];


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15032
Fixes Issue #13460, keeps changes from pull request #12284

### Description
This fix only sets the value of a group if it doesn't already exist when calling \Magento\Payment\Helper\Data::getPaymentMethodList with parameter $withGroups = true.

### Fixed Issues
magento/magento2#13460
magento/magento2#12284

### Manual testing scenarios
1. Call method \Magento\Payment\Helper\Data::getPaymentMethodList
2. Value of group e.g. "offline" in $labelValues doesn't get set to null because there are already group-related values such as "checkmo".
