### PR TITLE
[Forwardport] [fix] typo in method name _getCharg[e]ableOptionPrice

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
@@ -341,7 +341,7 @@ class DefaultType extends \Magento\Framework\DataObject
     {
         $option = $this->getOption();
 
-        return $this->_getChargableOptionPrice($option->getPrice(), $option->getPriceType() == 'percent', $basePrice);
+        return $this->_getChargeableOptionPrice($option->getPrice(), $option->getPriceType() == 'percent', $basePrice);
     }
 
     /**
@@ -395,14 +395,14 @@ class DefaultType extends \Magento\Framework\DataObject
     }
 
     /**
-     * Return final chargable price for option
+     * Return final chargeable price for option
      *
      * @param float $price Price of option
      * @param boolean $isPercent Price type - percent or fixed
      * @param float $basePrice For percent price type
      * @return float
      */
-    protected function _getChargableOptionPrice($price, $isPercent, $basePrice)
+    protected function _getChargeableOptionPrice($price, $isPercent, $basePrice)
     {
         if ($isPercent) {
             return $basePrice * $price / 100;

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
@@ -395,6 +395,19 @@ class DefaultType extends \Magento\Framework\DataObject
     }
 
     /**
+     * @param float $price Price of option
+     * @param boolean $isPercent Price type - percent or fixed
+     * @param float $basePrice For percent price type
+     * @return float
+     * @deprecated 102.0.4 typo in method name
+     * @see _getChargeableOptionPrice
+     */
+    protected function _getChargableOptionPrice($price, $isPercent, $basePrice)
+    {
+        return $this->_getChargeableOptionPrice($price, $isPercent, $basePrice);
+    }
+
+    /**
      * Return final chargeable price for option
      *
      * @param float $price Price of option

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -231,7 +231,7 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
             foreach (explode(',', $optionValue) as $value) {
                 $_result = $option->getValueById($value);
                 if ($_result) {
-                    $result += $this->_getChargableOptionPrice(
+                    $result += $this->_getChargeableOptionPrice(
                         $_result->getPrice(),
                         $_result->getPriceType() == 'percent',
                         $basePrice
@@ -246,7 +246,7 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         } elseif ($this->_isSingleSelection()) {
             $_result = $option->getValueById($optionValue);
             if ($_result) {
-                $result = $this->_getChargableOptionPrice(
+                $result = $this->_getChargeableOptionPrice(
                     $_result->getPrice(),
                     $_result->getPriceType() == 'percent',
                     $basePrice


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15276
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Method name `\Magento\Catalog\Model\Product\Option\Type::_getChargableOptionPrice` contained typo.

Renamed it to `_getChargeableOptionPrice`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
