### PR TITLE
[fix] misspelling in demo store notice

### DIFF
--- a/app/code/Magento/Theme/i18n/en_US.csv
+++ b/app/code/Magento/Theme/i18n/en_US.csv
@@ -107,7 +107,7 @@ Remove,Remove
 "For the best experience on our site, be sure to turn on Javascript in your browser.","For the best experience on our site, be sure to turn on Javascript in your browser."
 "Local Storage seems to be disabled in your browser.","Local Storage seems to be disabled in your browser."
 "For the best experience on our site, be sure to turn on Local Storage in your browser.","For the best experience on our site, be sure to turn on Local Storage in your browser."
-"This is demo store. No orders will be fulfilled.","This is demo store. No orders will be fulfilled."
+"This is a demo store. No orders will be fulfilled.","This is a demo store. No orders will be fulfilled."
 "Items %1 to %2 of %3 total","Items %1 to %2 of %3 total"
 "%1 Item","%1 Item"
 "%1 Item(s)","%1 Item(s)"

--- a/app/code/Magento/Theme/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/notices.phtml
@@ -54,7 +54,7 @@ require(['jquery'], function(jQuery){
 <?php if ($block->displayDemoNotice()): ?>
     <div class="message global demo">
         <div class="content">
-            <p><?= /* @escapeNotVerified */ __('This is demo store. No orders will be fulfilled.') ?></p>
+            <p><?= /* @escapeNotVerified */ __('This is a demo store. No orders will be fulfilled.') ?></p>
         </div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
When demo notice is active it spells: "This is demo store. No orders will be fulfilled." which sounds weird. This PR corrects the spelling to "This is **a** demo store. No orders will be fulfilled."

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
No know issues

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set "Display Demo Store Notice" to "Yes" in Backend > Content > Design > Configuration on you store or website in the HTML Head section.
2. Go to the frontend and see the correct spelled notice.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
