### PR TITLE
Issue-4053. Cannot create full datetime product attribute

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/datepicker.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/datepicker.js
@@ -16,7 +16,7 @@ define([
 
     var defaults = {
         dateFormat: 'mm\/dd\/yyyy',
-        showsTime: false,
+        showsTime: true,
         timeFormat: null,
         buttonImage: null,
         buttonImageOnly: null,


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4053: Cannot create full datetime product attribute

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Go to Admin Panel -> Catalog -> Products
2. Edit any product from list
3. Click on the attribute "Set product as New To" calendar
4. Time pick should be visible, choose any time and save the product
5. After save time should be set on this attribute (optionally you can check this in `catalog_product_entity_datetime` table)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
