### PR TITLE
Fotorama gallery configuration fix

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -47,11 +47,11 @@
                 "data": <?= /* @escapeNotVerified */ $block->getGalleryImagesJson() ?>,
                 "options": {
                     "nav": "<?= /* @escapeNotVerified */ $block->getVar("gallery/nav") ?>",
-                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/loop") ? 'true' : 'false' ?>
-                    "keyboard": <?= /* @escapeNotVerified */ $block->getVar("gallery/keyboard") ? 'true' : 'false' ?>
-                    "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/arrows") ? 'true' : 'false' ?>
-                    "allowfullscreen": <?= /* @escapeNotVerified */ $block->getVar("gallery/allowfullscreen") ? 'true' : 'false' ?>
-                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ? 'true' : 'false' ?>
+                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/loop") ? 'true' : 'false' ?>,
+                    "keyboard": <?= /* @escapeNotVerified */ $block->getVar("gallery/keyboard") ? 'true' : 'false' ?>,
+                    "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/arrows") ? 'true' : 'false' ?>,
+                    "allowfullscreen": <?= /* @escapeNotVerified */ $block->getVar("gallery/allowfullscreen") ? 'true' : 'false' ?>,
+                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ? 'true' : 'false' ?>,
                     "width": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'width') ?>",
                     "thumbwidth": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_small', 'width') ?>",
                     <?php if ($block->getImageAttribute('product_page_image_small', 'height') || $block->getImageAttribute('product_page_image_small', 'width')): ?>
@@ -69,18 +69,18 @@
                         "transitionduration": <?= /* @escapeNotVerified */ $block->getVar("gallery/transition/duration") ?>,
                     <?php endif; ?>
                     "transition": "<?= /* @escapeNotVerified */ $block->getVar("gallery/transition/effect") ?>",
-                    <?= /* @escapeNotVerified */ $block->getVar("gallery/navarrows") ? 'true' : 'false' ?>
+                    "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/navarrows") ? 'true' : 'false' ?>,
                     "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navtype") ?>",
                     "navdir": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navdir") ?>"
                 },
                 "fullscreen": {
                     "nav": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/nav") ?>",
-                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/loop") ? 'true' : 'false' ?>
+                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/loop") ? 'true' : 'false' ?>,
                     "navdir": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navdir") ?>",
-                    "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navarrows") ? 'true' : 'false' ?>
+                    "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navarrows") ? 'true' : 'false' ?>,
                     "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navtype") ?>",
                     "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/arrows") ? 'true' : 'false' ?>
-                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/caption") ? 'true' : 'false' ?>
+                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/caption") ? 'true' : 'false' ?>,
                     <?php if ($block->getVar("gallery/fullscreen/transition/duration")): ?>
                         "transitionduration": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/transition/duration") ?>,
                     <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -47,21 +47,11 @@
                 "data": <?= /* @escapeNotVerified */ $block->getGalleryImagesJson() ?>,
                 "options": {
                     "nav": "<?= /* @escapeNotVerified */ $block->getVar("gallery/nav") ?>",
-                    <?php if (($block->getVar("gallery/loop"))): ?>
-                        "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/loop") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/keyboard"))): ?>
-                        "keyboard": <?= /* @escapeNotVerified */ $block->getVar("gallery/keyboard") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/arrows"))): ?>
-                        "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/arrows") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/allowfullscreen"))): ?>
-                        "allowfullscreen": <?= /* @escapeNotVerified */ $block->getVar("gallery/allowfullscreen") ?>,
-                    <?php endif; ?>
-                    <?php if (($block->getVar("gallery/caption"))): ?>
-                        "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
-                    <?php endif; ?>
+                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/loop") ? 'true' : 'false' ?>
+                    "keyboard": <?= /* @escapeNotVerified */ $block->getVar("gallery/keyboard") ? 'true' : 'false' ?>
+                    "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/arrows") ? 'true' : 'false' ?>
+                    "allowfullscreen": <?= /* @escapeNotVerified */ $block->getVar("gallery/allowfullscreen") ? 'true' : 'false' ?>
+                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ? 'true' : 'false' ?>
                     "width": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'width') ?>",
                     "thumbwidth": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_small', 'width') ?>",
                     <?php if ($block->getImageAttribute('product_page_image_small', 'height') || $block->getImageAttribute('product_page_image_small', 'width')): ?>
@@ -79,28 +69,18 @@
                         "transitionduration": <?= /* @escapeNotVerified */ $block->getVar("gallery/transition/duration") ?>,
                     <?php endif; ?>
                     "transition": "<?= /* @escapeNotVerified */ $block->getVar("gallery/transition/effect") ?>",
-                    <?php if (($block->getVar("gallery/navarrows"))): ?>
-                        "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/navarrows") ?>,
-                    <?php endif; ?>
+                    <?= /* @escapeNotVerified */ $block->getVar("gallery/navarrows") ? 'true' : 'false' ?>
                     "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navtype") ?>",
                     "navdir": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navdir") ?>"
                 },
                 "fullscreen": {
                     "nav": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/nav") ?>",
-                    <?php if ($block->getVar("gallery/fullscreen/loop")): ?>
-                        "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/loop") ?>,
-                    <?php endif; ?>
+                    "loop": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/loop") ? 'true' : 'false' ?>
                     "navdir": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navdir") ?>",
-                    <?php if ($block->getVar("gallery/transition/navarrows")): ?>
-                        "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navarrows") ?>,
-                    <?php endif; ?>
+                    "navarrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navarrows") ? 'true' : 'false' ?>
                     "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/navtype") ?>",
-                    <?php if ($block->getVar("gallery/fullscreen/arrows")): ?>
-                        "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/arrows") ?>,
-                    <?php endif; ?>
-                    <?php if ($block->getVar("gallery/fullscreen/caption")): ?>
-                        "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/caption") ?>,
-                    <?php endif; ?>
+                    "arrows": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/arrows") ? 'true' : 'false' ?>
+                    "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/caption") ? 'true' : 'false' ?>
                     <?php if ($block->getVar("gallery/fullscreen/transition/duration")): ?>
                         "transitionduration": <?= /* @escapeNotVerified */ $block->getVar("gallery/fullscreen/transition/duration") ?>,
                     <?php endif; ?>


### PR DESCRIPTION
### Description

Fotorama gallery configuration fix: Removing check for boolean variables. This check will prevent populating "false" value - default value will be used instead.

Previous code for boolean config looked like:
`
                    <?php if (($block->getVar("gallery/caption"))): ?>
                        "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
                    <?php endif; ?>
`
In this case if show caption option set to "false", we will simply won't get the condition body output, so fotorama will use a default configuration. 

app/design/frontend/Magento/blank/etc/view.xml has:
`
<vars module="Magento_Catalog">
    <var name="gallery">
        <var name="caption">false</var>
    </var>
</vars>
`
So the default value will be shown:
lib/web/fotorama/fotorama.js line 621:
`
showcaption: true,
`
Which means that image caption will be shown always, ignoring theme's configuration.


### Manual testing scenarios
1. In 2.2 develop branch go to the product view page.
2. Product gallery will have image caption
