### PR TITLE
FIX for issue #15457 - Bundle Products price range is showing expired…

### DIFF
--- a/app/code/Magento/Bundle/Pricing/Adjustment/DefaultSelectionPriceListProvider.php
+++ b/app/code/Magento/Bundle/Pricing/Adjustment/DefaultSelectionPriceListProvider.php
@@ -61,8 +61,8 @@ class DefaultSelectionPriceListProvider implements SelectionPriceListProviderInt
 
             if (!$useRegularPrice) {
                 $selectionsCollection->addAttributeToSelect('special_price');
-                $selectionsCollection->addAttributeToSelect('special_price_from');
-                $selectionsCollection->addAttributeToSelect('special_price_to');
+                $selectionsCollection->addAttributeToSelect('special_from_date');
+                $selectionsCollection->addAttributeToSelect('special_to_date');
                 $selectionsCollection->addAttributeToSelect('tax_class_id');
             }
 


### PR DESCRIPTION
… special price from bundle options

### Fixed Issues (if relevant)
1. magento/magento2#15457: Bundle Products price range is showing expired

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
