### PR TITLE
[BackPort]15319 : misleading data-container in product list

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
@@ -47,7 +47,7 @@ $_helper = $this->helper('Magento\Catalog\Helper\Output');
             <?php /** @var $_product \Magento\Catalog\Model\Product */ ?>
             <?php foreach ($_productCollection as $_product): ?>
                 <?php /* @escapeNotVerified */ echo($iterator++ == 1) ? '<li class="item product product-item">' : '</li><li class="item product product-item">' ?>
-                <div class="product-item-info" data-container="product-grid">
+                <div class="product-item-info" data-container="product-<?= /* @escapeNotVerified */ $viewMode ?>">
                     <?php
                     $productImage = $block->getImage($_product, $image);
                     if ($pos != null) {


### PR DESCRIPTION
### Original Pull Request
magento#15350

### Fixed Issues (if relevant)
1. magento/magento2#15319 : misleading data-container in product list 

### Description 
 - change data-container class name based on view mode in Product Listing Page.

