### PR TITLE
[Backport] fix: support multiple minisearch widget instances

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -51,7 +51,7 @@ define([
             this.autoComplete = $(this.options.destinationSelector);
             this.searchForm = $(this.options.formSelector);
             this.submitBtn = this.searchForm.find(this.options.submitBtn)[0];
-            this.searchLabel = $(this.options.searchLabel);
+            this.searchLabel = this.searchForm.find(this.options.searchLabel);
             this.isExpandable = this.options.isExpandable;
 
             _.bindAll(this, '_onKeyDown', '_onPropertyChange', '_onSubmit');


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15485
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
When cloning the minisearch widget and changing the ID's and selectors they still trigger all instances as the label searchLabel is globally searched instead of in the form.


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. clone module-search/view/frontend/templates/form.mini.phtml 
2. add custom block with the cloned and changed minisearch widget (after changing ID's and selectors in it)
3. click on search icon on mobile

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
