### PR TITLE
Fixes in widget component (2.3-develop)

### DIFF
--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -97,6 +97,16 @@ class Instance extends \Magento\Framework\Model\AbstractModel
     protected $_relatedCacheTypes;
 
     /**
+     * @var \Magento\Catalog\Model\Product\Type
+     */
+    protected $_productType;
+
+    /**
+     * @var \Magento\Widget\Model\Config\Reader
+     */
+    protected $_reader;
+
+    /**
      * @var \Magento\Framework\Escaper
      */
     protected $_escaper;

--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -22,6 +22,7 @@ use Magento\Framework\Serialize\Serializer\Json;
  * @method int getThemeId()
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  * @since 100.0.2
  */
 class Instance extends \Magento\Framework\Model\AbstractModel

--- a/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml
+++ b/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml
@@ -41,7 +41,7 @@
             </parameter>
             <parameter name="id_path" xsi:type="block" visible="true" required="true" sort_order="10">
                 <label translate="true">Product</label>
-                <block class="Magento\Backend\Block\Catalog\Product\Widget\Chooser">
+                <block class="Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser">
                     <data>
                         <item name="button" xsi:type="array">
                             <item name="open" xsi:type="string" translate="true">Select Product...</item>

--- a/app/code/Magento/Widget/Test/Unit/Model/_files/widget_config.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/_files/widget_config.php
@@ -48,7 +48,7 @@ return [
                 'type' => 'label',
                 '@' => ['type' => 'complex'],
                 'helper_block' => [
-                    'type' => \Magento\Backend\Block\Catalog\Product\Widget\Chooser::class,
+                    'type' => \Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser::class,
                     'data' => ['button' => ['open' => 'Select Product...']],
                 ],
                 'visible' => '1',


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR fixes two issues in the Magento/Widget Component:

1. Adding missing properties which are assigned in the `_construct()` on line [177](https://github.com/magento/magento2/blob/a0c157e7b9470dd23901404c1583ad61d1adee8c/app/code/Magento/Widget/Model/Widget/Instance.php#L177) and [178](https://github.com/magento/magento2/blob/a0c157e7b9470dd23901404c1583ad61d1adee8c/app/code/Magento/Widget/Model/Widget/Instance.php#L178)

1. Fix class reference to a non-existent class in the tests. See on line [55](https://github.com/magento/magento2/blob/a0c157e7b9470dd23901404c1583ad61d1adee8c/app/code/Magento/Widget/Test/Unit/Model/_files/widget_config.php#L51) in `Magento/Widget/Test/Unit/Model/_files/widget_config.php` and line [44](https://github.com/magento/magento2/blob/a0c157e7b9470dd23901404c1583ad61d1adee8c/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml#L44) in `Magento/Widget/Test/Unit/Model/_files/widget.xml`


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
