### PR TITLE
ISSUE:7121 - warning when try to create multiple products with the sa…

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -11,6 +11,7 @@
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
+
 namespace Magento\Catalog\Model\Product\Attribute\Backend;
 
 use Magento\Catalog\Model\Product;
@@ -44,6 +45,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Validate SKU
      *
      * @param Product $object
+     *
      * @return bool
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -53,7 +55,9 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
         $attrCode = $this->getAttribute()->getAttributeCode();
         $value = $object->getData($attrCode);
         if ($this->getAttribute()->getIsRequired() && strlen($value) === 0) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('The value of attribute "%1" must be set', $attrCode));
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('The value of attribute "%1" must be set', $attrCode)
+            );
         }
 
         if ($this->string->strlen($object->getSku()) > self::SKU_MAX_LENGTH) {
@@ -61,6 +65,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
                 __('SKU length should be %1 characters maximum.', self::SKU_MAX_LENGTH)
             );
         }
+
         return true;
     }
 
@@ -68,7 +73,10 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Check unique SKU for product
      *
      * @param Product $object
+     *
      * @return void
+     *
+     * @throws AlreadyExistsException
      */
     private function checkUniqueSku($object)
     {
@@ -82,7 +90,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
                     'Duplicated %attribute found: %value',
                     [
                         'attribute' => $attributeCode,
-                        'value' => $attributeValue
+                        'value' => $attributeValue,
                     ]
                 )
             );
@@ -93,8 +101,8 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Generate and set unique SKU to product
      *
      * @param Product $object
+     *
      * @return void
-     * @deprecated
      */
     protected function _generateUniqueSku($object)
     {
@@ -119,11 +127,17 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Make SKU unique before save
      *
      * @param Product $object
+     *
      * @return $this
      */
     public function beforeSave($object)
     {
-        $this->checkUniqueSku($object);
+        if (true === $object->getIsDuplicate()) {
+            $this->_generateUniqueSku($object);
+        } else {
+            $this->checkUniqueSku($object);
+        }
+
         return parent::beforeSave($object);
     }
 
@@ -132,6 +146,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      *
      * @param \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
      * @param Product $object
+     *
      * @return int
      * @deprecated
      */
@@ -153,6 +168,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
             1
         );
         $data = $connection->fetchOne($select, $bind);
-        return abs((int)str_replace($value, '', $data));
+
+        return abs((int) str_replace($value, '', $data));
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -70,7 +70,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * @param Product $object
      * @return void
      */
-    protected function _checkUniqueSku($object)
+    private function checkUniqueSku($object)
     {
         $attribute = $this->getAttribute();
         $entity = $attribute->getEntity();
@@ -90,6 +90,32 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     }
 
     /**
+     * Generate and set unique SKU to product
+     *
+     * @param Product $object
+     * @return void
+     * @deprecated
+     */
+    protected function _generateUniqueSku($object)
+    {
+        $attribute = $this->getAttribute();
+        $entity = $attribute->getEntity();
+        $attributeValue = $object->getData($attribute->getAttributeCode());
+        $increment = null;
+        while (!$entity->checkAttributeUniqueValue($attribute, $object)) {
+            if ($increment === null) {
+                $increment = $this->_getLastSimilarAttributeValueIncrement($attribute, $object);
+            }
+            $sku = trim($attributeValue);
+            if (strlen($sku . '-' . ++$increment) > self::SKU_MAX_LENGTH) {
+                $sku = substr($sku, 0, -strlen($increment) - 1);
+            }
+            $sku = $sku . '-' . $increment;
+            $object->setData($attribute->getAttributeCode(), $sku);
+        }
+    }
+
+    /**
      * Make SKU unique before save
      *
      * @param Product $object
@@ -97,7 +123,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      */
     public function beforeSave($object)
     {
-        $this->_checkUniqueSku($object);
+        $this->checkUniqueSku($object);
         return parent::beforeSave($object);
     }
 
@@ -107,6 +133,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * @param \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
      * @param Product $object
      * @return int
+     * @deprecated
      */
     protected function _getLastSimilarAttributeValueIncrement($attribute, $object)
     {

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -90,7 +90,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
                     'Duplicated %attribute found: %value',
                     [
                         'attribute' => $attributeCode,
-                        'value' => $attributeValue,
+                        'value' => $attributeValue
                     ]
                 )
             );
@@ -134,9 +134,8 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     {
         if (true === $object->getIsDuplicate()) {
             $this->_generateUniqueSku($object);
-        } else {
-            $this->checkUniqueSku($object);
         }
+        $this->checkUniqueSku($object);
 
         return parent::beforeSave($object);
     }

--- a/app/code/Magento/Catalog/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Catalog/Setup/UpgradeSchema.php
@@ -142,7 +142,24 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->enableSegmentation($setup);
         }
 
+        if (version_compare($context->getVersion(), '2.2.6', '<')) {
+            $this->modifySkuColumn($setup);
+        }
+
         $setup->endSetup();
