### PR TITLE
Only load attributes relevant to the product's current attribute set

### DIFF
--- a/app/code/Magento/Catalog/Model/Entity/GetCategoryCustomAttributeCodes.php
+++ b/app/code/Magento/Catalog/Model/Entity/GetCategoryCustomAttributeCodes.php
@@ -29,7 +29,7 @@ class GetCategoryCustomAttributeCodes implements GetCustomAttributeCodesInterfac
     /**
      * @inheritdoc
      */
-    public function execute(MetadataServiceInterface $metadataService): array
+    public function execute(MetadataServiceInterface $metadataService, ?int $attributeSetId = null): array
     {
         $customAttributesCodes = $this->baseCustomAttributeCodes->execute($metadataService);
         return array_diff($customAttributesCodes, CategoryInterface::ATTRIBUTES);

--- a/app/code/Magento/Catalog/Model/Entity/GetProductCustomAttributeCodes.php
+++ b/app/code/Magento/Catalog/Model/Entity/GetProductCustomAttributeCodes.php
@@ -7,8 +7,10 @@
 namespace Magento\Catalog\Model\Entity;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
 use Magento\Eav\Model\Entity\GetCustomAttributeCodesInterface;
 use Magento\Framework\Api\MetadataServiceInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 
 class GetProductCustomAttributeCodes implements GetCustomAttributeCodesInterface
 {
@@ -18,20 +20,76 @@ class GetProductCustomAttributeCodes implements GetCustomAttributeCodesInterface
     private $baseCustomAttributeCodes;
 
     /**
-     * @param GetCustomAttributeCodesInterface $baseCustomAttributeCodes
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var ProductAttributeRepositoryInterface
+     */
+    private $attributeRepository;
+
+    /**
+     * @var array[]
+     */
+    private $customAttributeCodes = [];
+
+    /**
+     * @param GetCustomAttributeCodesInterface    $baseCustomAttributeCodes
+     * @param SearchCriteriaBuilder               $searchCriteriaBuilder
+     * @param ProductAttributeRepositoryInterface $attributeRepository
      */
     public function __construct(
-        GetCustomAttributeCodesInterface $baseCustomAttributeCodes
+        GetCustomAttributeCodesInterface $baseCustomAttributeCodes,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        ProductAttributeRepositoryInterface $attributeRepository
     ) {
         $this->baseCustomAttributeCodes = $baseCustomAttributeCodes;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->attributeRepository = $attributeRepository;
     }
 
     /**
      * @inheritdoc
      */
-    public function execute(MetadataServiceInterface $metadataService): array
+    public function execute(MetadataServiceInterface $metadataService, ?int $attributeSetId = null): array
+    {
+        if (null !== $attributeSetId) {
+            return $this->getAttributesForSet($attributeSetId);
+        }
+
+
+        return $this->getAttributes($metadataService);
+    }
+
+    private function getAttributesForSet(int $attributeSetId)
+    {
+        if (!isset($this->customAttributeCodes[$attributeSetId])) {
+            $codes = [];
+            $criteria = $this->searchCriteriaBuilder->addFilter('attribute_set_id', $attributeSetId, 'eq');
+            $attributes = $this->attributeRepository->getList($criteria->create())->getItems();
+
+            if (is_array($attributes)) {
+                /** @var $attribute \Magento\Framework\Api\MetadataObjectInterface */
+                foreach ($attributes as $attribute) {
+                    $codes[] = $attribute->getAttributeCode();
+                }
+            }
+
+            $codes = array_values(
+                array_diff($codes, ProductInterface::ATTRIBUTES)
+            );
+
+            $this->customAttributeCodes[$attributeSetId] = $codes;
+        }
+
+        return $this->customAttributeCodes[$attributeSetId];
+    }
+
+    private function getAttributes(MetadataServiceInterface $metadataService)
     {
         $customAttributesCodes = $this->baseCustomAttributeCodes->execute($metadataService);
+
         return array_diff($customAttributesCodes, ProductInterface::ATTRIBUTES);
     }
 }

--- a/app/code/Magento/Catalog/Model/Entity/GetProductCustomAttributeCodes.php
+++ b/app/code/Magento/Catalog/Model/Entity/GetProductCustomAttributeCodes.php
@@ -58,7 +58,6 @@ class GetProductCustomAttributeCodes implements GetCustomAttributeCodesInterface
             return $this->getAttributesForSet($attributeSetId);
         }
 
