### PR TITLE
#15493: Allow shipping method usage in RMA but not in checkout

### DIFF
--- a/app/code/Magento/Shipping/Model/CarrierFactory.php
+++ b/app/code/Magento/Shipping/Model/CarrierFactory.php
@@ -83,16 +83,13 @@ class CarrierFactory implements CarrierFactoryInterface
      * Get carrier by its code if it is active
      *
      * @param string $carrierCode
+     * @param int $storeId
+     * @param bool $isReturn
      * @return bool|Carrier\AbstractCarrier
      */
-    public function getIfActive($carrierCode)
+    public function getIfActive(string $carrierCode, int $storeId, bool $isReturn)
     {
-        return $this->_scopeConfig->isSetFlag(
-            'carriers/' . $carrierCode . '/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        ) ? $this->get(
-            $carrierCode
-        ) : false;
+        return $this->isFlagSet($carrierCode, $storeId, $isReturn) ? $this->get($carrierCode) : false;
     }
 
     /**
@@ -100,17 +97,29 @@ class CarrierFactory implements CarrierFactoryInterface
      *
      * @param string $carrierCode
      * @param null|int $storeId
+     * @param bool $isReturn
      * @return bool|Carrier\AbstractCarrier
      */
-    public function createIfActive($carrierCode, $storeId = null)
+    public function createIfActive(string $carrierCode, int $storeId, bool $isReturn)
+    {
+        return $this->isFlagSet($carrierCode, $storeId, $isReturn) ? $this->create($carrierCode, $storeId) : false;
+    }
+
+    private function isFlagSet(string $carrierCode, int $storeId, bool $isReturn): bool
     {
         return $this->_scopeConfig->isSetFlag(
-            'carriers/' . $carrierCode . '/active',
+            $this->getActiveFlagPath($carrierCode, $isReturn),
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $storeId
-        ) ? $this->create(
-            $carrierCode,
-            $storeId
-        ) : false;
+        );
+    }
+
+    private function getActiveFlagPath(string $carrierCode, bool $isReturn): string
+    {
+        if ($isReturn) {
+            return 'carriers/' . $carrierCode . '/active_rma';
+        }
+
+        return 'carriers/' . $carrierCode . '/active';
     }
 }

--- a/app/code/Magento/Shipping/Model/CarrierFactoryInterface.php
+++ b/app/code/Magento/Shipping/Model/CarrierFactoryInterface.php
@@ -38,15 +38,15 @@ interface CarrierFactoryInterface
      * @return bool|AbstractCarrierInterface
      * @api
      */
-    public function getIfActive($carrierCode);
+    public function getIfActive(string $carrierCode, int $storeId, bool $isReturn);
 
     /**
      * Create carrier by its code if it is active
      *
      * @param string $carrierCode
-     * @param null|int $storeId
+     * @param int $storeId
      * @return bool|AbstractCarrierInterface
      * @api
      */
-    public function createIfActive($carrierCode, $storeId = null);
+    public function createIfActive(string $carrierCode, int $storeId, bool $isReturn);
 }

--- a/app/code/Magento/Shipping/Model/Shipping.php
+++ b/app/code/Magento/Shipping/Model/Shipping.php
@@ -255,7 +255,7 @@ class Shipping implements RateCollectorInterface
         $carrier = $this->_carrierFactory->createIfActive(
             $carrierCode,
             $request->getStoreId(),
-            $request->getData('is_return')
+            (bool) $request->getData('is_return')
         );
 
         if (!$carrier) {

--- a/app/code/Magento/Shipping/Model/Shipping.php
+++ b/app/code/Magento/Shipping/Model/Shipping.php
@@ -252,7 +252,12 @@ class Shipping implements RateCollectorInterface
     public function collectCarrierRates($carrierCode, $request)
     {
         /* @var $carrier \Magento\Shipping\Model\Carrier\AbstractCarrier */
-        $carrier = $this->_carrierFactory->createIfActive($carrierCode, $request->getQuoteStoreId());
+        $carrier = $this->_carrierFactory->createIfActive(
+            $carrierCode,
+            $request->getStoreId(),
+            $request->getData('is_return')
+        );
+
         if (!$carrier) {
             return $this;
         }

--- a/dev/tests/integration/testsuite/Magento/Quote/Model/Quote/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Quote/Model/Quote/AddressTest.php
@@ -331,22 +331,11 @@ class AddressTest extends \PHPUnit\Framework\TestCase
      */
     public function testRequestShippingRates($storeCode, $expectedRate)
     {
-        $store = $this->storeRepository->get($storeCode);
-        $this->_quote->setStoreId($store->getId());
+        $this->_quote->setStoreId($this->storeRepository->get($storeCode)->getId());
         $this->_address->setItemQty(1);
         $this->_address->requestShippingRates();
-        /**
-         * @var \Magento\Quote\Model\ResourceModel\Quote\Address\Rate\Collection $shippingRatesCollection
-         */
-        $shippingRatesCollection = $this->_address->getShippingRatesCollection();
-        /**
-         * @var \Magento\Quote\Model\Quote\Address\Rate[] $shippingRates
-         */
-        $shippingRates = $shippingRatesCollection->getItems();
-        self::assertEquals(
-            $expectedRate,
-            $shippingRates[0]->getPrice()
-        );
+
+        self::assertContains($expectedRate, $this->_address->getShippingRatesCollection()->getItems());
     }
 
     /**


### PR DESCRIPTION
Currently it is not possible to use shipping method for RMA without enabling it for checkout.

### Description
Allow shipping method usage in RMA but not in checkout

### Fixed Issues
1. magento/magento2#15493: Allow shipping method usage in RMA but not in checkout

### Manual testing scenarios
1. Enable shipping method for RMA bit not for checkout
2. Go to authorised return request and click on "Create Shipping Label" button
3. The enabled method is available for returns

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)