### PR TITLE
[Backport] Fix #4803: Incorrect return value from Product Attribute Repository

### DIFF
--- a/app/code/Magento/Eav/Api/Data/AttributeInterface.php
+++ b/app/code/Magento/Eav/Api/Data/AttributeInterface.php
@@ -10,7 +10,7 @@ namespace Magento\Eav\Api\Data;
  * Interface AttributeInterface
  * @api
  */
-interface AttributeInterface extends \Magento\Framework\Api\CustomAttributesDataInterface
+interface AttributeInterface extends \Magento\Framework\Api\CustomAttributesDataInterface, \Magento\Framework\Api\MetadataObjectInterface
 {
     const ATTRIBUTE_ID = 'attribute_id';
 

--- a/app/code/Magento/Eav/Api/Data/AttributeInterface.php
+++ b/app/code/Magento/Eav/Api/Data/AttributeInterface.php
@@ -10,8 +10,8 @@ namespace Magento\Eav\Api\Data;
  * Interface AttributeInterface
  * @api
  */
-interface AttributeInterface extends 
-    \Magento\Framework\Api\CustomAttributesDataInterface, 
+interface AttributeInterface extends
+    \Magento\Framework\Api\CustomAttributesDataInterface,
     \Magento\Framework\Api\MetadataObjectInterface
 {
     const ATTRIBUTE_ID = 'attribute_id';

--- a/app/code/Magento/Eav/Api/Data/AttributeInterface.php
+++ b/app/code/Magento/Eav/Api/Data/AttributeInterface.php
@@ -10,7 +10,9 @@ namespace Magento\Eav\Api\Data;
  * Interface AttributeInterface
  * @api
  */
-interface AttributeInterface extends \Magento\Framework\Api\CustomAttributesDataInterface, \Magento\Framework\Api\MetadataObjectInterface
+interface AttributeInterface extends 
+    \Magento\Framework\Api\CustomAttributesDataInterface, 
+    \Magento\Framework\Api\MetadataObjectInterface
 {
     const ATTRIBUTE_ID = 'attribute_id';
 


### PR DESCRIPTION
### Description
@vkublytskyi Suggested this fix to resolve issue #4803, 

### Fixed Issues (if relevant)
1. magento/magento2#4803: Incorrect return value from Product Attribute Repository

### Manual testing scenarios
1. This can be tested by calling the function Magento\Catalog\Model\Product\Attribute\Repository::getCustomAttributesMetadata and check return type.

### Contribution checklist
 - [✓] Pull request has a meaningful description of its purpose
 - [✓] All commits are accompanied by meaningful commit messages
 - [✓] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
