### PR TITLE
[Forwardport] Wrong annotation in _toOptionArray : lib\internal\Magento\Framework\D…

### DIFF
--- a/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
+++ b/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
@@ -188,8 +188,8 @@ class SearchResultProcessor extends AbstractDataObject implements SearchResultPr
     }
 
     /**
-     * @param string $labelField
-     * @param string $labelField
+     * @param string|null $valueField
+     * @param string|null $labelField
      * @param array $additional
      * @return array
      */

--- a/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
+++ b/lib/internal/Magento/Framework/Data/SearchResultProcessor.php
@@ -188,8 +188,8 @@ class SearchResultProcessor extends AbstractDataObject implements SearchResultPr
     }
 
     /**
-     * @param null $valueField
-     * @param null $labelField
+     * @param string $labelField
+     * @param string $labelField
      * @param array $additional
      * @return array
      */


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/15892

### Description
Set correct annotation in _toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<12820>: Wrong annotation in _toOptionArray - lib\internal\Magento\Framework\Data\SearchResultProcessor.php

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Please check request parameter in _toOptionArray - magento/framework/Data/Collection/AbstractDb.php

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
