### PR TITLE
[Forwardport] Fixed Datetime Error on Newsletter Template

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -309,10 +309,16 @@ class Timezone implements TimezoneInterface
      */
     public function convertConfigTimeToUtc($date, $format = 'Y-m-d H:i:s')
     {
+        $zendFormat = $this->getDateTimeFormat(\IntlDateFormatter::MEDIUM);
+        $zendDate = new \Zend_Date($date, $zendFormat, $this->_localeResolver->getLocale());
+        $time = $zendDate->getTimestamp();
+        $dateTime = new DateTime($this);
+
         if (!($date instanceof \DateTimeInterface)) {
             if ($date instanceof \DateTimeImmutable) {
                 $date = new \DateTime($date->format('Y-m-d H:i:s'), new \DateTimeZone($this->getConfigTimezone()));
             } else {
+                $date = $dateTime->gmtDate(null, $time);
                 $date = new \DateTime($date, new \DateTimeZone($this->getConfigTimezone()));
             }
         } else {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15783
Fixed Datetime Error on Newsletter Template

### Description
While save Queue Newsletter Queue Date Start Magento throw DateTime parse error. I have fixed that issue using Zend_Date class

### Fixed Issues (if relevant)

1. magento/magento2#5037: Datetime Error on Newsletter Template

### Manual testing scenarios
1. Login in Admin
2. Click on Top right corner admin name then click on Account Setting. 
3. Change admin *Interface Locale* to *Italiano (Svizzera) / italiano (Svizzera)*
4. Go to Admin->Marketing->Newsletter Template
5. Select "Queue Newsletter" from right dropdown
6. Select a "Queue Date Start" and try to save it

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
