### PR TITLE
[Forwardport] Use stored value of method instead of calling same method again.

### DIFF
--- a/app/code/Magento/Directory/view/frontend/templates/currency.phtml
+++ b/app/code/Magento/Directory/view/frontend/templates/currency.phtml
@@ -24,7 +24,7 @@
              data-mage-init='{"dropdown":{}}'
              data-toggle="dropdown"
              data-trigger-keypress-button="true">
-            <strong class="language-<?= $block->escapeHtml($block->getCurrentCurrencyCode()) ?>">
+            <strong class="language-<?= $block->escapeHtml($currentCurrencyCode) ?>">
                 <span><?= $block->escapeHtml($currentCurrencyCode) ?> - <?= @$block->escapeHtml($currencies[$currentCurrencyCode]) ?></span>
             </strong>
         </div>

--- a/app/code/Magento/Directory/view/frontend/templates/currency.phtml
+++ b/app/code/Magento/Directory/view/frontend/templates/currency.phtml
@@ -24,7 +24,7 @@
              data-mage-init='{"dropdown":{}}'
              data-toggle="dropdown"
              data-trigger-keypress-button="true">
-            <strong class="language-<?= $block->escapeHtml($currentCurrencyCode) ?>">
+            <strong class="language-<?= $block->escapeHtml($block->getCurrentCurrencyCode()) ?>">
                 <span><?= $block->escapeHtml($currentCurrencyCode) ?> - <?= @$block->escapeHtml($currencies[$currentCurrencyCode]) ?></span>
             </strong>
         </div>

--- a/app/code/Magento/Marketplace/view/adminhtml/templates/partners.phtml
+++ b/app/code/Magento/Marketplace/view/adminhtml/templates/partners.phtml
@@ -11,7 +11,7 @@
 $partners = $block->getPartners();
 ?>
 <?php if ($partners) : ?>
-    <?php foreach ($block->getPartners() as $partner) : ?>
+    <?php foreach ($partners as $partner) : ?>
         <div class="partner">
             <img
                 class="partner-image"


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15517
Use stored value of method instead of calling same method again.

### Description
$block->getPartners() is stored in variable name $partners. So it should use the variable value instead of calling $block->getPartners() again. 

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Check the currency drop-down in frontend part.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
