### PR TITLE
Removed mageMenu widget dependency from breadcrumbs component

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
@@ -20,22 +20,6 @@ define([
             },
 
             /** @inheritdoc */
-            _init: function () {
-                var menu;
-
-                // render breadcrumbs after navigation menu is loaded.
-                menu = $(this.options.menuContainer).data('mageMenu');
-
-                if (typeof menu === 'undefined') {
-                    this._on($(this.options.menuContainer), {
-                        'menucreate': this._super
-                    });
-                } else {
-                    this._super();
-                }
-            },
-
-            /** @inheritdoc */
             _render: function () {
                 this._appendCatalogCrumbs();
                 this._super();
@@ -87,18 +71,10 @@ define([
              * @private
              */
             _getCategoryCrumb: function (menuItem) {
-                var categoryId,
-                    categoryName,
-                    categoryUrl;
-
-                categoryId = /(\d+)/i.exec(menuItem.attr('id'))[0];
-                categoryName = menuItem.text();
-                categoryUrl = menuItem.attr('href');
-
                 return {
-                    'name': 'category' + categoryId,
-                    'label': categoryName,
-                    'link': categoryUrl,
+                    'name': 'category',
+                    'label': menuItem.text(),
+                    'link': menuItem.attr('href'),
                     'title': ''
                 };
             },

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
@@ -13,7 +13,6 @@ define([
 
     var injector = new Squire(),
         widget,
-        parentWidget,
         menuContainer,
         mocks = {
             'Magento_Theme/js/model/breadcrumb-list': jasmine.createSpyObj(['push'])
@@ -44,7 +43,6 @@ define([
                 'Magento_Theme/js/view/breadcrumbs'
             ], function (mixin, breadcrumb) {
                 widget = mixin(breadcrumb);
-                parentWidget = breadcrumb;
                 done();
             }
         );

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
@@ -20,7 +20,7 @@ define([
         },
         defaultContext = require.s.contexts._,
         menuSelector = '[data-action="navigation"] > ul',
-        menuItem = $('<li class="level0"><a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a></li>')[0],
+        menuItem = $('<li class="level0"><a href="http://localhost.com/cat1.html">Cat1</a></li>')[0],
 
         /**
          * Create context object.
@@ -107,14 +107,14 @@ define([
             });
 
             it('Check _getCategoryCrumb call', function () {
-                var item = $('<a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a>');
+                var item = $('<a href="http://localhost.com/cat1.html">Cat1</a>');
 
                 expect(widget).toBeDefined();
                 expect(widget).toEqual(jasmine.any(Function));
                 expect(widget.prototype._getCategoryCrumb).toBeDefined();
                 expect(widget.prototype._getCategoryCrumb(item)).toEqual(jasmine.objectContaining(
                     {
-                        'name': 'category3',
+                        'name': 'category',
                         'label': 'Cat1',
                         'link': 'http://localhost.com/cat1.html'
                     }
@@ -223,7 +223,7 @@ define([
                 expect(result.length).toBe(1);
                 expect(result[0]).toEqual(jasmine.objectContaining(
                     {
-                        'name': 'category3',
+                        'name': 'category',
                         'label': 'Cat1',
                         'link': 'http://localhost.com/cat1.html'
                     }
@@ -234,10 +234,10 @@ define([
                 var result,
                     menuItems = $(
                         '<li class="level0 nav-1">' +
-                            '<a href="http://localhost.com/cat1.html" id="ui-id-3">cat1</a>' +
+                            '<a href="http://localhost.com/cat1.html">cat1</a>' +
                             '<ul>' +
                                 '<li class="level1 nav-1-1">' +
-                                    '<a href="http://localhost.com/cat1/cat21.html" id="ui-id-9">cat21</a>' +
+                                    '<a href="http://localhost.com/cat1/cat21.html">cat21</a>' +
                                 '</li>' +
                             '</ul>' +
                         '</li>'
@@ -253,58 +253,16 @@ define([
 
                 context = createContext(widget.prototype);
                 getParentMenuHandler = widget.prototype._getParentMenuItem.bind(context);
-                result = getParentMenuHandler($('#ui-id-9'));
+                result = getParentMenuHandler($('[href="http://localhost.com/cat1/cat21.html"]'));
 
                 expect(result).toBeDefined();
                 expect(result.length).toBe(1);
                 expect(result[0].tagName.toLowerCase()).toEqual('a');
-                expect(result.attr('id')).toEqual('ui-id-3');
+                expect(result.attr('href')).toEqual('http://localhost.com/cat1.html');
 
-                result = getParentMenuHandler($('#ui-id-3'));
+                result = getParentMenuHandler($('[href="http://localhost.com/cat1.html"]'));
 
                 expect(result).toBeNull();
-            });
-
-            it('Check _init event binding', function () {
-                var context,
-                    initMethod;
-
-                expect(parentWidget).toBeDefined();
-                expect(parentWidget).toEqual(jasmine.any(Function));
-
-                context = createContext(widget.prototype);
-                initMethod = widget.prototype._init.bind(context);
-
-                spyOn(parentWidget.prototype, '_init');
-                spyOn(widget.prototype, '_on').and.returnValue(widget);
-
-                initMethod();
-
-                expect(parentWidget.prototype._init).not.toHaveBeenCalled();
-                expect(widget.prototype._on).toHaveBeenCalledWith(
-                    jasmine.objectContaining({
-                        selector: menuSelector
-                    }),
-                    {
-                        'menucreate': jasmine.any(Function)
-                    }
-                );
-            });
-
-            it('Check parent _init call', function () {
-                var context,
-                    initMethod;
-
-                expect(parentWidget).toBeDefined();
-                expect(parentWidget).toEqual(jasmine.any(Function));
-
-                context = createContext(widget.prototype);
-                initMethod = widget.prototype._init.bind(context);
-                spyOn(parentWidget.prototype, '_init');
-
-                jQuery(menuSelector).attr('data-mage-menu', '<li></li>');
-                initMethod();
-                expect(parentWidget.prototype._init).toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
### Description
For now, breadcrumbs on the product page hardly rely on mageMenu widget. This commit completely removes this dependency to allow to use third-party menus.

### Fixed Issues
1. magento/magento2#14987: Invisible breadcrumbs at product page when mageMenu widget is not used

### Manual testing scenarios
1. Open `app/code/Magento/Theme/view/frontend/templates/html/topmenu.phtml`
2. Remove the following code from the template:

```
data-mage-init='{"menu":{"responsive":true, "expanded":true, "position":{"my":"left top","at":"left bottom"}}}'
```

3. Navigate to the product page.
4. Breadcrumbs are not rendered.

### Comments

- I removed categoryId from the crumb name, since links id is a ~~random~~ number generated by jQueryUI menu. It has nothing to actual category id.
- Two tests where removed, because I removed `_init` method completely

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
