### PR TITLE
[Forwardport] set correct annotation

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -260,8 +260,8 @@ class Timezone implements TimezoneInterface
      * @param string|\DateTimeInterface $date
      * @param int $dateType
      * @param int $timeType
-     * @param null $locale
-     * @param null $timezone
+     * @param string|null $locale
+     * @param string|null $timezone
      * @param string|null $pattern
      * @return string
      */

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
@@ -124,8 +124,8 @@ interface TimezoneInterface
      * @param string|\DateTimeInterface $date
      * @param int $dateType
      * @param int $timeType
-     * @param null $locale
-     * @param null $timezone
+     * @param string|null $locale
+     * @param string|null $timezone
      * @param string|null $pattern
      * @return string
      */


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15602

### Description
Set correct annotation to formatDateTime function in lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php file 

### Fixed Issues (if relevant)
1. magento/magento2#15601: Wrong annotation in formatDateTime - lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Please review lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
2. Please review lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
