### PR TITLE
Fix typos in PHPDocs and comments

### DIFF
--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimplifiedselectElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SimplifiedselectElement.php
@@ -21,7 +21,7 @@ class SimplifiedselectElement extends SelectElement
     protected $optionGroupValue = ".//*[@data-title='%s' or contains(normalize-space(.), %s)]";
 
     /**
-     * Select value in ropdown which has option groups.
+     * Select value in dropdown which has option groups.
      *
      * @param string $value
      * @return void

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/SwitcherElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/SwitcherElement.php
@@ -22,7 +22,7 @@ class SwitcherElement extends SimpleElement
     protected $parentContainer = 'parent::div[@data-role="switcher"]';
 
     /**
-     * XPath selector for label text on swticher element.
+     * XPath selector for label text on switcher element.
      *
      * @var string
      */

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/TestCase/CancelPartiallyInvoicedOrderTest.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/TestCase/CancelPartiallyInvoicedOrderTest.php
@@ -20,7 +20,7 @@ use Magento\Mtf\TestCase\Scenario;
  * 3. Open the created order.
  * 4. Create partial invoice
  * 4. Do cancel Order.
- * 5. Perform all assetions.
+ * 5. Perform all assertions.
  *
  * @group Order_Management
  * @ZephyrId MAGETWO-67787

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Edit/Section/Attributes/Search.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Edit/Section/Attributes/Search.php
@@ -37,7 +37,7 @@ class Search extends SuggestElement
     protected $actionToggle = '.action-toggle';
 
     /**
-     * Saerch result dropdown.
+     * Search result dropdown.
      *
      * @var string
      */

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductAttributeIsHtmlAllowed.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductAttributeIsHtmlAllowed.php
@@ -23,7 +23,7 @@ class AssertProductAttributeIsHtmlAllowed extends AbstractConstraint
 
     /**
      * Check whether html tags are using in attribute value.
-     * Checked tag structure <b><i>atttribute_default_value</p></i></b>
+     * Checked tag structure <b><i>attribute_default_value</p></i></b>
      *
      * @param InjectableFixture $product
      * @param CatalogProductAttribute $attribute

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/Product/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/Product/WebsiteIds.php
@@ -37,7 +37,7 @@ class WebsiteIds extends DataSource
     private $fixtureFactory;
 
     /**
-     * Rought fixture field data.
+     * Rough fixture field data.
      *
      * @var array
      */

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/ReSavingProductAfterInitialSaveTest.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/ReSavingProductAfterInitialSaveTest.php
@@ -19,7 +19,7 @@ use Magento\Mtf\TestCase\Injectable;
  *
  * 1. Login to backend.
  * 2. Create a product with invalid from and To dates
- * 3. Save the product which generates an error messsage
+ * 3. Save the product which generates an error message
  * 4. Modify the  dates to valid values
  * 5. Save the product again
  * 6. Product is saved successfully

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertBillingAddressSameAsShippingCheckbox.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertBillingAddressSameAsShippingCheckbox.php
@@ -37,7 +37,7 @@ class AssertBillingAddressSameAsShippingCheckbox extends AbstractConstraint
     }
 
     /**
-     * Returns a string representation of successfull assertion.
+     * Returns a string representation of successful assertion.
      *
      * @return string
      */

--- a/dev/tests/functional/tests/app/Magento/Config/Test/TestCase/VerifyAdminAccountSharingEntityTest.php
+++ b/dev/tests/functional/tests/app/Magento/Config/Test/TestCase/VerifyAdminAccountSharingEntityTest.php
@@ -13,7 +13,7 @@ use Magento\Config\Test\Page\Adminhtml\AdminAccountSharing;
  * Steps:
  * 1. Log in to Admin.
  * 2. Go to Stores>Configuration>Advanced>admin>Security.
