### PR TITLE
[Forwardport 2.3] Trim username on customer account login page

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
@@ -42,3 +42,13 @@
         </form>
     </div>
 </div>
+
+<script type="text/x-magento-init">
+    {
+        ".field.email": {
+            "Magento_Customer/js/trim-username": {
+                "formSelector": "form.form-login"
+            }
+        }
+    }
+</script>

--- a/app/code/Magento/Customer/view/frontend/web/js/trim-username.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/trim-username.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'jquery'
+], function ($) {
+    'use strict';
+
+    $.widget('mage.trimUsername', {
+        options: {
+            cache: {},
+            formSelector: 'form',
+            emailSelector: 'input[type="email"]'
+        },
+
+        /**
+         * Widget initialization
+         * @private
+         */
+        _create: function () {
+            // We need to look outside the module for backward compatibility, since someone can already use the module.
+            // @todo Narrow this selector in 2.3 so it doesn't accidentally finds the email field from the
+            // newsletter email field or any other "email" field.
+            this.options.cache.email = $(this.options.formSelector).find(this.options.emailSelector);
+            this._bind();
+        },
+
+        /**
+         * Event binding, will monitor change, keyup and paste events.
+         * @private
+         */
+        _bind: function () {
+            if (this.options.cache.email.length) {
+                this._on(this.options.cache.email, {
+                    'change': this._trimUsername,
+                    'keyup': this._trimUsername,
+                    'paste': this._trimUsername
+                });
+            }
+        },
+
+        /**
+         * Trim username
+         * @private
+         */
+        _trimUsername: function () {
+            var username = this._getUsername().trim();
+
+            this.options.cache.email.val(username);
+        },
+
+        /**
+         * Get username value
+         * @returns {*}
+         * @private
+         */
+        _getUsername: function () {
+            return this.options.cache.email.val();
+        }
+    });
+
+    return $.mage.trimUsername;
+});


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15365
<!--- Provide a general summary of the Pull Request in the Title above -->
Trim email address on customer account login page generally when copy and paste.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Trim email address by remove leading or trailing space on the customer account login page email field.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6058: IE11 user login email validation fails if field has leading or trailing space

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open customer account login page in Firefox or IE browser.
2. Try to add space before entering an email address in the Email field.
3. Copy `" johndoe@domain.com "` and paste in the Email field. It will automatically remove leading or trailing space.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
