### PR TITLE
1163 Fix Functional Test Magento\Sales\Test\TestCase\CreateCreditMemoEntityTest::test with data set "CreateCreditMemoEntityTestVariation1_0"

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Sales/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/etc/testcase.xml
@@ -145,7 +145,8 @@
     <scenario name="CreateCreditMemoEntityTest" firstStep="setupConfiguration">
         <step name="setupConfiguration" module="Magento_Config" next="createOrder" />
         <step name="createOrder" module="Magento_Sales" next="createInvoice" />
-        <step name="createInvoice" module="Magento_Sales" next="createCreditMemo" />
+        <step name="createInvoice" module="Magento_Sales" next="createShipment" />
+        <step name="createShipment" module="Magento_Sales" next="createCreditMemo" />
         <step name="createCreditMemo" module="Magento_Sales" />
     </scenario>
 </config>


### PR DESCRIPTION
### Description

Add shipment step to CreateCreditMemoEntityTest to support new quantity decreasing behaviour.

Standard magento behaviour - product quantity decreasing immediately after place order, but with MSI quantity decreasing after shipment created, as MSI introduces additional property for product as 'salable quantity'. And after order placement, 'salable quantity' decreasing, not quantity itself(more about reservation mechanism [here](https://github.com/magento-engcom/msi/wiki/Reservations)). Quantity decreasing only after shipment creation. So, in order to pass CreateCreditMemoEntityTest with MSI, additional step with shipment creation should be added into test before assertions.

### Fixed Issues (if relevant)
1. magento/magento2#1163: Fix Functional Test Magento\Sales\Test\TestCase\CreateCreditMemoEntityTest::test with data set "CreateCreditMemoEntityTestVariation1_0"

### Manual testing scenarios
1. none

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