- * 3. * 7. Verify admin Acoount Sharing option availability.
+ * 3. Verify admin Account Sharing option availability.
  *
  * @group Config_(PS)
  * @ZephyrId MAGETWO-47822

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertProductTierPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertProductTierPriceOnProductPage.php
@@ -10,7 +10,7 @@ use Magento\Catalog\Test\Constraint\AssertProductPage;
 use Magento\ConfigurableProduct\Test\Block\Product\View\ConfigurableOptions;
 
 /**
- * Open created configurble product on frontend and choose variation with tier price
+ * Open created configurable product on frontend and choose variation with tier price
  */
 class AssertProductTierPriceOnProductPage extends AssertProductPage
 {

--- a/dev/tests/functional/tests/app/Magento/Customer/Test/Fixture/Customer/WebsiteId.php
+++ b/dev/tests/functional/tests/app/Magento/Customer/Test/Fixture/Customer/WebsiteId.php
@@ -38,7 +38,7 @@ class WebsiteId extends DataSource
     private $fixtureFactory;
 
     /**
-     * Rought fixture field data.
+     * Rough fixture field data.
      *
      * @var array
      */

--- a/dev/tests/functional/tests/app/Magento/Customer/Test/TestCase/AbstractApplyVatIdTest.php
+++ b/dev/tests/functional/tests/app/Magento/Customer/Test/TestCase/AbstractApplyVatIdTest.php
@@ -76,7 +76,7 @@ abstract class AbstractApplyVatIdTest extends Injectable
     }
 
     /**
-     * Prepare VAT ID confguration.
+     * Prepare VAT ID configuration.
      *
      * @param ConfigData $vatConfig
      * @param string $customerGroup

--- a/dev/tests/functional/tests/app/Magento/Integration/Test/TestCase/ReAuthorizeTokensIntegrationEntityTest.php
+++ b/dev/tests/functional/tests/app/Magento/Integration/Test/TestCase/ReAuthorizeTokensIntegrationEntityTest.php
@@ -51,7 +51,7 @@ class ReAuthorizeTokensIntegrationEntityTest extends Injectable
      *
      * @param FixtureFactory $fixtureFactory
      * @param IntegrationIndex $integrationIndex
-     * @retun void
+     * @return void
      */
     public function __inject(IntegrationIndex $integrationIndex, FixtureFactory $fixtureFactory)
     {

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/CustomerActivities/Sidebar.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/CustomerActivities/Sidebar.php
@@ -36,7 +36,7 @@ abstract class Sidebar extends Block
     protected $addToOrderProductName = './/tr/td[.="%s"]';
 
     /**
-     * Add productz to order.
+     * Add products to order.
      *
      * @param array $products
      * @return void

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CancelCreatedOrderTest.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CancelCreatedOrderTest.php
@@ -23,7 +23,7 @@ use Magento\Mtf\TestStep\TestStepFactory;
  * 2. Sales > Orders.
  * 3. Open the created order.
  * 4. Do cancel Order.
- * 5. Perform all assetions.
+ * 5. Perform all assertions.
  *
  * @group Order_Management
  * @ZephyrId MAGETWO-28191

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateCustomOrderStatusEntityTest.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateCustomOrderStatusEntityTest.php
@@ -30,7 +30,7 @@ class CreateCustomOrderStatusEntityTest extends Injectable
     /* end tags */
 
     /**
-     * Order staus page.
+     * Order status page.
      *
      * @var OrderStatusIndex
      */

--- a/dev/tests/functional/tests/app/Magento/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
+++ b/dev/tests/functional/tests/app/Magento/SalesRule/Test/Constraint/AssertCartPriceRuleSuccessDeleteMessage.php
@@ -10,7 +10,7 @@ use Magento\SalesRule\Test\Page\Adminhtml\PromoQuoteIndex;
 use Magento\Mtf\Constraint\AbstractConstraint;
 
 /**
- * Assert sales rule delte message.
+ * Assert sales rule delete message.
  */
 class AssertCartPriceRuleSuccessDeleteMessage extends AbstractConstraint
 {

--- a/dev/tests/functional/tests/app/Magento/Shipping/Test/TestStep/FillShippingAddressesStep.php
+++ b/dev/tests/functional/tests/app/Magento/Shipping/Test/TestStep/FillShippingAddressesStep.php
@@ -13,7 +13,7 @@ use Magento\Checkout\Test\Page\CheckoutOnepage;
 use Magento\Shipping\Test\Constraint\AssertCityBasedShippingRateChanged;
 
 /**
- * Fill shipping addresses and assert rates relouding.
+ * Fill shipping addresses and assert rates reloading.
  */
 class FillShippingAddressesStep implements TestStepInterface
 {

--- a/dev/tests/functional/tests/app/Magento/Theme/Test/Block/Html/Footer.php
+++ b/dev/tests/functional/tests/app/Magento/Theme/Test/Block/Html/Footer.php
@@ -120,7 +120,7 @@ class Footer extends Block
     }
 
     /**
-     * Check if correspondent "Store" is present in "Store" swither or not.
+     * Check if correspondent "Store" is present in "Store" switcher or not.
      *
      * @param Store $store
      * @return bool

--- a/dev/tests/functional/tests/app/Magento/Ui/Test/Block/Adminhtml/DataGrid.php
+++ b/dev/tests/functional/tests/app/Magento/Ui/Test/Block/Adminhtml/DataGrid.php
@@ -332,7 +332,7 @@ class DataGrid extends Grid
     }
 
     /**
-     * Peform action using the dropdown above the grid.
+     * Perform action using the dropdown above the grid.
      *
      * @param array|string $action [array -> key = value from first select; value => value from subselect]
      * @return void

--- a/dev/tests/functional/tests/app/Magento/Ui/Test/Block/Adminhtml/Modal.php
+++ b/dev/tests/functional/tests/app/Magento/Ui/Test/Block/Adminhtml/Modal.php
@@ -150,7 +150,7 @@ class Modal extends Block
     }
 
     /**
-     * Wait until modal window will disapper.
+     * Wait until modal window will disappear.
      *
      * @return void
      */

--- a/dev/tests/functional/tests/app/Magento/Ui/Test/TestCase/GridFullTextSearchTest.php
+++ b/dev/tests/functional/tests/app/Magento/Ui/Test/TestCase/GridFullTextSearchTest.php
@@ -19,8 +19,8 @@ use Magento\Ui\Test\Block\Adminhtml\DataGrid;
  * Steps:
  * 1. Navigate to backend.
  * 2. Go to grid page
- * 3. Perfrom full text search
- * 5. Perform Asserts
+ * 3. Perform full text search
+ * 4. Perform Asserts
  *
  * @group Ui
  * @ZephyrId MAGETWO-41330

--- a/dev/tests/functional/tests/app/Magento/UrlRewrite/Test/Block/Adminhtml/Catalog/Edit/UrlRewriteForm.php
+++ b/dev/tests/functional/tests/app/Magento/UrlRewrite/Test/Block/Adminhtml/Catalog/Edit/UrlRewriteForm.php
@@ -39,7 +39,7 @@ class UrlRewriteForm extends Form
      *
      * @param array $data
      * @param SimpleElement $context
-     * @retun void
+     * @return void
      */
     protected function fillFields(array $data, SimpleElement $context)
     {

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Constraint/AssertWidgetCmsPageLink.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Constraint/AssertWidgetCmsPageLink.php
@@ -12,7 +12,7 @@ use Magento\Widget\Test\Fixture\Widget;
 use Magento\Mtf\Constraint\AbstractConstraint;
 
 /**
- * Check that created widget displayed on frontent on Home page and on Advanced Search and
+ * Check that created widget displayed on frontend on Home page and on Advanced Search and
  * after click on widget link on frontend system redirects you to cms page.
  */
 class AssertWidgetCmsPageLink extends AbstractConstraint

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/AbstractDb.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/AbstractDb.php
@@ -84,7 +84,7 @@ abstract class AbstractDb
     abstract protected function getSetupDbDumpFilename();
 
     /**
-     * Is dump esxists
+     * Is dump exists
      *
      * @return bool
      */

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -89,7 +89,7 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     }
 
     /**
-     * Is dump esxists
+     * Is dump exists
      *
      * @return bool
      */

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractConfigFiles.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractConfigFiles.php
@@ -47,7 +47,7 @@ abstract class AbstractConfigFiles extends \PHPUnit\Framework\TestCase
                 \Magento\Framework\App\Arguments\FileResolver\Primary::class
             )->disableOriginalConstructor()->getMock();
 
-            /* Enable Validation regardles of MAGE_MODE */
+            /* Enable Validation regardless of MAGE_MODE */
             $validateStateMock = $this->getMockBuilder(
                 \Magento\Framework\Config\ValidationStateInterface::class
             )->disableOriginalConstructor()->getMock();

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/TypeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/TypeTest.php
@@ -20,7 +20,7 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param sring|null $typeId
+     * @param string|null $typeId
      * @param string $expectedClass
      * @dataProvider factoryDataProvider
      */
@@ -52,7 +52,7 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param sring|null $typeId
+     * @param string|null $typeId
      * @dataProvider factoryReturnsSingletonDataProvider
      */
     public function testFactoryReturnsSingleton($typeId)
@@ -82,7 +82,7 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param sring|null $typeId
+     * @param string|null $typeId
      * @param string $expectedClass
      * @dataProvider priceFactoryDataProvider
      */

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/_files/product_export_with_product_links_data.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/_files/product_export_with_product_links_data.php
@@ -7,7 +7,7 @@
 require dirname(dirname(__DIR__)) . '/Catalog/_files/category.php';
 /** Create fixture store */
 require dirname(dirname(__DIR__)) . '/Store/_files/second_store.php';
-/** Create product with mulselect attribute */
+/** Create product with multiselect attribute */
 require dirname(dirname(__DIR__)) . '/Catalog/_files/products_with_multiselect_attribute.php';
 
 $productModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/CustomerMetadataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/CustomerMetadataTest.php
@@ -159,7 +159,7 @@ class CustomerMetadataTest extends \PHPUnit\Framework\TestCase
         );
 
         // Verify the consistency of custom attribute metadata from two services
