### PR TITLE
[Backport-2.1] magento/magento2#12405: Impossible to create a new storeview

### DIFF
--- a/app/code/Magento/Config/etc/module.xml
+++ b/app/code/Magento/Config/etc/module.xml
@@ -6,5 +6,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Config" setup_version="2.0.0"/>
+    <module name="Magento_Config" setup_version="2.0.0">
+        <sequence>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13943
- Magento_Config should depend on Magento_Store

### Description
This is a retake of https://github.com/magento/magento2/pull/12407, but with only a single dependency added.
I'm still not exactly sure if this is the right way to solve this, but nobody seems to give feedback in the [original issue](https://github.com/magento/magento2/issues/12405), so I'm trying it again with a PR.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/12405: Magento 2.2.1 - Impossible to create a new storeview
2. https://github.com/magento/magento2/issues/12421: 'Requested store is not found' when trying to create a store view in the back end

### Manual testing scenarios
1. Install Magento 2.2-develop branch (tested with commit b17b9c90662)
2. Manually edit the file `app/etc/config.php` and move the line `'Magento_Config' => 1,` higher up the list then `'Magento_Store' => 1,` (normally you shouldn't do this manually, but installing certain 3rd party modules give the same as a result)
3. Flush the cache
4. Login into the backend
5. Go to Stores => All Stores
6. Click 'Create Store View'
7. Enter some dummy content in the fields and click 'Save Store View'
8. An error `Requested store is not found` is shown and no storeview is added.

By defining `Magento_Store` as a dependency of `Magento_Config` we make sure that this sort order of modules outlined in step 2 can never happen.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
