### PR TITLE
Fix for cart rule for carts that have free and paid shipping products

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
@@ -65,9 +65,7 @@ class FreeShipping implements \Magento\Quote\Model\Quote\Address\FreeShippingInt
             $itemFreeShipping = (bool)$item->getFreeShipping();
             $addressFreeShipping = $addressFreeShipping && $itemFreeShipping;
 
-            if ($addressFreeShipping && !$item->getAddress()->getFreeShipping()) {
-                $item->getAddress()->setFreeShipping(true);
-            }
+            $shippingAddress->setFreeShipping($addressFreeShipping && $itemFreeShipping);
 
             /** Parent free shipping we apply to all children*/
             $this->applyToChildren($item, $itemFreeShipping);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
The previous code considered only the first item in the cart. Resulting in free shipping be offered when it should not be.

This implementation considers all items in the cart when deciding to offer free shipping.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2# #12573 Free Shipping Shopping Cart Rule doesn't work with UPS 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Adding products with paid and unpaid products to cart in various orders.
2. Completing Order

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)