### PR TITLE
[Backport] Feature space between category page

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
@@ -494,6 +494,16 @@
         }
     }
 
+    //
+    //  Category page 1 column layout
+    //  ---------------------------------------------
+
+    .catalog-category-view.page-layout-1column {
+        .column.main {
+            min-height: inherit;
+        }
+    }
+
 }
 
 //

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -562,6 +562,16 @@
             }
         }
     }
+
+    //
+    //  Category page 1 column layout
+    //  ---------------------------------------------
+
+    .catalog-category-view.page-layout-1column {
+        .column.main {
+            min-height: inherit;
+        }
+    }
 }
 
 //


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13026
A space between the category page and the main footer when applying specific settings

### Description
Added some style to solve space issue on a category page with one column layout.

### Fixed Issues (if relevant)
1. magento/magento2#12601: A space between the category page and the main footer when applying specific settings

### Manual testing scenarios
1. Go to Content -> Blocks
2. Add new block
3. Block information:
a. Enable block -> Yes
b. Block title: Contact Us menu
c. Identifier: contactusmenu
d. Store View: All Store Views
e. I am trying to create a contact us form on a cetegory page. I added the following content to the static block editor:
```
<p>{{block class="Magento\Contact\Block\ContactForm" template="Magento_Contact::form.phtml"}}</p>
<hr />
<p style="text-align: justify;">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

  