### PR TITLE
toOptionArray() as f(toArray())

### DIFF
--- a/app/code/Magento/Config/Model/Config/Source/Yesno.php
+++ b/app/code/Magento/Config/Model/Config/Source/Yesno.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Config\Model\Config\Source;
 
 /**
@@ -11,6 +12,8 @@ namespace Magento\Config\Model\Config\Source;
  */
 class Yesno implements \Magento\Framework\Option\ArrayInterface
 {
+    private $optionArray = null;
+
     /**
      * Options getter
      *
@@ -18,7 +21,20 @@ class Yesno implements \Magento\Framework\Option\ArrayInterface
      */
     public function toOptionArray()
     {
-        return [['value' => 1, 'label' => __('Yes')], ['value' => 0, 'label' => __('No')]];
+        if ($this->optionArray === null) {
+            $array = $this->toArray();
+            $array = array_reverse($array, true);
+
+            $optionArray = [];
+
+            foreach ($array as $value => $label) {
+                $optionArray[] = $this->toOption($value, $label);
+            }
+
+            $this->optionArray = $optionArray;
+        }
+
+        return $this->optionArray;
     }
 
     /**
@@ -29,5 +45,18 @@ class Yesno implements \Magento\Framework\Option\ArrayInterface
     public function toArray()
     {
         return [0 => __('No'), 1 => __('Yes')];
+    }
+
+    /**
+     * @param $value
+     * @param $label
+     * @return array
+     */
+    private function toOption($value, $label)
+    {
+        return [
+            'value' => $value,
+            'label' => $label
+        ];
     }
 }

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Source/YesNoTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Source/YesNoTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Config\Test\Unit\Model\Config\Source;
+
+use Magento\Config\Model\Config\Source\Yesno;
+
+/**
+ * Test class for \Magento\Config\Model\Config\Source\Yesno
+ */
+class YesNoTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Yesno
+     */
+    private $model;
+
+    /**
+     * @var null|array
+     */
+    private $expectedToOptionArray = null;
+
+    protected function setUp()
+    {
+        $this->model = new Yesno();
+    }
+
+    /**
+     * @return array
+     */
+    private function getExpectedToOptionArray()
+    {
+        if ($this->expectedToOptionArray === null) {
+            $this->expectedToOptionArray = [
+                ['value' => 1, 'label' => __('Yes')],
+                ['value' => 0, 'label' => __('No')]
+            ];
+        }
+
+        return $this->expectedToOptionArray;
+    }
+
+    public function testToOptionArray()
+    {
+        $expected = $this->getExpectedToOptionArray();
+        $this->assertEquals($expected, $this->model->toOptionArray());
+    }
+
+    /**
+     * @depends testToOptionArray
+     */
+    public function testToOptionArrayTwice()
+    {
+        $expected = $this->getExpectedToOptionArray();
+        $this->assertEquals($expected, $this->model->toOptionArray());
+    }
+
+    public function testToArray()
+    {
+        $expected = [0 => __('No'), 1 => __('Yes')];
+        $this->assertEquals($expected, $this->model->toArray());
+    }
+}


### PR DESCRIPTION

### Description
Initially I just wanted to make `toOptionArray()` as function based on `toArray()` to make last as "datasource" and prevent Yes/No strings duplicates. But in result class become quite difficult.
Therefore I'm not sure that it really good refactoring case and should be merged. I leave it to your discretion :)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
