### PR TITLE
Fixes in config module

### DIFF
--- a/app/code/Magento/Config/Model/Config/Importer.php
+++ b/app/code/Magento/Config/Model/Config/Importer.php
@@ -124,7 +124,7 @@ class Importer implements ImporterInterface
                 $this->scopeConfig->clean();
             }
 
-            $this->state->emulateAreaCode(Area::AREA_ADMINHTML, function () use ($changedData, $data) {
+            $this->state->emulateAreaCode(Area::AREA_ADMINHTML, function () use ($changedData) {
                 $this->scope->setCurrentScope(Area::AREA_ADMINHTML);
 
                 // Invoke saving of new values.

--- a/app/code/Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php
+++ b/app/code/Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php
@@ -74,7 +74,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 'showInWebsite' => '1',
                 'showInStore' => '1',
                 'label' => null,
-                'backend_model' => \Magento\BackendModelConfig\Backend\Image::class,
+                'backend_model' => \Magento\Config\Model\Config\Backend\Image::class,
                 'upload_dir' => [
                     'config' => 'system/filesystem/media',
                     'scope_info' => '1',


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR fixes two issues in the Magento/Config Module:

1. The method `Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php::testGetElementHtmlWithValue()` references to a invalid Backend Model on line [77](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Config/Test/Unit/Block/System/Config/Form/Field/ImageTest.php#L77)

1. The anonymous function has an unused use `$data` in `Magento/Config/Model/Config/Importer.php` on line [127](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Config/Model/Config/Importer.php#L127)


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
