### PR TITLE
Add "before_load" event for product collection used in wishlist item collection

### DIFF
--- a/app/code/Magento/Wishlist/Model/ResourceModel/Item/Collection.php
+++ b/app/code/Magento/Wishlist/Model/ResourceModel/Item/Collection.php
@@ -292,7 +292,14 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $productCollection->addPriceData()
             ->addTaxPercents()
             ->addIdFilter($this->_productIds)
-            ->addAttributeToSelect($this->_wishlistConfig->getProductAttributes())
+            ->addAttributeToSelect($this->_wishlistConfig->getProductAttributes());
+
+        $this->_eventManager->dispatch(
+            'wishlist_item_collection_products_before_load',
+            ['product_collection' => $productCollection]
+        );
+
+        $productCollection
             ->addOptionsToResult()
             ->addUrlRewrite();
 


### PR DESCRIPTION
### Description
The `before_load` event was missing in the product collection which is being used internally in the wishlist item collection. Now `wishlist_item_collection_products_before_load` was added.

### Manual testing scenarios
1. Create a new observer in a custom module for the event `wishlist_item_collection_products_before_load`
2. Login as a customer in the frontend
3. Add a product to the wishlist
4. Go to the wishlist in the customer account
5. Check that the observer has been called (i.e. with a debugger or with logging)

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
