### PR TITLE
#15849 Fix for fallback options for swatches

### DIFF
--- a/app/code/Magento/Swatches/Helper/Data.php
+++ b/app/code/Magento/Swatches/Helper/Data.php
@@ -495,8 +495,7 @@ class Data
     {
         $currentStoreId = $this->storeManager->getStore()->getId();
         foreach ($fallbackValues as $optionId => $optionsArray) {
-            if (isset($optionsArray[$currentStoreId], $swatches[$optionId]['type'])
-                && $swatches[$optionId]['type'] === $optionsArray[$currentStoreId]['type']
+            if (isset($optionsArray[$currentStoreId])
             ) {
                 $swatches[$optionId] = $optionsArray[$currentStoreId];
             } else {


### PR DESCRIPTION
### Description
Removed some checks for the swatch fallback data. The check was to strict and didn't add correct store id to the swatch.

### Fixed Issues (if relevant)
1. magento/magento2#15849: 2.2.4 Product text swatch displays admin swatch value instead of store value

### Manual testing scenarios
1. Open an text swatch attribute in the adminhtml
2. Add a text to a label for an store view (not the admin store, but for example the default store view)
3. Check if the label is being showed on the frontend when saved

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
