### PR TITLE
Number Interpreter returns float

### DIFF
--- a/lib/internal/Magento/Framework/Data/Argument/Interpreter/Number.php
+++ b/lib/internal/Magento/Framework/Data/Argument/Interpreter/Number.php
@@ -14,7 +14,7 @@ class Number implements InterpreterInterface
 {
     /**
      * {@inheritdoc}
-     * @return string|int|float
+     * @return float
      * @throws \InvalidArgumentException
      */
     public function evaluate(array $data)
@@ -22,7 +22,9 @@ class Number implements InterpreterInterface
         if (!isset($data['value']) || !is_numeric($data['value'])) {
             throw new \InvalidArgumentException('Numeric value is expected.');
         }
-        $result = $data['value'];
+
+        $result = (float) $data['value'];
+
         return $result;
     }
 }

--- a/lib/internal/Magento/Framework/Data/Argument/Interpreter/Number.php
+++ b/lib/internal/Magento/Framework/Data/Argument/Interpreter/Number.php
@@ -14,7 +14,7 @@ class Number implements InterpreterInterface
 {
     /**
      * {@inheritdoc}
-     * @return float
+     * @return int|float
      * @throws \InvalidArgumentException
      */
     public function evaluate(array $data)
@@ -23,7 +23,7 @@ class Number implements InterpreterInterface
             throw new \InvalidArgumentException('Numeric value is expected.');
         }
 
-        $result = (float) $data['value'];
+        $result = $data['value'] + 0;
 
         return $result;
     }

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Argument/Interpreter/NumberTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Argument/Interpreter/NumberTest.php
@@ -52,8 +52,8 @@ class NumberTest extends \PHPUnit\Framework\TestCase
         return [
             'integer' => [10, 10],
             'float' => [10.5, 10.5],
-            'string numeric (integer)' => ['10', '10'],
-            'string numeric (float)' => ['10.5', '10.5']
+            'string numeric (integer)' => ['10', 10],
+            'string numeric (float)' => ['10.5', 10.5]
         ];
     }
 }


### PR DESCRIPTION
### Description
Currently number interpreter doesn't convert numeric string numbers to float or int, just return its as string.

### Fixed Issues (if relevant)
When describe in ui-conponent number type (for example for select options) it's not converted to number (float or int). 
Number interpreter should return real number (float or int). Currently its not convert numeric strings to float or int.

### Manual testing scenarios
1. Add to ui component select field with number options. Like below:
```
 <field name="qty_type" formElement="select">
            <formElements>
                    <select>
                        <settings>
                            <options>
                                <option name="0" xsi:type="array">
                                    <item name="label" xsi:type="string" translate="true">Static</item>
                                    <item name="value" xsi:type="number">0.5</item>
                                </option>
                                <option name="1" xsi:type="array">
                                    <item name="label" xsi:type="string" translate="true">Dynamic</item>
                                    <item name="value" xsi:type="number">1</item>
                                </option>
                            </options>
                        </settings>
                    </select>
                </formElements>
</field>
```

2. Inspect field by "Knockout Context Debugger"
Expected value: {{"label":"Static", "value": 0.5}, {"label": "Dynamic", "value": 1};
Current value:  {{"label":"Static", "value": "0.5"}, {"label": "Dynamic", "value": "1"};

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
