### PR TITLE
14294 switching store breaks back functionality

### DIFF
--- a/app/code/Magento/Store/Block/Switcher.php
+++ b/app/code/Magento/Store/Block/Switcher.php
@@ -234,4 +234,15 @@ class Switcher extends \Magento\Framework\View\Element\Template
             $data
         );
     }
+
+    /**
+     * Returns target store url
+     *
+     * @param Store $store
+     * @return string
+     */
+    public function getStoreUrl(Store $store)
+    {
+        return $store->getCurrentUrl(true);
+    }
 }

--- a/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
@@ -27,7 +27,7 @@
             <?php foreach ($block->getStores() as $_lang): ?>
                 <?php if ($_lang->getId() != $block->getCurrentStoreId()): ?>
                     <li class="view-<?= $block->escapeHtml($_lang->getCode()) ?> switcher-option">
-                        <a href="#" data-post='<?= /* @noEscape */ $block->getTargetStorePostData($_lang) ?>'>
+                        <a href="<?= $block->getStoreUrl($_lang) ?>">
                             <?= $block->escapeHtml($_lang->getName()) ?>
                         </a>
                     </li>

--- a/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
@@ -27,7 +27,7 @@
             <?php foreach ($block->getStores() as $_lang): ?>
                 <?php if ($_lang->getId() != $block->getCurrentStoreId()): ?>
                     <li class="view-<?= $block->escapeHtml($_lang->getCode()) ?> switcher-option">
-                        <a href="<?= $block->getStoreUrl($_lang) ?>">
+                        <a href="<?= $block->escapeUrl($block->getStoreUrl($_lang)) ?>">
                             <?= $block->escapeHtml($_lang->getName()) ?>
                         </a>
                     </li>

--- a/app/code/Magento/Store/view/frontend/templates/switch/stores.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/stores.phtml
@@ -31,7 +31,7 @@
             <?php foreach ($block->getGroups() as $_group): ?>
             <?php if (!($_group->getId() == $block->getCurrentGroupId())): ?>
                 <li class="switcher-option">
-                    <a href="#" data-post='<?= /* @noEscape */ $block->getTargetStorePostData($_group->getDefaultStore()) ?>'>
+                    <a href="<?= $block->getStoreUrl($_group) ?>">
                         <?= $block->escapeHtml($_group->getName()) ?>
                     </a>
                 </li>

--- a/app/code/Magento/Store/view/frontend/templates/switch/stores.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/stores.phtml
@@ -31,7 +31,7 @@
             <?php foreach ($block->getGroups() as $_group): ?>
             <?php if (!($_group->getId() == $block->getCurrentGroupId())): ?>
                 <li class="switcher-option">
-                    <a href="<?= $block->getStoreUrl($_group) ?>">
+                    <a href="<?= $block->escapeUrl($block->getStoreUrl($_group)) ?>">
                         <?= $block->escapeHtml($_group->getName()) ?>
                     </a>
                 </li>


### PR DESCRIPTION
### Description
Adds getStoreUrl() method to app/code/Magento/Store/Block/Switcher.php
Modifies switcher-option's links in Magento/Store/view/frontend/templates/switch/stores.phtml and Magento/Store/view/frontend/templates/switch/languages.phtml templates

### Fixed Issues (if relevant)
1. magento/magento2#14294: Since MagentoCE2.1.11, after swithing store view, ___store=xx is added to url. Breaks 'back' functionality.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
