### PR TITLE
ISSUE-14747 Newsletter subscription confirmation message does not dis…

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
@@ -32,6 +32,8 @@ class Confirm extends \Magento\Newsletter\Controller\Subscriber
             }
         }
 
-        $this->getResponse()->setRedirect($this->_storeManager->getStore()->getBaseUrl());
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setUrl($this->_storeManager->getStore()->getBaseUrl());
+        return $resultRedirect;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14747: Newsletter subscription confirmation message does not display after clicking link in email

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. I've tested with my local environment and its working fine.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
