### PR TITLE
Restored app:config:status command after it was accidentally removed.

### DIFF
--- a/app/code/Magento/Deploy/etc/di.xml
+++ b/app/code/Magento/Deploy/etc/di.xml
@@ -31,6 +31,7 @@
                 <item name="dumpApplicationCommand" xsi:type="object">\Magento\Deploy\Console\Command\App\ApplicationDumpCommand</item>
                 <item name="sensitiveConfigSetCommand" xsi:type="object">\Magento\Deploy\Console\Command\App\SensitiveConfigSetCommand</item>
                 <item name="configImportCommand" xsi:type="object">Magento\Deploy\Console\Command\App\ConfigImportCommand</item>
+                <item name="configStatusCommand" xsi:type="object">Magento\Deploy\Console\Command\App\ConfigStatusCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description
This is a fix to restore the functionality added by https://github.com/magento/magento2/pull/12441

It is mentioned in the [release notes of Magento 2.2.4](https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.html) that there is supposed to be a new command `app:config:status`:
> You can now use the app:config:status command to check whether configuration propagation is up-to-date. Fix submitted by Juan Alonso in pull request 12441.

But when trying this out on a cleanly installed Magento 2.2.4, that new command doesn't seem to exist.

This is because the line which was added to the `di.xml` file of the `Magento_Deploy` module by #12441 was (accidentally?) removed in https://github.com/magento/magento2/commit/e6b6c652edf7810cf1e3a69a5b2294a31bba78e8#diff-2bf3eac66ec091433127117dae63d6a5L34

Just to be sure, the commit which introduced the problem is fixing this issue: https://github.com/magento/magento2/issues/14104 and I verified that restoring this one line in the `di.xml` file has no influence on issue #14104, so I'm pretty sure that line was accidentally removed (probably by a merge conflict or something like that).

*Be aware*, if https://github.com/magento/magento2/commit/e6b6c652edf7810cf1e3a69a5b2294a31bba78e8 gets forward ported to Magento 2.3, the fix in this PR will also need to be forward ported.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/pull/12441: Add command "app:config:status" to check if "app:config:import" needed

### Manual testing scenarios
1. Install Magento 2.2.4
2. Try to execute: `bin/magento app:config:status`
3. It won't work, but after applying this PR, it will work again.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
