### PR TITLE
Fixed date display issue after filtration on sales order page.

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -106,7 +106,12 @@ define([
              *
              * @type {String}
              */
-            shiftedValue: ''
+            shiftedValue: '',
+
+            /**
+             * @type {bool}
+             */
+            ispageLoad: true
         },
 
         /**
@@ -146,6 +151,11 @@ define([
         onValueChange: function (value) {
             var dateFormat,
                 shiftedValue;
+
+            if (this.ispageLoad == true) {
+                this.ispageLoad = false;
+                return false;
+            }
 
             if (value) {
                 if (this.options.showsTime && !this.outputDateTimeToISO) {

--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -95,7 +95,7 @@ define([
             timezoneFormat: 'YYYY-MM-DD HH:mm',
 
             listens: {
-                'value': 'onValueChange',
+                //'value': 'onValueChange',
                 'shiftedValue': 'onShiftedValueChange'
             },
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -95,7 +95,7 @@ define([
             timezoneFormat: 'YYYY-MM-DD HH:mm',
 
             listens: {
-                //'value': 'onValueChange',
+                'value': 'onValueChange',
                 'shiftedValue': 'onShiftedValueChange'
             },
 
@@ -106,12 +106,7 @@ define([
              *
              * @type {String}
              */
-            shiftedValue: '',
-
-            /**
-             * @type {bool}
-             */
-            ispageLoad: true
+            shiftedValue: ''
         },
 
         /**
@@ -152,11 +147,6 @@ define([
             var dateFormat,
                 shiftedValue;
 
-            if (this.ispageLoad == true) {
-                this.ispageLoad = false;
-                return false;
-            }
-
             if (value) {
                 if (this.options.showsTime && !this.outputDateTimeToISO) {
                     dateFormat = this.shiftedValue() ?
@@ -169,7 +159,7 @@ define([
                 if (this.options.showsTime) {
                     shiftedValue = moment.tz(value, 'UTC').tz(this.storeTimeZone);
                 } else {
-                    dateFormat = this.shiftedValue() ?
+                    dateFormat = this.shiftedValue(value) ?
                         this.outputDateFormat :
                         this.inputDateFormat;
 


### PR DESCRIPTION
### Description
In `date.js` file at line no 97, there were two method used to format/shift date value as `listens` param.
The method `onShiftedValueChange` is call `onValueChange` method inside it's body content so there is no need to use both methods.
Because of both methods, the values of date fields are format/shift two times and rises the issue of `Invalid Date`.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13428: Date range filter in admin ui grid displaying "Invalid date" after reload

### Manual testing scenarios
1. Try to filter the records of sales orders using date range and then reload page again.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
