### PR TITLE
chore: remove unused less import

### DIFF
--- a/lib/web/css/docs/source/docs.less
+++ b/lib/web/css/docs/source/docs.less
@@ -21,7 +21,6 @@
 @import '_icons.less';
 @import '_loaders.less';
 @import '_messages.less';
-//@import 'navigation.less';
 @import '_layout.less';
 @import '_pages.less';
 @import '_popups.less';


### PR DESCRIPTION
Removes unused `import` declaration.