### PR TITLE
15950-Set out of stock status when import product though CSV

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
+++ b/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
@@ -80,6 +80,9 @@ class StockStateProvider implements StockStateProviderInterface
         ) {
             return false;
         }
+        if ($stockItem->getQty() > 0 && !$stockItem->getIsInStock()) {
+            return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

### Description
	This pull request is created to set the out of stock status with the quantity greater than zero when importing the products through CSV.

### Fixed Issues
	magento/magento2 #15950 : Magento2 CSV product import qty and is_in_stock not working correct

### Manual testing scenarios
    Importing the simple products through CSV with the quantity greater than zero and is_in_stock field value is zero.
	
	Path to import products:
		1) Choose System -> Import under Data transfer
		2) Choose Products from the Entity dropdown
		3) Choose Add/Update from the Import Behavior dropdown
		4) Keep other fields as default
		5) Import the products
		6)  Now check the product status is out of stock with the quantity as given in CSV.