### PR TITLE
Add @deprecated annotation to \Magento\Framework\Option\ArrayInterface

### DIFF
--- a/lib/internal/Magento/Framework/Option/ArrayInterface.php
+++ b/lib/internal/Magento/Framework/Option/ArrayInterface.php
@@ -7,6 +7,7 @@ namespace Magento\Framework\Option;
 
 /**
  * @todo Remove in favor of the ancestor interface
+ * @deprecated
  */
 interface ArrayInterface extends \Magento\Framework\Data\OptionSourceInterface
 {


### PR DESCRIPTION
Add @deprecated annotation to \Magento\Framework\Option\ArrayInterface so IDE users are aware of the intended removal

### Description
Add @deprecated annotation to \Magento\Framework\Option\ArrayInterface

### Manual testing scenarios
1. Implementing \Magento\Framework\Option\ArrayInterface now alerts a developer of the removal intention, making code future proof

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)