### PR TITLE
[Forwardport] Attribute set save admin controller refactor

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -6,6 +6,9 @@
  */
 namespace Magento\Catalog\Controller\Adminhtml\Product\Set;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
 {
     /**
@@ -17,22 +20,46 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
      * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     protected $resultJsonFactory;
-
+    
+    /*
+     * @var \Magento\Eav\Model\Entity\Attribute\SetFactory
+     */
+    private $attributeSetFactory;
+    
+    /*
+     * @var \Magento\Framework\Filter\FilterManager
+     */
+    private $filterManager;
+    
+    /*
+     * @var \Magento\Framework\Json\Helper\Data
+     */
+    private $jsonHelper;
+    
     /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\Registry $coreRegistry
      * @param \Magento\Framework\View\LayoutFactory $layoutFactory
      * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
+     * @param \Magento\Eav\Model\Entity\Attribute\SetFactory $attributeSetFactory
+     * @param \Magento\Framework\Filter\FilterManager $filterManager
+     * @param \Magento\Framework\Json\Helper\Data $jsonHelper
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\Registry $coreRegistry,
         \Magento\Framework\View\LayoutFactory $layoutFactory,
-        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
+        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
+        \Magento\Eav\Model\Entity\Attribute\SetFactory $attributeSetFactory = null,
+        \Magento\Framework\Filter\FilterManager $filterManager = null,
+        \Magento\Framework\Json\Helper\Data $jsonHelper = null
     ) {
         parent::__construct($context, $coreRegistry);
         $this->layoutFactory = $layoutFactory;
         $this->resultJsonFactory = $resultJsonFactory;
+        $this->attributeSetFactory =  $attributeSetFactory ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Eav\Model\Entity\Attribute\SetFactory::class);
+        $this->filterManager =  $filterManager ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Filter\FilterManager::class);
+        $this->jsonHelper =  $jsonHelper ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Json\Helper\Data::class);
     }
 
     /**
@@ -65,16 +92,12 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         $isNewSet = $this->getRequest()->getParam('gotoEdit', false) == '1';
 
         /* @var $model \Magento\Eav\Model\Entity\Attribute\Set */
-        $model = $this->_objectManager->create(\Magento\Eav\Model\Entity\Attribute\Set::class)
-            ->setEntityTypeId($entityTypeId);
-
-        /** @var $filterManager \Magento\Framework\Filter\FilterManager */
-        $filterManager = $this->_objectManager->get(\Magento\Framework\Filter\FilterManager::class);
+        $model = $this->attributeSetFactory->create()->setEntityTypeId($entityTypeId);
 
         try {
             if ($isNewSet) {
                 //filter html tags
-                $name = $filterManager->stripTags($this->getRequest()->getParam('attribute_set_name'));
+                $name = $this->filterManager->stripTags($this->getRequest()->getParam('attribute_set_name'));
                 $model->setAttributeSetName(trim($name));
             } else {
                 if ($attributeSetId) {
@@ -85,11 +108,10 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
                         __('This attribute set no longer exists.')
                     );
                 }
-                $data = $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)
-                    ->jsonDecode($this->getRequest()->getPost('data'));
+                $data = $this->jsonHelper->jsonDecode($this->getRequest()->getPost('data'));
 
                 //filter html tags
-                $data['attribute_set_name'] = $filterManager->stripTags($data['attribute_set_name']);
+                $data['attribute_set_name'] = $this->filterManager->stripTags($data['attribute_set_name']);
 
                 $model->organizeData($data);
             }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -57,12 +57,12 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         parent::__construct($context, $coreRegistry);
         $this->layoutFactory = $layoutFactory;
         $this->resultJsonFactory = $resultJsonFactory;
-        $this->attributeSetFactory =  $attributeSetFactory ?: 
-                \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Eav\Model\Entity\Attribute\SetFactory::class);
-        $this->filterManager =  $filterManager ?: 
-                \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Filter\FilterManager::class);
-        $this->jsonHelper =  $jsonHelper ?: 
-                \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Json\Helper\Data::class);
+        $this->attributeSetFactory = $attributeSetFactory ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Eav\Model\Entity\Attribute\SetFactory::class);
+        $this->filterManager = $filterManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Filter\FilterManager::class);
+        $this->jsonHelper = $jsonHelper ?: \Magento\Framework\App\ObjectManager::getInstance()
+                    ->get(\Magento\Framework\Json\Helper\Data::class);
     }
 
     /**

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -62,7 +62,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         $this->filterManager = $filterManager ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Filter\FilterManager::class);
         $this->jsonHelper = $jsonHelper ?: \Magento\Framework\App\ObjectManager::getInstance()
-                    ->get(\Magento\Framework\Json\Helper\Data::class);
+            ->get(\Magento\Framework\Json\Helper\Data::class);
     }
 
     /**

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -57,9 +57,12 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         parent::__construct($context, $coreRegistry);
         $this->layoutFactory = $layoutFactory;
         $this->resultJsonFactory = $resultJsonFactory;
-        $this->attributeSetFactory =  $attributeSetFactory ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Eav\Model\Entity\Attribute\SetFactory::class);
-        $this->filterManager =  $filterManager ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Filter\FilterManager::class);
-        $this->jsonHelper =  $jsonHelper ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Json\Helper\Data::class);
+        $this->attributeSetFactory =  $attributeSetFactory ?: 
+                \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Eav\Model\Entity\Attribute\SetFactory::class);
+        $this->filterManager =  $filterManager ?: 
+                \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Filter\FilterManager::class);
+        $this->jsonHelper =  $jsonHelper ?: 
+                \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Json\Helper\Data::class);
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15990
Description
Remove direct use of object manager for admin attribute set save controller using constructor based dependency injection.

Manual testing scenarios
Created a new attribute set in admin under Stores -> Attribute Set -> Add Attribute Set.
Edit an existing attribute set under Stores -> Attribute Set