### PR TITLE
[Backport] Typo in SSL port number

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -256,7 +256,7 @@ class Processor
         $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off');
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 
-        if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 433])
+        if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 443])
             && !preg_match('/.*?\:[0-9]+$/', $url)
         ) {
             $url .= ':' . $_SERVER['SERVER_PORT'];


### PR DESCRIPTION
Original PR: #14062

### Description
SSL is run on port 433, but in pub/errors/processor.php we check for port 433. This looks like a typo. I ran into this problem when visiting an URL of an image that was not on the server. It resulted in a weird base URL with the port number 443.