### PR TITLE
Feature : Add tracking URL to sales_shipment_track and expose via API…

### DIFF
--- a/app/code/Magento/Sales/Api/Data/ShipmentTrackInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentTrackInterface.php
@@ -46,6 +46,10 @@ interface ShipmentTrackInterface extends TrackInterface, ExtensibleDataInterface
      */
     const TRACK_NUMBER = 'track_number';
     /*
+     * Track URL.
+     */
+    const TRACK_URL = 'track_url';
+    /*
      * Description.
      */
     const DESCRIPTION = 'description';

--- a/app/code/Magento/Sales/Api/Data/TrackInterface.php
+++ b/app/code/Magento/Sales/Api/Data/TrackInterface.php
@@ -31,6 +31,23 @@ interface TrackInterface
     public function getTrackNumber();
 
     /**
+     * Sets the track URL for the shipment package.
+     *
+     * @param string $trackUrl
+     * @return $this
+     * @since 100.1.2
+     */
+    public function setTrackUrl($trackUrl);
+
+    /**
+     * Gets the track URL for the shipment package.
+     *
+     * @return string Track number.
+     * @since 100.1.2
+     */
+    public function getTrackUrl();
+
+    /**
      * Sets the title for the shipment package.
      *
      * @param string $title

--- a/app/code/Magento/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Track.php
@@ -53,7 +53,7 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      *
      * @var \Zend\Validator\Uri
      */
