### PR TITLE
Fixed issue #8258 - Form validation with identical field names does not work as expected

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1865,6 +1865,7 @@
          * @protected
          */
         _create: function () {
+            this._workaroundForArrayInputs();
             this.validate = this.element.validate(this.options);
 
             // ARIA (adding aria-required attribute)
@@ -1875,6 +1876,27 @@
                 .attr('aria-required', 'true');
 
             this._listenFormValidate();
+        },
+
+        _workaroundForArrayInputs: function () {
+            /* Store original names for array inputs */
+            var originalElements = [];
+
+            /* For all array inputs, assign index so that validation is proper */
+            this.element.find('[name$="[]"]').each(function (key, input) {
+                input = $(input);
+                var originalName = input.attr('name');
+                var name = originalName.replace("[]", "["+key+"]");
+                $(input).attr("name", name);
+                originalElements.push({element: $(input), name: originalName});
+            });
+            this.options.submitHandler = function (form) {
+                /* Before submitting the actual form, remove the previously assigned indices */
+                originalElements.forEach(function (element) {
+                    element.element.attr("name", element.name);
+                });
+                form.submit();
+            };
         },
 
         /**


### PR DESCRIPTION
Form validation with identical field names does not work as expected

### Description
Assign indices to array inputs and later remove them before submitting as a workaround for the validation library to work properly.

### Fixed Issues (if relevant)
1. magento/magento2#8258 Form validation with identical field names does not work as expected

### Manual testing scenarios
1. Create a form with identical fields and add JavaScript validation
2. Submit the form with improper values in fields.
3. Validation should work properly now