### PR TITLE
check if order data is available to incl ec

### DIFF
--- a/app/code/Magento/GoogleAnalytics/view/frontend/web/js/google-analytics.js
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/web/js/google-analytics.js
@@ -53,7 +53,7 @@ define([
             }
 
             // Process orders data
-            if (config.ordersTrackingData.length) {
+            if (config.ordersTrackingData.hasOwnProperty('currency')) {
                 ga('require', 'ec', 'ec.js');
 
                 //Set currency code


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
After merging #13034 ecommerce tracking wasn't working, because it's not possible to call length on an object (ordersTrackingData).

### Fixed Issues (if relevant)
1. magento/magento2#12221: Google analytics pageview being triggered twice (see comment https://github.com/magento/magento2/issues/12221#issuecomment-364455895)

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Created a Google Analytics test account
2. Order something
3. Order will appear in Google Analytics (Conversion -> E-Commerce) or see console with running Google Analytics Debugger (https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna). Transfered data will contain product specific data.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
