### PR TITLE
[Forwardport] ISSUE-11477 - fixed Swagger response for searchCriteria - added zero …

### DIFF
--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -39,7 +39,7 @@ class Generator extends AbstractSchemaGenerator
     const UNAUTHORIZED_DESCRIPTION = '401 Unauthorized';
 
     /** Array signifier */
-    const ARRAY_SIGNIFIER = '[]';
+    const ARRAY_SIGNIFIER = '[0]';
 
     /**
      * Swagger factory instance.


### PR DESCRIPTION
### Original Pull Request
#15322 

Added zero index to array signifier in searchCriteria parameters builder

### Description
This fix allows to generate correct response when user want to test method with some search criteria parameters in Swagger.

### Fixed Issues (if relevant)
1. magento/magento2#11477: Magento REST API Schema (Swagger) is not compatible with Search Criteria

### Manual testing scenarios
1. Open Swagger
2. In method "catalogProductRepositoryV1" fill in "Parameters" tab values for searchCriteria which use "filterGroups" key
3. Click "Try it out!"
4. Check if Response Code is 200

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
