### PR TITLE
Fix issue #15832

### DIFF
--- a/lib/web/css/source/lib/_buttons.less
+++ b/lib/web/css/source/lib/_buttons.less
@@ -277,6 +277,9 @@
 //  ---------------------------------------------
 
 .lib-button-primary(
+    @_button-font-family: @button-primary__font-family,
+    @_button-font-size: @button-primary__font-size,
+    @_button-font-weight: @button-primary__font-weight,
     @_button-line-height: @button-primary__line-height,
     @_button-width: @button-primary__width,
     @_button-margin: @button-primary__margin,
@@ -300,6 +303,9 @@
     @_button-gradient-direction: @button-primary__gradient-direction
 ) {
     .lib-button(
+        @_button-font-family: @_button-font-family,
+        @_button-font-size: @_button-font-size,
+        @_button-font-weight: @_button-font-weight,
         @_button-line-height: @_button-line-height,
         @_button-width: @_button-width,
         @_button-margin: @_button-margin,

--- a/lib/web/css/source/lib/variables/_buttons.less
+++ b/lib/web/css/source/lib/variables/_buttons.less
@@ -47,6 +47,9 @@
 @button__active__gradient-color-end: false;
 
 //  Primary button
+@button-primary__font-family: @button__font-family;
+@button-primary__font-size: @button__font-size;
+@button-primary__font-weight: @button__font-weight;
 @button-primary__line-height: false;
 @button-primary__width: false;
 @button-primary__margin: false;


### PR DESCRIPTION

### Description

Added new less variables for primary button to change font-weight, font-size, font-family without changing default button attributes.  

### Fixed Issues (if relevant)

1. magento/magento2#15832: No button-primary__font-weight


### Manual testing scenarios


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
