### PR TITLE
[Backport 2.1] Fix for displaying a negative price for a custom option

### DIFF
--- a/app/code/Magento/Catalog/view/base/web/js/price-options.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-options.js
@@ -19,8 +19,10 @@ define([
         optionConfig: {},
         optionHandlers: {},
         optionTemplate: '<%= data.label %>' +
-        '<% if (data.finalPrice.value) { %>' +
+        '<% if (data.finalPrice.value > 0) { %>' +
         ' +<%- data.finalPrice.formatted %>' +
+        '<% } else if (data.finalPrice.value < 0) { %>' +
+        ' <%- data.finalPrice.formatted %>' +
         '<% } %>',
         controlContainer: 'dd'
     };


### PR DESCRIPTION
Original PR: #14975

Fix for displaying a negative price for a custom option. 

### Description
Currently a negative price is displayed as +-€ 5,51 for instance. By changing the template to check of the value is actually positive, a negative value will be displayed as -€ 5,51 and a positive value will be displayed as +€ 5,51. When the value is exactly 0 nothing will be displayed after the label. 

![image](https://user-images.githubusercontent.com/1058480/39597515-ebab7be4-4f15-11e8-8177-32a451708282.png)
_Screenshot displaying the current situation._

### Manual testing scenarios
1. Have a product with a negative price as a custom option
2. Price in the dropdown will be displayed as -€ 5,51