### PR TITLE
[Backport] Fix dynamical assigned property as it wasn't assigned to an existing one

### DIFF
--- a/app/code/Magento/Webapi/Model/Soap/Fault.php
+++ b/app/code/Magento/Webapi/Model/Soap/Fault.php
@@ -39,7 +39,9 @@ class Fault
     const NODE_DETAIL_WRAPPER = 'GenericFault';
     /**#@-*/
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $_soapFaultCode;
 
     /**
@@ -114,7 +116,7 @@ class Fault
         \Magento\Framework\Locale\ResolverInterface $localeResolver,
         State $appState
     ) {
-        $this->_soapCode = $exception->getOriginator();
+        $this->_soapFaultCode = $exception->getOriginator();
         $this->_parameters = $exception->getDetails();
         $this->_wrappedErrors = $exception->getErrors();
         $this->stackTrace = $exception->getStackTrace() ?: $exception->getTraceAsString();
@@ -194,7 +196,7 @@ class Fault
      */
     public function getSoapCode()
     {
-        return $this->_soapCode;
+        return $this->_soapFaultCode;
     }
 
     /**


### PR DESCRIPTION
Original PR: #15515

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

The constructor in `Magento\Webapi\Model\Soap\Fault.php` assigns the `$exception->getOriginator()` to a dynamical property `_soapCode` instead of the existing `_soapFaultCode`. See on line [177](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Webapi/Model/Soap/Fault.php#L117) 


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
