### PR TITLE
Add Currency Converter API connecting feature

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -1,0 +1,141 @@
+<?php
+namespace Magento\Directory\Model\Currency\Import;
+
+class CurrencyConverterApi extends AbstractImport
+{
+    /**
+     * @var string
+     */
+    const CURRENCY_CONVERTER_URL = 'http://free.currencyconverterapi.com/api/v3/convert?q={{CURRENCY_FROM}}_{{CURRENCY_TO}}&compact=ultra';
+
+    /**
+     * Http Client Factory
+     *
+     * @var \Magento\Framework\HTTP\ZendClientFactory
+     */
+    protected $httpClientFactory;
+
+    /**
+     * Core scope config
+     *
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * Initialize dependencies
+     *
+     * @param \Magento\Directory\Model\CurrencyFactory $currencyFactory
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\HTTP\ZendClientFactory $httpClientFactory
+     */
+    public function __construct(
+        \Magento\Directory\Model\CurrencyFactory $currencyFactory,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\HTTP\ZendClientFactory $httpClientFactory
+    ) {
+        parent::__construct($currencyFactory);
+        $this->scopeConfig = $scopeConfig;
+        $this->httpClientFactory = $httpClientFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchRates()
+    {
+        $data = [];
+        $currencies = $this->_getCurrencyCodes();
+        $defaultCurrencies = $this->_getDefaultCurrencyCodes();
+
+        foreach ($defaultCurrencies as $currencyFrom) {
+            if (!isset($data[$currencyFrom])) {
+                $data[$currencyFrom] = [];
+            }
+            $data = $this->convertBatch($data, $currencyFrom, $currencies);
+            ksort($data[$currencyFrom]);
+        }
+        return $data;
+    }
+
+    /**
+     * Return currencies convert rates in batch mode
+     *
+     * @param array $data
+     * @param string $currencyFrom
+     * @param array $currenciesTo
+     * @return array
+     */
+    private function convertBatch($data, $currencyFrom, $currenciesTo)
+    {
+        foreach($currenciesTo as $to) {
+            set_time_limit(0);
+            try {
+                $url = str_replace('{{CURRENCY_FROM}}', $currencyFrom, self::CURRENCY_CONVERTER_URL);
+                $url = str_replace('{{CURRENCY_TO}}', $to, $url);
+                $response = $this->getServiceResponse($url);
+                if ($currencyFrom == $to) {
+                    $data[$currencyFrom][$to] = $this->_numberFormat(1);
+                } else {
+                    if (empty($response)) {
+                        $this->_messages[] = __('We can\'t retrieve a rate from %1 for %2.', $url, $to);
+                        $data[$currencyFrom][$to] = null;
+                    } else {
+                        $data[$currencyFrom][$to] = $this->_numberFormat(
+                            (double)$response[$currencyFrom . '_' . $to]
+                        );
+                    }
+                }
+            } finally {
+                ini_restore('max_execution_time');
+            }
+
+        }
+
+
+        return $data;
+    }
+
+    /**
+     * Get Fixer.io service response
+     *
+     * @param string $url
+     * @param int $retry
+     * @return array
+     */
+    private function getServiceResponse($url, $retry = 0)
+    {
+        /** @var \Magento\Framework\HTTP\ZendClient $httpClient */
+        $httpClient = $this->httpClientFactory->create();
+        $response = [];
+
+        try {
+            $jsonResponse = $httpClient->setUri(
+                $url
+            )->setConfig(
+                [
+                    'timeout' => $this->scopeConfig->getValue(
+                        'currency/currencyconverterapi/timeout',
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    ),
+                ]
+            )->request(
+                'GET'
+            )->getBody();
+
+            $response = json_decode($jsonResponse, true);
+        } catch (\Exception $e) {
+            if ($retry == 0) {
+                $response = $this->getServiceResponse($url, 1);
+            }
+        }
+        return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _convert($currencyFrom, $currencyTo)
+    {
+    }
+}

--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -89,9 +89,7 @@ class CurrencyConverterApi extends AbstractImport
             } finally {
                 ini_restore('max_execution_time');
             }
-
         }
-
 
         return $data;
     }

--- a/app/code/Magento/Directory/etc/adminhtml/system.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/system.xml
@@ -52,6 +52,12 @@
                     <label>Connection Timeout in Seconds</label>
                 </field>
             </group>
+            <group id="currencyconverterapi" translate="label" sortOrder="45" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Currency Converter API</label>
+                <field id="timeout" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Connection Timeout in Seconds</label>
+                </field>
+            </group>
             <group id="import" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Scheduled Import Settings</label>
                 <field id="enabled" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">

--- a/app/code/Magento/Directory/etc/config.xml
+++ b/app/code/Magento/Directory/etc/config.xml
@@ -27,6 +27,9 @@
             <webservicex>
                 <timeout>100</timeout>
             </webservicex>
+            <currencyconverterapi>
+                <timeout>100</timeout>
+            </currencyconverterapi>
             <import>
                 <enabled>0</enabled>
                 <error_email />

--- a/app/code/Magento/Directory/etc/di.xml
+++ b/app/code/Magento/Directory/etc/di.xml
@@ -22,6 +22,10 @@
                     <item name="label" xsi:type="string" translatable="true">Fixer.io</item>
                     <item name="class" xsi:type="string">Magento\Directory\Model\Currency\Import\FixerIo</item>
                 </item>
+                <item name="currencyconverterapi" xsi:type="array">
+                    <item name="label" xsi:type="string" translatable="true">Currency Converter API</item>
+                    <item name="class" xsi:type="string">Magento\Directory\Model\Currency\Import\CurrencyConverterApi</item>
+                </item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR aims to add "[Currency Converter API](https://free.currencyconverterapi.com/)" connecting feature for retrieving TWD currency rate.
Currency rates services that Magento can connect by default can't retrieve TWD rates.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15541: Cannot retrieve currency rates for TWD


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Allow TWD from admin panel
2. Access to "Store > Currency Rates"
3. Choose "Currency Converter API" from the drop down
4. Click "Import" and wait
5. Currency rate for TWD will be set the form

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
