### PR TITLE
Fulltext replacement with like condition

### DIFF
--- a/lib/internal/Magento/Framework/Api/SearchCriteria/CollectionProcessor/FilterProcessor.php
+++ b/lib/internal/Magento/Framework/Api/SearchCriteria/CollectionProcessor/FilterProcessor.php
@@ -72,6 +72,15 @@ class FilterProcessor implements CollectionProcessorInterface
             if (!$isApplied) {
                 $condition = $filter->getConditionType() ? $filter->getConditionType() : 'eq';
                 $fields[] = $this->getFieldMapping($filter->getField());
+
+                if ($condition === 'fulltext') {
+                    // NOTE: This is not a fulltext search, but the best way to search something when
+                    // a SearchCriteria with "fulltext" condition is provided over a MySQL table
+                    // (see https://github.com/magento-engcom/msi/issues/1221)
+                    $condition = 'like';
+                    $filter->setValue('%' . $filter->getValue() . '%');
+                }
+
                 $conditions[] = [$condition => $filter->getValue()];
             }
         }


### PR DESCRIPTION
Fulltext replacement with like condition when a SearchCriteria is app…lied to a DB collection.
See https://github.com/magento-engcom/msi/issues/1221

### Description
When a search criteria is run over a MySQL based entty, the condition is improperly translated with `eq` condition.
Translating with a `like` condition is much more similar to a fulltext.

See https://github.com/magento-engcom/msi/issues/1221
See https://github.com/magento-engcom/msi/pull/1285

### Fixed Issues (if relevant)
1. magento-engcom/msi/issues#1221: Issue title

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
