### PR TITLE
[Forwardport] FIX for issue #14849 - In Sales Emails no translation using order.getStatusLabel()

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -8,6 +8,7 @@ namespace Magento\Sales\Model;
 use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -986,7 +987,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Retrieve frontend label of order status
      *
      * @return string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function getFrontendStatusLabel()
     {
@@ -997,7 +998,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Retrieve label of order status
      *
      * @return string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function getStatusLabel()
     {
@@ -1083,12 +1084,12 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
 
     /**
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function hold()
     {
         if (!$this->canHold()) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('A hold action is not available.'));
+            throw new LocalizedException(__('A hold action is not available.'));
         }
         $this->setHoldBeforeState($this->getState());
         $this->setHoldBeforeStatus($this->getStatus());
@@ -1101,12 +1102,12 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Attempt to unhold the order
      *
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function unhold()
     {
         if (!$this->canUnhold()) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('You cannot remove the hold.'));
+            throw new LocalizedException(__('You cannot remove the hold.'));
         }
 
         $this->setState($this->getHoldBeforeState())
@@ -1150,7 +1151,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param string $comment
      * @param bool $graceful
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function registerCancellation($comment = '', $graceful = true)
@@ -1189,7 +1190,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
                 $this->addStatusHistoryComment($comment, false);
             }
         } elseif (!$graceful) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('We cannot cancel this order.'));
+            throw new LocalizedException(__('We cannot cancel this order.'));
         }
         return $this;
     }

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -983,9 +983,21 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     }
 
     /**
+     * Retrieve frontend label of order status
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getFrontendStatusLabel()
+    {
+        return $this->getConfig()->getStatusLabel($this->getStatus(), \Magento\Framework\App\Area::AREA_FRONTEND);
+    }
+
+    /**
      * Retrieve label of order status
      *
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getStatusLabel()
     {

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 namespace Magento\Sales\Model\Order;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Order configuration model
@@ -85,7 +86,7 @@ class Config
 
     /**
      * @param string $state
-     * @return Status|null
+     * @return Status
      */
     protected function _getState($state)
     {
@@ -101,7 +102,7 @@ class Config
      * Retrieve default status for state
      *
      * @param   string $state
-     * @return  string
+     * @return  string|null
      */
     public function getStateDefaultStatus($state)
     {
@@ -117,10 +118,10 @@ class Config
     /**
      * Retrieve status label
      *
-     * @param   string $code
-     * @param null $forceArea
-     * @return  string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @param string $code
+     * @param string|null $forceArea
+     * @return string
+     * @throws LocalizedException
      */
     public function getStatusLabel($code, $forceArea = null)
     {

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -118,11 +118,13 @@ class Config
      * Retrieve status label
      *
      * @param   string $code
+     * @param null $forceArea
      * @return  string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getStatusLabel($code)
+    public function getStatusLabel($code, $forceArea = null)
     {
-        $area = $this->state->getAreaCode();
+        $area = $forceArea ?: $this->state->getAreaCode();
         $code = $this->maskStatusForArea($area, $code);
         $status = $this->orderStatusFactory->create()->load($code);
 

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 namespace Magento\Sales\Model\Order;
+
 use Magento\Framework\Exception\LocalizedException;
 
 /**

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo_update.html
@@ -11,7 +11,7 @@
 "var this.getUrl($store, 'customer/account/')":"Customer Account URL",
 "var order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo_update_guest.html
@@ -10,7 +10,7 @@
 "var creditmemo.increment_id":"Credit Memo Id",
 "var billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/code/Magento/Sales/view/frontend/email/invoice_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_update.html
@@ -11,7 +11,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/invoice_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_update_guest.html
@@ -10,7 +10,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/code/Magento/Sales/view/frontend/email/order_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/order_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -22,7 +22,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/code/Magento/Sales/view/frontend/email/shipment_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/shipment_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update.html
@@ -11,7 +11,7 @@
 "var this.getUrl($store, 'customer/account/')":"Customer Account URL",
 "var order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update_guest.html
@@ -10,7 +10,7 @@
 "var creditmemo.increment_id":"Credit Memo Id",
 "var billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update.html
@@ -11,7 +11,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update_guest.html
@@ -10,7 +10,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -22,7 +22,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14914
### Description
\Magento\Sales\Model\Order\Config::getStatusLabel(), used by template email was forcing the usage of getLabel() when in adminhtml area.
I added a new method getFrontendStatusLabel() in \Magento\Sales\Model\Order and modified email template files to use it instead of the original implementation.
I did not modify the original implementation because still in use by backend and frontend.

### Fixed Issues (if relevant)
1. magento/magento2#14849: In Sales Emails no translation using order.getStatusLabel()

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
