### PR TITLE
[Backport] Fixed product tier pricing pagination issue in admin

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
@@ -722,6 +722,8 @@ define([
          * @param {Number} page - current page
          */
         changePage: function (page) {
+            this.clear();
+
             if (page === 1 && !this.recordData().length) {
                 return false;
             }
@@ -763,7 +765,6 @@ define([
          * Change page to next
          */
         nextPage: function () {
-            this.clear();
             this.currentPage(this.currentPage() + 1);
         },
 
@@ -771,7 +772,6 @@ define([
          * Change page to previous
          */
         previousPage: function () {
-            this.clear();
             this.currentPage(this.currentPage() - 1);
         },
 


### PR DESCRIPTION
Original PR: #15360

### Description:
Resolved product tier price pagination loader issue in admin.
The issue was reproduced in Magento *2.2-develop* branch.

### Fixed Issues

1. magento/magento2#15210: Advanced pricing pagination issue

### Manual testing scenarios

Navigate Admin => Catalog => Products => Create New / Edit Product.

1. Go to Advanced Pricing link under Price text field.
2. Add tier price more than a page and do save.
3. Jump to other pages by directly editing the pagination text box.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
