### PR TITLE
Fixed format of purchase date in order grid again.

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -187,7 +187,6 @@
                     <item name="dataType" xsi:type="string">date</item>
                     <item name="label" xsi:type="string" translate="true">Purchase Date</item>
                     <item name="sorting" xsi:type="string">desc</item>
-                    <item name="dateFormat" xsi:type="string">MMM dd, YYYY, H:mm:ss A</item>
                 </item>
             </argument>
         </column>


### PR DESCRIPTION
### Description
This was initially fixed in https://github.com/magento/magento2/pull/10260, but was (accidentally?) reverted by https://github.com/magento/magento2/commit/bbaebf76f61e2bfc8a2aa235cf39787dbd9568c2#diff-f13026afcc46259a8ef9e8bc19ccf79eR190

This is for Magento 2.1
In Magento 2.2 it was already fixed by https://github.com/magento/magento2/commit/c4c0cf86a086d21440395f92e967cee94514e87a#diff-f13026afcc46259a8ef9e8bc19ccf79e

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/pull/10260: Fix order date format in Orders Grid

### Manual testing scenarios
1. Create customer, create product, create order in the afternoon
2. Go to admin, navigate to Sales->Orders grid
3. See the date, i.e. "May 12, 2018, **16**:02:00 PM" (should be May 12, 2018 **4**:02:00 PM)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
