### PR TITLE
Making configurable settings for MAX_IMAGE_WIDTH and MAX_IMAGE_HEIGHT

### DIFF
--- a/app/code/Magento/Backend/Block/Media/Uploader.php
+++ b/app/code/Magento/Backend/Block/Media/Uploader.php
@@ -28,16 +28,24 @@ class Uploader extends \Magento\Backend\Block\Widget
     protected $_fileSizeService;
 
     /**
+     * @var \Magento\Framework\Image\Config
+     */
+    protected $imageConfig;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\File\Size $fileSize
      * @param array $data
+     * @param \Magento\Framework\Image\Adapter\Config $imageConfig
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\File\Size $fileSize,
+        \Magento\Framework\Image\Adapter\Config $imageConfig,
         array $data = []
     ) {
         $this->_fileSizeService = $fileSize;
+        $this->imageConfig = $imageConfig;
         parent::__construct($context, $data);
     }
 
@@ -77,6 +85,16 @@ class Uploader extends \Magento\Backend\Block\Widget
     public function getFileSizeService()
     {
         return $this->_fileSizeService;
+    }
+
+    /**
+     * Get image config
+     *
+     * @return \Magento\Framework\Image\Adapter\Config
+     */
+    public function getImageConfigService()
+    {
+        return $this->imageConfig;
     }
 
     /**

--- a/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
@@ -13,8 +13,8 @@
     data-mage-init='{
         "Magento_Backend/js/media-uploader" : {
             "maxFileSize": <?= /* @escapeNotVerified */ $block->getFileSizeService()->getMaxFileSize() ?>,
-            "maxWidth":<?= /* @escapeNotVerified */ \Magento\Framework\File\Uploader::MAX_IMAGE_WIDTH ?> ,
-            "maxHeight": <?= /* @escapeNotVerified */ \Magento\Framework\File\Uploader::MAX_IMAGE_HEIGHT ?>
+            "maxWidth":<?= /* @escapeNotVerified */ $block->getImageConfigService()->getMaxWidth() ?> ,
+            "maxHeight": <?= /* @escapeNotVerified */ $block->getImageConfigService()->getMaxHeight() ?>
         }
     }'
 >

--- a/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content/Uploader.php
@@ -19,6 +19,11 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
     protected $_imagesStorage;
 
     /**
+     * @var \Magento\Framework\Image\Adapter\Config
+     */
+    protected $imageConfig;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\File\Size $fileSize
      * @param \Magento\Cms\Model\Wysiwyg\Images\Storage $imagesStorage
@@ -28,10 +33,12 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\File\Size $fileSize,
         \Magento\Cms\Model\Wysiwyg\Images\Storage $imagesStorage,
+        \Magento\Framework\Image\Adapter\Config $imageConfig,
         array $data = []
     ) {
         $this->_imagesStorage = $imagesStorage;
-        parent::__construct($context, $fileSize, $data);
+        $this->imageConfig = $imageConfig;
+        parent::__construct($context, $fileSize, $imageConfig, $data);
     }
 
     /**

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -101,8 +101,8 @@ require([
             maxFileSize: <?= (int) $block->getFileSizeService()->getMaxFileSize() ?> * 10
         }, {
             action: 'resize',
-            maxWidth: <?= (float) \Magento\Framework\File\Uploader::MAX_IMAGE_WIDTH ?> ,
-            maxHeight: <?= (float) \Magento\Framework\File\Uploader::MAX_IMAGE_HEIGHT ?>
+            maxWidth: <?= (float) $block->getImageConfigService()->getMaxWidth() ?> ,
+            maxHeight: <?= (float) $block->getImageConfigService()->getMaxHeight() ?>
         }, {
             action: 'save'
         }]

--- a/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
+++ b/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
@@ -30,6 +30,17 @@
                     <label>Environment Update Time</label>
                 </field>
             </group>
+            <group id="media_configuration" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Images Configuration</label>
+                <field id="max_width" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Max width</label>
+                    <validate>validate-zero-or-greater validate-digits</validate>
+                </field>
+                <field id="max_height" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Max height</label>
+                    <validate>validate-zero-or-greater validate-digits</validate>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/app/code/Magento/MediaStorage/etc/config.xml
+++ b/app/code/Magento/MediaStorage/etc/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <system>
+            <media_configuration>
+                <max_width>3200</max_width>
+                <max_height>1200</max_height>
+            </media_configuration>
+        </system>
+    </default>
+</config>

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
@@ -27,6 +27,11 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
     protected $_storageHelper;
 
     /**
+     * @var \Magento\Framework\Image\Adapter\Config
+     */
+    protected $imageConfig;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\File\Size $fileSize
      * @param \Magento\Theme\Helper\Storage $storageHelper
