### PR TITLE
Issue12202

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
@@ -59,7 +59,7 @@
                                 <span><?= $block->escapeHtml(__('Street Address %1', $_i + 1)) ?></span>
                             </label>
                             <div class="control">
-                                <input type="text" name="street[]"
+                                <input type="text" name="street[<?php echo $i;?>]"
                                        value="<?= $block->escapeHtmlAttr($block->getStreetLine($_i + 1)) ?>"
                                        title="<?= $block->escapeHtmlAttr(__('Street Address %1', $_i + 1)) ?>"
                                        id="street_<?= /* @noEscape */ $_i + 1 ?>"

--- a/app/code/Magento/Sales/view/frontend/email/invoice_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_new_guest.html
@@ -22,7 +22,7 @@
 <table>
     <tr class="email-intro">
         <td>
-            <p class="greeting">{{trans "%name," name=$billing.getName()}}</p>
+            <p class="greeting">{{trans "%customer_name," customer_name=$billing.getName()}}</p>
             <p>
                 {{trans "Thank you for your order from %store_name." store_name=$store.getFrontendName()}}
                 {{trans 'If you have questions about your order, you can email us at <a href="mailto:%store_email">%store_email</a>' store_email=$store_email |raw}}{{depend store_phone}} {{trans 'or call us at <a href="tel:%store_phone">%store_phone</a>' store_phone=$store_phone |raw}}{{/depend}}.

--- a/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
@@ -22,7 +22,7 @@
 <table>
     <tr class="email-intro">
         <td>
-            <p class="greeting">{{trans "%name," name=$order.getBillingAddress().getName()}}</p>
+            <p class="greeting">{{trans "%customer_name," customer_name=$order.getBillingAddress().getName()}}</p>
             <p>
                 {{trans "Thank you for your order from %store_name." store_name=$store.getFrontendName()}}
                 {{trans "Once your package ships we will send an email with a link to track your order."}}


### PR DESCRIPTION
Fix #12202

### Description
M2.1.9 : Cannot make all address fields required in customer address edit page (frontend)
Edit following:
 Edit the section in Magento_Customer/templates/address/edit.phtml

### Fixed Issue
1.  magento/magento2#12202, if relevant  -->

### Manual testing scenarios
1. customer/address/edit.phtml -> add class required for additional address fields.
2. try to change address in checkout check additional fields are required.


