### PR TITLE
Update AbstractCollection.php

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -393,7 +393,8 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
      */
     public function addFieldToFilter($attribute, $condition = null)
     {
-        return $this->addAttributeToFilter($attribute, $condition);
+        $joinType = $condition ? 'inner' : 'left';
+        return $this->addAttributeToFilter($attribute, $condition, $joinType);
     }
 
     /**


### PR DESCRIPTION
Use case:

Create new product, with `newFromDate` in the past and `toDate` not set; when you try to get the product with a repository:

```
$filterBuilder = $objectManager->get(\Magento\Framework\Api\FilterBuilder::class);
$toDateFilter = $filterBuilder
    ->setField('news_to_date')
    ->setConditionType('null')
    ->create();

$searchCriteriaBuilder = $objectManager->get(\Magento\Framework\Api\SearchCriteriaBuilder::class);
$searchCriteria = $searchCriteriaBuilder
    ->addFilters([$toDateFilter])
    ->create();

$repo = $objectManager->get(\Magento\Catalog\Model\ProductRepository::class);
$products = $repo->getList($searchCriteria)->getItems();
```
you don't get the expected result because the attribute value is not set into the table and the inner excludes the product to be selected.

see \Magento\Eav\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor::addFilterGroupToCollection:59
and \Magento\Eav\Model\Entity\Collection\AbstractCollection::addFieldToFilter:394

Proposed solution sets join type from `inner` (default value) to `left` when the condition type is `null`
