### PR TITLE
Fix missing PHPDocs hinting for AdvancedPricingImportExport module

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
@@ -103,7 +103,6 @@ class AdvancedPricing extends \Magento\CatalogImportExport\Model\Export\Product
      * @param \Magento\CatalogImportExport\Model\Export\RowCustomizerInterface $rowCustomizer
      * @param ImportProduct\StoreResolver $storeResolver
      * @param \Magento\Customer\Api\GroupRepositoryInterface $groupRepository
-     * @throws \Magento\Framework\Exception\LocalizedException
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -192,6 +191,7 @@ class AdvancedPricing extends \Magento\CatalogImportExport\Model\Export\Product
      * Export process
      *
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function export()
     {
@@ -461,6 +461,7 @@ class AdvancedPricing extends \Magento\CatalogImportExport\Model\Export\Product
      *
      * @param int $websiteId
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function _getWebsiteCode(int $websiteId): string
     {
@@ -491,6 +492,8 @@ class AdvancedPricing extends \Magento\CatalogImportExport\Model\Export\Product
      * @param int $customerGroupId
      * @param int $allGroups
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     protected function _getCustomerGroupById(
         int $customerGroupId,

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing.php
@@ -8,7 +8,6 @@ namespace Magento\AdvancedPricingImportExport\Model\Import;
 use Magento\CatalogImportExport\Model\Import\Product as ImportProduct;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface as ValidatorInterface;
 use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregatorInterface;
-use Magento\Framework\App\ResourceConnection;
 
 /**
  * Class AdvancedPricing
@@ -619,6 +618,7 @@ class AdvancedPricing extends \Magento\ImportExport\Model\Import\Entity\Abstract
      * Get product entity link field
      *
      * @return string
+     * @throws \Exception
      */
     private function getProductEntityLinkField()
     {

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator.php
@@ -28,6 +28,7 @@ class Validator extends AbstractValidator implements RowValidatorInterface
      *
      * @param array $value
      * @return bool
+     * @throws \Zend_Validate_Exception
      */
     public function isValid($value)
     {

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Export/AdvancedPricingTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Export/AdvancedPricingTest.php
@@ -347,6 +347,7 @@ class AdvancedPricingTest extends \PHPUnit\Framework\TestCase
      * @param $object
      * @param $property
      * @return mixed
+     * @throws \ReflectionException
      */
     protected function getPropertyValue($object, $property)
     {
@@ -362,6 +363,8 @@ class AdvancedPricingTest extends \PHPUnit\Framework\TestCase
      * @param $object
      * @param $property
      * @param $value
+     * @return mixed
+     * @throws \ReflectionException
      */
     protected function setPropertyValue(&$object, $property, $value)
     {

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/TierPriceTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/TierPriceTest.php
@@ -340,6 +340,7 @@ class TierPriceTest extends \PHPUnit\Framework\TestCase
      * @param object $object
      * @param string $property
      * @return mixed
+     * @throws \ReflectionException
      */
     protected function getPropertyValue($object, $property)
     {
@@ -357,6 +358,7 @@ class TierPriceTest extends \PHPUnit\Framework\TestCase
      * @param string $property
      * @param mixed $value
      * @return object
+     * @throws \ReflectionException
      */
     protected function setPropertyValue(&$object, $property, $value)
     {

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricingTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricingTest.php
@@ -209,6 +209,10 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * Test method validateRow against its result.
      *
      * @dataProvider validateRowResultDataProvider
+     * @param array $rowData
+     * @param string|null $behavior
+     * @param bool $expectedResult
+     * @throws \ReflectionException
      */
     public function testValidateRowResult($rowData, $behavior, $expectedResult)
     {
@@ -234,6 +238,10 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * Test method validateRow whether AddRowError is called.
      *
      * @dataProvider validateRowAddRowErrorCallDataProvider
+     * @param array $rowData
+     * @param string|null $behavior
+     * @param string $error
+     * @throws \ReflectionException
      */
     public function testValidateRowAddRowErrorCall($rowData, $behavior, $error)
     {
@@ -324,6 +332,13 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * Take into consideration different data and check relative internal calls.
      *
      * @dataProvider saveAndReplaceAdvancedPricesAppendBehaviourDataProvider
+     * @param array $data
+     * @param string $tierCustomerGroupId
+     * @param string $groupCustomerGroupId
+     * @param string $tierWebsiteId
+     * @param string $groupWebsiteId
+     * @param array $expectedTierPrices
+     * @throws \ReflectionException
      */
     public function testSaveAndReplaceAdvancedPricesAppendBehaviourDataAndCalls(
         $data,
@@ -947,6 +962,7 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * @param $object
      * @param $property
      * @return mixed
+     * @throws \ReflectionException
      */
     protected function getPropertyValue($object, $property)
     {
@@ -963,6 +979,8 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * @param $object
      * @param $property
      * @param $value
+     * @return mixed
+     * @throws \ReflectionException
      */
     protected function setPropertyValue(&$object, $property, $value)
     {
@@ -981,7 +999,8 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * @param string $method
      * @param array $args
      *
-     * @return mixed the method result.
+     * @return mixed
+     * @throws \ReflectionException
      */
     private function invokeMethod($object, $method, $args = [])
     {
@@ -998,6 +1017,7 @@ class AdvancedPricingTest extends \Magento\ImportExport\Test\Unit\Model\Import\A
      * @param array $methods
      *
      * @return \PHPUnit_Framework_MockObject_MockObject
+     * @throws \ReflectionException
      */
     private function getAdvancedPricingMock($methods = [])
     {


### PR DESCRIPTION
### Description
1. Fix missing PHPDocs hinting for AdvancedPricingImportExport module classes
2. Remove redundant ``@throws`` hinting
3. Remove unused import

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
