### PR TITLE
Advanced Reporting > Unable to disable without providing Industry val…

### DIFF
--- a/app/code/Magento/Analytics/Model/Config/Backend/Vertical.php
+++ b/app/code/Magento/Analytics/Model/Config/Backend/Vertical.php
@@ -23,10 +23,9 @@ class Vertical extends \Magento\Framework\App\Config\Value
      */
     public function beforeSave()
     {
-        if (empty($this->getValue())) {
+        if (empty($this->getValue()) && $this->getFieldsetDataValue('enabled') != 0) {
             throw new LocalizedException(__('Please select a vertical.'));
         }
-
         return $this;
     }
 }


### PR DESCRIPTION
Advanced Reporting > Unable to disable without providing Industry value - fixed


### Description
Added a condition check while disabling the module, it should not check for other fields to be filled or not.

### Fixed Issues (if relevant)
1. magento/magento2#15259: Advanced Reporting > Unable to disable without providing Industry value
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open Store Configuration -> General -> Advanced Reporting
2. Disable module should now work fine without vertical being selected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
