### PR TITLE
[Backport] Wrong annotation in _toOptionArray - magento/framework/Data/…

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -627,7 +627,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
     /**
      * Overridden to use _idFieldName by default.
      *
-     * @param null $valueField
+     * @param string|null $valueField
      * @param string $labelField
      * @param array $additional
      * @return array


### PR DESCRIPTION
### Original Pull Request
#15336

### Description
Set correct annotation to formatDateTime function in lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php file 

### Fixed Issues (if relevant)
1. magento/magento2#15601: Wrong annotation in formatDateTime - lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Please review lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
2. Please review lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
