### PR TITLE
[Forwardport] Changed the length of the remote_ip field to store ipv6 addresses

### DIFF
--- a/app/code/Magento/Quote/etc/db_schema.xml
+++ b/app/code/Magento/Quote/etc/db_schema.xml
@@ -61,7 +61,7 @@
                 identity="false" default="1" comment="Customer Note Notify"/>
         <column xsi:type="smallint" name="customer_is_guest" padding="5" unsigned="true" nullable="true"
                 identity="false" default="0" comment="Customer Is Guest"/>
-        <column xsi:type="varchar" name="remote_ip" nullable="true" length="32" comment="Remote Ip"/>
+        <column xsi:type="varchar" name="remote_ip" nullable="true" length="45" comment="Remote Ip"/>
         <column xsi:type="varchar" name="applied_rule_ids" nullable="true" length="255" comment="Applied Rule Ids"/>
         <column xsi:type="varchar" name="reserved_order_id" nullable="true" length="64" comment="Reserved Order Id"/>
         <column xsi:type="varchar" name="password_hash" nullable="true" length="255" comment="Password Hash"/>

--- a/app/code/Magento/Sales/etc/db_schema.xml
+++ b/app/code/Magento/Sales/etc/db_schema.xml
@@ -216,7 +216,7 @@
         <column xsi:type="varchar" name="relation_parent_id" nullable="true" length="32" comment="Relation Parent Id"/>
         <column xsi:type="varchar" name="relation_parent_real_id" nullable="true" length="32"
                 comment="Relation Parent Real Id"/>
-        <column xsi:type="varchar" name="remote_ip" nullable="true" length="32" comment="Remote Ip"/>
+        <column xsi:type="varchar" name="remote_ip" nullable="true" length="45" comment="Remote Ip"/>
         <column xsi:type="varchar" name="shipping_method" nullable="true" length="120"/>
         <column xsi:type="varchar" name="store_currency_code" nullable="true" length="3" comment="Store Currency Code"/>
         <column xsi:type="varchar" name="store_name" nullable="true" length="32" comment="Store Name"/>


### PR DESCRIPTION
Original PR: #14976.

Expands the `remote_ip` field to 45 characters in both the `sales_order` and `quote` tables, to cope with the ipv6 addresses, otherwise, they get truncated.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#10395 : REMOTE_IP gets saved partially when using IPV6

### Manual testing scenarios
1. trigger a `bin/magento setup:upgrade` and check both tables mentioned to check for the changes; also, check the versions of the modules in `setup_module`


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
