### PR TITLE
Do not display anchor if admin submenu has no children

### DIFF
--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -211,9 +211,12 @@ class Menu extends \Magento\Backend\Block\Template
     protected function _renderAnchor($menuItem, $level)
     {
         if ($level == 1 && $menuItem->getUrl() == '#') {
-            $output = '<strong class="submenu-group-title" role="presentation">'
-                . '<span>' . $this->_getAnchorLabel($menuItem) . '</span>'
-                . '</strong>';
+            $output = '';
+            if ($menuItem->hasChildren()) {
+                $output = '<strong class="submenu-group-title" role="presentation">'
+                    . '<span>' . $this->_getAnchorLabel($menuItem) . '</span>'
+                    . '</strong>';
+            }
         } else {
             $output = '<a href="' . $menuItem->getUrl() . '" ' . $this->_renderItemAnchorTitle(
                 $menuItem


### PR DESCRIPTION
### Description
In the admin panel if some submenu has no items it's still shown in the menu. Out of the box, we have "Other Settings" submenu in the "Stores" menu which is empty and looks not very good. 
The fix prevents rendering submenus with no items (the same behavior we have within a scope of versions 2.2 and 2.3)

### Manual testing scenarios
Preconditions: Magento 2.1.x
1. Go to admin panel
2. Open "Stores" menu item

#### Expected behavior
There are no empty submenus

#### Actual behavior
There's an empty "Other Settings" submenu item with "dimmed" title.

<img width="506" alt="screen shot 2018-06-07 at 14 26 47" src="https://user-images.githubusercontent.com/2148959/41099469-edf527d8-6a5e-11e8-8660-20037ee5c491.png">

