### PR TITLE
[Forwardport] Fixes in ui module

### DIFF
--- a/app/code/Magento/Ui/Component/Bookmark.php
+++ b/app/code/Magento/Ui/Component/Bookmark.php
@@ -82,11 +82,11 @@ class Bookmark extends AbstractComponent
             }
         }
 
-        $this->setData('config', array_replace_recursive($config, $this->getConfiguration($this)));
+        $this->setData('config', array_replace_recursive($config, $this->getConfiguration()));
 
         parent::prepare();
 
-        $jsConfig = $this->getConfiguration($this);
+        $jsConfig = $this->getConfiguration();
         $this->getContext()->addComponentDefinition($this->getComponentName(), $jsConfig);
     }
 }

--- a/app/code/Magento/Ui/Test/Unit/Component/Control/ActionPoolTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Control/ActionPoolTest.php
@@ -83,8 +83,7 @@ class ActionPoolTest extends \PHPUnit\Framework\TestCase
         $this->items[$this->key] = $this->createPartialMock(\Magento\Ui\Component\Control\Item::class, ['setData']);
         $this->actionPool = new ActionPool(
             $this->contextMock,
-            $this->itemFactoryMock,
-            $this->toolbarBlockMock
+            $this->itemFactoryMock
         );
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15512
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR fixes two issues in the Magento/Ui Module:

1. `getConfiguration()` invoked with 1 parameter, 0 required, see `Magento/Ui/Component/Bookmark.php` on line [85](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Ui/Component/Bookmark.php#L85) and [89](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Ui/Component/Bookmark.php#L89)

1. Class` Magento\Ui\Component\Control\ActionPool` constructor invoked with 3 parameters, 2 required. see `Magento/Ui/Test/Unit/Component/Control/ActionPoolTest.php` on line [87](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Ui/Test/Unit/Component/Control/ActionPoolTest.php#L87)


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
