### PR TITLE
[backport] fixes for instant purchase module from #15257

### DIFF
--- a/app/code/Magento/InstantPurchase/Model/InstantPurchaseOption.php
+++ b/app/code/Magento/InstantPurchase/Model/InstantPurchaseOption.php
@@ -19,22 +19,22 @@ use InvalidArgumentException;
 class InstantPurchaseOption
 {
     /**
-     * @var PaymentTokenInterface
+     * @var PaymentTokenInterface|null
      */
     private $paymentToken;
 
     /**
-     * @var AddressIn
+     * @var Address|null
      */
     private $shippingAddress;
 
     /**
-     * @var Address
+     * @var Address|null
      */
     private $billingAddress;
 
     /**
-     * @var ShippingMethodInterface
+     * @var ShippingMethodInterface|null
      */
     private $shippingMethod;
 

--- a/app/code/Magento/InstantPurchase/Model/InstantPurchaseOptionLoadingFactory.php
+++ b/app/code/Magento/InstantPurchase/Model/InstantPurchaseOptionLoadingFactory.php
@@ -100,7 +100,7 @@ class InstantPurchaseOptionLoadingFactory
     /**
      * Loads customer address model by identifier.
      *
-     * @param $addressId
+     * @param int $addressId
      * @return Address
      */
     private function getAddress($addressId): Address

--- a/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php
+++ b/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php
@@ -32,7 +32,7 @@ class DeferredShippingMethodChooserPool
     {
         if (!isset($this->choosers[$type])) {
             throw new \InvalidArgumentException(sprintf(
-                'Deferred shipping method chooser is not registered.',
+                'Deferred shipping method %s is not registered.',
                 $type
             ));
         }

--- a/app/code/Magento/InstantPurchase/PaymentMethodIntegration/IntegrationsManager.php
+++ b/app/code/Magento/InstantPurchase/PaymentMethodIntegration/IntegrationsManager.php
@@ -146,7 +146,7 @@ class IntegrationsManager
      *    </instant_purchase>
      *
      * @param VaultPaymentInterface $paymentMethod
-     * @param $storeId
+     * @param int|string|null|\Magento\Store\Model\Store $storeId
      * @return bool
      */
     private function isIntegrationAvailable(VaultPaymentInterface $paymentMethod, $storeId): bool


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

Original PR: https://github.com/magento/magento2/pull/15257

The Method `get($type)` in `/Magento/InstantPurchase/Model/ShippingMethodChoose/DeferredShippingMethodChooserPool.php ` throws an Exception without showing the shipping method $type as it was hardcoded as` 'chooser'`.

Allowing `null` for properties in `InstantPurchaseOption.php` as they are null in the constructor by default.

Fixing PHPDocs as they refer to wrong [Classes](https://github.com/magento/magento2/commit/770d8bae159c7fdfc9a35a17b1b66e988acc9e2f) or have missing type declarations.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
