### PR TITLE
Swatches module file was missing in 2.1

### DIFF
--- a/app/code/Magento/Swatches/etc/acl.xml
+++ b/app/code/Magento/Swatches/etc/acl.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_attributes">
+                        <resource id="Magento_Swatches::iframe" title="Swatches" translate="title" sortOrder="70" />
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
ACL Files was missing in Swatches core module Magento 2.1

I've added acl.xml file fo swatches mdoule.

### Manual testing scenarios
After added acl file we can give assess control to other users also who don't have Administrator access.

