### PR TITLE
Disabling sorting in glob and scandir functions for better performance

### DIFF
--- a/dev/tests/static/framework/Magento/TestFramework/Utility/ChangedFiles.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Utility/ChangedFiles.php
@@ -32,7 +32,7 @@ class ChangedFiles
         $fileUtilities = Files::init();
         if (isset($_ENV['INCREMENTAL_BUILD'])) {
             $phpFiles = [];
-            foreach (glob($changedFilesList) as $listFile) {
+            foreach (glob($changedFilesList, GLOB_NOSORT) as $listFile) {
                 $phpFiles = array_merge($phpFiles, file($listFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
             }
             array_walk(

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -392,7 +392,7 @@ class Files
             $configXmlPaths = array_merge($globPaths, $configXmlPaths);
             $files = [];
             foreach ($configXmlPaths as $xmlPath) {
-                $files = array_merge($files, glob($xmlPath));
+                $files = array_merge($files, glob($xmlPath, GLOB_NOSORT));
             }
             self::$_cache[$cacheKey] = $files;
         }

--- a/lib/internal/Magento/Framework/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Archive/Tar.php
@@ -252,7 +252,7 @@ class Tar extends \Magento\Framework\Archive\AbstractArchive implements \Magento
         $file = $this->_getCurrentFile();
 
         if (is_dir($file)) {
-            $dirFiles = scandir($file);
+            $dirFiles = scandir($file, SCANDIR_SORT_NONE);
 
             if (false === $dirFiles) {
                 throw new \Magento\Framework\Exception\LocalizedException(

--- a/lib/internal/Magento/Framework/Backup/Test/Unit/_files/app_dirs_rollback.php
+++ b/lib/internal/Magento/Framework/Backup/Test/Unit/_files/app_dirs_rollback.php
@@ -15,7 +15,7 @@ foreach ($appDirs as $dir) {
     }
 }
 
-$files = glob(TESTS_TEMP_DIR . '/Magento/Backup/data/*');
+$files = glob(TESTS_TEMP_DIR . '/Magento/Backup/data/*', GLOB_NOSORT);
 foreach ($files as $file) {
     unlink($file);
 }

--- a/lib/internal/Magento/Framework/Data/Collection/Filesystem.php
+++ b/lib/internal/Magento/Framework/Data/Collection/Filesystem.php
@@ -243,7 +243,7 @@ class Filesystem extends \Magento\Framework\Data\Collection
             $dir = [$dir];
         }
         foreach ($dir as $folder) {
-            if ($nodes = glob($folder . '/*')) {
+            if ($nodes = glob($folder . '/*', GLOB_NOSORT)) {
                 foreach ($nodes as $node) {
                     $collectedResult[] = $node;
                 }

--- a/lib/internal/Magento/Framework/Filesystem/Io/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/File.php
@@ -364,7 +364,7 @@ class File extends AbstractIo
             $dirCallback = $fileCallback;
         }
         if (is_dir($dir)) {
-            foreach (scandir($dir) as $item) {
+            foreach (scandir($dir, SCANDIR_SORT_NONE) as $item) {
                 if (!strcmp($item, '.') || !strcmp($item, '..')) {
                     continue;
                 }

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/ConfigTest.php
@@ -51,7 +51,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     protected function _initConfig(array $files = null)
     {
         if (null === $files) {
-            $files = glob(__DIR__ . '/_files/validation/positive/*/validation.xml');
+            $files = glob(__DIR__ . '/_files/validation/positive/*/validation.xml', GLOB_NOSORT);
         }
         $configFiles = [];
         foreach ($files as $path) {

--- a/setup/src/Magento/Setup/Fixtures/FixtureModel.php
+++ b/setup/src/Magento/Setup/Fixtures/FixtureModel.php
@@ -105,7 +105,7 @@ class FixtureModel
      */
     public function loadFixtures()
     {
-        $files = glob(__DIR__ . DIRECTORY_SEPARATOR . self::FIXTURE_PATTERN);
+        $files = glob(__DIR__ . DIRECTORY_SEPARATOR . self::FIXTURE_PATTERN, GLOB_NOSORT);
 
         foreach ($files as $file) {
             $file = basename($file, '.php');


### PR DESCRIPTION
Disabling sorting in glob and scandir functions for better performance

### Description
Disabling sorting in glob and scandir functions for better performance

https://www.exakat.io/php-likes-sorting/
