### PR TITLE
[Backport] Added additional headers for avoiding customer data caching

### DIFF
--- a/app/code/Magento/Customer/Controller/Section/Load.php
+++ b/app/code/Magento/Customer/Controller/Section/Load.php
@@ -61,6 +61,8 @@ class Load extends \Magento\Framework\App\Action\Action
     {
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
         $resultJson = $this->resultJsonFactory->create();
+        $resultJson->setHeader('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store', true);
+        $resultJson->setHeader('Pragma', 'no-cache', true);
         try {
             $sectionNames = $this->getRequest()->getParam('sections');
             $sectionNames = $sectionNames ? array_unique(\explode(',', $sectionNames)) : null;


### PR DESCRIPTION
### Description
Within a scope of MAGETWO-82057 there were additional headers added to the customer section load in order to avoid sensitive data caching. This PR contains the solution's backport for 2.1.x versions. Improvements from https://github.com/magento/magento2/pull/14176 are also included
