### PR TITLE
1 character product attribute default_value bugfix

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Date.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Date.php
@@ -90,6 +90,7 @@ class Date extends AbstractElement
 
         try {
             $this->_value = new \DateTime($value, new \DateTimeZone($this->localeDate->getConfigTimezone()));
+            $this->getValue();
         } catch (\Exception $e) {
             $this->_value = '';
         }


### PR DESCRIPTION
A bugfix to allow single character strings to be used for product attribute default values of text fields. Currently they create new DateTime instances and cause a fatal error on the product attribute page.

### Manual testing steps
1. Set a default_value for a product attribute that is 1 letter
2. Refresh the edit product attribute page (***/admin/catalog/product_attribute/edit/attribute_id/***/key/***)