### PR TITLE
[Forwardport] Variant product image in sidebar wishlist block

### DIFF
--- a/app/code/Magento/Wishlist/CustomerData/Wishlist.php
+++ b/app/code/Magento/Wishlist/CustomerData/Wishlist.php
@@ -149,7 +149,8 @@ class Wishlist implements SectionSourceInterface
      */
     protected function getImageData($product)
     {
-        /* Set variant product if it is configurable product. It will show variant product image in sidebar instead of configurable product image. */
+        /*Set variant product if it is configurable product.
+        It will show variant product image in sidebar instead of configurable product image.*/
         $simpleOption = $product->getCustomOption('simple_product');
         if ($simpleOption !== null) {
             $optionProduct = $simpleOption->getProduct();

--- a/app/code/Magento/Wishlist/CustomerData/Wishlist.php
+++ b/app/code/Magento/Wishlist/CustomerData/Wishlist.php
@@ -149,6 +149,13 @@ class Wishlist implements SectionSourceInterface
      */
     protected function getImageData($product)
     {
+        /* Set variant product if it is configurable product. It will show variant product image in sidebar instead of configurable product image. */
+        $simpleOption = $product->getCustomOption('simple_product');
+        if ($simpleOption !== null) {
+            $optionProduct = $simpleOption->getProduct();
+            $product = $optionProduct;
+        }
+
         /** @var \Magento\Catalog\Helper\Image $helper */
         $helper = $this->imageHelperFactory->create()
             ->init($product, 'wishlist_sidebar_block');


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15477
Display variant product image in sidebar "My Wishlist" items block.

### Description
In case of configurable product, by default main configurable image was showing in sidebar "My Wishlist" block. By this changes, Magento will show variant product image instead of configurable product image

<!--- ### Fixed Issues (if relevant)
 Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  
1. magento/magento2#<issue_number>: Issue title
2. ... -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Login using customer account
2. Open any configurable product
3. Choose option like size and color
4. Click add to wishlist
5. Go to my wishlist page
6. Check product image in "My Wishlist" block on left sidebar

<!--- ### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green) -->
