### PR TITLE
[Backport 2.1] Fixed return type of wishlist's getImageData in DocBlock

### DIFF
--- a/app/code/Magento/Wishlist/CustomerData/Wishlist.php
+++ b/app/code/Magento/Wishlist/CustomerData/Wishlist.php
@@ -142,7 +142,7 @@ class Wishlist implements SectionSourceInterface
      * Retrieve product image data
      *
      * @param \Magento\Catalog\Model\Product $product
-     * @return \Magento\Catalog\Block\Product\Image
+     * @return array
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     protected function getImageData($product)


### PR DESCRIPTION
### Description
`\Magento\Wishlist\CustomerData\Wishlist::getImageData()` method returns an array but in DocBlock the `\Magento\Catalog\Block\Product\Image` is highligted as the return type. The fix corrects the return type in method's DockBlock. 

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A
 