### PR TITLE
[TASK] Add Sort order to the Related Produt Collection in the Admin P…

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
@@ -48,9 +48,21 @@ class CollectionProvider
         $products = $this->providers[$type]->getLinkedProducts($product);
         $converter = $this->converterPool->getConverter($type);
         $output = [];
+        $sorterItems = [];
         foreach ($products as $item) {
             $output[$item->getId()] = $converter->convert($item);
         }
-        return $output;
+        foreach ($output as $item) {
+            $itemPosition = (int)$item['position'];
+            while (true) {
+                if (!isset($sorterItems[$itemPosition])) {
+                    break;
+                }
+                $itemPosition += 1;
+            }
+            $sorterItems[$itemPosition] = $item;
+        }
+        ksort($sorterItems);
+        return $sorterItems;
     }
 }


### PR DESCRIPTION
…anel for Related Products

<!--- Provide a general summary of the Pull Request in the Title above -->
[BACKPORT] - Sort Order for Related Products + [BACKPORT] https://github.com/magento/magento2/pull/15251

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The Related Products are not sorted in the admin panel and in the fix of 2.2 only 2 related products are showing in backend

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13720: Only 2 related products are showing in backend

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Update products related products using csv and update via magento default import.
2. Flush the cache storage and reindexing .
3. Check the frontend and backend

### Expected result
<!--- Tell us what should happen -->
1. Updated related products should come in the frontend of product page and backend of product edit page

### Actual result
<!--- Tell us what happens instead -->
1. The update related products are showing in the frontend . But only 2 related products are showing in the backend and in a incorrect sort order

### Apply changes
Now the expected result will be the outcome.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
