### PR TITLE
Extend default config instead overwrite

### DIFF
--- a/lib/web/mage/adminhtml/form.js
+++ b/lib/web/mage/adminhtml/form.js
@@ -389,7 +389,7 @@ define([
             var idTo, idFrom, values, fromId, radioFrom;
 
             if (config) {
-                this._config = config;
+                this._config = jQuery.extend(this._config, config);
             }
 
             for (idTo in elementsMap) { //eslint-disable-line guard-for-in


### PR DESCRIPTION
### Description
Default FormElementDependenceController config should be extended by custom config but not overridden.

### Manual testing scenarios
1. Add custom options to FormElementDependenceController config;
2. Open System config page.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
