### PR TITLE
Fix #5730 - added new system option to set default sort by in search …

### DIFF
--- a/app/code/Magento/Catalog/Model/Config.php
+++ b/app/code/Magento/Catalog/Model/Config.php
@@ -17,6 +17,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 class Config extends \Magento\Eav\Model\Config
 {
     const XML_PATH_LIST_DEFAULT_SORT_BY = 'catalog/frontend/default_sort_by';
+    const XML_PATH_SEARCH_LIST_DEFAULT_SORT_BY = 'catalog/search/default_sort_by';
 
     /**
      * @var mixed
@@ -492,5 +493,21 @@ class Config extends \Magento\Eav\Model\Config
     public function getProductListDefaultSortBy($store = null)
     {
         return $this->_scopeConfig->getValue(self::XML_PATH_LIST_DEFAULT_SORT_BY, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
+    }
+
+    /**
+     * Retrieve Search Product List Default Sort By
+     *
+     * @param mixed $store
+     * @return string
+     */
+    public function getSearchProductListDefaultSortBy($store = null)
+    {
+        $configValue = $this->_scopeConfig->getValue(
+            self::XML_PATH_SEARCH_LIST_DEFAULT_SORT_BY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+        return $configValue ? $configValue : 'relevance';
     }
 }

--- a/app/code/Magento/CatalogSearch/Block/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Result.php
@@ -12,6 +12,7 @@ use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Search\Model\QueryFactory;
+use Magento\Catalog\Model\Config;
 
 /**
  * Product search result block
@@ -48,10 +49,16 @@ class Result extends Template
     private $queryFactory;
 
     /**
+     * @var Config
+     */
+    protected $catalogConfig;
+
+    /**
      * @param Context $context
      * @param LayerResolver $layerResolver
      * @param Data $catalogSearchData
      * @param QueryFactory $queryFactory
+     * @param Config $catalogConfig
      * @param array $data
      */
     public function __construct(
@@ -59,11 +66,13 @@ class Result extends Template
         LayerResolver $layerResolver,
         Data $catalogSearchData,
         QueryFactory $queryFactory,
+        Config $catalogConfig,
         array $data = []
     ) {
         $this->catalogLayer = $layerResolver->get();
         $this->catalogSearchData = $catalogSearchData;
         $this->queryFactory = $queryFactory;
+        $this->catalogConfig = $catalogConfig;
         parent::__construct($context, $data);
     }
 
@@ -143,7 +152,7 @@ class Result extends Template
         )->setDefaultDirection(
             'desc'
         )->setDefaultSortBy(
-            'relevance'
+            $this->catalogConfig->getSearchProductListDefaultSortBy($category->getStoreId())
         );
 
         return $this;

--- a/app/code/Magento/CatalogSearch/Model/Config/Source/ListSort.php
+++ b/app/code/Magento/CatalogSearch/Model/Config/Source/ListSort.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Catalog Search Product List Sortable allowed sortable attributes source
+ *
+ * @author     Magento Core Team <core@magentocommerce.com>
+ */
+namespace Magento\CatalogSearch\Model\Config\Source;
+
+class ListSort implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * Catalog config
+     *
+     * @var \Magento\Catalog\Model\Config
+     */
+    protected $catalogConfig;
+
+    /**
+     * Construct
+     *
+     * @param \Magento\Catalog\Model\Config $catalogConfig
+     */
+    public function __construct(\Magento\Catalog\Model\Config $catalogConfig)
+    {
+        $this->catalogConfig = $catalogConfig;
+    }
+
+    /**
+     * Retrieve option values array
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $options = [];
+        $options[] = ['label' => __('Relevance'), 'value' => 'relevance'];
+        foreach ($this->getCatalogConfig()->getAttributesUsedForSortBy() as $attribute) {
+            $options[] = ['label' => __($attribute['frontend_label']), 'value' => $attribute['attribute_code']];
+        }
+        return $options;
+    }
+
+    /**
+     * Retrieve Catalog Config Singleton
+     *
+     * @return \Magento\Catalog\Model\Config
+     */
+    protected function getCatalogConfig()
+    {
+        return $this->catalogConfig;
+    }
+}

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
@@ -32,6 +32,10 @@
                     <comment>Number of popular search terms to be cached for faster response. Use “0” to cache all results after a term is searched for the second time.</comment>
                     <validate>validate-digits</validate>
                 </field>
+                <field id="default_sort_by" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Product Listing Sort by</label>
+                    <source_model>Magento\CatalogSearch\Model\Config\Source\ListSort</source_model>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->
This PR adds a new option in `admin -> stores -> configuration -> catalog -> catalog -> catalog search -> Product Listing Sort by` for setting a default sort order for search results page. The `admin -> stores -> configuration -> catalog -> catalog -> Product Listing Sort by` setting should stay a separate option as it makes no sense to change sorting on both pages (category page and search page) with one option.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5730: Changing sort order in admin doesn't work for catalog search


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Login to magento store admin
2. Navigate to Stores->Configuration->Catalog->Catalog->Catalog Search
3. Change Product Listing Sort by to Price
4. Clear Cache
5. Goto magento store frontend and search by keyword
6. Verify that default sorting is the one set in admin

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