@@ -36,10 +41,12 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\File\Size $fileSize,
         \Magento\Theme\Helper\Storage $storageHelper,
+        \Magento\Framework\Image\Adapter\Config $imageConfig,
         array $data = []
     ) {
         $this->_storageHelper = $storageHelper;
-        parent::__construct($context, $fileSize, $data);
+        $this->imageConfig = $imageConfig;
+        parent::__construct($context, $fileSize, $imageConfig, $data);
     }
 
     /**

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -133,16 +133,6 @@ class Uploader
     const TMP_NAME_EMPTY = 666;
 
     /**
-     * Max Image Width resolution in pixels. For image resizing on client side
-     */
-    const MAX_IMAGE_WIDTH = 1920;
-
-    /**
-     * Max Image Height resolution in pixels. For image resizing on client side
-     */
-    const MAX_IMAGE_HEIGHT = 1200;
-
-    /**
      * Resulting of uploaded file
      *
      * @var array|bool      Array with file info keys: path, file. Result is

--- a/lib/internal/Magento/Framework/Image/Adapter/Config.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Config.php
@@ -11,6 +11,10 @@ class Config implements \Magento\Framework\Image\Adapter\ConfigInterface
 
     const XML_PATH_IMAGE_ADAPTERS = 'dev/image/adapters';
 
+    const XML_PATH_MAX_WIDTH_IMAGE = 'system/media_configuration/max_width';
+
+    const XML_PATH_MAX_HEIGHT_IMAGE = 'system/media_configuration/max_height';
+
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -42,5 +46,25 @@ class Config implements \Magento\Framework\Image\Adapter\ConfigInterface
     public function getAdapters()
     {
         return $this->config->getValue(self::XML_PATH_IMAGE_ADAPTERS);
+    }
+
+    /**
+     * Get Max Image Width resolution in pixels. For image resizing on client side
+     *
+     * @return int
+     */
+    public function getMaxWidth()
+    {
+        return $this->config->getValue(self::XML_PATH_MAX_WIDTH_IMAGE);
+    }
+
+    /**
+     * Get Max Image Height resolution in pixels. For image resizing on client side
+     *
+     * @return int
+     */
+    public function getMaxHeight()
+    {
+        return $this->config->getValue(self::XML_PATH_MAX_HEIGHT_IMAGE);
     }
 }

--- a/lib/internal/Magento/Framework/Image/Adapter/ConfigInterface.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/ConfigInterface.php
@@ -20,4 +20,14 @@ interface ConfigInterface
      * @return array
      */
     public function getAdapters();
+
+    /**
+     * @return int
+     */
+    public function getMaxWidth();
+
+    /**
+     * @return int
+     */
+    public function getMaxHeight();
 }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

It was added a new system fieldset, where the max-width and max-height can be set.
`Stores / Configuration / Advanced / System / Images Configuration`

So these 2 values are more flexible now for those which need to have bigger images in their shops.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#1374: Wysiwyg > Image Uploader >Max width/height
2. ...

### Manual testing scenarios
1. Get an image of 3000x700
https://dummyimage.com/3000x700
2. Open any wysiwyg editor
3. Upload an image

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
