### PR TITLE
Fixed a minor styling issue in page footer in order to align the columns indentations

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -327,6 +327,9 @@
         .widget.block {
             .lib-css(margin, @indent__base 0);
         }
+        .links .widget.block {
+            margin: 0;
+        }
     }
 
     .no-display:extend(.abs-no-display all) {


### PR DESCRIPTION
Fixed a minor styling issue in page footer in order to align the columns indentations.

### Description
The issue can be reproduced in ``2.1-develop`` branch with sample data.

**Before:**
<img width="553" alt="screen shot 2018-06-11 at 8 09 25 pm" src="https://user-images.githubusercontent.com/11693779/41247945-2e80ef10-6db8-11e8-84b1-892c7cf3d490.png">

**After:**
<img width="580" alt="screen shot 2018-06-11 at 8 09 11 pm" src="https://user-images.githubusercontent.com/11693779/41247917-1d8e17d2-6db8-11e8-9d6b-c7be7f975ce4.png">

**Please note:** The issue has been already fixed for 2.2 and 2.3 versions.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
