### PR TITLE
[Backport] Fix typo in Image::open exception message

### DIFF
--- a/lib/internal/Magento/Framework/Image.php
+++ b/lib/internal/Magento/Framework/Image.php
@@ -49,7 +49,7 @@ class Image
         $this->_adapter->checkDependencies();
 
         if (!file_exists($this->_fileName)) {
-            throw new \Exception("File '{$this->_fileName}' does not exists.");
+            throw new \Exception("File '{$this->_fileName}' does not exist.");
         }
 
         $this->_adapter->open($this->_fileName);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15269
### Description

Fixes a typo in the `\Magento\Framework\Image::open` exception message.

Previous message:

>File {file} does not exists.

Corrected message:

>File {file} does not exist.

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios

1. Given that...
  - There exists a page where an image is opened,
  - but the actual image file does not exist,
  - and the exception is not silently caught and ignored,
2. Expect to receive a properly-spelled exception message.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
