### PR TITLE
Wishlist: Remove unnecessary parameter from invoking toHtml() method

### DIFF
--- a/app/code/Magento/Wishlist/view/frontend/templates/item/list.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/list.phtml
@@ -19,7 +19,7 @@ $columns = $block->getColumns();
             <li data-row="product-item" class="product-item" id="item_<?= $block->escapeHtmlAttr($item->getId()) ?>">
                 <div class="product-item-info" data-container="product-grid">
                     <?php foreach ($columns as $column): ?>
-                        <?php $column->setItem($item); echo $column->toHtml($item);?>
+                        <?php $column->setItem($item); echo $column->toHtml();?>
                     <?php endforeach; ?>
                 </div>
             </li>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/list.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/list.phtml
@@ -19,7 +19,7 @@ $columns = $block->getColumns();
             <li data-row="product-item" class="product-item" id="item_<?= $block->escapeHtmlAttr($item->getId()) ?>">
                 <div class="product-item-info" data-container="product-grid">
                     <?php foreach ($columns as $column): ?>
-                        <?php $column->setItem($item); echo $column->toHtml();?>
+                        <?= $column->setItem($item)->toHtml();?>
                     <?php endforeach; ?>
                 </div>
             </li>


### PR DESCRIPTION
### Description
There's an extra parameter upon invoking the `toHtml()` method in the `Wishlist/view/frontend/templates/item/list.phtml` file. The original method call is the following:

```
 $column->toHtml($item);
```
which is not correct since `toHtml()` method of the `Magento\Wishlist\Block\Customer\Wishlist\Item\Column` has no additional parameters. The current PR removes the redundant parameter from invoking the method. 

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A