### PR TITLE
[BUGFIX] [issue-13720] Allow more then 2 products with the same posit…

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
@@ -54,13 +54,14 @@ class CollectionProvider
         }
 
         foreach ($output as $item) {
-            $itemPosition = $item['position'];
-            if (!isset($sorterItems[$itemPosition])) {
-                $sorterItems[$itemPosition] = $item;
-            } else {
-                $newPosition = $itemPosition + 1;
-                $sorterItems[$newPosition] = $item;
+            $itemPosition = (int)$item['position'];
+            while (true) {
+                if (!isset($sorterItems[$itemPosition])) {
+                    break;
+                }
+                $itemPosition += 1;
             }
+            $sorterItems[$itemPosition] = $item;
         }
         ksort($sorterItems);
         return $sorterItems;


### PR DESCRIPTION
…ion in the Admin for Related Products

same as https://github.com/magento/magento2/pull/15251

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Only 2 related products are showing in backend

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13720: Only 2 related products are showing in backend

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Update products related products using csv and update via magento default import.
2. Flush the cache storage and reindexing .
3. Check the frontend and backend

### Expected result
<!--- Tell us what should happen -->
1. Updated related products should come in the frontend of product page and backend of product edit page

### Actual result
<!--- Tell us what happens instead -->
1. The update related products are showing in the frontend .But only 2 related products are showing in the backend 

### Apply changes
Now the expected result will be the outcome.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
