### PR TITLE
 [Backport] Fixes in catalog component blocks [2.3-develop] 

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -325,7 +325,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
      *
      * @param Node|array $node
      * @param int $level
-     * @return string
+     * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
@@ -144,7 +144,7 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Category\Tree
      *
      * @param \Magento\Framework\Data\Tree\Node|array $node
      * @param int $level
-     * @return string
+     * @return array
      */
     protected function _getNodeJson($node, $level = 0)
     {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Fieldset/Element.php
@@ -21,7 +21,7 @@ class Element extends \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Eleme
     /**
      * Retrieve data object related with form
      *
-     * @return \Magento\Catalog\Model\Product || \Magento\Catalog\Model\Category
+     * @return \Magento\Catalog\Model\Product|\Magento\Catalog\Model\Category
      */
     public function getDataObject()
     {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Grid.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Grid.php
@@ -101,8 +101,7 @@ class Grid extends AbstractGrid
                 'type' => 'options',
                 'options' => ['1' => __('Yes'), '0' => __('No')],
                 'align' => 'center'
-            ],
-            'is_user_defined'
+            ]
         );
 
         $this->_eventManager->dispatch('product_attribute_grid_build', ['grid' => $this]);

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Attributes/Search.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Attributes/Search.php
@@ -81,7 +81,7 @@ class Search extends \Magento\Backend\Block\Widget
      *
      * @param string $labelPart
      * @param int $templateId
-     * @return \Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection
+     * @return array
      */
     public function getSuggestedAttributes($labelPart, $templateId = null)
     {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
@@ -69,7 +69,7 @@ class Link extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return string
+     * @return array
      */
     protected function getLinkParams()
     {

--- a/app/code/Magento/Catalog/Block/Category/Rss/Link.php
+++ b/app/code/Magento/Catalog/Block/Category/Rss/Link.php
@@ -62,7 +62,7 @@ class Link extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return string
+     * @return array
      */
     protected function getLinkParams()
     {

--- a/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -195,7 +195,7 @@ class AbstractProduct extends \Magento\Framework\View\Element\Template
      * Gets minimal sales quantity
      *
      * @param \Magento\Catalog\Model\Product $product
-     * @return int|null
+     * @return float|null
      */
     public function getMinimalQty($product)
     {

--- a/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
@@ -178,7 +178,7 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
      * Returns price converted to current currency rate
      *
      * @param float $price
-     * @return float
+     * @return float|string
      */
     public function getCurrencyPrice($price)
     {

--- a/app/code/Magento/Catalog/Block/Rss/Product/Special.php
+++ b/app/code/Magento/Catalog/Block/Rss/Product/Special.php
@@ -107,7 +107,7 @@ class Special extends \Magento\Framework\View\Element\AbstractBlock implements D
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getRssData()
     {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15558
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This PR fixes a few PHPDocs and annotations typos along with wrong return type suggestions.

It also solves an issue with the method `Magento\Backend\Block\Widget\Grid\Extended::addColumn()` invoking with 3 parameters when only 2 are required. See line [105](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Grid.php#L105)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
