### PR TITLE
Fix Magento_ImportExport not supporting unicode characters in column names

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/AbstractEntity.php
@@ -831,7 +831,7 @@ abstract class AbstractEntity
                 if (!$this->isAttributeParticular($columnName)) {
                     if (trim($columnName) == '') {
                         $emptyHeaderColumns[] = $columnNumber;
-                    } elseif (!preg_match('/^[a-z][a-z0-9_]*$/', $columnName)) {
+                    } elseif (!preg_match('/^[a-z][\w]*$/u', $columnName)) {
                         $invalidColumns[] = $columnName;
                     } elseif ($this->needColumnCheck && !in_array($columnName, $this->getValidColumnNames())) {
                         $invalidAttributes[] = $columnName;

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -803,7 +803,7 @@ abstract class AbstractEntity
                     if (!$this->isAttributeParticular($columnName)) {
                         if (trim($columnName) == '') {
                             $emptyHeaderColumns[] = $columnNumber;
-                        } elseif (!preg_match('/^[a-z][a-z0-9_]*$/', $columnName)) {
+                        } elseif (!preg_match('/^[a-z][\w]*$/u', $columnName)) {
                             $invalidColumns[] = $columnName;
                         } elseif ($this->needColumnCheck && !in_array($columnName, $this->getValidColumnNames())) {
                             $invalidAttributes[] = $columnName;


### PR DESCRIPTION
### Description
Column names like `vitamin_a_µg` were being marked invalid.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Import a catalog product csv with a column like `vitamin_a_µg`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
