### PR TITLE
Fix Configurable Product Type resource model 'getChildrenIds' method …

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable.php
@@ -17,7 +17,6 @@ use Magento\ConfigurableProduct\Model\AttributeOptionProviderInterface;
 use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionProvider;
 use Magento\Framework\App\ScopeResolverInterface;
 use Magento\Framework\App\ObjectManager;
-use Magento\Framework\DB\Adapter\AdapterInterface;
 
 class Configurable extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {
@@ -157,7 +156,9 @@ class Configurable extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function getChildrenIds($parentId, $required = true)
     {
-        $select = $this->getConnection()->select()->from(
+        $connection = $this->getConnection();
+
+        $select = $connection->select()->from(
             ['l' => $this->getMainTable()],
             ['product_id', 'parent_id']
         )->join(
@@ -173,9 +174,9 @@ class Configurable extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $parentId
         );
 
-        $childrenIds = [0 => []];
-        foreach ($this->getConnection()->fetchAll($select) as $row) {
-            $childrenIds[0][$row['product_id']] = $row['product_id'];
+        $childrenIds = [];
+        foreach ($connection->fetchAll($select) as $row) {
+            $childrenIds[$row['parent_id']][] = $row['product_id'];
         }
 
         return $childrenIds;

--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable.php
@@ -174,10 +174,10 @@ class Configurable extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $parentId
         );
 
-        $childrenIds = [];
+        $childrenIds = [[]];
         foreach ($connection->fetchAll($select) as $row) {
             $childrenIds[$row['parent_id']][] = $row['product_id'];
-            // Alternative declaration format for backward compatibility
+            // Alternative format for backward compatibility
             $childrenIds[0][$row['product_id']] = $row['product_id'];
         }
 

--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable.php
@@ -177,6 +177,8 @@ class Configurable extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $childrenIds = [];
         foreach ($connection->fetchAll($select) as $row) {
             $childrenIds[$row['parent_id']][] = $row['product_id'];
+            // Alternative declaration format for backward compatibility
+            $childrenIds[0][$row['product_id']] = $row['product_id'];
         }
 
         return $childrenIds;

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
@@ -518,16 +518,16 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
 
         $this->productRepository->save($product);
 
-        //Check grouped array, ex
-        //array(group => array(ids))
-        $resultArray[$product->getId()] = $oneChildId;
         // Check alternative format for backward compatibility
-        $resultArray[0] = [
+        $expectedArray[0] = [
             $oneChildId => $oneChildId
         ];
+        //Check grouped array, ex
+        //array(group => array(ids))
+        $expectedArray[$product->getId()][] = $oneChildId;
 
         self::assertEquals(
-            $resultArray,
+            $expectedArray,
             $this->model->getChildrenIds($this->product->getId())
         );
     }

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
@@ -518,12 +518,16 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
 
         $this->productRepository->save($product);
 
+        //Check grouped array, ex
+        //array(group => array(ids))
+        $resultArray[$product->getId()] = $oneChildId;
+        // Check alternative format for backward compatibility
+        $resultArray[0] = [
+            $oneChildId => $oneChildId
+        ];
+
         self::assertEquals(
-            [
-                [
-                    $oneChildId => $oneChildId
-                ]
-            ],
+            $resultArray,
             $this->model->getChildrenIds($this->product->getId())
         );
     }


### PR DESCRIPTION
…return format

Has been fixed return type of Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable:getChildrenIds method.

### Fixed Issues (if relevant)

1. magento/magento2#14061: Configurable Product Type resource model 'getChildrenIds' method incorrect return format.

### Manual testing scenarios

1. Inject class \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type
2. Apply the array of multiple configurable ids to method getChildrenIds
3. Expecting array to have such structure: [
"parent id" => ["child id"]
]