### PR TITLE
[Forwardport] Fixed js error when product has double quote in its name

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
@@ -11,7 +11,7 @@ $viewModel = $block->getData('viewModel');
     "breadcrumbs": {
         "categoryUrlSuffix": "<?= $block->escapeHtml($viewModel->getCategoryUrlSuffix()); ?>",
         "useCategoryPathInUrl": <?= (int)$viewModel->isCategoryUsedInProductUrl(); ?>,
-        "product": "<?= $block->escapeHtml($viewModel->getProductName()); ?>"
+        "product": "<?= $block->escapeHtml($block->escapeJsQuote($viewModel->getProductName(), '"')); ?>"
     }
 }'>
 </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15162
### Description
Magento 2.2.4 only.
When a product has `"` symbol in its name - js error appears on the page.

### Manual testing scenarios
1. Add `"` to the product name in the backend.
2. Open this product on the frontend.
3. Breadcrumbs are missing and product image block is not initialized. Console has the following error: 

```
Uncaught SyntaxError: Unexpected string in JSON at position ..
```

![screen shot 2018-05-11 at 10 03 46 pm](https://user-images.githubusercontent.com/306080/39942159-562bc0f8-5567-11e8-8a08-080a35bde825.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
