### PR TITLE
14294 - Fixes 'back' functionality after switching a store view.

### DIFF
--- a/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
@@ -27,7 +27,7 @@
             <?php foreach ($block->getStores() as $_lang): ?>
                 <?php if ($_lang->getId() != $block->getCurrentStoreId()): ?>
                     <li class="view-<?= $block->escapeHtml($_lang->getCode()) ?> switcher-option">
-                        <a href="#" data-post='<?= /* @noEscape */ $block->getTargetStorePostData($_lang) ?>'>
+                        <a href="<?= $block->escapeUrl($_lang->getCurrentUrl(true)) ?>">
                             <?= $block->escapeHtml($_lang->getName()) ?>
                         </a>
                     </li>


### PR DESCRIPTION
### Description
Modifies switcher-option's link Magento/Store/view/frontend/templates/switch/languages.phtml template.

### Fixed Issues (if relevant)
1. magento/magento2#14294: Since MagentoCE2.1.11, after swithing store view, ___store=xx is added to url. Breaks 'back' functionality.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
