### PR TITLE
#4942 and bundle checkbox bug

### DIFF
--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -186,10 +186,9 @@ class Bundle extends \Magento\Catalog\Block\Product\View\AbstractView
                     $defaultValues[$optionId] = $configValue;
                 }
                 
-                
                 $preConfiguredQtys = $preConfiguredValues->getData("bundle_option_qty/${optionId}") ?? [];
                 $selections = $options[$optionId]['selections'];
-                array_walk($selections, function(&$selection, $selectionId) use ($preConfiguredQtys) {
+                array_walk($selections, function (&$selection, $selectionId) use ($preConfiguredQtys) {
                     if (is_array($preConfiguredQtys) && isset($preConfiguredQtys[$selectionId])) {
                         $selection['qty'] = $preConfiguredQtys[$selectionId];
                     } else if ((int)$preConfiguredQtys > 0) {

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -185,6 +185,18 @@ class Bundle extends \Magento\Catalog\Block\Product\View\AbstractView
                 if ($configValue) {
                     $defaultValues[$optionId] = $configValue;
                 }
+                
+                
+                $preConfiguredQtys = $preConfiguredValues->getData("bundle_option_qty/${optionId}") ?? [];
+                $selections = $options[$optionId]['selections'];
+                array_walk($selections, function(&$selection, $selectionId) use ($preConfiguredQtys) {
+                    if (is_array($preConfiguredQtys) && isset($preConfiguredQtys[$selectionId])) {
+                        $selection['qty'] = $preConfiguredQtys[$selectionId];
+                    } else if ((int)$preConfiguredQtys > 0) {
+                        $selection['qty'] = $preConfiguredQtys;
+                    }
+                });
+                $options[$optionId]['selections'] = $selections;
             }
             $position++;
         }

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
@@ -169,7 +169,9 @@ class Option extends \Magento\Bundle\Block\Catalog\Product\Price
      */
     protected function assignSelection(\Magento\Bundle\Model\Option $option, $selectionId)
     {
-        if ($selectionId && $option->getSelectionById($selectionId)) {
+        if (is_array($selectionId)) {
+            $this->_selectedOptions = $selectionId;
+        } else if ($selectionId && $option->getSelectionById($selectionId)) {
             $this->_selectedOptions = $selectionId;
         } elseif (!$option->getRequired()) {
             $this->_selectedOptions = 'None';


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

This fixes two bugs in relation to bundled products and a customer editing their selections in the cart.

### Description
When a bundle item was edited after being in the cart, it was no different than loading the original product. There are two aspects to the fix:
* Updating the JSON config to show the new quantities and selections
* Adding selection array matching for checkboxes.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#4942: On editing a Bundle product from shopping cart the user defined quantities of the options are overwritten

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Locate a bundled item with checkboxes
2. Add that bundled item to the cart (with at least some checkboxes checked)
3. Edit the item in the cart.
4. Ensure that all items are checked and that the specified quantities match.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
