### PR TITLE
15210-Fixed product tier pricing pagination issue in admin

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
@@ -28,29 +28,6 @@ define([
             });
 
             this.labels(labels);
-        },
-
-        /** @inheritdoc */
-        changePage: function (page) {
-            this.clear();
-
-            if (page === 1 && !this.recordData().length) {
-                return false;
-            }
-
-            if (~~page > this.pages()) {
-                this.currentPage(this.pages());
-
-                return false;
-            } else if (~~page < 1) {
-                this.currentPage(1);
-
-                return false;
-            }
-
-            this.initChildren();
-
-            return true;
         }
     });
 });

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
@@ -37,7 +37,7 @@ define([
          */
         changePage: function (page) {
             this.clear(); /* Clear the children when directly edit the text field */
-            
+
             if (page === 1 && !this.recordData().length) {
                 return false;
             }

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
@@ -37,6 +37,7 @@ define([
          */
         changePage: function (page) {
             this.clear(); /* Clear the children when directly edit the text field */
+            
             if (page === 1 && !this.recordData().length) {
                 return false;
             }

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
@@ -28,6 +28,32 @@ define([
             });
 
             this.labels(labels);
+        },
+
+        /**
+         * Change page
+         *
+         * @param {Number} page - current page
+         */
+        changePage: function (page) {
+            this.clear(); /* Clear the children when directly edit the text field */
+            if (page === 1 && !this.recordData().length) {
+                return false;
+            }
+
+            if (~~page > this.pages()) {
+                this.currentPage(this.pages());
+
+                return false;
+            } else if (~~page < 1) {
+                this.currentPage(1);
+
+                return false;
+            }
+
+            this.initChildren();
+
+            return true;
         }
     });
 });

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
@@ -36,7 +36,7 @@ define([
          * @param {Number} page - current page
          */
         changePage: function (page) {
-            this.clear(); /* Clear the children when directly edit the text field */
+            this.clear();
 
             if (page === 1 && !this.recordData().length) {
                 return false;

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/dynamic-rows-tier-price.js
@@ -30,11 +30,7 @@ define([
             this.labels(labels);
         },
 
-        /**
-         * Change page
-         *
-         * @param {Number} page - current page
-         */
+        /** @inheritdoc */
         changePage: function (page) {
             this.clear();
 

--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
@@ -764,7 +764,6 @@ define([
          * Change page to next
          */
         nextPage: function () {
-            this.clear();
             this.currentPage(this.currentPage() + 1);
         },
 
@@ -772,7 +771,6 @@ define([
          * Change page to previous
          */
         previousPage: function () {
-            this.clear();
             this.currentPage(this.currentPage() - 1);
         },
 

--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
@@ -721,6 +721,8 @@ define([
          * @param {Number} page - current page
          */
         changePage: function (page) {
+            this.clear();
+
             if (page === 1 && !this.recordData().length) {
                 return false;
             }


### PR DESCRIPTION
Resolved product tier price pagination loader issue in admin

Description:

Navigate Admin => Catalog => Products => Create New / Edit Product.

1. Go to Advanced Pricing link under Price text field.
2. Add tier price more than a page and do save.
3. Jump to other pages by directly editing the pagination text box.


### Fixed Issues (if relevant)

1. magento/magento2#15210: Advanced pricing pagination issue