### PR TITLE
Fix unsupported <translate tags

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
@@ -30,8 +30,12 @@
             <span class="count" if="maxItemsToDisplay < getCartLineItemsCount()" text="maxItemsToDisplay"/>
             <translate args="'of'" if="maxItemsToDisplay < getCartLineItemsCount()"/>
             <span class="count" text="getCartLineItemsCount()"/>
-            <translate args="'Item in Cart'" if="getCartLineItemsCount() === 1"/>
-            <translate args="'Items in Cart'" if="getCartLineItemsCount() > 1"/>
+                <!-- ko if: (getCartLineItemsCount() === 1) -->
+                    <span translate="'Item in Cart'"/>
+                <!--/ko-->
+                <!-- ko if: (getCartLineItemsCount() > 1) -->
+                    <span translate="'Items in Cart'"/>
+                <!--/ko-->
         </div>
 
         <each args="getRegion('subtotalContainer')" render=""/>

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -741,7 +741,7 @@ class Installer
             )->addColumn(
                 'flag_data',
                 \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                '64k',
+                '128k',
                 [],
                 'Flag Data'
             )->addColumn(


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Fix unsupported translate tags in mini cart content 
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Minicart template has several usages of `<tranlsate />` tags , however according to this 
Config (that has inside defined preg expressions for translator template parser)
```
            <argument name="patterns" xsi:type="array">
                <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
                <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
                <item name="mage_translation_widget" xsi:type="string"><![CDATA[~(?:\$|jQuery)\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
                <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
            </argument>
```
Magento supports such definition of translate attribute` <span translate="'Text to translate'">` but not the tag <translate>,
this tag will be translated without problem on frontend, if such translation has additiona properl definitions 
When magento initialize translations for FE, and put it in Magento\Translation\Model\Js\Config::DICTIONARY_FILE_NAME file , it parses templates to get proper set of translations, in case template has <tranlsate /> definition, it will not match preg's, so it will not be translated on frontend

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. "Item in cart" translation does not work 
Magento has around 20 definitions of` <template />` tag, so it does not make sense to add additional preg to create additional load for template parser, only for 20 templates


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create additional locale 
2. Add own label + translation in locale csv (for exaple "My custom text")
3. And this text to KO template via "`<translate />`" tag 
4. This translate will not not work 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
