### PR TITLE
Move Magento_Contact to suggest for the Magento_Shipping

### DIFF
--- a/app/code/Magento/Shipping/composer.json
+++ b/app/code/Magento/Shipping/composer.json
@@ -8,7 +8,6 @@
         "magento/module-sales": "101.0.*",
         "magento/module-backend": "100.2.*",
         "magento/module-directory": "100.2.*",
-        "magento/module-contact": "100.2.*",
         "magento/module-customer": "101.0.*",
         "magento/module-payment": "100.2.*",
         "magento/module-tax": "100.2.*",
@@ -22,7 +21,8 @@
     "suggest": {
         "magento/module-fedex": "100.2.*",
         "magento/module-ups": "100.2.*",
-        "magento/module-config": "101.0.*"
+        "magento/module-config": "101.0.*",
+        "magento/module-contact": "100.2.*"
     },
     "type": "magento2-module",
     "version": "100.2.4",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Magento_Contact is a soft-dependency, used to determine whether or not to include a link to Contact Us

### Fixed Issues (if relevant)
Fixed build failures encountered by third parties:

There was 1 failure:
1) Magento\Test\Integrity\DependencyTest::testRedundant
Redundant dependencies found!
Module Magento\Shipping: hard [Magento\Contact]
/home/travis/build/Vendor/Module/magento2/dev/tests/static/testsuite/Magento/Test/Integrity/DependencyTest.php:442

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
