### PR TITLE
fix: prevent inline-block issue in name form due to space and font-size

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/widget/name.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/name.phtml
@@ -28,9 +28,7 @@ $suffix = $block->showSuffix();
 ?>
 <?php if (($prefix || $middle || $suffix) && !$block->getNoWrap()): ?>
 <div class="field required fullname <?= $block->escapeHtmlAttr($block->getContainerClassName()) ?>">
-    <label for="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>" class="label">
-        <span><?= $block->escapeHtml(__('Name')) ?></span>
-    </label>
+    <label for="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>" class="label"><span><?= $block->escapeHtml(__('Name')) ?></span></label>
     <div class="control">
         <fieldset class="fieldset fieldset-fullname">
         <div class="fields">
@@ -38,10 +36,7 @@ $suffix = $block->showSuffix();
 
     <?php if ($prefix): ?>
         <div class="field field-name-prefix<?php if ($block->isPrefixRequired()) echo ' required' ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('prefix')) ?>">
-                <span><?= $block->escapeHtml($block->getStoreLabel('prefix')) ?></span>
-            </label>
-
+            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('prefix')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('prefix')) ?></span></label>
             <div class="control">
                 <?php if ($block->getPrefixOptions() === false): ?>
                     <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('prefix')) ?>"
@@ -65,10 +60,7 @@ $suffix = $block->showSuffix();
         </div>
     <?php endif; ?>
         <div class="field field-name-firstname required">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>">
-                <span><?= $block->escapeHtml($block->getStoreLabel('firstname')) ?></span>
-            </label>
-
+            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('firstname')) ?></span></label>
             <div class="control">
                 <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>"
                        name="<?= $block->escapeHtmlAttr($block->getFieldName('firstname')) ?>"
@@ -80,10 +72,7 @@ $suffix = $block->showSuffix();
     <?php if ($middle): ?>
         <?php $isMiddlenameRequired = $block->isMiddlenameRequired(); ?>
         <div class="field field-name-middlename<?= $isMiddlenameRequired ? ' required' : '' ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('middlename')) ?>">
-                <span><?= $block->escapeHtml($block->getStoreLabel('middlename')) ?></span>
-            </label>
-
+            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('middlename')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('middlename')) ?></span></label>
             <div class="control">
                 <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('middlename')) ?>"
                        name="<?= $block->escapeHtmlAttr($block->getFieldName('middlename')) ?>"
@@ -94,10 +83,7 @@ $suffix = $block->showSuffix();
         </div>
     <?php endif; ?>
         <div class="field field-name-lastname required">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('lastname')) ?>">
-                <span><?= $block->escapeHtml($block->getStoreLabel('lastname')) ?></span>
-            </label>
-
+            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('lastname')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('lastname')) ?></span></label>
             <div class="control">
                 <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('lastname')) ?>"
                        name="<?= $block->escapeHtmlAttr($block->getFieldName('lastname')) ?>"
@@ -108,10 +94,7 @@ $suffix = $block->showSuffix();
         </div>
     <?php if ($suffix): ?>
         <div class="field field-name-suffix<?php if ($block->isSuffixRequired()) echo ' required' ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('suffix')) ?>">
-                <span><?= $block->escapeHtml($block->getStoreLabel('suffix')) ?></span>
-            </label>
-
+            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('suffix')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('suffix')) ?></span></label>
             <div class="control">
                 <?php if ($block->getSuffixOptions() === false): ?>
                     <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('suffix')) ?>"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/16047

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. open a page where the name form is eg /customer/account/edit/
2. compare the space between asterisk / required field indicator to other fields with the required field indicator

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
