### PR TITLE
Fixes for #15393

### DIFF
--- a/app/code/Magento/Catalog/Helper/Output.php
+++ b/app/code/Magento/Catalog/Helper/Output.php
@@ -151,7 +151,7 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
                 $attributeHtml = nl2br($attributeHtml);
             }
         }
-        if ($attribute->getIsHtmlAllowedOnFront() && $attribute->getIsWysiwygEnabled()) {
+        if ($attribute->getIsHtmlAllowedOnFront() || $attribute->getIsWysiwygEnabled()) {
             if ($this->_catalogData->isUrlDirectivesParsingAllowed()) {
                 $attributeHtml = $this->_getTemplateProcessor()->filter($attributeHtml);
             }

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -167,7 +167,9 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
         $optionsText = [];
         foreach ($options as $item) {
             if (in_array($item['value'], $value)) {
-                $optionsText[] = $this->escaper->escapeHtml($item['label']);
+                $optionsText[] = ($this->_attribute->getIsHtmlAllowedOnFront())
+                    ? $item['label']
+                    : $this->escaper->escapeHtml($item['label']);
             }
         }
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductGettersTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductGettersTest.php
@@ -217,7 +217,7 @@ class ProductGettersTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'Option 2',
             'Option 3',
-            'Option 4 &quot;!@#$%^&amp;*'
+            'Option 4 "!@#$%^&*'
         ];
         self::assertEquals(
             $expected,


### PR DESCRIPTION
Issue fix for: https://github.com/magento/magento2/issues/15393
1. Fixed the check for allowed HTML tags OR wysiwyg for textarea attribute types.
2. Fix for options so that they can be rendered as HTML as well.