### PR TITLE
Fixed issue #13480 - Unable to activate logs after switching from production mode to developer

### DIFF
--- a/app/code/Magento/Deploy/etc/di.xml
+++ b/app/code/Magento/Deploy/etc/di.xml
@@ -78,14 +78,6 @@
                     <item name="production" xsi:type="array">
                         <item name="dev/debug/debug_logging" xsi:type="string">0</item>
                     </item>
-                </item>
-            </argument>
-        </arguments>
-    </type>
-    <type name="Magento\Deploy\App\Mode\ConfigProvider">
-        <arguments>
-            <argument name="config" xsi:type="array">
-                <item name="developer" xsi:type="array">
                     <item name="developer" xsi:type="array">
                         <item name="dev/debug/debug_logging" xsi:type="null" />
                     </item>

--- a/app/code/Magento/Deploy/etc/di.xml
+++ b/app/code/Magento/Deploy/etc/di.xml
@@ -82,4 +82,15 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Deploy\App\Mode\ConfigProvider">
+        <arguments>
+            <argument name="config" xsi:type="array">
+                <item name="developer" xsi:type="array">
+                    <item name="developer" xsi:type="array">
+                        <item name="dev/debug/debug_logging" xsi:type="null" />
+                    </item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Description
Set the ENV value of dev/debug/debug_logging to null when deployment mode is "developer"

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13480:  Unable to activate logs after switching from production mode to developer

### Manual testing scenarios
1. Set deployment version to "production"
2. Clean the cache (if necessary)
3. Set deployment version to "developer"
4. Check the "Log To File" field under Stores > Configuration > Advanced > Developer > Debug
5. "Log To File" field should be enabled