### PR TITLE
New products widget swatches

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
@@ -6,6 +6,12 @@
 namespace Magento\Catalog\Block\Product\Widget;
 
 /**
+ * Add to cart postparams
+ */
+use Magento\Catalog\Model\Product;
+use Magento\Swatches\Block\Product\Renderer\Listing\Configurable;
+
+/**
  * New products widget
  */
 class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Magento\Widget\Block\BlockInterface
@@ -49,7 +55,9 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
      */
     private $serializer;
 
-
+    /**
+     * @var \Magento\Swatches\Block\Product\Renderer\Listing\Configurable
+     */
     protected $_listConfigurable;
 
     /**
@@ -67,7 +75,7 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory,
         \Magento\Catalog\Model\Product\Visibility $catalogProductVisibility,
         \Magento\Framework\App\Http\Context $httpContext,
-        \Magento\Swatches\Block\Product\Renderer\Listing\Configurable $listconfigurable,
+        Configurable $listconfigurable,
         array $data = [],
         \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
@@ -291,10 +299,10 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
     {
         $renderer =  $this->_listConfigurable;
 
-       if ($renderer) {
-          $renderer->setProduct($product);
+        if ($renderer) {
+            $renderer->setProduct($product);
             return $renderer->setTemplate('product/listing/renderer.phtml')->toHtml();
-        }
+    }
         return '';
     }
     public function getAddToCartPostParams(\Magento\Catalog\Model\Product $product)

--- a/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
@@ -5,10 +5,6 @@
  */
 namespace Magento\Catalog\Block\Product\Widget;
 
-/**
- * Add to cart postparams
- */
-use Magento\Catalog\Model\Product;
 use Magento\Swatches\Block\Product\Renderer\Listing\Configurable;
 
 /**

--- a/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
@@ -281,7 +281,7 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
             ? $arguments['display_minimal_price']
             : true;
 
-            /** @var \Magento\Framework\Pricing\Render $priceRender */
+        /** @var \Magento\Framework\Pricing\Render $priceRender */
         $priceRender = $this->getLayout()->getBlock('product.price.render.default');
 
         $price = '';
@@ -295,6 +295,10 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
         return $price;
     }
 
+    /**
+     * @param \Magento\Catalog\Model\Product $product
+     * @return string
+     */
     public function getProductDetailHtml(\Magento\Catalog\Model\Product $product)
     {
         $renderer =  $this->_listConfigurable;
@@ -302,9 +306,14 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
         if ($renderer) {
             $renderer->setProduct($product);
             return $renderer->setTemplate('product/listing/renderer.phtml')->toHtml();
-    }
+        }
         return '';
     }
+
+    /**
+     * @param \Magento\Catalog\Model\Product $product
+     * @return array
+     */
     public function getAddToCartPostParams(\Magento\Catalog\Model\Product $product)
     {
         $url = $this->getAddToCartUrl($product);

--- a/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
@@ -49,6 +49,9 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
      */
     private $serializer;
 
+
+    protected $_listConfigurable;
+
     /**
      * NewWidget constructor.
      *
@@ -64,6 +67,7 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory,
         \Magento\Catalog\Model\Product\Visibility $catalogProductVisibility,
         \Magento\Framework\App\Http\Context $httpContext,
+        \Magento\Swatches\Block\Product\Renderer\Listing\Configurable $listconfigurable,
         array $data = [],
         \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
@@ -74,6 +78,7 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
             $httpContext,
             $data
         );
+        $this->_listConfigurable = $listconfigurable;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
@@ -280,5 +285,23 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
             );
         }
         return $price;
+    }
+
+    public function getProductDetailHtml(\Magento\Catalog\Model\Product $product)
+    {
+        $renderer =  $this->_listConfigurable;
+
+       if ($renderer) {
+          $renderer->setProduct($product);
+            return $renderer->setTemplate('product/listing/renderer.phtml')->toHtml();
+        }
+        return '';
+    }
+    public function getAddToCartPostParams(\Magento\Catalog\Model\Product $product)
+    {
+        $url = $this->getAddToCartUrl($product);
+        return [
+            'action' => $url
+        ];
     }
 }

--- a/app/code/Magento/Catalog/composer.json
+++ b/app/code/Magento/Catalog/composer.json
@@ -4,6 +4,7 @@
     "require": {
         "php": "~7.0.13|~7.1.0",
         "magento/module-store": "100.2.*",
+        "magento/module-swatches": "100.2.*",
         "magento/module-eav": "101.0.*",
         "magento/module-cms": "102.0.*",
         "magento/module-indexer": "100.2.*",

--- a/app/code/Magento/Catalog/etc/module.xml
+++ b/app/code/Magento/Catalog/etc/module.xml
@@ -8,6 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Magento_Catalog" setup_version="2.2.5">
         <sequence>
+            <module name="Magento_Swatches"/>
             <module name="Magento_Eav"/>
             <module name="Magento_Cms"/>
             <module name="Magento_Indexer"/>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-use Magento\Framework\App\Action\Action;
 // @codingStandardsIgnoreFile
 
 ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
+use Magento\Framework\App\Action\Action;
 // @codingStandardsIgnoreFile
 
 ?>
@@ -61,8 +61,10 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                 <?php if ($templateType): ?>
                                     <?= $block->getReviewsSummaryHtml($_item, $templateType) ?>
                                 <?php endif; ?>
+                                <?= $block->getProductDetailHtml($_item) ?>
 
                                 <?php if ($showWishlist || $showCompare || $showCart): ?>
+                                    <div class="product-item-inner">
                                     <div class="product-item-actions">
                                         <?php if ($showCart): ?>
                                             <div class="actions-primary">
@@ -74,15 +76,15 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                             <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
                                                         </button>
                                                     <?php else: ?>
-                                                        <?php
-                                                            $postDataHelper = $this->helper('Magento\Framework\Data\Helper\PostHelper');
-                                                            $postData = $postDataHelper->getPostData($block->getAddToCartUrl($_item), ['product' => $_item->getEntityId()])
-                                                        ?>
-                                                        <button class="action tocart primary"
-                                                                data-post='<?= /* @escapeNotVerified */ $postData ?>'
-                                                                type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
-                                                            <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
-                                                        </button>
+                                                <?php $postParams = $block->getAddToCartPostParams($_item); ?>
+                                                <form data-role="tocart-form" data-product-sku="<?= $block->escapeHtml($_item->getSku()) ?>" action="<?= /* @NoEscape */ $postParams['action'] ?>" method="post">
+                                            <?= $block->getBlockHtml('formkey') ?>
+                                            <button type="submit"
+                                                    title="<?= $block->escapeHtml(__('Add to Cart')) ?>"
+                                                    class="action tocart primary">
+                                                <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
+                                            </button>
+                                        </form>
                                                     <?php endif; ?>
                                                 <?php else: ?>
                                                     <?php if ($_item->getIsSalable()): ?>
@@ -113,6 +115,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                 <?php endif; ?>
                                             </div>
                                         <?php endif; ?>
+                                    </div>
                                     </div>
                                 <?php endif; ?>
                             </div>

--- a/app/code/Magento/Swatches/view/frontend/layout/cms_index_index.xml
+++ b/app/code/Magento/Swatches/view/frontend/layout/cms_index_index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Magento_Swatches::css/swatches.css"/>
+    </head>
+</page>
+


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14134: Swatches not showing on homepage New products widget

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a widget and call New products on home page
2. Add to New product list any configurable products

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
