### PR TITLE
Fix #7333 Unable to set negative custom option fixed price in admin view.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
@@ -132,7 +132,7 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
      */
     protected function validateOptionValue(Option $option)
     {
-        return $this->isInRange($option->getPriceType(), $this->priceTypes) && !$this->isNegative($option->getPrice());
+        return $this->isInRange($option->getPriceType(), $this->priceTypes);
     }
 
     /**

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
@@ -923,7 +923,7 @@ class CustomOptions extends AbstractModifier
                         'addbeforePool' => $this->productOptionsPrice->prefixesToOptionArray(),
                         'sortOrder' => $sortOrder,
                         'validation' => [
-                            'validate-zero-or-greater' => true
+                            'validate-number' => true
                         ],
                     ],
                 ],


### PR DESCRIPTION
Fixes the ability to set a negative custom option price in the backend. 

### Description
In Magento 1 it was possible to set a negative price change to a custom option. This PR fixes issue #7333 and makes it possible to set a negative price in the backend of Magento. This PR fixes the backend so that the negative price change can actually be entered in the Magento admin. There is a separate PR for the frontend changes which is PR #14975 

There also seem to be two other PR's for this issue which are stale and are not moving along: 
#13393
#14342

### Fixed Issues
1. magento/magento2#7333: Unable to set negative custom option fixed price in admin view.

### Manual testing scenarios
1. Create a new simple product in the backend and try to create new custom options where the price change has a negative value (for instance, "-10").
