### PR TITLE
Unable to call getAllIds() on \Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection if the AllAttributeSetsFilter is applied

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/AbstractCollection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/AbstractCollection.php
@@ -132,12 +132,7 @@ abstract class AbstractCollection extends \Magento\Framework\Model\ResourceModel
      */
     protected function _getAllIdsSelect($limit = null, $offset = null)
     {
-        $idsSelect = clone $this->getSelect();
-        $idsSelect->reset(\Magento\Framework\DB\Select::ORDER);
-        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
-        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
-        $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
-        $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
+        $idsSelect = parent::_getAllIdsSelect();
         $idsSelect->limit($limit, $offset);
         return $idsSelect;
     }

--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
@@ -28,7 +28,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      *
      * @var bool
      */
-    protected $_inAllAttributeSetsFilterApplied = false;
+    protected $_setFilterApplied = false;
 
     /**
      * @var \Magento\Eav\Model\Config
@@ -231,7 +231,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
                 ->group('entity_attribute.attribute_id')
                 ->having('count = ' . count($setIds));
 
-            $this->_inAllAttributeSetsFilterApplied = true;
+            $this->_setFilterApplied = true;
         }
 
         //$this->getSelect()->distinct(true);
@@ -501,10 +501,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     {
         $idsSelect = parent::_getAllIdsSelect();
 
-        if ($this->_inAllAttributeSetsFilterApplied) {
-            $idsSelect->columns(array(
-                'count' => new \Zend_Db_Expr('COUNT(*)')), 'main_table'
-            );
+        if ($this->_setFilterApplied) {
+            $idsSelect->columns(['count' => new \Zend_Db_Expr('COUNT(*)')], 'main_table');
         }
 
         return $idsSelect;

--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
@@ -24,6 +24,13 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     protected $_addSetInfoFlag = false;
 
     /**
+     * All attribute sets filter is applied flag
+     *
+     * @var bool
+     */
+    protected $_inAllAttributeSetsFilterApplied = false;
+
+    /**
      * @var \Magento\Eav\Model\Config
      */
     protected $eavConfig;
@@ -223,6 +230,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
                 )
                 ->group('entity_attribute.attribute_id')
                 ->having('count = ' . count($setIds));
+
+            $this->_inAllAttributeSetsFilterApplied = true;
         }
 
         //$this->getSelect()->distinct(true);
@@ -483,6 +492,22 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $countSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
         $countSelect->columns('COUNT(DISTINCT main_table.attribute_id)');
         return $countSelect;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getAllIdsSelect()
+    {
+        $idsSelect = parent::_getAllIdsSelect();
+
+        if ($this->_inAllAttributeSetsFilterApplied) {
+            $idsSelect->columns(array(
+                'count' => new \Zend_Db_Expr('COUNT(*)')), 'main_table'
+            );
+        }
+
+        return $idsSelect;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
@@ -476,12 +476,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
         return $this->getResource()->getTable($table);
     }
 
-    /**
-     * Retrieve all ids for collection
-     *
-     * @return array
-     */
-    public function getAllIds()
+    protected function _getAllIdsSelect()
     {
         $idsSelect = clone $this->getSelect();
         $idsSelect->reset(\Magento\Framework\DB\Select::ORDER);
@@ -490,7 +485,17 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
         $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
 
         $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
-        return $this->getConnection()->fetchCol($idsSelect, $this->_bindParams);
+        return $idsSelect;
+    }
+
+    /**
+     * Retrieve all ids for collection
+     *
+     * @return array
+     */
+    public function getAllIds()
+    {
+        return $this->getConnection()->fetchCol($this->_getAllIdsSelect(), $this->_bindParams);
     }
 
     /**


### PR DESCRIPTION
### Description

When the filter **AllAttributeSetsFilter** is used for **Attribute\Collection**, then method call **getAllIds()** causes the following mysql syntax error:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'count' in 'having clause'

### Manual testing scenarios
`$attributeCollection = \Magento\Framework\App\ObjectManager::getInstance()`
 `  ->get(\Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory::class)`
`   ->create();`

`$attributeSetsCollection = \Magento\Framework\App\ObjectManager::getInstance()`
`            ->get(\Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory::class)`
`            ->create();`

`$attributeSetsCollection->getSelect()->limit(5);`
`$attributeSetIds = $attributeSetsCollection->getColumnValues('attribute_set_id');`

`$attributeCollection->addVisibleFilter();`
`$attributeCollection->setInAllAttributeSetsFilter($attributeSetIds);`

`var_dump($attributeCollection->getAllIds());`
`die;`
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
