### PR TITLE
[Resolved : Menu widget submenu alignment #7897]

### DIFF
--- a/lib/web/css/source/lib/_navigation.less
+++ b/lib/web/css/source/lib/_navigation.less
@@ -305,6 +305,10 @@
             .lib-css(border-top, none);
         }
 
+        li.level1 {
+            position: relative;
+        }
+
         .level0 {
             .lib-css(margin, @_nav-level0-item-margin);
             display: inline-block;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
the submenu relative to the "Bottoms 2" element in the image should be aligned next to it

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)

<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#https://github.com/magento/magento2/issues/7897: Issue title Menu widget submenu alignment

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. hover a menu item which contains some nested elements


### Actual Result
![a241f354-c6ac-11e6-839a-48c5accde3da](https://user-images.githubusercontent.com/23443991/40824118-8caa5b6a-6590-11e8-8e04-71b5056e60ac.jpg)


### Expected Result

![expected-result](https://user-images.githubusercontent.com/23443991/40824152-b80562dc-6590-11e8-940f-5ef12917d26e.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