-        // after getAttrbiuteCode was called
+        // after getAttributeCode was called
         foreach ($customAttributesMetadata2 as $attribute) {
             $attribute->getAttributeCode();
         }

--- a/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/FieldsetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/FieldsetTest.php
@@ -246,7 +246,7 @@ class FieldsetTest extends \PHPUnit\Framework\TestCase
         $fieldsetField = $textField;
         $fieldsetField[1] = 'fieldset';
         $advancedFieldsetFld = $fieldsetField;
-        // set isAdvenced flag
+        // set isAdvanced flag
         $advancedFieldsetFld[4] = true;
         $result = [[[$fieldsetField, $textField, $advancedFieldsetFld], 1]];
         return $result;

--- a/dev/tests/integration/testsuite/Magento/Integration/Model/ResourceModel/Oauth/TokenTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Model/ResourceModel/Oauth/TokenTest.php
@@ -252,7 +252,7 @@ class TokenTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Make that only exired tokens were cleaned up
+     * Make that only expired tokens were cleaned up
      *
      * @param array $expectedRemovedTokenNumbers
      * @param array $expectedPreservedTokenNumbers

--- a/dev/tests/integration/testsuite/Magento/Search/Model/SearchEngine/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Search/Model/SearchEngine/ConfigTest.php
@@ -17,7 +17,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $xmlPath = __DIR__ . '/../../_files/search_engine.xml';
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
 
-        // Clear out the clache
+        // Clear out the cache
         $cacheManager = $objectManager->create(\Magento\Framework\App\Cache\Manager::class);
         /** @var \Magento\Framework\App\Cache\Manager $cacheManager */
         $cacheManager->clean($cacheManager->getAvailableTypes());

--- a/dev/tests/static/framework/Magento/Sniffs/Less/ZeroUnitsSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Less/ZeroUnitsSniff.php
@@ -25,7 +25,7 @@ class ZeroUnitsSniff implements Sniff
     const CSS_PROPERTY_UNIT_REM = 'rem';
 
     /**
-     * List of available CSS Propery units
+     * List of available CSS Property units
      *
      * @var array
      */

--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -117,7 +117,7 @@ class DeploymentConfig
     }
 
     /**
-     * Check if data from deploy files is avaiable
+     * Check if data from deploy files is available
      *
      * @return bool
      * @since 100.1.3


### PR DESCRIPTION
Note: Most of the typos have been already fixed in 2.3-develop (as part of #13300), no forwardport needed.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Fix typos in PHPDocs and comments

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
