### PR TITLE
[Forwardport] Fix outdated address data when using Braintree's "Pay with PayPal" button #15133

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -7,6 +7,7 @@
 define([
     'jquery',
     'underscore',
+    'mage/utils/wrapper',
     'Magento_Checkout/js/view/payment/default',
     'Magento_Braintree/js/view/payment/adapter',
     'Magento_Checkout/js/model/quote',
@@ -18,6 +19,7 @@ define([
 ], function (
     $,
     _,
+    wrapper,
     Component,
     Braintree,
     quote,
@@ -218,8 +220,9 @@ define([
 
         /**
          * Re-init PayPal Auth Flow
+         * @param {Function} callback - Optional callback
          */
-        reInitPayPal: function () {
+        reInitPayPal: function (callback) {
             if (Braintree.checkout) {
                 Braintree.checkout.teardown(function () {
                     Braintree.checkout = null;
@@ -228,6 +231,18 @@ define([
 
             this.disableButton();
             this.clientConfig.paypal.amount = this.grandTotalAmount;
+            this.clientConfig.paypal.shippingAddressOverride = this.getShippingAddress();
+
+            if (callback) {
+                this.clientConfig.onReady = wrapper.wrap(
+                    this.clientConfig.onReady,
+                    function (original, checkout) {
+                        this.clientConfig.onReady = original;
+                        original(checkout);
+                        callback();
+                    }.bind(this)
+                );
+            }
 
             Braintree.setConfig(this.clientConfig);
             Braintree.setup();
@@ -403,7 +418,11 @@ define([
          * Triggers when customer click "Continue to PayPal" button
          */
         payWithPayPal: function () {
-            if (additionalValidators.validate()) {
+            this.reInitPayPal(function () {
+                if (!additionalValidators.validate()) {
+                    return;
+                }
+
                 try {
                     Braintree.checkout.paypal.initAuthFlow();
                 } catch (e) {
@@ -411,7 +430,7 @@ define([
                         message: $t('Payment ' + this.getTitle() + ' can\'t be initialized.')
                     });
                 }
-            }
+            }.bind(this));
         },
 
         /**

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/paypal.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/paypal.test.js
@@ -27,7 +27,24 @@ define([
                     })
                 },
                 'Magento_Braintree/js/view/payment/adapter': {
+                    config: {},
+
+                    /** Stub */
+                    onReady: function () {},
+
+                    /** Stub */
+                    setConfig: function (config) {
+                        this.config = config;
+                    },
+
+                    /** Stub */
+                    setup: function () {
+                        this.config.onReady(this.checkout);
+                    },
+
                     checkout: {
+                        /** Stub */
+                        teardown: function () {},
                         paypal: {
                             /** Stub */
                             initAuthFlow: function () {}


### PR DESCRIPTION
It's a cherry pick of https://github.com/magento/magento2/pull/15133

### Description
This commit fixes the case when customer navigates back
to the shipping step and change address fields.

### Manual testing scenarios
1. Navigate to checkout, fill address and proceed to the Payment step.
2. Select "PayPal (Braintree)" method.
3. Go back to the shipping information step, change first and last names and proceed to the Payment step again.
4. Click "Pay with PayPal" button.
5. Popup will be opened with the first entered address instead of the latest one.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
