### PR TITLE
set alignment purchase order form and place order button

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -46,7 +46,7 @@
                     .lib-css(border-top, @checkout-payment-method-title__border);
                 }
             }
-            form{
+            form {
                 &.form-purchase-order {
                     margin-bottom: 15px;
                 }

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -46,6 +46,11 @@
                     .lib-css(border-top, @checkout-payment-method-title__border);
                 }
             }
+            form{
+                &.form-purchase-order {
+                    margin-bottom: 15px;
+                }
+            }
         }
 
         .payment-method-content {


### PR DESCRIPTION
<!--- Purchase Order Form Button Alignment -->

### Description
Purchased Order Form button should visible properly

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#15334 Purchased Order Form button should visible properly

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Enable Purchase Order Payment Method from Admin
2. Add Product to cart
3. Go to Checkout 
4. Enter Address Details and select Shipping Method 
5. Go to Review and Payment Method

### Actual Result
![screenshot-2018-5-19 checkout 1](https://user-images.githubusercontent.com/33098216/40265233-253edd40-5b52-11e8-8e48-89b34bcdb3f9.png)

### Expected Result
![screenshot-2018-5-19 checkout](https://user-images.githubusercontent.com/33098216/40265235-2f5fba9c-5b52-11e8-9920-e7bf48e92590.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
