### PR TITLE
Fix #13445

### DIFF
--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
@@ -7,6 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
+        <attribute name="class" value="page-with-filter"/>
         <attribute name="class" value="page-products"/>
         <referenceContainer name="content">
             <block class="Magento\CatalogSearch\Block\Result" name="search.result" template="Magento_CatalogSearch::result.phtml">


### PR DESCRIPTION
### Description
Added the class "page-with-filter" in the catalogsearch_result_index.xml for fixing the issue.

### Fixed Issues (if relevant)
1. magento/magento2 [#13445](https://github.com/magento/magento2/issues/13445): "Shop By" button disabling broken on the search page

### Manual testing scenarios
1. click on the "Search" icon and search for "jacket";
2. resize the window to a mobile size;
3. click on "Shop By" and choose a filter with one product (e.g. "Category -> Gear");

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
