### PR TITLE
[Backport] Fix typo in design rule hint message

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/web/template/dynamic-rows/grid.html
+++ b/app/code/Magento/Backend/view/adminhtml/web/template/dynamic-rows/grid.html
@@ -85,7 +85,7 @@
 <div class="messages">
     <div class="message message-notice notice">
         <span
-            translate="'Search strings are either normal strings or regular exceptions (PCRE). They are matched in the same order as entered.'"></span>
+            translate="'Search strings are either normal strings or regular expressions (PCRE). They are matched in the same order as entered.'"></span>
         <br>
         <span
             translate="'Examples'"></span>:


### PR DESCRIPTION
Original PR: #11390

### Description
Change text in design rule hint message from "Search strings are either normal strings or regular **exceptions** (PCRE)" to "Search strings are either normal strings or regular **expressions** (PCRE)".