### PR TITLE
[Forwardport] Issue 15469: Javascript error dropdowns.js

### DIFF
--- a/lib/web/mage/dropdowns.js
+++ b/lib/web/mage/dropdowns.js
@@ -127,11 +127,9 @@ define([
             }
 
             elem.on('click.toggleDropdown', function () {
-                var el;
+                var el = actionElem;
 
                 if (options.autoclose === true) {
-                    el = actionElem;
-
                     actionElem = $();
                     $(document).trigger('click.hideDropdown');
                     actionElem = el;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15499
Fixes Javascript error in dropdowns.js by properly initializing the el variable. options.autoclose can now be set to false

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Initialize the `el` variable outside of the condition checking for `options.autoclose === true`

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#15469: lib/web/mage/dropdowns.js fails when autoclose is set to true

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. In a javascript file, call dropdown on an element with `autoclose: false`
```
$(this.selector).dropdown({
    autoclose: false
});
```
2. Open and close the dropdown, verifying no javascript errors occur in the console

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
