### PR TITLE
declare var to fix scope error

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/js/category-checkbox-tree.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/category-checkbox-tree.js
@@ -168,7 +168,7 @@ define([
                 }
 
                 if (parent && config && config.length) {
-                    for (i = 0; i < config.length; i++) {
+                    for (var i = 0; i < config.length; i++) {
                         categoryLoader.processCategoryTree(parent, config, i);
                     }
                 }
@@ -185,7 +185,7 @@ define([
                 if ((node.childNodes.length > 0) || (node.loaded === false && node.loading === false)) {
                     hash.children = [];
 
-                    for (i = 0, len = node.childNodes.length; i < len; i++) {
+                    for (var i = 0, len = node.childNodes.length; i < len; i++) {
                         /* eslint-disable */
                         if (!hash.children) {
                             hash.children = [];


### PR DESCRIPTION
By not declaring `var i = 0`, the code is referencing the i declared in the outer function. This causes an infinite loop condition that crashes browsers since multiple methods modify i from the other scope.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. MAGETWO-91158
2. https://github.com/magento/magento2/issues/15121