### PR TITLE
[Forwardport 2.3] Removed extra slash from use statement classpath

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator.php
@@ -6,7 +6,7 @@
 namespace Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing;
 
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
-use \Magento\Framework\Validator\AbstractValidator;
+use Magento\Framework\Validator\AbstractValidator;
 
 class Validator extends AbstractValidator implements RowValidatorInterface
 {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15780
Removed extra slash from use statement classpath

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Removed extra slash from use statement classpath from AdvancedPricingImportExport module file

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
