### PR TITLE
[Forwardport] Prevent not category links in breadcrumbs at product page #14994

### DIFF
--- a/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
+++ b/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
@@ -162,6 +162,7 @@ class Topmenu
             'url' => $this->catalogCategory->getCategoryUrl($category),
             'has_active' => in_array((string)$category->getId(), explode('/', $currentCategory->getPath()), true),
             'is_active' => $category->getId() == $currentCategory->getId(),
+            'is_category' => true,
             'is_parent_active' => $isParentActive
         ];
     }

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/breadcrumbs.js
@@ -16,6 +16,7 @@ define([
                 categoryUrlSuffix: '',
                 useCategoryPathInUrl: false,
                 product: '',
+                categoryItemSelector: '.category-item',
                 menuContainer: '[data-action="navigation"] > ul'
             },
 
@@ -163,7 +164,10 @@ define([
                     categoryMenuItem = null;
 
                 if (categoryUrl && menu.length) {
-                    categoryMenuItem = menu.find('a[href="' + categoryUrl + '"]');
+                    categoryMenuItem = menu.find(
+                        this.options.categoryItemSelector +
+                        ' > a[href="' + categoryUrl + '"]'
+                    );
                 }
 
                 return categoryMenuItem;

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -309,6 +309,10 @@ class Topmenu extends Template implements IdentityInterface
         $classes[] = 'level' . $item->getLevel();
         $classes[] = $item->getPositionClass();
 
+        if ($item->getIsCategory()) {
+            $classes[] = 'category-item';
+        }
+
         if ($item->getIsFirst()) {
             $classes[] = 'first';
         }

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Catalog/frontend/js/product/breadcrumbs.test.js
@@ -18,7 +18,11 @@ define([
             'Magento_Theme/js/model/breadcrumb-list': jasmine.createSpyObj(['push'])
         },
         defaultContext = require.s.contexts._,
-        menuItem = $('<li class="level0"><a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a></li>')[0],
+        menuItem = $(
+            '<li class="level0 category-item">' +
+            '<a href="http://localhost.com/cat1.html" id="ui-id-3">Cat1</a>' +
+            '</li>'
+        )[0],
 
         /**
          * Create context object.


### PR DESCRIPTION
It's a cherry-pick of https://github.com/magento/magento2/pull/14994

### Description
Magento 2.2.4 only.
When a product is opened from a homepage and menu has a link to the homepage,
two home links will be inserted into breadcrumbs.

**Update: Added the case with "Contacts" link in the navigation.**

### Manual testing scenarios
1. Open `app/code/Magento/Theme/view/frontend/templates/html/topmenu.phtml`
2. Insert the following code:

```php
<li class="level0 level-top" role="presentation">
    <a href="<?php echo $block->getUrl() ?>" class="level-top" tabindex="-1" role="menuitem"><span>Home</span></a>
</li>
<li class="level0 level-top" role="presentation">
    <a href="<?php echo $block->getUrl('contact') ?>" class="level-top" tabindex="-1" role="menuitem"><span>Contacts</span></a>
</li>
```

Right before 

```php
<?= /* @escapeNotVerified */ $_menu ?>
```

3. Open homepage or contacts page
4. Click on any product to navigate to its page (It may be a product in cart)
5. Breadcrumbs will have two "Home" links, or Contacts page will be added into breadcrumbs.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
