### PR TITLE
Create ability to set is_visible_on_front to order status history comment

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1008,8 +1008,24 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param string $comment
      * @param bool|string $status
      * @return OrderStatusHistoryInterface
+     * @deprecated
+     * @see addCommentToStatusHistory
      */
-    public function addStatusHistoryComment($comment, $status = false, $isVisibleOnFront = false)
+    public function addStatusHistoryComment($comment, $status = false)
+    {
+        return $this->addCommentToStatusHistory($comment, $status, false);
+    }
+    
+    /**
+     * Add a comment to order status history
+     * Different or default status may be specified
+     *
+     * @param string $comment
+     * @param bool|string $status
+     * @param bool $isVisibleOnFront
+     * @return OrderStatusHistoryInterface
+     */
+    public function addCommentToStatusHistory($comment, $status = false, $isVisibleOnFront = false)
     {
         if (false === $status) {
             $status = $this->getStatus();

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1009,7 +1009,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param bool|string $status
      * @return OrderStatusHistoryInterface
      */
-    public function addStatusHistoryComment($comment, $status = false)
+    public function addStatusHistoryComment($comment, $status = false, $isVisibleOnFront = false)
     {
         if (false === $status) {
             $status = $this->getStatus();
@@ -1024,6 +1024,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             $comment
         )->setEntityName(
             $this->entityType
+        )->setIsVisibleOnFront(
+            $isVisibleOnFront
         );
         $this->addStatusHistory($history);
         return $history;


### PR DESCRIPTION
Create ability to set is_visible_on_front to order status history comment.

### Description
The parameter `is_visible_on_front` is able to be set from the admin, but not from `addStatusHistoryComment` of the order model. This would provide the ability to set this value from custom code such as event observers.

### Manual testing scenarios
1. Call `->addStatusHistoryComment($comment, false)` to not set is_visible_on_front (backwards compatible with no extra param)
2. Call `->addStatusHistoryComment($comment, false, true)` to set is_visible_on_front
3. Call `->addStatusHistoryComment($comment, false, false)` to not set is_visible_on_front

### Contribution checklist
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x ] All automated tests passed successfully (all builds on Travis CI are green)
