### PR TITLE
Generalized error with MassDelete actions

### DIFF
--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -1080,4 +1080,10 @@
             <argument name="nativeAttributeConditionBuilder" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\ConditionProcessor\ConditionBuilder\NativeAttributeCondition</argument>
         </arguments>
     </type>
+
+    <type name="Magento\Catalog\Controller\Adminhtml\Product\MassDelete">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Ui\Component\MassAction\DeleteFilter</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Cms/etc/adminhtml/di.xml
+++ b/app/code/Magento/Cms/etc/adminhtml/di.xml
@@ -52,4 +52,16 @@
             <argument name="path" xsi:type="string">web/default_layouts/default_cms_layout</argument>
         </arguments>
     </virtualType>
+
+    <type name="Magento\Cms\Controller\Adminhtml\Block\MassDelete">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Ui\Component\MassAction\DeleteFilter</argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\Cms\Controller\Adminhtml\Page\MassDelete">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Ui\Component\MassAction\DeleteFilter</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Customer/etc/adminhtml/di.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/di.xml
@@ -28,5 +28,5 @@
         <arguments>
             <argument name="filter" xsi:type="object">Magento\Ui\Component\MassAction\DeleteFilter</argument>
         </arguments>
-    </type
+    </type>
 </config>

--- a/app/code/Magento/Customer/etc/adminhtml/di.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/di.xml
@@ -23,4 +23,10 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\Customer\Controller\Adminhtml\Index\MassDelete">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Ui\Component\MassAction\DeleteFilter</argument>
+        </arguments>
+    </type
 </config>

--- a/app/code/Magento/Search/etc/adminhtml/di.xml
+++ b/app/code/Magento/Search/etc/adminhtml/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+* Copyright © Magento, Inc. All rights reserved.
+* See COPYING.txt for license details.
+*/
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Search\Controller\Adminhtml\Synonyms\MassDelete">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Ui\Component\MassAction\DeleteFilter</argument>
+        </arguments>
+    </type>
+</config>

--- a/app/code/Magento/Ui/Component/MassAction/Filter.php
+++ b/app/code/Magento/Ui/Component/MassAction/Filter.php
@@ -48,20 +48,27 @@ class Filter
      * @var DataProviderInterface
      */
     private $dataProvider;
+    /**
+     * @var bool
+     */
+    private $avoidEmptyFilter;
 
     /**
      * @param UiComponentFactory $factory
      * @param RequestInterface $request
      * @param FilterBuilder $filterBuilder
+     * @param bool $avoidEmptyFilter
      */
     public function __construct(
         UiComponentFactory $factory,
         RequestInterface $request,
-        FilterBuilder $filterBuilder
+        FilterBuilder $filterBuilder,
+        $avoidEmptyFilter = false
     ) {
         $this->factory = $factory;
         $this->request = $request;
         $this->filterBuilder = $filterBuilder;
+        $this->avoidEmptyFilter = $avoidEmptyFilter;
     }
 
     /**
@@ -101,10 +108,10 @@ class Filter
         }
         /** @var \Magento\Customer\Model\ResourceModel\Customer\Collection $collection */
         $idsArray = $this->getFilterIds();
-        if (!empty($idsArray)) {
+        if (!empty($idsArray) || $this->avoidEmptyFilter) {
             $collection->addFieldToFilter(
                 $collection->getIdFieldName(),
-                ['in' => $idsArray]
+                ['in' => (array) $idsArray]
             );
         }
         return $collection;

--- a/app/code/Magento/Ui/etc/adminhtml/di.xml
+++ b/app/code/Magento/Ui/etc/adminhtml/di.xml
@@ -61,4 +61,10 @@
             </argument>
         </arguments>
     </type>
+
+    <virtualType name="Magento\Ui\Component\MassAction\DeleteFilter" type="Magento\Ui\Component\MassAction\Filter">
+        <arguments>
+            <argument name="avoidEmptyFilter" xsi:type="boolean">true</argument>
+        </arguments>
+    </virtualType>
 </config>


### PR DESCRIPTION
Signed-off-by: Paolo Vecchiocattivi <paolo.vecchiocattivi@magespecialist.it>

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Following the inputs from issue #15935, I have found a **critical issue** in most of backend `MassDelete` actions:
- when a `MassDelete` action is called twice with same selected items quickly after the first time, during the second call the filter applied to items collection query does not contain any `WHERE` condition, resulting in deletion for all the items in the collection
- the issue is certainly present also in **Customer**, **Page**, **CMS Block**, and **Search Synonyms** Grids

The proposed patch adds a boolean option in the constructor to `app/code/Magento/Ui/Component/MassAction/Filter` to avoid to apply the empty filter to a collection.
Then a virtualtype to pass the boolean parameter to the filter used in MassDelete actions, and I have applied this virtualtype in all the delete actions that used such filter.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15935: Mass delete deletes all products

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Follow the steps listed in the issue to reproduce
2. The result now is the expected result
3. Try the same steps in Customer, Page, CMS Block, and Search Synonyms Grids
![peek 10-06-2018 13-10](https://user-images.githubusercontent.com/4538539/41200994-2aa92488-6cb0-11e8-997d-708cb6efa5aa.gif)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)