### PR TITLE
[fix] typo in method name _exportAddress[s]es

### DIFF
--- a/app/code/Magento/Paypal/Model/Api/Nvp.php
+++ b/app/code/Magento/Paypal/Model/Api/Nvp.php
@@ -1463,6 +1463,19 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
      *
      * @param array $data
      * @return void
+     * @deprecated 100.2.2 typo in method name
+     * @see _exportAddresses
+     */
+    protected function _exportAddressses($data)
+    {
+        $this->_exportAddresses($data);
+    }
+
+    /**
+     * Create billing and shipping addresses basing on response data
+     *
+     * @param array $data
+     * @return void
      */
     protected function _exportAddresses($data)
     {

--- a/app/code/Magento/Paypal/Model/Api/Nvp.php
+++ b/app/code/Magento/Paypal/Model/Api/Nvp.php
@@ -846,7 +846,7 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
         $request = $this->_exportToRequest($this->_getExpressCheckoutDetailsRequest);
         $response = $this->call(self::GET_EXPRESS_CHECKOUT_DETAILS, $request);
         $this->_importFromResponse($this->_paymentInformationResponse, $response);
-        $this->_exportAddressses($response);
+        $this->_exportAddresses($response);
     }
 
     /**
@@ -1464,7 +1464,7 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
      * @param array $data
      * @return void
      */
-    protected function _exportAddressses($data)
+    protected function _exportAddresses($data)
     {
         $address = new \Magento\Framework\DataObject();
         \Magento\Framework\DataObject\Mapper::accumulateByMap($data, $address, $this->_billingAddressMap);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Method name `\Magento\Paypal\Model\Api\Nvp::_exportAddressses` contained typo
Renamed it to `_exportAddresses`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