-
         return $this->getAttributes($metadataService);
     }
 

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -497,7 +497,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      */
     protected function getCustomAttributesCodes()
     {
-        return $this->getCustomAttributeCodes->execute($this->metadataService);
+        return $this->getCustomAttributeCodes->execute($this->metadataService, $this->getAttributeSetId());
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Entity/GetProductCustomAttributeCodesTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Entity/GetProductCustomAttributeCodesTest.php
@@ -6,9 +6,14 @@
 
 namespace Magento\Catalog\Test\Unit\Model\Entity;
 
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Api\Data\ProductAttributeSearchResultsInterface;
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
 use Magento\Catalog\Model\Entity\GetProductCustomAttributeCodes;
 use Magento\Eav\Model\Entity\GetCustomAttributeCodesInterface;
 use Magento\Framework\Api\MetadataServiceInterface;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\TestCase;
 
@@ -30,6 +35,16 @@ class GetProductCustomAttributeCodesTest extends TestCase
     private $baseCustomAttributeCodes;
 
     /**
+     * @var SearchCriteriaBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var ProductAttributeRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $attributeRepository;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -38,10 +53,24 @@ class GetProductCustomAttributeCodesTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['execute'])
             ->getMockForAbstractClass();
+
+        $this->searchCriteriaBuilder = $this->getMockBuilder(SearchCriteriaBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->attributeRepository = $this->getMockBuilder(ProductAttributeRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getList'])
+            ->getMockForAbstractClass();
+
         $objectManager = new ObjectManager($this);
         $this->getProductCustomAttributeCodes = $objectManager->getObject(
             GetProductCustomAttributeCodes::class,
-            ['baseCustomAttributeCodes' => $this->baseCustomAttributeCodes]
+            [
+                'baseCustomAttributeCodes' => $this->baseCustomAttributeCodes,
+                'searchCriteriaBuilder' => $this->searchCriteriaBuilder,
+                'attributeRepository' => $this->attributeRepository
+            ]
         );
     }
 
@@ -50,17 +79,145 @@ class GetProductCustomAttributeCodesTest extends TestCase
      */
     public function testExecute()
     {
-        /** @var MetadataServiceInterface|\PHPUnit_Framework_MockObject_MockObject $metadataService */
-        $metadataService = $this->getMockBuilder(MetadataServiceInterface::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $metadataService = $this->getMockMetadataService();
+
         $this->baseCustomAttributeCodes->expects($this->once())
             ->method('execute')
             ->with($this->identicalTo($metadataService))
             ->willReturn(['test_custom_attribute_code', 'name']);
+
         $this->assertEquals(
             ['test_custom_attribute_code'],
             $this->getProductCustomAttributeCodes->execute($metadataService)
         );
+    }
+
+    public function testExecuteForAttributesInASet()
+    {
+        $metadataService = $this->getMockMetadataService();
+
+        $this->baseCustomAttributeCodes->expects($this->never())->method('execute');
+
+        $this->searchCriteriaBuilder->expects($this->once())
+            ->method('addFilter')
+            ->with('attribute_set_id', 99, 'eq')
+            ->willReturnSelf();
+
+        $this->searchCriteriaBuilder->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockSearchCriteria());
+
+        $result = $this->getMockBuilder(ProductAttributeSearchResultsInterface::class)
+            ->setMethods(['getItems'])
+            ->getMockForAbstractClass();
+
+        $this->attributeRepository->expects($this->once())
+            ->method('getList')
+            ->willReturn($result);
+
+        $result->expects($this->once())
+            ->method('getItems')
+            ->willReturn([$this->getMockAttribute('test_code'), $this->getMockAttribute('another_code'), $this->getMockAttribute('sku'), $this->getMockAttribute('price')]);
+
+        $this->assertEquals(
+            ['test_code', 'another_code'],
+            $this->getProductCustomAttributeCodes->execute($metadataService, 99)
+        );
+    }
+
+    public function testExecuteForAttributesInASetMemoizesResult()
+    {
+        $metadataService = $this->getMockMetadataService();
+
+        $this->baseCustomAttributeCodes->expects($this->never())->method('execute');
+
+        $this->searchCriteriaBuilder->expects($this->once())
+            ->method('addFilter')
+            ->with('attribute_set_id', 100, 'eq')
+            ->willReturnSelf();
+
+        $this->searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($this->getMockSearchCriteria());
+
+        $result = $this->getMockBuilder(ProductAttributeSearchResultsInterface::class)
+            ->setMethods(['getItems'])
+            ->getMockForAbstractClass();
+
+        $this->attributeRepository->expects($this->once())
+            ->method('getList')
+            ->willReturn($result);
+
+        $result->expects($this->once())
+            ->method('getItems')
+            ->willReturn([$this->getMockAttribute('foo'), $this->getMockAttribute('price')]);
+
+        $this->assertEquals(
+            ['foo'],
+            $this->getProductCustomAttributeCodes->execute($metadataService, 100)
+        );
+
+        $this->assertEquals(
+            ['foo'],
+            $this->getProductCustomAttributeCodes->execute($metadataService, 100)
+        );
+    }
+
+    public function testExecuteForAttributesInASetReturnsEmptyArrayWhenNoAttributesFound()
+    {
+        $metadataService = $this->getMockMetadataService();
+
+        $this->baseCustomAttributeCodes->expects($this->never())->method('execute');
+
+        $this->searchCriteriaBuilder->expects($this->once())
+            ->method('addFilter')
+            ->with('attribute_set_id', 101, 'eq')
+            ->willReturnSelf();
+
+        $this->searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($this->getMockSearchCriteria());
+
+        $result = $this->getMockBuilder(ProductAttributeSearchResultsInterface::class)
+            ->setMethods(['getItems'])
+            ->getMockForAbstractClass();
+
+        $this->attributeRepository->expects($this->once())
+            ->method('getList')
+            ->willReturn($result);
+
+        $result->expects($this->once())
+            ->method('getItems')
+            ->willReturn([]);
+
+        $this->assertEquals(
+            [],
+            $this->getProductCustomAttributeCodes->execute($metadataService, 101)
+        );
+    }
+
+    /**
+     * @return MetadataServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockMetadataService()
+    {
+        return $this->getMockBuilder(MetadataServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+    }
+
+    private function getMockSearchCriteria()
+    {
+        return $this->getMockBuilder(SearchCriteria::class)->disableOriginalConstructor()->getMock();
+    }
+
+    private function getMockAttribute($code)
+    {
+        $attribute = $this->getMockBuilder(ProductAttributeInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getAttributeCode'])
+            ->getMockForAbstractClass();
+
+        $attribute->expects($this->any())
+            ->method('getAttributeCode')
+            ->willReturn($code);
+
+        return $attribute;
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Entity/GetProductCustomAttributeCodesTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Entity/GetProductCustomAttributeCodesTest.php
@@ -117,7 +117,14 @@ class GetProductCustomAttributeCodesTest extends TestCase
 
         $result->expects($this->once())
             ->method('getItems')
-            ->willReturn([$this->getMockAttribute('test_code'), $this->getMockAttribute('another_code'), $this->getMockAttribute('sku'), $this->getMockAttribute('price')]);
+            ->willReturn(
+                [
+                    $this->getMockAttribute('test_code'),
+                    $this->getMockAttribute('another_code'),
+                    $this->getMockAttribute('sku'),
+                    $this->getMockAttribute('price')
+                ]
+            );
 
         $this->assertEquals(
             ['test_code', 'another_code'],
@@ -136,7 +143,9 @@ class GetProductCustomAttributeCodesTest extends TestCase
             ->with('attribute_set_id', 100, 'eq')
             ->willReturnSelf();
 
-        $this->searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($this->getMockSearchCriteria());
+        $this->searchCriteriaBuilder->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockSearchCriteria());
 
         $result = $this->getMockBuilder(ProductAttributeSearchResultsInterface::class)
             ->setMethods(['getItems'])
@@ -172,7 +181,9 @@ class GetProductCustomAttributeCodesTest extends TestCase
             ->with('attribute_set_id', 101, 'eq')
             ->willReturnSelf();
 
-        $this->searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($this->getMockSearchCriteria());
+        $this->searchCriteriaBuilder->expects($this->once())
+            ->method('create')
+            ->willReturn($this->getMockSearchCriteria());
 
         $result = $this->getMockBuilder(ProductAttributeSearchResultsInterface::class)
             ->setMethods(['getItems'])

--- a/app/code/Magento/Eav/Model/Entity/GetCustomAttributeCodes.php
+++ b/app/code/Magento/Eav/Model/Entity/GetCustomAttributeCodes.php
@@ -19,9 +19,12 @@ class GetCustomAttributeCodes implements GetCustomAttributeCodesInterface
      * Receive a list of custom EAV attributes using provided metadata service. The results are cached per entity type
      *
      * @param MetadataServiceInterface $metadataService Custom attribute metadata service to be used
+     * @param int|null                 $attributeSetId  Optional attribute set ID, if provided will only load attributes
+     *                                                  for that attribute set.
+     *
      * @return string[]
      */
-    public function execute(MetadataServiceInterface $metadataService): array
+    public function execute(MetadataServiceInterface $metadataService, ?int $attributeSetId = null): array
     {
         $cacheKey = get_class($metadataService);
         if (!isset($this->customAttributesCodes[$cacheKey])) {

--- a/app/code/Magento/Eav/Model/Entity/GetCustomAttributeCodesInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/GetCustomAttributeCodesInterface.php
@@ -14,7 +14,9 @@ interface GetCustomAttributeCodesInterface
      * Receive a list of custom EAV attributes using provided metadata service.
      *
      * @param MetadataServiceInterface $metadataService Custom attribute metadata service to be used
+     * @param int|null                 $attributeSetId
+     *
      * @return string[]
      */
-    public function execute(MetadataServiceInterface $metadataService): array;
+    public function execute(MetadataServiceInterface $metadataService, ?int $attributeSetId = null): array;
 }


### PR DESCRIPTION
### Description
This is a port of the fix suggested in https://github.com/magento/magento2/pull/13308#discussion_r167904619. Currently Magento will load every attribute in the system when creating / updating a product, instead it should only load attributes that are in the product's attribute set. 

Consider the following setup:

* 1000 attribute sets
* 100 attributes in each set

Magento would load 100,000 attributes, causing a huge increase in the number of queries to the database. 

After this change Magento will only load 100 attributes for a product because there are 100 in each attribute set. It also has no impact on smaller set ups.

We observed a ~10x performance boost in the above example setup when creating products via the REST API.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Create example set up as above
2. Test creating a product via REST API on Magento 2.2
3. Re-test creating a product with this code and observe performance increase.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
