### PR TITLE
[Forwardport]No need to pass method parameter as method definition does not requir…

### DIFF
--- a/app/code/Magento/UrlRewrite/Block/Catalog/Product/Edit.php
+++ b/app/code/Magento/UrlRewrite/Block/Catalog/Product/Edit.php
@@ -55,7 +55,7 @@ class Edit extends \Magento\UrlRewrite\Block\Edit
         }
 
         if ($this->_getProduct()->getId()) {
-            $this->_addProductLinkBlock($this->_getProduct());
+            $this->_addProductLinkBlock();
         }
 
         if ($this->_getCategory()->getId()) {


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/15891
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->
Remove parameter from method calling
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Method definition does not require any parameters. But when it was actually called extra parameter was passed. I remove extra parameter while calling method.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1 You can check at magento admin panel -> Marketing -> SEO & Search -> URL Rewrites -> Add/Edit with product.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
