### PR TITLE
[Forwardport] Add 'const' type support to layout arguments

### DIFF
--- a/app/code/Magento/Ui/etc/di.xml
+++ b/app/code/Magento/Ui/etc/di.xml
@@ -252,6 +252,7 @@
     <type name="Magento\Framework\Data\Argument\Interpreter\Composite">
         <arguments>
             <argument name="interpreters" xsi:type="array">
+                <item name="const" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Constant</item>
                 <item name="object" xsi:type="object">configurableObjectArgumentInterpreterProxy</item>
                 <item name="configurableObject" xsi:type="object">configurableObjectArgumentInterpreterProxy</item>
                 <item name="array" xsi:type="object">arrayArgumentInterpreterProxy</item>

--- a/lib/internal/Magento/Framework/View/Layout/etc/layout_merged.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/layout_merged.xsd
@@ -62,4 +62,10 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+
+    <xs:complexType name="const">
+        <xs:complexContent>
+            <xs:extension base="argumentType" />
+        </xs:complexContent>
+    </xs:complexType>
 </xs:schema>

--- a/lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd
@@ -32,4 +32,10 @@
             <xs:field xpath="@name"/>
         </xs:unique>
     </xs:element>
+
+    <xs:complexType name="const">
+        <xs:complexContent>
+            <xs:extension base="argumentType" />
+        </xs:complexContent>
+    </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15058
### Description
For now in Magento we can not use **xsi:type="const"** in layout arguments. But it looks like such ability can be very useful. Moreover such code already exists in Magento core, we just need to include/enable it.

### Manual testing scenarios
1. Add argument with "const" type to any block via layout arguments. For example like this:
```
<referenceBlock name="product.info.sku">
    <arguments>
        <argument name="my_const_value" xsi:type="const">Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE</argument>
    </arguments>
</referenceBlock>
```
2. Verify that it is correctly passed to block constructor. Like here: http://prntscr.com/jf7qa0

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
