### PR TITLE
[Backport] [Fix] forgot to add lowercase conversion on grouped product assignation

### DIFF
--- a/app/code/Magento/GroupedImportExport/Model/Import/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedImportExport/Model/Import/Product/Type/Grouped.php
@@ -99,7 +99,7 @@ class Grouped extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abs
                     }
                     $scope = $this->_entityModel->getRowScope($rowData);
                     if (Product::SCOPE_DEFAULT == $scope) {
-                        $productData = $newSku[$rowData[Product::COL_SKU]];
+                        $productData = $newSku[strtolower($rowData[Product::COL_SKU])];
                     } else {
                         $colAttrSet = Product::COL_ATTR_SET;
                         $rowData[$colAttrSet] = $productData['attr_set_code'];


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15312
Forgot to add lowercase conversion on grouped product assignation after changes done in MAGETWO-67240

- See changes done for MAGETWO-67240 here https://github.com/magento/magento2/commit/02596b720fab5bd01fbc8026a1392c4971f78fed#diff-b876c962d83b3bee42acba83af842309

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
