### PR TITLE
[fix] typo in private method name getUniq[ue]ImageIndex

### DIFF
--- a/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
@@ -216,7 +216,7 @@ class ImagesResizeCommand extends Command
             ]);
             $images = $config->getMediaEntities('Magento_Catalog', ImageHelper::MEDIA_TYPE_CONFIG_NODE);
             foreach ($images as $imageId => $imageData) {
-                $uniqIndex = $this->getUniqImageIndex($imageData);
+                $uniqIndex = $this->getUniqueImageIndex($imageData);
                 $imageData['id'] = $imageId;
                 $viewImages[$uniqIndex] = $imageData;
             }
@@ -225,11 +225,11 @@ class ImagesResizeCommand extends Command
     }
 
     /**
-     * Get uniq image index
+     * Get unique image index
      * @param array $imageData
      * @return string
      */
-    private function getUniqImageIndex(array $imageData): string
+    private function getUniqueImageIndex(array $imageData): string
     {
         ksort($imageData);
         unset($imageData['type']);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Private method name `\Magento\Catalog\Console\Command\ImagesResizeCommand::getUniqImageIndex` contained typo/misspelling.

Renamed it to `getUniqueImageIndex`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
