### PR TITLE
Fix issue #14112

### DIFF
--- a/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
+++ b/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
@@ -6,20 +6,20 @@
 namespace Magento\Bundle\Model\Product\CopyConstructor;
 
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\CopyConstructorInterface;
 use Magento\Catalog\Model\Product\Type;
 
-class Bundle implements \Magento\Catalog\Model\Product\CopyConstructorInterface
+class Bundle implements CopyConstructorInterface
 {
     /**
      * Duplicating bundle options and selections
-     *
      * @param Product $product
      * @param Product $duplicate
      * @return void
      */
-    public function build(Product $product, Product $duplicate)
+    public function build(Product $product, Product $duplicate): void
     {
-        if ($product->getTypeId() != Type::TYPE_BUNDLE) {
+        if ($product->getTypeId() !== Type::TYPE_BUNDLE) {
             //do nothing if not bundle
             return;
         }
@@ -35,8 +35,6 @@ class Bundle implements \Magento\Catalog\Model\Product\CopyConstructorInterface
             $duplicatedBundleOptions[$key]->setOptionId(null);
             /** @var \Magento\Bundle\Api\Data\LinkInterface[]|null $bundleSelections */
             $bundleSelections = $duplicatedBundleOptions[$key]->getProductLinks();
-
-            /** @var \Magento\Bundle\Api\Data\LinkInterface $bundleSelection */
             foreach ($bundleSelections as $bundleSelection) {
                 $bundleSelection->setSelectionId(null);
             }

--- a/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
+++ b/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
@@ -24,10 +24,22 @@ class Bundle implements \Magento\Catalog\Model\Product\CopyConstructorInterface
             return;
         }
 
+        /** @var \Magento\Bundle\Api\Data\OptionInterface[]|null $bundleOptions */
         $bundleOptions = $product->getExtensionAttributes()->getBundleProductOptions() ?: [];
+
+        /** @var \Magento\Bundle\Api\Data\OptionInterface[]|null $duplicatedBundleOptions */
         $duplicatedBundleOptions = [];
+
         foreach ($bundleOptions as $key => $bundleOption) {
             $duplicatedBundleOptions[$key] = clone $bundleOption;
+            $duplicatedBundleOptions[$key]->setOptionId(null);
+            /** @var \Magento\Bundle\Api\Data\LinkInterface[]|null $bundleSelections */
+            $bundleSelections = $duplicatedBundleOptions[$key]->getProductLinks();
+
+            /** @var \Magento\Bundle\Api\Data\LinkInterface $bundleSelection */
+            foreach($bundleSelections as $bundleSelection){
+                $bundleSelection->setSelectionId(null);
+            }
         }
         $duplicate->getExtensionAttributes()->setBundleProductOptions($duplicatedBundleOptions);
     }

--- a/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
+++ b/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
@@ -37,7 +37,7 @@ class Bundle implements \Magento\Catalog\Model\Product\CopyConstructorInterface
             $bundleSelections = $duplicatedBundleOptions[$key]->getProductLinks();
 
             /** @var \Magento\Bundle\Api\Data\LinkInterface $bundleSelection */
-            foreach($bundleSelections as $bundleSelection){
+            foreach ($bundleSelections as $bundleSelection) {
                 $bundleSelection->setSelectionId(null);
             }
         }

--- a/app/code/Magento/Bundle/Test/Unit/Model/Product/CopyConstructor/BundleTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Product/CopyConstructor/BundleTest.php
@@ -8,6 +8,7 @@ namespace Magento\Bundle\Test\Unit\Model\Product\CopyConstructor;
 use Magento\Bundle\Api\Data\BundleOptionInterface;
 use Magento\Bundle\Model\Product\CopyConstructor\Bundle;
 use Magento\Catalog\Api\Data\ProductExtensionInterface;
+use Magento\Catalog\Api\Data\ProductLinkInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -61,12 +62,8 @@ class BundleTest extends \PHPUnit\Framework\TestCase
             ->willReturn($extensionAttributesProduct);
 
         $bundleOptions = [
-            $this->getMockBuilder(BundleOptionInterface::class)
-                ->disableOriginalConstructor()
-                ->getMockForAbstractClass(),
-            $this->getMockBuilder(BundleOptionInterface::class)
-                ->disableOriginalConstructor()
-                ->getMockForAbstractClass()
+            $this->createBundleOption(),
+            $this->createBundleOption()
         ];
         $extensionAttributesProduct->expects($this->once())
             ->method('getBundleProductOptions')
@@ -86,7 +83,6 @@ class BundleTest extends \PHPUnit\Framework\TestCase
         $extensionAttributesDuplicate->expects($this->once())
             ->method('setBundleProductOptions')
             ->withConsecutive([$bundleOptions]);
-
         $this->model->build($product, $duplicate);
     }
 
@@ -130,5 +126,33 @@ class BundleTest extends \PHPUnit\Framework\TestCase
             ->with([]);
 
         $this->model->build($product, $duplicate);
+    }
+
+    /**
+     * @return BundleOptionInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createBundleOption()
+    {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|BundleOptionInterface $bundleOptionMock */
+        $bundleOptionMock = $this->getMockBuilder(BundleOptionInterface::class)
+            ->setMethods(['getProductLinks'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|ProductLinkInterface $productLinkMock */
+        $productLinkMock = $this->getMockBuilder(ProductLinkInterface::class)
+            ->setMethods(['setSelectionId'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $productLinkMock->expects($this->once())
+            ->method('setSelectionId')
+            ->with(null);
+
+        $bundleOptionMock->expects($this->once())
+            ->method('getProductLinks')
+            ->willReturn([$productLinkMock]);
+
+        return $bundleOptionMock;
     }
 }


### PR DESCRIPTION
- set null OptionId
- set null all ProductLink
- updated unit test

to prevent overwrite of duplicated bundle product in table `catalog_product_bundle_selection`
