### PR TITLE
[Forwardport] Error 500 in Module Manager

### DIFF
--- a/setup/src/Magento/Setup/Model/Grid/Module.php
+++ b/setup/src/Magento/Setup/Model/Grid/Module.php
@@ -178,7 +178,7 @@ class Module
     private function addGeneralInfo(array $items)
     {
         foreach ($items as &$item) {
-            $item['moduleName'] = isset($item['moduleName']) ? $item['moduleName'] : $this->packageInfo->getModuleName($item['name']);
+            $item['moduleName'] = $item['moduleName'] ?? $this->packageInfo->getModuleName($item['name']);
             $item['enable'] = $this->moduleList->has($item['moduleName']);
             $vendorSource = $item['name'] == self::UNKNOWN_PACKAGE_NAME ? $item['moduleName'] : $item['name'];
             $item['vendor'] = ucfirst(current(preg_split('%[/_]%', $vendorSource)));

--- a/setup/src/Magento/Setup/Model/Grid/Module.php
+++ b/setup/src/Magento/Setup/Model/Grid/Module.php
@@ -178,7 +178,7 @@ class Module
     private function addGeneralInfo(array $items)
     {
         foreach ($items as &$item) {
-            $item['moduleName'] = $item['moduleName'] ?: $this->packageInfo->getModuleName($item['name']);
+            $item['moduleName'] = isset($item['moduleName']) ? $item['moduleName'] : $this->packageInfo->getModuleName($item['name']);
             $item['enable'] = $this->moduleList->has($item['moduleName']);
             $vendorSource = $item['name'] == self::UNKNOWN_PACKAGE_NAME ? $item['moduleName'] : $item['name'];
             $item['vendor'] = ucfirst(current(preg_split('%[/_]%', $vendorSource)));


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15211
### Description
There is an error in Module Manager (http://store.com/setup/index.php/moduleGrid/modules) if some module has no "moduleName" property:
```
{
  "name": "amzn\/amazon-pay-and-login-magento-2-module",
  "type": "magento2-module",
  "version": "2.0.4"
}
```

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/15192

### Manual testing scenarios
Module Manager doesn't show module grid when going through below step:
* System > Tools > Web Setup Wizard > Module Manager

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
