### PR TITLE
[Backport] Resolve Error While Trying To Load Quote Item Collection Using Magent… #2

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
@@ -89,13 +89,13 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
     }
 
     /**
-     * Retrieve store Id (From Quote)
+     * Retrieve store Id (From Quote) 
      *
      * @return int
      */
     public function getStoreId()
     {
-        return (int)$this->_quote->getStoreId();
+        return (int)$this->_productCollectionFactory->create()->getStoreId();
     }
 
     /**

--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
@@ -89,7 +89,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
     }
 
     /**
-     * Retrieve store Id (From Quote) 
+     * Retrieve store Id (From Quote)
      *
      * @return int
      */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11869

<!--- Provide a general summary of the Pull Request in the Title above -->
While Getting Collection of Quote Item using Magento\Quote\Model\ResourceModel\QuoteItem\Collection::getItems() was throwing Fatal error: Uncaught Error: Call to a member function getStoreId() on null in C:\www\magento2\vendor\magento\module-quote\Model\ResourceModel\Quote\Item\Collection.php:98
because of used of injected class. 
### Description
<!--- Provide a description of the changes proposed in the pull request -->
I have used injected class  \Magento\Quote\Model\ResourceModel\Quote\Item\Option\CollectionFactory's getStoreId() method. 

It seems working fine with Load Quote Item Collection using Magento\Quote\Model\ResourceModel\QuoteItem\Collection::getItems()
$quoteItemCollection = $this->quoteItemCollectionFactory->create()->getItems();


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<8954>: Error While Trying To Load Quote Item Collection Using Magento\Quote\Model\ResourceModel\QuoteItem\Collection::getItems() #8954

2. . [https://github.com/magento/magento2/issues/8954](8954)

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ... Inject class Magento\Quote\Model\ResourceModel\QuoteItem\Collection $quoteItemCollectionFactory
2. ... $quoteItemCollection = $this->quoteItemCollectionFactory->create()->getItems();
It will return array as expected result.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
