### PR TITLE
[Forwardport] chore: checkout last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ language: php
 php:
   - 7.1
   - 7.2
+git:
+  depth: 5
 env:
   global:
     - COMPOSER_BIN_DIR=~/bin


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15032

### Description
<!--- Provide a description of the changes proposed in the pull request -->
By default Travis checks out the last 50 commits. This PR is meant to see the performance gain by checking out the last 5 commits.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
