### PR TITLE
[Backport] Fixed php notice when invalid ui_component config is used

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -127,12 +127,12 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     protected function resolveArgument(&$argument, $paramType, $paramDefault, $paramName, $requestedType)
     {
         if ($paramType && $argument !== $paramDefault && !is_object($argument)) {
-            $argumentType = $argument['instance'];
             if (!isset($argument['instance']) || $argument !== (array)$argument) {
                 throw new \UnexpectedValueException(
                     'Invalid parameter configuration provided for $' . $paramName . ' argument of ' . $requestedType
                 );
             }
+            $argumentType = $argument['instance'];
 
             if (isset($argument['shared'])) {
                 $isShared = $argument['shared'];


### PR DESCRIPTION
Original PR: #12239

### Description
Just a tiny fix. Move $argument['instance'] usage below isset($argument['instance']) check.