### PR TITLE
fix for Wrong price amount on product page #11717

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -99,7 +99,10 @@ class Format implements \Magento\Framework\Locale\FormatInterface
             $currency = $this->_scopeResolver->getScope()->getCurrentCurrency();
         }
 
-        $formatter = new \NumberFormatter($localeCode . '@currency=' . $currency->getCode(), \NumberFormatter::CURRENCY);
+        $formatter = new \NumberFormatter(
+            $localeCode . '@currency=' . $currency->getCode(),
+            \NumberFormatter::CURRENCY
+        );
         $format = $formatter->getPattern();
         $decimalSymbol = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $groupSymbol = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);

--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -99,7 +99,7 @@ class Format implements \Magento\Framework\Locale\FormatInterface
             $currency = $this->_scopeResolver->getScope()->getCurrentCurrency();
         }
 
-        $formatter = new \NumberFormatter($localeCode, \NumberFormatter::CURRENCY);
+        $formatter = new \NumberFormatter($localeCode . '@currency=' . $currency->getCode(), \NumberFormatter::CURRENCY);
         $format = $formatter->getPattern();
         $decimalSymbol = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
         $groupSymbol = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes broken currency format for some locales.
Since Magento2.2, price in product pages were not shown as expected against integer currencies.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#11717: Wrong price amount on product page

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create store views for USD(or EUR) and JPY(or KRW, IDR, VND)
2. Setup currency rates
3. Create products
4. Access frontend product page
5. Price shown as expected format (ex. JPY, KRW, IDR, VND are integer currencies!)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
