### PR TITLE
Fix HTML syntax in report.phtml error template

### DIFF
--- a/pub/errors/default/report.phtml
+++ b/pub/errors/default/report.phtml
@@ -36,25 +36,25 @@
         </div>
         <div class="field lastname required">
             <label for="lastname" class="label">Last Name</label>
-            <div class=control">
+            <div class="control">
                 <input type="text" name="lastname" id="lastname" value="<?= $this->postData['lastName'] ?>" title="Last Name" class="required-entry input-text" />
             </div>
         </div>
         <div class="field email required">
             <label for="email_address" class="label">Email Address</label>
-            <div class=control">
+            <div class="control">
                 <input type="text" name="email" id="email_address" value="<?= $this->postData['email'] ?>" title="Email Address" class="validate-email required-entry input-text" />
             </div>
         </div>
         <div class="field telephone">
             <label for="telephone" class="label">Telephone</label>
-            <div class=control">
+            <div class="control">
                 <input type="text" name="telephone" id="telephone" value="<?= $this->postData['telephone'] ?>" title="Telephone" class="input-text" />
             </div>
         </div>
         <div class="field comment">
             <label for="comment" class="label">Comment</label>
-            <div class=control">
+            <div class="control">
                 <textarea name="comment" cols="5" rows="3" class="textarea"><?= $this->postData['comment'] ?></textarea>
             </div>
         </div>


### PR DESCRIPTION
Added missing quotes to the div tags with class `control`.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Added **missing quotes** to the class attribute of div tags in the default reporting template file in **pub/errors/default/report.phtml**

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open in any editor with syntax highlighting, it shouldn't show any more syntax warnings.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
