### PR TITLE
Complete the fix for cache issue due to the currencies with no symbol

### DIFF
--- a/app/code/Magento/Catalog/Block/Category/Plugin/PriceBoxTags.php
+++ b/app/code/Magento/Catalog/Block/Category/Plugin/PriceBoxTags.php
@@ -71,7 +71,7 @@ class PriceBoxTags
             '-',
             [
                 $result,
-                $this->priceCurrency->getCurrencySymbol(),
+                $this->priceCurrency->getCurrency()->getCode(),
                 $this->dateTime->scopeDate($this->scopeResolver->getScope()->getId())->format('Ymd'),
                 $this->scopeResolver->getScope()->getId(),
                 $this->customerSession->getCustomerGroupId(),

--- a/app/code/Magento/Catalog/Test/Unit/Block/Category/Plugin/PriceBoxTagsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Category/Plugin/PriceBoxTagsTest.php
@@ -17,6 +17,11 @@ class PriceBoxTagsTest extends \PHPUnit\Framework\TestCase
     private $priceCurrencyInterface;
 
     /**
+     * @var \Magento\Directory\Model\Currency | \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $currency;
+
+    /**
      * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface | \PHPUnit_Framework_MockObject_MockObject
      */
     private $timezoneInterface;
@@ -46,6 +51,9 @@ class PriceBoxTagsTest extends \PHPUnit\Framework\TestCase
         $this->priceCurrencyInterface = $this->getMockBuilder(
             \Magento\Framework\Pricing\PriceCurrencyInterface::class
         )->getMock();
+        $this->currency = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->timezoneInterface = $this->getMockBuilder(
             \Magento\Framework\Stdlib\DateTime\TimezoneInterface::class
         )->getMock();
@@ -82,7 +90,7 @@ class PriceBoxTagsTest extends \PHPUnit\Framework\TestCase
     public function testAfterGetCacheKey()
     {
         $date = date('Ymd');
-        $currencySymbol = '$';
+        $currencyCode = 'USD';
         $result = 'result_string';
         $billingAddress = ['billing_address'];
         $shippingAddress = ['shipping_address'];
@@ -95,7 +103,7 @@ class PriceBoxTagsTest extends \PHPUnit\Framework\TestCase
             '-',
             [
                 $result,
-                $currencySymbol,
+                $currencyCode,
                 $date,
                 $scopeId,
                 $customerGroupId,
@@ -104,7 +112,8 @@ class PriceBoxTagsTest extends \PHPUnit\Framework\TestCase
         );
         $priceBox = $this->getMockBuilder(\Magento\Framework\Pricing\Render\PriceBox::class)
             ->disableOriginalConstructor()->getMock();
-        $this->priceCurrencyInterface->expects($this->once())->method('getCurrencySymbol')->willReturn($currencySymbol);
+        $this->priceCurrencyInterface->expects($this->once())->method('getCurrency')->willReturn($this->currency);
+        $this->currency->expects($this->once())->method('getCode')->willReturn($currencyCode);
         $scope = $this->getMockBuilder(\Magento\Framework\App\ScopeInterface::class)->getMock();
         $this->scopeResolverInterface->expects($this->any())->method('getScope')->willReturn($scope);
         $scope->expects($this->any())->method('getId')->willReturn($scopeId);


### PR DESCRIPTION
### Description
Using ``getCurrencySymbol()`` leads to a bug for currencies where there is no currency symbol - cache ends up being non-unique. Using currency code for caching is a more foolproof way.

The issue has been partially fixed in ``2.2-develop`` branch in #13894 (``Magento\ConfigurableProduct\Block\Product\View\Type\Configurable``)
and #14559 (``Magento\CatalogWidget\Block\Product\ProductsList``).

### Manual testing scenarios
1. Test the Catalog Category View page (including configurable products)
2. Test the Catalog Product List widget

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)