### PR TITLE
Updated return type in SaleRule Module #13278

### DIFF
--- a/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
+++ b/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
@@ -173,7 +173,7 @@ interface RuleInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set whether the coupon is active
      *
      * @param bool $isActive
-     * @return bool
+     * @return $this
      */
     public function setIsActive($isActive);
 

--- a/app/code/Magento/SalesRule/Model/Data/Rule.php
+++ b/app/code/Magento/SalesRule/Model/Data/Rule.php
@@ -188,7 +188,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements
      * Set whether the coupon is active
      *
      * @param bool $isActive
-     * @return bool
+     * @return $this
      */
     public function setIsActive($isActive)
     {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

- Updated return type hint of setIsActive() of Magento\SalesRule\Api\Data\RuleInterface is RuleInterface type ($this).
- Updated return type hint of setIsActive() of Magento\SalesRule\Model\Data\Rule is Rule type ($this).


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13278: Wrong return type in Salesrule Module RuleInterface.php

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. N/A


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
