### PR TITLE
Adding support for variadic arguments' method in generated proxy c…

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Proxy.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Proxy.php
@@ -155,7 +155,8 @@ class Proxy extends \Magento\Framework\Code\Generator\EntityAbstract
         $parameterNames = [];
         $parameters = [];
         foreach ($method->getParameters() as $parameter) {
-            $parameterNames[] = '$' . $parameter->getName();
+            $name = $parameter->isVariadic() ? '... $' . $parameter->getName() : '$' . $parameter->getName();
+            $parameterNames[] = $name;
             $parameters[] = $this->_getMethodParameterInfo($parameter);
         }
 


### PR DESCRIPTION
Proxy for class with variadic argument method

Pull request fixes proxy class generation, so class with method with variadic arguments can be also used in proxy class.

### Description
In `Magento/Framework/ObjectManager/Code/Generator/Proxy` (lines 158, 159) I added check if parameter is variadic and if so its name is suffixed by '...', so then in method `_getMethodBody()` proxy method body is generated properly.

### Fixed Issues (if relevant)
Extends fixes from https://github.com/magento/magento2/commit/27065cfbaeb41dd5c648125bc533082de2da6f77

### Manual testing scenarios
1. Create class, containing method, which as last argument takes variadic argument.
2. Declare in di.xml proxy for this class.
3. Let Magento generate it.
4. Test if using class is possible and there are no errors. Moreover check manually content of generated proxy in `/generated/code`.

I was trying to extend unit test for modified class (`Magento\Framework\ObjectManager\Test\Unit\Code\Generator`), so it also would generate and test class with method with variadic argument, but with no success. Test broke on (mocked) method - `generateResultFileName()`. Actually, I only tried to edit fixtures files for test, not test itself:

`Magento\Framework\ObjectManager\Code\Generator\Sample`, adding method like:

```
/**
     * @param int $int
     * @param Sample[] ...$samples
     * @return int
     */
    public function takeVariadicObjectArguments(int $int, Sample ...$samples) : int
    {
        return (int) count($samples);
    }
```

And `Magento\Framework\ObjectManager\Code\Generator\Sample_Proxy.txt`, adding generated method like this:

```
/**
     * {@inheritdoc}
     */
    public function takeVariadicObjectArguments(int $int, \Magento\Framework\ObjectManager\Code\Generator\Sample ... $samples) : int
    {
        return $this->_getSubject()->takeVariadicObjectArguments($int, ... $samples);
    }
```

Maybe someone else would be able to extend unit test for this class. If we don't change anything in case of unit tests, test is green.

### Original PR
https://github.com/magento/magento2/pull/16080