### PR TITLE
[Forwardport] bugfix checkout page cart icon color

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
@@ -35,7 +35,11 @@
             .action {
                 &.showcart {
                     &:before {
-                        .lib-css(color, @primary__color);
+                        .lib-css(color, @button__color);
+                    }
+                    
+                    &:hover:before {
+                        .lib-css(color, @button__hover__color);
                     }
                 }
             }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16002
### Description
On smaller screens checkout page cart icon didn't had hover color and regular color was not implemented through correct variable. (Should be button color, not primary color)  


### Manual testing scenarios

1. Go to checkout page
2. scale screen down - to see cart icon
3. move mouse over cart icon

### Expected result
cart icon color changes 

### Actual result
cart icon color stays same

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
