### PR TITLE
Exception message added for Virtual or Empty Cart

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -126,7 +126,7 @@ class ShippingMethodManagement implements
 
         // no methods applicable for empty carts or carts with virtual products
         if ($quote->isVirtual() || 0 == $quote->getItemsCount()) {
-            return [];
+            throw new StateException(__('No methods applicable for empty carts or carts with virtual products'));
         }
 
         $shippingAddress = $quote->getShippingAddress();


### PR DESCRIPTION
Added exception message for Virtual Products or Empty Cart 

### Description
If Virtual products are added in cart, Shipping methods are no applicable which is fine. But it was returning blank array []. Instead of blank it should show a exception message which I have added.

Message is always helpful for developers to identify error/exception. Specially with REST APIs.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
1. Add a virtual product in cart.
2. Estimate shipping
3. It was returning blank array [], I just added a exception message instead of blank array.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