+    }
+
+    /**
+     * @param SchemaSetupInterface $setup
+     */
+    private function modifySkuColumn(SchemaSetupInterface $setup)
+    {
+        $setup->getConnection()->addIndex(
+            $setup->getTable('catalog_product_entity'),
+            $setup->getIdxName('catalog_product_entity', ['sku']),
+            ['sku'],
+            \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
+        );
     }
 
     /**

--- a/app/code/Magento/Catalog/etc/module.xml
+++ b/app/code/Magento/Catalog/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Catalog" setup_version="2.2.5">
+    <module name="Magento_Catalog" setup_version="2.2.6">
         <sequence>
             <module name="Magento_Eav"/>
             <module name="Magento_Cms"/>

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
@@ -180,5 +180,4 @@ class SkuTest extends \PHPUnit\Framework\TestCase
             \Magento\Catalog\Model\Product\Copier::class
         );
     }
-
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
@@ -3,10 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Model\Product\Attribute\Backend;
 
 /**
  * Test class for \Magento\Catalog\Model\Product\Attribute\Backend\Sku.
+ *
  * @magentoAppArea adminhtml
  */
 class SkuTest extends \PHPUnit\Framework\TestCase
@@ -14,7 +16,28 @@ class SkuTest extends \PHPUnit\Framework\TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple.php
      */
-    public function testGenerateUniqueSkuExistingProduct()
+    public function testGenerateUniqueSkuDuplicatedProduct()
+    {
+        $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\ProductRepository::class
+        );
+        $product = $repository->get('simple');
+        /** @var \Magento\Catalog\Model\Product\Copier $copier */
+        $copier = $this->getCopier();
+        /** @var \Magento\Catalog\Model\Product; $product2 */
+        $product2 = $copier->copy($product);
+
+        $this->assertEquals('simple', $product->getSku());
+        $product2->getResource()->getAttribute('sku')->getBackend()->beforeSave($product2);
+        $this->assertEquals('simple-1', $product2->getSku());
+    }
+
+    /**
+     * Checks if generation of unique sku is not allowed
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testPreventGenerateUniqueSkuExistingProduct()
     {
         $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\ProductRepository::class
@@ -22,12 +45,16 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         $product = $repository->get('simple');
         $product->setId(null);
         $this->assertEquals('simple', $product->getSku());
+
+        $this->expectException('Magento\Framework\Exception\AlreadyExistsException');
         $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('simple-1', $product->getSku());
+
+        $this->fail('Unique sku generation should be allowed only for product duplication.');
     }
 
     /**
      * @param $product \Magento\Catalog\Model\Product
+     *
      * @dataProvider uniqueSkuDataProvider
      */
     public function testGenerateUniqueSkuNotExistingProduct($product)
@@ -42,7 +69,38 @@ class SkuTest extends \PHPUnit\Framework\TestCase
      * @magentoAppArea adminhtml
      * @magentoDbIsolation enabled
      */
-    public function testGenerateUniqueLongSku()
+    public function testGenerateUniqueLongSkuDuplicatedProduct()
+    {
+        $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\ProductRepository::class
+        );
+        $product = $repository->get('simple');
+        $product->setSku('0123456789012345678901234567890123456789012345678901234567890124');
+        $product->save();
+        $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
+        $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890124', $product->getSku());
+
+        /** @var \Magento\Catalog\Model\Product\Copier $copier */
+        $copier = $this->getCopier();
+        $product2 = $copier->copy($product);
+
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product2->getSku());
+        $product2->getResource()->getAttribute('sku')->getBackend()->beforeSave($product2);
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product2->getSku());
+
+        $product2->setId(null);
+        $product2->getResource()->getAttribute('sku')->getBackend()->beforeSave($product2);
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-2', $product2->getSku());
+    }
+
+    /**
+     * Checks if generation of long unique sku is not allowed
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoAppArea adminhtml
+     * @magentoDbIsolation enabled
+     */
+    public function testPreventGenerateUniqueLongSku()
     {
         $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\ProductRepository::class
@@ -51,13 +109,14 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         $product->setSku('0123456789012345678901234567890123456789012345678901234567890123');
 
         /** @var \Magento\Catalog\Model\Product\Copier $copier */
-        $copier = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Catalog\Model\Product\Copier::class
-        );
+        $copier = $this->getCopier();
+
         $copier->copy($product);
         $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890123', $product->getSku());
+        $this->expectException('Magento\Framework\Exception\AlreadyExistsException');
         $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product->getSku());
+
+        $this->fail('Unique long sku generation should be allowed only for product duplication.');
     }
 
     /**
@@ -68,6 +127,7 @@ class SkuTest extends \PHPUnit\Framework\TestCase
     public function uniqueSkuDataProvider()
     {
         $product = $this->_getProduct();
+
         return [[$product]];
     }
 
@@ -107,6 +167,18 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         )->setStockData(
             ['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1]
         );
+
         return $product;
     }
+
+    /**
+     * @return \Magento\Catalog\Model\Product\Copier
+     */
+    protected function getCopier()
+    {
+        return \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Catalog\Model\Product\Copier::class
+        );
+    }
+
 }


### PR DESCRIPTION
…me SKU

Warning when try to add product with the same SKU

### Description
Before changes when you try to save non-exist product with same SKU, attribute was incremented and it is wrong for business uses.
Now when you try to save product with same SKU, magento return a warning about it. 

### Fixed Issues (if relevant)
magento/magento2#7121: It's possible to create multiple products with the same SKU
https://github.com/magento/magento2/issues/7121

### Manual testing scenarios
1. Add a new product by panel or API with SKU which is already in database

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
