### PR TITLE
Update flag_data column size

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -777,7 +777,7 @@ class Installer
             )->addColumn(
                 'flag_data',
                 \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                '64k',
+                '128k',
                 [],
                 'Flag Data'
             )->addColumn(


### PR DESCRIPTION
data_flag column mostly used for config:import & config:dump console commands , one of the features is to save app:config:import data as a system_config_snapshot, if store has several scopes + multiple extensions, it can be not enough to save config snapshot

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This fix is related to config dump\import mechanism. If we run php bin/magento app:config:dump command, it saves snapshot of previous data to flag table with system_config_snapshot key. by default it is defined 64k.
I have faced this issue on 2.2.3 EE , I have 6 websites , and few custom extensions (not so much), however if I do app:config:import it generates config with size around 95 Kb, so serialized data in this column will be cropped (it will save everything it can save from serialized field , 64 kb and that's all, other 20 kb of serialized string in my case will be lose ).

As I have just few custom system configs, I am assuming this issue will appear on every site that has more that 3-4 website
flag table has very small amount of entries so we can little increase size of this column without any memory issue (but we will be sure issue does not appear again)

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create 6-7 websites
2. Run php bin/magento app:config:dump
3. Change something in config files, to be able to run php bin/magento app:config:import
4. Run php bin/magento app:config:import (system_config_snapshot should be created around here )
5. Repeat 3-4 and you will see "Import failed: Unable to unserialize value, string is corrupted." - if your system config size is more than 64kb, saved serialized string that exceeded 64 kb will be broken 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
