### PR TITLE
Make possible to set NULL values using config:set command

### DIFF
--- a/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
@@ -173,9 +173,14 @@ class ConfigSetCommand extends Command
                     $lockTargetPath = ConfigFilePool::APP_CONFIG;
                 }
 
+                $value = $input->getArgument(static::ARG_VALUE);
+                if ($value === 'NULL') {
+                    $value = null;
+                }
+
                 return $this->processorFacadeFactory->create()->processWithLockTarget(
                     $input->getArgument(static::ARG_PATH),
-                    $input->getArgument(static::ARG_VALUE),
+                    $value,
                     $input->getOption(static::OPTION_SCOPE),
                     $input->getOption(static::OPTION_SCOPE_CODE),
                     $lock,


### PR DESCRIPTION
### Description
Currently is not possible to set `null` values using `config:set` command. That is needed, if we want to overwrite `core_config_data` values using `config.php` and `env.php` files.

This PR makes that possible by replacing "NULL" param value with `null` before the value is saved into the config files.

### Manual testing scenarios

1. `bin/magento config:set <path> NULL`
2. I would expect this value set to `null`. However, the current status is that "NULL" string is saved instead.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
