### PR TITLE
[Forwardport] [BUGFIX] #15564 Generated admin API token expires immediately

### DIFF
--- a/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
+++ b/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
@@ -134,7 +134,7 @@ class TokenUserContext implements UserContextInterface
         }
 
         if (empty($tokenTtl)) {
-        	return false;
+            return false;
         }
 
         if ($this->dateTime->strToTime($token->getCreatedAt()) < ($this->date->gmtTimestamp() - $tokenTtl * 3600)) {

--- a/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
+++ b/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
@@ -132,6 +132,11 @@ class TokenUserContext implements UserContextInterface
             // other user-type tokens are considered always valid
             return false;
         }
+
+        if (empty($tokenTtl)) {
+        	return false;
+        }
+
         if ($this->dateTime->strToTime($token->getCreatedAt()) < ($this->date->gmtTimestamp() - $tokenTtl * 3600)) {
             return true;
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15598
When admin token lifetime setting is empty, the token will expire
immediatly

### Fixed Issues

1. magento/magento2#15564 2.2.4 Created admin token has no access
