### PR TITLE
Unable to render page when 'meta title' page config param is set #issue-2956

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -137,7 +137,11 @@ class Renderer implements RendererInterface
     {
         $method = 'get' . $this->string->upperCaseWords($name, '_', '');
         if (method_exists($this->pageConfig, $method)) {
-            $content = $this->pageConfig->$method();
+            //$content = $this->pageConfig->$method();
+            $contentUpdated = $this->pageConfig->$method();
+            if(!is_object ($contentUpdated)){
+                $content = $contentUpdated;
+            }
         }
         return $content;
     }

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -137,11 +137,11 @@ class Renderer implements RendererInterface
     {
         $method = 'get' . $this->string->upperCaseWords($name, '_', '');
         if (method_exists($this->pageConfig, $method)) {
-            //$content = $this->pageConfig->$method();
             $contentUpdated = $this->pageConfig->$method();
-            if(!is_object ($contentUpdated)){
+            if (!is_object ($contentUpdated)) {
                 $content = $contentUpdated;
             }
+            
         }
         return $content;
     }

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -138,9 +138,9 @@ class Renderer implements RendererInterface
         $method = 'get' . $this->string->upperCaseWords($name, '_', '');
         if (method_exists($this->pageConfig, $method)) {
             $contentUpdated = $this->pageConfig->$method();
-            if(!is_object ($contentUpdated)) {
+            if (!is_object($contentUpdated)) {
                 $content = $contentUpdated;
-            }            
+            }
         }
         return $content;
     }

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -138,10 +138,9 @@ class Renderer implements RendererInterface
         $method = 'get' . $this->string->upperCaseWords($name, '_', '');
         if (method_exists($this->pageConfig, $method)) {
             $contentUpdated = $this->pageConfig->$method();
-            if (!is_object ($contentUpdated)) {
+            if(!is_object ($contentUpdated)) {
                 $content = $contentUpdated;
-            }
-            
+            }            
         }
         return $content;
     }


### PR DESCRIPTION
### Description
Fixed. Added a check to to see if returned content is object or not. As objects will never be converted to string and will throw error for str_replace at line 125

### Fixed Issues (if relevant)
1. magento/magento2#2956: Unable to render page when 'meta title' page config param is set

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Use the "Steps to reproduce" in original issue.
2. View the source generated in browser.
3. You will be able to see `<meta name="title" content="some meta title"/>` in source code. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
