### PR TITLE
#11627 Fix query filter for custom attribute

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilter.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilter.php
@@ -141,7 +141,10 @@ class CustomAttributeFilter
     {
         return [
             sprintf('`%s`.`entity_id` = `%s`.`entity_id`', $mainTable, $joinTable),
-            sprintf('`%s`.`source_id` = `%s`.`source_id`', $mainTable, $joinTable),
+            '(' . $this->conditionManager->combineQueries([
+                sprintf('`%s`.`source_id` = `%s`.`source_id`', $mainTable, $joinTable),
+                sprintf('`%s`.`source_id` = `%s`.`entity_id`', $mainTable, $joinTable),
+            ], Select::SQL_OR) . ')',
             $this->conditionManager->generateCondition(
                 sprintf('%s.attribute_id', $joinTable),
                 '=',

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilterTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilterTest.php
@@ -155,7 +155,10 @@ class CustomAttributeFilterTest extends \PHPUnit\Framework\TestCase
 
         $joinConditions = [
             '`some_index`.`entity_id` = `field1_filter`.`entity_id`',
-            '`some_index`.`source_id` = `field1_filter`.`source_id`',
+            $this->conditionManager->combineQueries([
+                '`some_index`.`entity_id` = `field1_filter`.`entity_id`',
+                '`some_index`.`source_id` = `field1_filter`.`source_id`',
+            ], Select::SQL_OR),
             sprintf('`field1_filter`.`attribute_id` = %s', $firstAttribute->getId()),
             sprintf('`field1_filter`.`store_id` = %s', (int) $this->storeManager->getStore()->getId())
         ];
@@ -182,14 +185,20 @@ class CustomAttributeFilterTest extends \PHPUnit\Framework\TestCase
 
         $joinConditions1 = [
             '`some_index`.`entity_id` = `field1_filter`.`entity_id`',
-            '`some_index`.`source_id` = `field1_filter`.`source_id`',
+            $this->conditionManager->combineQueries([
+                '`some_index`.`entity_id` = `field1_filter`.`entity_id`',
+                '`some_index`.`source_id` = `field1_filter`.`source_id`',
+            ], Select::SQL_OR),
             sprintf('`field1_filter`.`attribute_id` = %s', $firstAttribute->getId()),
             sprintf('`field1_filter`.`store_id` = %s', (int) $this->storeManager->getStore()->getId())
         ];
 
         $joinConditions2 = [
             '`some_index`.`entity_id` = `field2_filter`.`entity_id`',
-            '`some_index`.`source_id` = `field2_filter`.`source_id`',
+            $this->conditionManager->combineQueries([
+                '`some_index`.`entity_id` = `field2_filter`.`entity_id`',
+                '`some_index`.`source_id` = `field2_filter`.`source_id`',
+            ], Select::SQL_OR),
             sprintf('`field2_filter`.`attribute_id` = %s', $secondAttribute->getId()),
             sprintf('`field2_filter`.`store_id` = %s', (int) $this->storeManager->getStore()->getId())
         ];


### PR DESCRIPTION
Duplicate of the pull request #12123 that has been closed due to inactivity.
It fixes the problem that occurs when we filter a product list with configurable product attribute and simple product attribute.

### Description

Change the query that do a join when apply filters in catalog product list. Now the query validate that the attribute exist for configurable product or for simple product assigned to configurable.

(apply @AVoskoboinikov patches from the linked pull request)

### Fixed Issues (if relevant)

1. magento/magento2#11627 : Problem with the attribute color

### Manual testing scenarios

Click Men - Bottoms - Pants -> 12 items
Click Style - Leggings -> 4 items, 2 in green
Click Color - Green

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