-    protected $_zendValidatorUri;    
+    protected $_zendValidatorUri;
 
     /**
      * @param \Magento\Framework\Model\Context $context
@@ -450,7 +450,8 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      * @return string|bool
      */
     public function getValidTrackUrl(){
-        if ($this->getTrackUrl() && $this->_zendValidatorUri->isValid($this->getTrackUrl())) {
+        if ($this->getTrackUrl() && $this->_zendValidatorUri->isValid($this->getTrackUrl()))
+        {
             return $this->getTrackUrl();
         }
         return false;

--- a/app/code/Magento/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Track.php
@@ -47,6 +47,13 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      * @var \Magento\Sales\Api\ShipmentRepositoryInterface
      */
     protected $shipmentRepository;
+    
+    /**
+     * Zend Validator Uri
+     *
+     * @var \Zend\Validator\Uri
+     */
+    protected $_zendValidatorUri;    
 
     /**
      * @param \Magento\Framework\Model\Context $context
@@ -55,6 +62,7 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      * @param AttributeValueFactory $customAttributeFactory
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Sales\Api\ShipmentRepositoryInterface $shipmentRepository
+     * @param \Zend\Validator\Uri $zendValidatorUri
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
@@ -67,6 +75,7 @@ class Track extends AbstractModel implements ShipmentTrackInterface
         AttributeValueFactory $customAttributeFactory,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Sales\Api\ShipmentRepositoryInterface $shipmentRepository,
+        \Zend\Validator\Uri $zendValidatorUri,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
@@ -82,6 +91,8 @@ class Track extends AbstractModel implements ShipmentTrackInterface
         );
         $this->_storeManager = $storeManager;
         $this->shipmentRepository = $shipmentRepository;
+        $this->_zendValidatorUri = $zendValidatorUri;
+        $this->_zendValidatorUri->setAllowAbsolute(true)->setAllowRelative(false);
     }
 
     /**
@@ -222,6 +233,16 @@ class Track extends AbstractModel implements ShipmentTrackInterface
     public function getTrackNumber()
     {
         return $this->getData(ShipmentTrackInterface::TRACK_NUMBER);
+    }
+
+    /**
+     * Returns track_url
+     *
+     * @return string
+     */
+    public function getTrackUrl()
+    {
+        return $this->getData(ShipmentTrackInterface::TRACK_URL);
     }
 
     /**
@@ -373,6 +394,14 @@ class Track extends AbstractModel implements ShipmentTrackInterface
     /**
      * {@inheritdoc}
      */
+    public function setTrackUrl($trackUrl)
+    {
+        return $this->setData(ShipmentTrackInterface::TRACK_URL, $trackUrl);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setDescription($description)
     {
         return $this->setData(ShipmentTrackInterface::DESCRIPTION, $description);
@@ -415,5 +444,16 @@ class Track extends AbstractModel implements ShipmentTrackInterface
         return $this->_setExtensionAttributes($extensionAttributes);
     }
 
+    /**
+     * Get Track Url for Track Item and return only if valid, absolute URI
+     *
+     * @return string|bool
+     */
+    public function getValidTrackUrl(){
+        if ($this->getTrackUrl() && $this->_zendValidatorUri->isValid($this->getTrackUrl())) {
+            return $this->getTrackUrl();
+        }
+        return false;
+    }
     //@codeCoverageIgnoreEnd
 }

--- a/app/code/Magento/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Track.php
@@ -47,7 +47,7 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      * @var \Magento\Sales\Api\ShipmentRepositoryInterface
      */
     protected $shipmentRepository;
-    
+
     /**
      * Zend Validator Uri
      *
@@ -449,7 +449,8 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      *
      * @return string|bool
      */
-    public function getValidTrackUrl(){
+    public function getValidTrackUrl()
+    {
         if ($this->getTrackUrl() && $this->_zendValidatorUri->isValid($this->getTrackUrl()))
         {
             return $this->getTrackUrl();

--- a/app/code/Magento/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Track.php
@@ -451,8 +451,7 @@ class Track extends AbstractModel implements ShipmentTrackInterface
      */
     public function getValidTrackUrl()
     {
-        if ($this->getTrackUrl() && $this->_zendValidatorUri->isValid($this->getTrackUrl()))
-        {
+        if ($this->getTrackUrl() && $this->_zendValidatorUri->isValid($this->getTrackUrl())) {
             return $this->getTrackUrl();
         }
         return false;

--- a/app/code/Magento/Sales/Model/Order/Shipment/TrackCreation.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/TrackCreation.php
@@ -20,6 +20,11 @@ class TrackCreation implements ShipmentTrackCreationInterface
     /**
      * @var string
      */
+    private $trackUrl;
+
+    /**
+     * @var string
+     */
     private $title;
 
     /**
@@ -48,6 +53,23 @@ class TrackCreation implements ShipmentTrackCreationInterface
     public function setTrackNumber($trackNumber)
     {
         $this->trackNumber = $trackNumber;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTrackUrl()
+    {
+        return $this->trackUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTrackUrl($trackUrl)
+    {
+        $this->trackUrl = $trackUrl;
         return $this;
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/TrackTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/TrackTest.php
@@ -14,10 +14,12 @@ class TrackTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $zendValidatorUri = $objectManager->getObject(\Zend\Validator\Uri::class);
         $arguments = [
             'shipmentRepository' => $this->createMock(\Magento\Sales\Model\Order\ShipmentRepository::class),
-            'zendValidatorUri' => \Zend\Validator\Uri,
+            'zendValidatorUri' => $zendValidatorUri,
         ];
 
         $this->_model = $objectManagerHelper->getObject(\Magento\Sales\Model\Order\Shipment\Track::class, $arguments);

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/TrackTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/TrackTest.php
@@ -17,7 +17,7 @@ class TrackTest extends \PHPUnit\Framework\TestCase
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $arguments = [
             'shipmentRepository' => $this->createMock(\Magento\Sales\Model\Order\ShipmentRepository::class),
-            'zendValidatorUri' => \Zend\Validator\Uri::class,
+            'zendValidatorUri' => \Zend\Validator\Uri,
         ];
 
         $this->_model = $objectManagerHelper->getObject(\Magento\Sales\Model\Order\Shipment\Track::class, $arguments);

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/TrackTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/TrackTest.php
@@ -17,6 +17,7 @@ class TrackTest extends \PHPUnit\Framework\TestCase
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $arguments = [
             'shipmentRepository' => $this->createMock(\Magento\Sales\Model\Order\ShipmentRepository::class),
+            'zendValidatorUri' => \Zend\Validator\Uri::class,
         ];
 
         $this->_model = $objectManagerHelper->getObject(\Magento\Sales\Model\Order\Shipment\Track::class, $arguments);

--- a/app/code/Magento/Sales/etc/db_schema.xml
+++ b/app/code/Magento/Sales/etc/db_schema.xml
@@ -876,6 +876,7 @@
         <column xsi:type="int" name="order_id" padding="10" unsigned="true" nullable="false" identity="false"
                 comment="Order Id"/>
         <column xsi:type="text" name="track_number" nullable="true" comment="Number"/>
+        <column xsi:type="varchar" name="track_url" nullable="true" length="255" comment="Url"/>
         <column xsi:type="text" name="description" nullable="true" comment="Description"/>
         <column xsi:type="varchar" name="title" nullable="true" length="255" comment="Title"/>
         <column xsi:type="varchar" name="carrier_code" nullable="true" length="32" comment="Carrier Code"/>

--- a/app/code/Magento/Sales/view/frontend/templates/email/shipment/track.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/shipment/track.phtml
@@ -19,11 +19,23 @@
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($_shipment->getAllTracks() as $_item): ?>
-        <tr>
-            <td><?= $block->escapeHtml($_item->getTitle()) ?>:</td>
-            <td><?= $block->escapeHtml($_item->getNumber()) ?></td>
-        </tr>
+    <?php
+    foreach ($_shipment->getAllTracks() as $_item): ?>
+    <tr>
+        <td><?= $block->escapeHtml($_item->getTitle()) ?>:</td>
+        <td>
+            <?php if($_itemUrl = $_item->getValidTrackUrl()): ?>
+                <a href="<?= $block->escapeUrl($_itemUrl) ?>"
+                   target="_blank"
+                   rel="noreferrer nofollow noopener"
+                >
+                    <?= $block->escapeHtml($_item->getNumber()) ?>
+                </a>
+            <?php else: ?>
+                <?= $block->escapeHtml($_item->getNumber()) ?>
+            <?php endif;?>
+        </td>
+    </tr>
     <?php endforeach ?>
     </tbody>
 </table>

--- a/app/code/Magento/Shipping/Block/Items.php
+++ b/app/code/Magento/Shipping/Block/Items.php
@@ -25,6 +25,13 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
     protected $_coreRegistry = null;
 
     /**
+     * Zend Validator Uri
+     *
+     * @var \Zend\Validator\Uri
+     */
+    protected $_zendValidatorUri;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param array $data
@@ -32,9 +39,12 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Framework\Registry $registry,
+        \Zend\Validator\Uri $zendValidatorUri,
         array $data = []
     ) {
         $this->_coreRegistry = $registry;
+        $this->_zendValidatorUri = $zendValidatorUri;
+        $this->_zendValidatorUri->setAllowAbsolute(true)->setAllowRelative(false);
         parent::__construct($context, $data);
     }
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddTrack.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddTrack.php
@@ -46,6 +46,7 @@ class AddTrack extends \Magento\Backend\App\Action
             $carrier = $this->getRequest()->getPost('carrier');
             $number = $this->getRequest()->getPost('number');
             $title = $this->getRequest()->getPost('title');
+            $track_url = $this->getRequest()->getPost('track_url');
             if (empty($carrier)) {
                 throw new \Magento\Framework\Exception\LocalizedException(__('Please specify a carrier.'));
             }
@@ -66,6 +67,8 @@ class AddTrack extends \Magento\Backend\App\Action
                     $carrier
                 )->setTitle(
                     $title
+                )->setTrackUrl(
+                    $track_url
                 );
                 $shipment->addTrack($track)->save();
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddTrack.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddTrack.php
@@ -46,7 +46,7 @@ class AddTrack extends \Magento\Backend\App\Action
             $carrier = $this->getRequest()->getPost('carrier');
             $number = $this->getRequest()->getPost('number');
             $title = $this->getRequest()->getPost('title');
-            $track_url = $this->getRequest()->getPost('track_url');
+            $trackUrl = $this->getRequest()->getPost('track_url');
             if (empty($carrier)) {
                 throw new \Magento\Framework\Exception\LocalizedException(__('Please specify a carrier.'));
             }
@@ -68,7 +68,7 @@ class AddTrack extends \Magento\Backend\App\Action
                 )->setTitle(
                     $title
                 )->setTrackUrl(
-                    $track_url
+                    $trackUrl
                 );
                 $shipment->addTrack($track)->save();
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
@@ -169,6 +169,7 @@ class ShipmentLoader extends DataObject
             $trackCreation = $this->trackFactory->create();
             $trackCreation->setTrackNumber($track['number']);
             $trackCreation->setTitle($track['title']);
+            $trackCreation->setTrackUrl($track['track_url']);
             $trackCreation->setCarrierCode($track['carrier_code']);
             $trackingCreation[] = $trackCreation;
         }

--- a/app/code/Magento/Shipping/Model/Order/Track.php
+++ b/app/code/Magento/Shipping/Model/Order/Track.php
@@ -7,6 +7,7 @@
 namespace Magento\Shipping\Model\Order;
 
 use Magento\Framework\Api\AttributeValueFactory;
+use Zend\Validator\Uri;
 
 /**
  * @method int getParentId()
@@ -35,6 +36,7 @@ class Track extends \Magento\Sales\Model\Order\Shipment\Track
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Sales\Api\ShipmentRepositoryInterface $shipmentRepository
      * @param \Magento\Shipping\Model\CarrierFactory $carrierFactory
+     * @param \Zend\Validator\Uri $zendValidatorUri
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
@@ -49,6 +51,7 @@ class Track extends \Magento\Sales\Model\Order\Shipment\Track
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Sales\Api\ShipmentRepositoryInterface $shipmentRepository,
         \Magento\Shipping\Model\CarrierFactory $carrierFactory,
+        \Zend\Validator\Uri $zendValidatorUri,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
@@ -60,6 +63,7 @@ class Track extends \Magento\Sales\Model\Order\Shipment\Track
             $customAttributeFactory,
             $storeManager,
             $shipmentRepository,
+            $zendValidatorUri,
             $resource,
             $resourceCollection,
             $data

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/ShipmentLoaderTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/ShipmentLoaderTest.php
@@ -100,8 +100,8 @@ class ShipmentLoaderTest extends \PHPUnit\Framework\TestCase
             'shipment_id' => 1000065,
             'shipment' => ['items' => [1 => 1, 2 => 2]],
             'tracking' => [
-                ['number' => 'jds0395', 'title' => 'DHL', 'carrier_code' => 'dhl'],
-                ['number' => 'lsk984g', 'title' => 'UPS', 'carrier_code' => 'ups'],
+                ['number' => 'jds0395', 'title' => 'DHL', 'carrier_code' => 'dhl', 'track_url' => ''],
+                ['number' => 'lsk984g', 'title' => 'UPS', 'carrier_code' => 'ups', 'track_url' => ''],
             ],
         ];
 

--- a/app/code/Magento/Shipping/Test/Unit/Model/Order/TrackTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/Order/TrackTest.php
@@ -9,6 +9,7 @@ class TrackTest extends \PHPUnit\Framework\TestCase
 {
     public function testLookup()
     {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $carrier = $this->createPartialMock(
@@ -26,10 +27,16 @@ class TrackTest extends \PHPUnit\Framework\TestCase
         $shipmentRepository = $this->createPartialMock(\Magento\Sales\Model\Order\ShipmentRepository::class, ['get']);
         $shipmentRepository->expects($this->any())->method('get')->willReturn($shipment);
 
+        $zendValidatorUri = $objectManager->getObject(\Zend\Validator\Uri::class);
+
         /** @var \Magento\Shipping\Model\Order\Track $model */
         $model = $helper->getObject(
             \Magento\Shipping\Model\Order\Track::class,
-            ['carrierFactory' => $carrierFactory, 'shipmentRepository' => $shipmentRepository]
+            [
+                'carrierFactory' => $carrierFactory,
+                'shipmentRepository' => $shipmentRepository,
+                'zendValidatorUri' => $zendValidatorUri
+            ]
         );
         $model->setParentId(1);
         $this->assertEquals('trackingInfo', $model->getNumberDetail());

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking.phtml
@@ -26,6 +26,7 @@ require(['prototype'], function(){
             $('trackingC' + this.index).disabled = false;
             $('trackingT' + this.index).disabled = false;
             $('trackingN' + this.index).disabled = false;
+            $('trackingU' + this.index).disabled = false;
             this.bindCurrierOnchange();
         },
         deleteRow : function(event) {
@@ -89,6 +90,14 @@ require(['prototype'], function(){
                    value=""
                    disabled="disabled" />
         </td>
+        <td class="col-url">
+            <input class="input-text admin__control-text"
+                   type="text"
+                   name="tracking[<%- data.index %>][track_url]"
+                   id="trackingU<%- data.index %>"
+                   value=""
+                   disabled="disabled" />
+        </td>
         <td class="col-delete">
             <button
                 type="button"
@@ -107,12 +116,13 @@ require(['prototype'], function(){
             <th class="col-carrier"><?= /* @escapeNotVerified */ __('Carrier') ?></th>
             <th class="col-title"><?= /* @escapeNotVerified */ __('Title') ?></th>
             <th class="col-number"><?= /* @escapeNotVerified */ __('Number') ?></th>
+            <th class="col-title"><?= /* @escapeNotVerified */ __('URL') ?></th>
             <th class="col-delete"><?= /* @escapeNotVerified */ __('Action') ?></th>
         </tr>
         </thead>
         <tfoot>
         <tr>
-            <td colspan="4" class="col-actions-add"><?= $block->getChildHtml('add_button') ?></td>
+            <td colspan="5" class="col-actions-add"><?= $block->getChildHtml('add_button') ?></td>
         </tr>
         </tfoot>
         <tbody id="track_row_container">

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
@@ -15,6 +15,7 @@
                 <th class="col-carrier"><?= /* @escapeNotVerified */ __('Carrier') ?></th>
                 <th class="col-title"><?= /* @escapeNotVerified */ __('Title') ?></th>
                 <th class="col-number"><?= /* @escapeNotVerified */ __('Number') ?></th>
+                <th class="col-title"><?= /* @escapeNotVerified */ __('URL') ?></th>
                 <th class="col-delete last"><?= /* @escapeNotVerified */ __('Action') ?></th>
             </tr>
         </thead>
@@ -43,6 +44,13 @@
                            name="number"
                            value="" />
                 </td>
+                <td class="col-url">
+                    <input class="input-text admin__control-text"
+                           type="text"
+                           id="tracking_url"
+                           name="track_url"
+                           value="" />
+                </td>
                 <td class="col-delete last"><?= $block->getSaveButtonHtml() ?></td>
             </tr>
         </tfoot>
@@ -58,6 +66,18 @@
                     <?php else: ?>
                     <a href="#" onclick="popWin('<?= /* @escapeNotVerified */ $this->helper('Magento\Shipping\Helper\Data')->getTrackingPopupUrlBySalesModel($_track) ?>','trackorder','width=800,height=600,resizable=yes,scrollbars=yes')"><?= $block->escapeHtml($_track->getNumber()) ?></a>
                     <div id="shipment_tracking_info_response_<?= /* @escapeNotVerified */ $_track->getId() ?>"></div>
+                    <?php endif; ?>
+                </td>
+                <td class="col-url">
+                    <?php if (($_track->isCustom()) && ($_trackUrl = $_track->getValidTrackUrl())): ?>
+                        <a href="<?= $block->escapeHtml($_trackUrl) ?>"
+                           target="_blank"
+                           rel="noreferrer nofollow noopener"
+                        >
+                            <?= $block->escapeHtml($_trackUrl) ?>
+                        </a>
+                    <?php else: ?>
+                        <?= $block->escapeHtml($_track->getTrackUrl()) ?>
                     <?php endif; ?>
                 </td>
                 <td class="col-delete last"><button class="action-delete" type="button" onclick="deleteTrackingNumber('<?= /* @escapeNotVerified */ $block->getRemoveUrl($_track) ?>'); return false;"><span><?= /* @escapeNotVerified */ __('Delete') ?></span></button></td>

--- a/app/code/Magento/Shipping/view/frontend/templates/items.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/items.phtml
@@ -47,7 +47,7 @@
             foreach ($tracks as $track): ?>
                 <?php if ($track->isCustom()): ?>
                     <?php if($trackUrl = $track->getValidTrackUrl()): ?><a
-                        href="<?= $trackUrl;?>"
+                        href="<?= $block->escapeHtml($trackUrl);?>"
                         target="_blank"
                         rel="noreferrer nofollow noopener"
                         class="action track"><span><?= $block->escapeHtml($track->getNumber()) ?></span>

--- a/app/code/Magento/Shipping/view/frontend/templates/items.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/items.phtml
@@ -45,11 +45,23 @@
             $i = 1;
             $_size = $tracks->count();
             foreach ($tracks as $track): ?>
-                <?php if ($track->isCustom()): ?><?= $block->escapeHtml($track->getNumber()) ?><?php else: ?><a
+                <?php if ($track->isCustom()): ?>
+                    <?php if($trackUrl = $track->getValidTrackUrl()): ?><a
+                        href="<?= $trackUrl;?>"
+                        target="_blank"
+                        rel="noreferrer nofollow noopener"
+                        class="action track"><span><?= $block->escapeHtml($track->getNumber()) ?></span>
+                        </a>
+                    <?php else: ?>
+                        <?= $block->escapeHtml($track->getNumber()) ?>
+                    <?php endif; ?>
+                <?php else: ?><a
                     href="#"
                     data-mage-init='{"popupWindow": {"windowURL":"<?= /* @escapeNotVerified */ $this->helper('Magento\Shipping\Helper\Data')->getTrackingPopupUrlBySalesModel($track) ?>","windowName":"trackorder","width":800,"height":600,"left":0,"top":0,"resizable":1,"scrollbars":1}}'
                     class="action track"><span><?= $block->escapeHtml($track->getNumber()) ?></span>
-                    </a><?php endif; ?><?php if ($i != $_size): ?>, <?php endif; ?>
+                    </a>
+                <?php endif; ?>
+                <?php if ($i != $_size): ?>, <?php endif; ?>
                 <?php $i++;
             endforeach; ?>
         </dd>

--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -4380,6 +4380,10 @@
             .col-number {
                 width: 25%;
             }
+
+            .col-url {
+                width: 25%;
+            }
         }
     }
 }

--- a/app/design/adminhtml/Magento/backend/web/mui/styles/_table.less
+++ b/app/design/adminhtml/Magento/backend/web/mui/styles/_table.less
@@ -174,6 +174,10 @@
         &:extend(.col-40 all);
     }
 
+    .col-url {
+        &:extend(.col-40 all);
+    }
+
     .col-select,
     .col-massaction {
         text-align: center;

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentTrackRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentTrackRepositoryInterfaceTest.php
@@ -41,14 +41,17 @@ class ShipmentTrackRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $filter3 = $filterBuilder->setField(ShipmentTrackInterface::TRACK_NUMBER)
             ->setValue('track number 4')
             ->create();
-        $filter4 = $filterBuilder->setField(ShipmentTrackInterface::CARRIER_CODE)
-            ->setValue('carrier code 5')
+        $filter4 = $filterBuilder->setField(ShipmentTrackInterface::TRACK_URL)
+            ->setValue('track url 5')
             ->create();
-        $filter5 = $filterBuilder->setField(ShipmentTrackInterface::QTY)
+        $filter5 = $filterBuilder->setField(ShipmentTrackInterface::CARRIER_CODE)
+            ->setValue('carrier code 6')
+            ->create();
+        $filter6 = $filterBuilder->setField(ShipmentTrackInterface::QTY)
             ->setConditionType('lt')
             ->setValue(5)
             ->create();
-        $filter6 = $filterBuilder->setField(ShipmentTrackInterface::WEIGHT)
+        $filter7 = $filterBuilder->setField(ShipmentTrackInterface::WEIGHT)
             ->setValue(1)
             ->create();
 
@@ -63,9 +66,9 @@ class ShipmentTrackRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder =  Bootstrap::getObjectManager()->create(SearchCriteriaBuilder::class);
 
-        $searchCriteriaBuilder->addFilters([$filter1, $filter2, $filter3, $filter4]);
-        $searchCriteriaBuilder->addFilters([$filter5]);
+        $searchCriteriaBuilder->addFilters([$filter1, $filter2, $filter3, $filter4, $filter5]);
         $searchCriteriaBuilder->addFilters([$filter6]);
+        $searchCriteriaBuilder->addFilters([$filter7]);
         $searchCriteriaBuilder->setSortOrders([$sortOrder]);
 
         $searchCriteriaBuilder->setPageSize(2);

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/shipment_tracks_for_search.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/shipment_tracks_for_search.php
@@ -34,6 +34,7 @@ $tracks = [
         'title' => 'title 1',
         'carrier_code' => 'carrier code 1',
         'track_number' => 'track number 1',
+        'track_url' => 'track url 1',
         'description' => 'description 1',
         'qty' => 1,
         'weight' => 1,
@@ -42,6 +43,7 @@ $tracks = [
         'title' => 'title 2',
         'carrier_code' => 'carrier code 2',
         'track_number' => 'track number 2',
+        'track_url' => 'track url 2',
         'description' => 'description 2',
         'qty' => 2,
         'weight' => 1,
@@ -50,6 +52,7 @@ $tracks = [
         'title' => 'title 3',
         'carrier_code' => 'carrier code 3',
         'track_number' => 'track number 3',
+        'track_url' => 'track url 3',
         'description' => 'description 3',
         'qty' => 3,
         'weight' => 1,
@@ -58,6 +61,7 @@ $tracks = [
         'title' => 'title 4',
         'carrier_code' => 'carrier code 4',
         'track_number' => 'track number 4',
+        'track_url' => 'track url 4',
         'description' => 'description 4',
         'qty' => 4,
         'weight' => 1,
@@ -66,6 +70,7 @@ $tracks = [
         'title' => 'title 5',
         'carrier_code' => 'carrier code 5',
         'track_number' => 'track number 5',
+        'track_url' => 'track url 5',
         'description' => 'description 5',
         'qty' => 5,
         'weight' => 2,
@@ -83,6 +88,7 @@ foreach ($tracks as $data) {
     $track->setTitle($data['title']);
     $track->setCarrierCode($data['carrier_code']);
     $track->setTrackNumber($data['track_number']);
+    $track->setTrackUrl($data['track_url']);
     $track->setDescription($data['description']);
     $track->setQty($data['qty']);
     $track->setWeight($data['weight']);


### PR DESCRIPTION
### Description
As a merchant I want to be able to add third party tracking URLs to the Shipment Track to help customers track their Shipments which do not have a Tracking Updates via The Tracking pop-up API request.

### Manual testing scenarios
Preconditions
- A shippable order exists for a registered Customer
- Merchant has navigated to the Ship Order page

Actions
- Merchant enters Tracking URL in the new field, and clicks Submit Shipment 

Expectations
* Merchant can see valid URL on View Shipment page
* Customer can see and click valid URL on View Shipments page
* API User can see tracking URL in response

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
