### PR TITLE
Fix #15627: Product order in category changed in Magento 2.2.4

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
@@ -196,7 +196,7 @@ class Toolbar extends \Magento\Framework\View\Element\Template
                 $this->_collection->addAttributeToSort(
                     $this->getCurrentOrder(),
                     $this->getCurrentDirection()
-                )->addAttributeToSort('entity_id', $this->getCurrentDirection());
+                );
             } else {
                 $this->_collection->setOrder($this->getCurrentOrder(), $this->getCurrentDirection());
             }


### PR DESCRIPTION
### Description
This PR is a fix for issue #15627 where the default sorting behaviour of Magento was changed in Magento 2.2.4.

### Fixed Issues
1. magento/magento2#15627: Product order in category changed after update to Magento 2.2.4

### Manual testing scenarios
1. Have a category in Magento with several products in it, all have the position in the category set to the value 0
2. The default sort order should be set to position
3. View the category. The product with the highest entity_id (newest product) should be shown first. 