### PR TITLE
Use the timeout when querying Elasticsearch

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/Client/Elasticsearch.php
+++ b/app/code/Magento/Elasticsearch/Model/Client/Elasticsearch.php
@@ -293,7 +293,8 @@ class Elasticsearch implements ClientInterface
      */
     public function query($query)
     {
-        return $this->client->search($query);
+        $params = array_merge($query, ['client' => ['timeout' => $this->clientOptions['timeout']]]);
+        return $this->client->search($params);
     }
 
     /**


### PR DESCRIPTION
### Description

Sets a timeout when querying Elasticsearch. Without a timeout the following can happen...

- For whatever reason Elasticsearch becomes REALLY slow to respond to a bunch of queries (on one site I've seen it taking like 900 seconds in New Relic)
- Lots of PHP processes wait A LONG TIME for these responses to come back from Elasticsearch.
- Build up of PHP processes cause entire site to go down due to high load average, php-fpm max children, etc, etc

If the timeout is exceeded the user will get a 503, but at least it won't bring the site down. Anyway, if it's waiting more than the timeout (default 15 seconds) it's a pretty awful user experience already at that point...

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios

Here's how I tested...

1. Create a dummy php server that sleeps for 60 seconds and returns nothing[1]
2. Run that on port 9201 [2]
3. Update the Magento Elasticseach settings to point to php instance running on port 9201
4. Visit any category page

[1]

Assuming Magento is querying index `magento2-3-develop`

```
$ tree
.
└── magento2-3-develop_product_1
    └── document
        └── _search
            └── index.php

3 directories, 1 file
$ cat magento2-3-develop_product_1/document/_search/index.php
<?php

sleep(60);
```

[2]

```
$ php -S localhost:9201
```

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
