### PR TITLE
ISSUE-14747 Newsletter subscription confirmation message does not dis…

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
@@ -31,7 +31,8 @@ class Confirm extends \Magento\Newsletter\Controller\Subscriber
                 $this->messageManager->addError(__('This is an invalid subscription ID.'));
             }
         }
-
-        $this->getResponse()->setRedirect($this->_storeManager->getStore()->getBaseUrl());
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setUrl($this->_storeManager->getStore()->getBaseUrl());
+        return $resultRedirect;
     }
 }

--- a/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
@@ -31,6 +31,7 @@ class Confirm extends \Magento\Newsletter\Controller\Subscriber
                 $this->messageManager->addError(__('This is an invalid subscription ID.'));
             }
         }
+
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setUrl($this->_storeManager->getStore()->getBaseUrl());
         return $resultRedirect;


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14747: Newsletter subscription confirmation message does not display after clicking link in email

### Manual testing scenarios
1. I've stested with my local enviorment and its working fine.
