### PR TITLE
#13904 [Back port for 2.1] Add To Cart success message link

### DIFF
--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -118,12 +118,7 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
             return $returnUrl;
         }
 
-        $shouldRedirectToCart = $this->_scopeConfig->getValue(
-            'checkout/cart/redirect_to_cart',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        );
-
-        if ($shouldRedirectToCart || $this->getRequest()->getParam('in_cart')) {
+        if ($this->shouldRedirectToCart() || $this->getRequest()->getParam('in_cart')) {
             if ($this->getRequest()->getActionName() == 'add' && !$this->getRequest()->getParam('in_cart')) {
                 $this->_checkoutSession->setContinueShoppingUrl($this->_redirect->getRefererUrl());
             }
@@ -131,5 +126,16 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
         }
 
         return $defaultUrl;
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldRedirectToCart()
+    {
+        return $this->_scopeConfig->isSetFlag(
+            'checkout/cart/redirect_to_cart',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/app/code/Magento/Checkout/Controller/Cart/Add.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Add.php
@@ -117,11 +117,21 @@ class Add extends \Magento\Checkout\Controller\Cart
 
             if (!$this->_checkoutSession->getNoCartRedirect(true)) {
                 if (!$this->cart->getQuote()->getHasError()) {
-                    $message = __(
-                        'You added %1 to your shopping cart.',
-                        $product->getName()
-                    );
-                    $this->messageManager->addSuccessMessage($message);
+                    if ($this->shouldRedirectToCart()) {
+                        $message = __(
+                            'You added %1 to your shopping cart.',
+                            $product->getName()
+                        );
+                        $this->messageManager->addSuccessMessage($message);
+                    } else {
+                        $this->messageManager->addComplexSuccessMessage(
+                            'addCartSuccessMessage',
+                            [
+                                'product_name' => $product->getName(),
+                                'cart_url' => $this->getCartUrl(),
+                            ]
+                        );
+                    }
                 }
                 return $this->goBack(null, $product);
             }
@@ -142,8 +152,7 @@ class Add extends \Magento\Checkout\Controller\Cart
             $url = $this->_checkoutSession->getRedirectUrl(true);
 
             if (!$url) {
-                $cartUrl = $this->_objectManager->get('Magento\Checkout\Helper\Cart')->getCartUrl();
-                $url = $this->_redirect->getRedirectUrl($cartUrl);
+                $url = $this->_redirect->getRedirectUrl($this->getCartUrl());
             }
 
             return $this->goBack($url);
@@ -182,6 +191,25 @@ class Add extends \Magento\Checkout\Controller\Cart
 
         $this->getResponse()->representJson(
             $this->_objectManager->get('Magento\Framework\Json\Helper\Data')->jsonEncode($result)
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getCartUrl()
+    {
+        return $this->_url->getUrl('checkout/cart', ['_secure' => true]);
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldRedirectToCart()
+    {
+        return $this->_scopeConfig->isSetFlag(
+            'checkout/cart/redirect_to_cart',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -81,6 +81,7 @@
                 <item name="custom_price" xsi:type="string">custom_price</item>
             </argument>
         </arguments>
+    </type>
     <type name="Magento\Framework\View\Element\Message\MessageConfigurationsPool">
         <arguments>
             <argument name="configurationsMap" xsi:type="array">

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -81,5 +81,16 @@
                 <item name="custom_price" xsi:type="string">custom_price</item>
             </argument>
         </arguments>
+    <type name="Magento\Framework\View\Element\Message\MessageConfigurationsPool">
+        <arguments>
+            <argument name="configurationsMap" xsi:type="array">
+                <item name="addCartSuccessMessage" xsi:type="array">
+                    <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\BlockRenderer::CODE</item>
+                    <item name="data" xsi:type="array">
+                        <item name="template" xsi:type="string">Magento_Checkout::messages/addCartSuccessMessage.phtml</item>
+                    </item>
+                </item>
+            </argument>
+        </arguments>
     </type>
 </config>

--- a/app/code/Magento/Checkout/view/frontend/templates/messages/addCartSuccessMessage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/messages/addCartSuccessMessage.phtml
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+// @codingStandardsIgnoreFile
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+
+<?= $block->escapeHtml(__(
+    'You added %1 to your <a href="%2">shopping cart</a>.',
+    $block->getData('product_name'),
+    $block->getData('cart_url')
+), ['a']);

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
@@ -281,4 +281,67 @@ class CartTest extends \Magento\TestFramework\TestCase\AbstractController
             'adminhtml' => ['adminhtml', 'expected_price' => 1]
         ];
     }
+
+    /**
+     * Test for \Magento\Checkout\Controller\Cart\Add::execute() with simple product and activated redirect to cart
+     *
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     * @magentoConfigFixture current_store checkout/cart/redirect_to_cart 1
+     * @magentoAppIsolation enabled
+     */
+    public function testMessageAtAddToCartWithRedirect()
+    {
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $postData = [
+            'qty' => '1',
+            'product' => '1',
+            'custom_price' => 1,
+            'form_key' => $formKey->getFormKey(),
+            'isAjax' => 1
+        ];
+        \Magento\TestFramework\Helper\Bootstrap::getInstance()->loadArea('frontend');
+        $this->getRequest()->setPostValue($postData);
+        $this->dispatch('checkout/cart/add');
+        $this->assertEquals(
+            '{"backUrl":"http:\/\/localhost\/index.php\/checkout\/cart\/"}',
+            $this->getResponse()->getBody()
+        );
+        $this->assertSessionMessages(
+            $this->contains(
+                'You added Simple Product to your shopping cart.'
+            ),
+            \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
+        );
+    }
+
+    /**
+     * Test for \Magento\Checkout\Controller\Cart\Add::execute() with simple product and deactivated redirect to cart
+     *
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     * @magentoConfigFixture current_store checkout/cart/redirect_to_cart 0
+     * @magentoAppIsolation enabled
+     */
+    public function testMessageAtAddToCartWithoutRedirect()
+    {
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $postData = [
+            'qty' => '1',
+            'product' => '1',
+            'custom_price' => 1,
+            'form_key' => $formKey->getFormKey(),
+            'isAjax' => 1
+        ];
+        \Magento\TestFramework\Helper\Bootstrap::getInstance()->loadArea('frontend');
+        $this->getRequest()->setPostValue($postData);
+        $this->dispatch('checkout/cart/add');
+        $this->assertFalse($this->getResponse()->isRedirect());
+        $this->assertEquals('[]', $this->getResponse()->getBody());
+        $this->assertSessionMessages(
+            $this->contains(
+                "\n" . 'You added Simple Product to your ' .
+                '<a href="http://localhost/index.php/checkout/cart/">shopping cart</a>.'
+            ),
+            \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
+        );
+    }
 }

--- a/setup/performance-toolkit/benchmark.jmx
+++ b/setup/performance-toolkit/benchmark.jmx
@@ -3966,7 +3966,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -4332,7 +4332,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -5847,7 +5847,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -6213,7 +6213,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -7153,7 +7153,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -7519,7 +7519,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -8965,7 +8965,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>
@@ -9331,7 +9331,7 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
     <hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
         <collectionProp name="Asserion.test_strings">
-          <stringProp name="210217247">You added ${product_name} to your shopping cart.</stringProp>
+          <stringProp name="210217247">You added ${product_name} to your <a href="${base_path}checkout/cart/">shopping cart</a>.</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
         <boolProp name="Assertion.assume_success">false</boolProp>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

Original PR:
https://github.com/magento/magento2/commit/073de209076d60ef12482551479b5f1f770f00d5

### Description
<!--- Provide a description of the changes proposed in the pull request -->
If I add a product to the shopping cart, I want to go to the cart directly after that in many cases without having to search for a link.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/pull/13904

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to a product view page
2. Click "Add to Cart"
3. Check if the success message contains the checkout cart link.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
