### PR TITLE
Fixed typo in MagentoUi abstract.js

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
@@ -220,7 +220,7 @@ define([
         },
 
         /**
-         * Sets 'value' as 'hidden' properties value, triggers 'toggle' event,
+         * Sets 'value' as 'hidden' property's value, triggers 'toggle' event,
          * sets instance's hidden identifier in params storage based on
          * 'value'.
          *

--- a/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
@@ -220,7 +220,7 @@ define([
         },
 
         /**
-         * Sets 'value' as 'hidden' propertie's value, triggers 'toggle' event,
+         * Sets 'value' as 'hidden' properties value, triggers 'toggle' event,
          * sets instance's hidden identifier in params storage based on
          * 'value'.
          *


### PR DESCRIPTION
Typo in abstract.js `propertie's` should be `properties` 

### Description
MagentoUI abstract.js:223 typo in doc block
  ` * Sets 'value' as 'hidden' propertie's value, triggers 'toggle' event,`

