### PR TITLE
Add missing false-check to the ConfiguredRegularPrice price-model

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
@@ -70,6 +70,11 @@ class ConfiguredRegularPrice extends RegularPrice implements ConfiguredPriceInte
     public function getValue()
     {
         $basePrice = parent::getValue();
+        
+        if ($basePrice === false) {
+            return $basePrice;
+        }
+
         return $this->item
             ? $basePrice + $this->configuredOptions->getItemOptionsValue($basePrice, $this->item)
             : $basePrice;

--- a/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
@@ -70,12 +70,8 @@ class ConfiguredRegularPrice extends RegularPrice implements ConfiguredPriceInte
     public function getValue()
     {
         $basePrice = parent::getValue();
-        
-        if ($basePrice === false) {
-            return $basePrice;
-        }
 
-        return $this->item
+        return ($this->item && $basePrice !== false)
             ? $basePrice + $this->configuredOptions->getItemOptionsValue($basePrice, $this->item)
             : $basePrice;
     }


### PR DESCRIPTION
### Description
`parent::getValue()` can return false while `$this->configuredOptions->getItemOptionsValue` only accepts float. So if the parent method returns false then it fails with the following error:

```
NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Catalog\Pricing\Price\ConfiguredOptions::getItemOptionsValue() must be of the type float, boolean given, called in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredRegularPrice.php on line 74 and defined in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredOptions.php:24
```
