### PR TITLE
[Forwardport] [Resolved : limiter float too generic]

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -188,10 +188,9 @@
         .lib-icon-font-symbol(@icon-list);
     }
 
-    .limiter {
-        float: right;
-
-        .products.wrapper ~ .toolbar & {
+    .toolbar {
+        .products.wrapper ~ & .limiter {
+            float: right;
             display: block;
         }
     }

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -233,9 +233,9 @@
         }
     }
 
-    .limiter {
-        float: right;
-        .products.wrapper ~ .toolbar & {
+    .toolbar {
+        .products.wrapper ~ & .limiter {
+            float: right;
             display: block;
         }
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15878
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
.limiter should have the same parent selectors like .pages to prevent clashes between styles and layouts

### Description
Added selector for floating the element `.limiter` 

### Fixed Issues (if relevant)

<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#https://github.com/magento/magento2/issues/15323: Issue title limiter float too generic

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. inspect toolbar in product list
2. compare styles of `.limiter` and `.pages`

### Actual Result
`.limiter` is too generic and is used as single selector for floating the element

### Expected Result

`.limiter` should have the same parent selectors like .pages to prevent clashes between styles and layouts



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
