### PR TITLE
Fix for issue-6578

### DIFF
--- a/app/code/Magento/Customer/Api/LinkTokenManagerInterface.php
+++ b/app/code/Magento/Customer/Api/LinkTokenManagerInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package  Magento\Customer
+ * @author Bartosz Herba <bherba@divante.pl>
+ * @copyright 2017 Divante Sp. z o.o.
+ * @license See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Magento\Customer\Api;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\Exception\InputException;
+
+/**
+ * Interface LinkTokenManagerInterface
+ */
+interface LinkTokenManagerInterface
+{
+    /**
+     * Change and store new reset password link token
+     *
+     * @param CustomerInterface $customerData
+     * @param string $passwordLinkToken
+     *
+     * @throws InputException
+     *
+     * @return bool
+     */
+    public function changeToken(CustomerInterface $customerData, string $passwordLinkToken): bool;
+}

--- a/app/code/Magento/Customer/Model/Account/Password/LinkTokenManager.php
+++ b/app/code/Magento/Customer/Model/Account/Password/LinkTokenManager.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @package  Magento\Customer
+ * @author Bartosz Herba <bherba@divante.pl>
+ * @copyright 2017 Divante Sp. z o.o.
+ * @license See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Magento\Customer\Model\Account\Password;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Api\LinkTokenManagerInterface;
+use Magento\Customer\Model\CustomerRegistry;
+use Magento\Customer\Model\ResourceModel\Customer as CustomerResource;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Stdlib\DateTime;
+
+/**
+ * Class LinkTokenManager
+ */
+class LinkTokenManager implements LinkTokenManagerInterface
+{
+    /**
+     * @var CustomerRegistry
+     */
+    private $customerRegistry;
+
+    /**
+     * @var DateTime\DateTimeFactory
+     */
+    private $dateTimeFactory;
+
+    /**
+     * @var CustomerResource
+     */
+    private $customerResource;
+
+    /**
+     * PasswordLinkToken constructor.
+     *
+     * @param CustomerRegistry $customerRegistry
+     * @param DateTimeFactory|DateTime\DateTimeFactory $dateTimeFactory
+     * @param CustomerResource $customerResource
+     */
+    public function __construct(
+        CustomerRegistry $customerRegistry,
+        DateTimeFactory $dateTimeFactory,
+        CustomerResource $customerResource
+    ) {
+        $this->customerRegistry = $customerRegistry;
+        $this->dateTimeFactory = $dateTimeFactory;
+        $this->customerResource = $customerResource;
+    }
+
+    /**
+     * Change and store new reset password link token
+     *
+     * @param CustomerInterface $customerData
+     * @param string $passwordLinkToken
+     *
+     * @throws InputException
+     *
+     * @return bool
+     */
+    public function changeToken(CustomerInterface $customerData, string $passwordLinkToken): bool
+    {
+        if (empty($passwordLinkToken)) {
+            throw new InputException(
+                __(
+                    'Invalid value of "%value" provided for the %fieldName field.',
+                    ['value' => $passwordLinkToken, 'fieldName' => 'password reset token']
+                )
+            );
+        }
+
+        $customer = $this->customerRegistry->retrieve($customerData->getId());
+
+        $customer->setRpToken($passwordLinkToken);
+        $customer->setRpTokenCreatedAt(
+            $this->dateTimeFactory->create()->format(DateTime::DATETIME_PHP_FORMAT)
+        );
+
+        $this->customerResource->save($customer);
+
+        return true;
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Model/Account/Password/LinkTokenManagerTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Account/Password/LinkTokenManagerTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @package  Magento\Customer
+ * @author Bartosz Herba <bherba@divante.pl>
+ * @copyright 2017 Divante Sp. z o.o.
+ * @license See LICENSE_DIVANTE.txt for license details.
+ */
+
+namespace Magento\Customer\Test\Unit\Model\Account\Password;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Api\LinkTokenManagerInterface;
+use Magento\Customer\Model\Account\Password\LinkTokenManager;
+use Magento\Customer\Model\CustomerRegistry;
+use Magento\Customer\Model\ResourceModel\Customer;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * Class LinkTokenManagerTest
+ */
+class LinkTokenManagerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Customer\Model\Data\Customer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockCustomerData;
+
+    /**
+     * @var LinkTokenManagerInterface
+     */
+    private $linkTokenManager;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var CustomerRegistry|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockCustomerRegistry;
+
+    /**
+     * @var DateTimeFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockDateTimeFactory;
+
+    /**
+     * @var DateTime|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockDateTime;
+
+    /**
+     * @var string
+     */
+    private $passwordLinkToken = 'token';
+
+    /**
+     * @var Customer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockCustomerResource;
+
+    public function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->mockCustomerRegistry = $this->getMockBuilder(CustomerRegistry::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['retrieve'])
+            ->getMock();
+
+        $this->mockDateTimeFactory = $this->getMockBuilder(DateTimeFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
+        $this->mockDateTime = $this->getMockBuilder(DateTime::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['format'])
+            ->getMock();
+
+        $this->mockCustomerResource = $this->getMockBuilder(Customer::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['save'])
+            ->getMock();
+
+        /** @var CustomerInterface $mockCustomerData */
+        $this->mockCustomerData = $this->getMockBuilder(\Magento\Customer\Model\Data\Customer::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId'])
+            ->getMock();
+
+        $this->linkTokenManager = $this->objectManager->getObject(LinkTokenManager::class, [
+            'customerRegistry' => $this->mockCustomerRegistry,
+            'dateTimeFactory'  => $this->mockDateTimeFactory,
+            'customerResource' => $this->mockCustomerResource,
+        ]);
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\InputException
+     * @expectedExceptionMessage Invalid value of "" provided for the password reset token field.
+     */
+    public function testEmptyTokenThrowsException()
+    {
+        $this->linkTokenManager->changeToken($this->mockCustomerData, '');
+    }
+
+    /**
+     * Test change method
+     */
+    public function testChangeRpToken()
+    {
+        $customerId = 1;
+
+        $this->mockCustomerData->expects($this->once())
+            ->method('getId')
+            ->willReturn($customerId);
+
+        $mockCustomer = $this->getMockBuilder(\Magento\Customer\Model\Customer::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setRpToken', 'setRpTokenCreatedAt'])
+            ->getMock();
+
+        $this->mockCustomerRegistry->expects($this->once())
+            ->method('retrieve')
+            ->with($customerId)
+            ->willReturn($mockCustomer);
+
+        $mockCustomer->expects($this->once())
+            ->method('setRpToken')
+            ->with($this->passwordLinkToken);
+
+        $this->mockDateTimeFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->mockDateTime);
+
+        $dateFormat = 'some-format';
+
+        $this->mockDateTime->expects($this->once())
+            ->method('format')
+            ->with(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT)
+            ->willReturn($dateFormat);
+
+        $mockCustomer->expects($this->once())
+            ->method('setRpTokenCreatedAt')
+            ->with($dateFormat);
+
+        $this->assertTrue($this->linkTokenManager->changeToken($this->mockCustomerData, $this->passwordLinkToken));
+    }
+}

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -61,6 +61,8 @@
                 type="Magento\Customer\Block\Account\SortLink"/>
     <preference for="Magento\Customer\Model\Group\RetrieverInterface"
                 type="Magento\Customer\Model\Group\Retriever"/>
+    <preference for="Magento\Customer\Api\LinkTokenManagerInterface"
+                type="Magento\Customer\Model\Account\Password\LinkTokenManager"/>
     <type name="Magento\Customer\Model\Session">
         <arguments>
             <argument name="configShare" xsi:type="object">Magento\Customer\Model\Config\Share\Proxy</argument>


### PR DESCRIPTION
Fix for #6578 
    - add LinkTokenManager class responsible for modification of RpToken on customer entity
    - add LinkTokenManager unit tests
    - udpdate relevant unit/integrations tests for AccountManagement class
    - mark AccountManagement::changeResetPasswordLinkToken() method as deprecated and delegate responsibility to token manager

### Description
On password reset request we should care only about preserving relevant data. Validation of whole model with all its relation is not our interest here.
The main problem is that the customer knows to much and some of its data as tokens should be a separate class. We can't do that easily. Therefore I created token manager class to take care of setting new token on the customer without using repository which leads to extended and unnecessary logic execution.

### Fixed Issues
Now customer's address data are irrelevant with regards of password reset request.

### Manual testing scenarios
1. Register a customer and log in
2. Create an address with empty phone number
3. Log out
4. Go to login view and try to reset your password

As a result you should be able to receive email with further instructions as expected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
