### PR TITLE
Error 500 on "/catalogsearch/advanced/" route

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Advanced/CollectionFactory.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Advanced/CollectionFactory.php
@@ -27,8 +27,10 @@ class CollectionFactory
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param string $instanceName
      */
-    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager, $instanceName = '\\Magento\\CatalogSearch\\Model\\ResourceModel\\Advanced\\Collection')
-    {
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $instanceName = '\\Magento\\CatalogSearch\\Model\\ResourceModel\\Advanced\\Collection'
+    ) {
         $this->_objectManager = $objectManager;
         $this->_instanceName = $instanceName;
     }
@@ -39,7 +41,7 @@ class CollectionFactory
      * @param array $data
      * @return \Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection
      */
-    public function create(array $data = array())
+    public function create(array $data = [])
     {
         return $this->_objectManager->create($this->_instanceName, $data);
     }

--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Advanced/CollectionFactory.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Advanced/CollectionFactory.php
@@ -5,8 +5,7 @@ namespace Magento\CatalogSearch\Model\ResourceModel\Advanced;
 /**
  * Factory class for @see \Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection
  */
-class CollectionFactory
-    extends \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory
+class CollectionFactory extends \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory
 {
     /**
      * Instance name to create
@@ -29,7 +28,7 @@ class CollectionFactory
      */
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager,
-        $instanceName = '\\Magento\\CatalogSearch\\Model\\ResourceModel\\Advanced\\Collection'
+        \Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection $instanceName
     ) {
         $this->_objectManager = $objectManager;
         $this->_instanceName = $instanceName;

--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Advanced/CollectionFactory.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Advanced/CollectionFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Magento\CatalogSearch\Model\ResourceModel\Advanced;
+
+/**
+ * Factory class for @see \Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection
+ */
+class CollectionFactory
+    extends \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory
+{
+    /**
+     * Instance name to create
+     *
+     * @var string
+     */
+    protected $_instanceName = null;
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    protected $_objectManager = null;
+
+    /**
+     * Factory constructor
+     *
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param string $instanceName
+     */
+    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager, $instanceName = '\\Magento\\CatalogSearch\\Model\\ResourceModel\\Advanced\\Collection')
+    {
+        $this->_objectManager = $objectManager;
+        $this->_instanceName = $instanceName;
+    }
+
+    /**
+     * Create class instance with specified parameters
+     *
+     * @param array $data
+     * @return \Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection
+     */
+    public function create(array $data = array())
+    {
+        return $this->_objectManager->create($this->_instanceName, $data);
+    }
+}


### PR DESCRIPTION
Class `\Magento\CatalogSearch\Model\Advanced` [awaits](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/CatalogSearch/Model/Advanced.php#L138) argument `$productCollectionFactory` of type `\Magento\Catalog\Model\ResourceModel\Product\CollectionFactory`.

[This is](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/CatalogSearch/etc/di.xml#L192) `./module-catalog-search/etc/di.xml`:
```
    <type name="Magento\CatalogSearch\Model\Advanced">
        <arguments>
            <argument name="productCollectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Advanced\CollectionFactory</argument>
        </arguments>
    </type>
```

Class `\Magento\CatalogSearch\Model\ResourceModel\Advanced\CollectionFactory` is autogenerated:
```
namespace Magento\CatalogSearch\Model\ResourceModel\Advanced;

/**
 * Factory class for @see \Magento\CatalogSearch\Model\ResourceModel\Advanced\Collection
 */
class CollectionFactory
{...}
```
... and does not extend class `\Magento\Catalog\Model\ResourceModel\Product\CollectionFactory` (that is autogenerated too).

So, we have an error when we try to go to "http://.../catalogsearch/advanced/"
```
PHP Fatal error:  Uncaught TypeError: Argument 9 passed to Magento\\CatalogSearch\\Model\\Advanced::__construct() 
must be an instance of Magento\\Catalog\\Model\\ResourceModel\\Product\\CollectionFactory, 
instance of Magento\\CatalogSearch\\Model\\ResourceModel\\Advanced\\CollectionFactory\\Interceptor given, 
called in /.../vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php on line 111 
and defined in /.../vendor/magento/module-catalog-search/Model/Advanced.php:129
Stack trace:
#0 /.../vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(111): 
Magento\\CatalogSearch\\Model\\Advanced->__construct(
    Object(Magento\\Framework\\Model\\Context), 
    Object(Magento\\Framework\\Registry), 
    Object(Magento\\Catalog\\Model\\ResourceModel\\Product\\Attribute\\CollectionFactory), 
    Object(Magento\\Catalog\\Model\\Product\\Visibility), 
    Object(Magento\\Catalog\\Model\\Config), 
    Object(Magento\\Directory\\Model\\CurrencyFactory), 
    Object 
in /.../vendor/magento/module-catalog-search/Model/Advanced.php on line 129
```
Unfortunately, the error is not stable. I cannot describe exactly how to repeat it.

As I see, there are other `CollectionFactory` classes that are not autogenerated (`\Magento\Framework\Mview\View\State\CollectionFactory`, for example). I suggest to place autogenerated  class `Magento\CatalogSearch\Model\ResourceModel\Advanced\CollectionFactory` into the `module-catalog-search` and extend autogenerated class `\Magento\Catalog\Model\ResourceModel\Product\CollectionFactory`.

Please, use this code as you want (according to your own conventions) without any doubts. I've added one only line to the autogenerated code:
```
extends \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory
```

Regards,

Alex.