### PR TITLE
Fix to have possibility use symlinked modules outside magento root dir

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -34,6 +34,11 @@ class Validator
     protected $_filesystem;
 
     /**
+     * @var \Magento\Framework\Filesystem\Io\File
+     */
+    protected $_file;
+
+    /**
      * Allow symlinks flag
      *
      * @var bool
@@ -72,17 +77,20 @@ class Validator
      * Class constructor
      *
      * @param \Magento\Framework\Filesystem $filesystem
+     * @param \Magento\Framework\Filesystem\Io\File $file
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface
      * @param ComponentRegistrar $componentRegistrar
      * @param string|null $scope
      */
     public function __construct(
         \Magento\Framework\Filesystem $filesystem,
+        \Magento\Framework\Filesystem\Io\File $file,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface,
         ComponentRegistrar $componentRegistrar,
         $scope = null
     ) {
         $this->_filesystem = $filesystem;
+        $this->_file = $file;
         $this->_isAllowSymlinks = $scopeConfigInterface->getValue(self::XML_PATH_TEMPLATE_ALLOW_SYMLINK, $scope);
         $this->_themesDir = $componentRegistrar->getPaths(ComponentRegistrar::THEME);
         $this->moduleDirs = $componentRegistrar->getPaths(ComponentRegistrar::MODULE);
@@ -110,7 +118,7 @@ class Validator
                     || $this->isPathInDirectories($filename, $this->moduleDirs)
                     || $this->isPathInDirectories($filename, $this->_themesDir)
                     || $this->_isAllowSymlinks)
-                && $this->getRootDirectory()->isFile($this->getRootDirectory()->getRelativePath($filename));
+                && $this->isFileExists($filename);
         }
         return $this->_templatesValidationResults[$filename];
     }
@@ -136,15 +144,11 @@ class Validator
     }
 
     /**
-     * Instantiates filesystem directory
-     *
-     * @return \Magento\Framework\Filesystem\Directory\ReadInterface
+     * @param $filename
+     * @return bool
      */
-    protected function getRootDirectory()
+    protected function isFileExists($filename)
     {
-        if (null === $this->directory) {
-            $this->directory = $this->_filesystem->getDirectoryRead(DirectoryList::ROOT);
-        }
-        return $this->directory;
+        return $this->_file->fileExists($filename);
     }
 }

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -114,10 +114,10 @@ class Validator
         $filename = str_replace('\\', '/', $filename);
         if (!isset($this->_templatesValidationResults[$filename])) {
             $this->_templatesValidationResults[$filename] =
-                ($this->isPathInDirectories($filename, $this->_compiledDir)
+                ($this->_isAllowSymlinks
+                    || $this->isPathInDirectories($filename, $this->_compiledDir)
                     || $this->isPathInDirectories($filename, $this->moduleDirs)
-                    || $this->isPathInDirectories($filename, $this->_themesDir)
-                    || $this->_isAllowSymlinks)
+                    || $this->isPathInDirectories($filename, $this->_themesDir))
                 && $this->isFileExists($filename);
         }
         return $this->_templatesValidationResults[$filename];


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
During magento extention development we need to test module in different magento versions. In this case its very useful to make symlink to developing module in many magento hosts and take module source in one place (with on opened and configured IDE).

Currently if symlinked module source placed outside magento root directory then we get exception like this:

```
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: '/home/httpd/htdocs/users/ivashchenko/puq220ee/app/code/Aitoc/ProductUnitsAndQuantities/view/adminhtml/templates/system/config/use_quantities_validation.phtml' in module: 'Magento_Backend' block's name: 'js_schedule_block2'
```

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5326: Can't Use a Symlinked Module During Development

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Place extension that have custom templates outside magento root directory.
2. Make symlink to `app/code/{Vendor}/{ExtentionName}`  directory.
3. Use extension.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
