### PR TITLE
Issue 15467 where a configuration sku gets deleted but is still saved…

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Cart/Item/Renderer/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Cart/Item/Renderer/Configurable.php
@@ -68,7 +68,7 @@ class Configurable extends Renderer implements IdentityInterface
             self::CONFIG_THUMBNAIL_SOURCE,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) == ThumbnailSource::OPTION_USE_PARENT_IMAGE ||
-            !($this->getChildProduct()->getThumbnail() && $this->getChildProduct()->getThumbnail() != 'no_selection')
+            !($this->getChildProduct() && $this->getChildProduct()->getThumbnail() && $this->getChildProduct()->getThumbnail() != 'no_selection')
         ) {
             $product = $this->getProduct();
         } else {

--- a/app/code/Magento/ConfigurableProduct/Block/Cart/Item/Renderer/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Cart/Item/Renderer/Configurable.php
@@ -68,7 +68,11 @@ class Configurable extends Renderer implements IdentityInterface
             self::CONFIG_THUMBNAIL_SOURCE,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) == ThumbnailSource::OPTION_USE_PARENT_IMAGE ||
-            !($this->getChildProduct() && $this->getChildProduct()->getThumbnail() && $this->getChildProduct()->getThumbnail() != 'no_selection')
+            !(
+                $this->getChildProduct() &&
+                $this->getChildProduct()->getThumbnail() &&
+                $this->getChildProduct()->getThumbnail() != 'no_selection'
+            )
         ) {
             $product = $this->getProduct();
         } else {

--- a/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
+++ b/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
@@ -63,7 +63,7 @@ class ConfigurableItem extends DefaultItem
         );
 
         $product = $config == ThumbnailSource::OPTION_USE_PARENT_IMAGE
-            || (!$this->getChildProduct()->getThumbnail() || $this->getChildProduct()->getThumbnail() == 'no_selection')
+            || (!$this->getChildProduct() || !$this->getChildProduct()->getThumbnail() || $this->getChildProduct()->getThumbnail() == 'no_selection')
             ? $this->getProduct()
             : $this->getChildProduct();
 

--- a/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
+++ b/app/code/Magento/ConfigurableProduct/CustomerData/ConfigurableItem.php
@@ -63,7 +63,11 @@ class ConfigurableItem extends DefaultItem
         );
 
         $product = $config == ThumbnailSource::OPTION_USE_PARENT_IMAGE
-            || (!$this->getChildProduct() || !$this->getChildProduct()->getThumbnail() || $this->getChildProduct()->getThumbnail() == 'no_selection')
+            || (
+                !$this->getChildProduct() ||
+                !$this->getChildProduct()->getThumbnail() ||
+                $this->getChildProduct()->getThumbnail() == 'no_selection'
+            )
             ? $this->getProduct()
             : $this->getChildProduct();
 


### PR DESCRIPTION
https://github.com/magento/magento2/issues/15467

Reproduce: Add a configuration product to your cart logged in as a customer. Log out.
Have an admin delete the product SKU from the configuration product.
Customer: login to your cart from checkout (add something to your cart logged out and login with the modal window).

You will get an error about getThumbnail() on a null object. This commit fixes the issue in two files.