### PR TITLE
[Forwordport2.2] Fix incorrect type hinting in PHPDocs

### DIFF
--- a/app/code/Magento/Backend/Block/Dashboard/Graph.php
+++ b/app/code/Magento/Backend/Block/Dashboard/Graph.php
@@ -331,7 +331,7 @@ class Graph extends \Magento\Backend\Block\Dashboard\AbstractDashboard
             $thisdataarray = $serie;
             if ($this->_encoding == "s") {
                 // SIMPLE ENCODING
-                for ($j = 0; $j < sizeof($thisdataarray); $j++) {
+                for ($j = 0, $jMax = sizeof($thisdataarray); $j < $jMax; $j++) {
                     $currentvalue = $thisdataarray[$j];
                     if (is_numeric($currentvalue)) {
                         $ylocation = round(
@@ -344,7 +344,7 @@ class Graph extends \Magento\Backend\Block\Dashboard\AbstractDashboard
                 }
             } else {
                 // EXTENDED ENCODING
-                for ($j = 0; $j < sizeof($thisdataarray); $j++) {
+                for ($j = 0, $jMax = sizeof($thisdataarray); $j < $jMax; $j++) {
                     $currentvalue = $thisdataarray[$j];
                     if (is_numeric($currentvalue)) {
                         if ($yrange) {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -325,7 +325,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
      *
      * @param Node|array $node
      * @param int $level
-     * @return string
+     * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
@@ -144,7 +144,7 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Category\Tree
      *
      * @param \Magento\Framework\Data\Tree\Node|array $node
      * @param int $level
-     * @return string
+     * @return array
      */
     protected function _getNodeJson($node, $level = 0)
     {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Fieldset/Element.php
@@ -21,7 +21,7 @@ class Element extends \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Eleme
     /**
      * Retrieve data object related with form
      *
-     * @return \Magento\Catalog\Model\Product || \Magento\Catalog\Model\Category
+     * @return \Magento\Catalog\Model\Product|\Magento\Catalog\Model\Category
      */
     public function getDataObject()
     {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Grid.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Grid.php
@@ -101,8 +101,7 @@ class Grid extends AbstractGrid
                 'type' => 'options',
                 'options' => ['1' => __('Yes'), '0' => __('No')],
                 'align' => 'center'
-            ],
-            'is_user_defined'
+            ]
         );
 
         $this->_eventManager->dispatch('product_attribute_grid_build', ['grid' => $this]);

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Attributes/Search.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Attributes/Search.php
@@ -81,7 +81,7 @@ class Search extends \Magento\Backend\Block\Widget
      *
      * @param string $labelPart
      * @param int $templateId
-     * @return \Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection
+     * @return array
      */
     public function getSuggestedAttributes($labelPart, $templateId = null)
     {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
@@ -69,7 +69,7 @@ class Link extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return string
+     * @return array
      */
     protected function getLinkParams()
     {

--- a/app/code/Magento/Catalog/Block/Category/Rss/Link.php
+++ b/app/code/Magento/Catalog/Block/Category/Rss/Link.php
@@ -62,7 +62,7 @@ class Link extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return string
+     * @return array
      */
     protected function getLinkParams()
     {

--- a/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -195,7 +195,7 @@ class AbstractProduct extends \Magento\Framework\View\Element\Template
      * Gets minimal sales quantity
      *
      * @param \Magento\Catalog\Model\Product $product
-     * @return int|null
+     * @return float|null
      */
     public function getMinimalQty($product)
     {

--- a/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
@@ -178,7 +178,7 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
      * Returns price converted to current currency rate
      *
      * @param float $price
-     * @return float
+     * @return float|string
      */
     public function getCurrencyPrice($price)
     {

--- a/app/code/Magento/Catalog/Block/Rss/Product/Special.php
+++ b/app/code/Magento/Catalog/Block/Rss/Product/Special.php
@@ -107,7 +107,7 @@ class Special extends \Magento\Framework\View\Element\AbstractBlock implements D
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getRssData()
     {

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/PriceTest.php
@@ -202,7 +202,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(is_array($tpArray));
         $this->assertEquals(sizeof($tps), sizeof($tpArray));
 
-        for ($i = 0; $i < sizeof($tps); $i++) {
+        for ($i = 0, $iMax = sizeof($tps); $i < $iMax; $i++) {
             $tpData = $tpArray[$i];
             $this->assertEquals($expectedWebsiteId, $tpData['website_id'], 'Website Id does not match');
             $this->assertEquals($tps[$i]->getValue(), $tpData['price'], 'Price/Value does not match');
@@ -233,7 +233,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals(50, $tpRest->getExtensionAttributes()->getPercentageValue());
         }
 
-        for ($i = 0; $i < sizeof($tps); $i++) {
+        for ($i = 0, $iMax = sizeof($tps); $i < $iMax; $i++) {
             $this->assertEquals(
                 $tps[$i]->getValue(),
                 $tpRests[$i]->getValue(),

--- a/app/code/Magento/Payment/Model/Method/Cc.php
+++ b/app/code/Magento/Payment/Model/Method/Cc.php
@@ -297,7 +297,7 @@ class Cc extends \Magento\Payment\Model\Method\AbstractMethod
         $cardNumber = strrev($ccNumber);
         $numSum = 0;
 
-        for ($i = 0; $i < strlen($cardNumber); $i++) {
+        for ($i = 0, $iMax = strlen($cardNumber); $i < $iMax; $i++) {
             $currentNum = substr($cardNumber, $i, 1);
 
             /**

--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -186,7 +186,7 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
         );
 
         $characters = [];
-        for ($i = 0; $i < strlen($drawingString); $i++) {
+        for ($i = 0, $iMax = strlen($drawingString); $i < $iMax; $i++) {
             $characters[] = ord($drawingString[$i++]) << 8 | ord($drawingString[$i]);
         }
         $glyphs = $font->glyphNumbersForCharacters($characters);

--- a/app/code/Magento/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Item.php
@@ -146,8 +146,7 @@ class Item extends AbstractModel implements ShipmentItemInterface
      * Declare qty
      *
      * @param float $qty
-     * @return \Magento\Sales\Model\Order\Shipment\Item
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return $this
      */
     public function setQty($qty)
     {
@@ -159,7 +158,6 @@ class Item extends AbstractModel implements ShipmentItemInterface
      * Applying qty to order item
      *
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function register()
     {

--- a/app/code/Magento/SalesInventory/Model/Order/ReturnProcessor.php
+++ b/app/code/Magento/SalesInventory/Model/Order/ReturnProcessor.php
@@ -10,6 +10,8 @@ use Magento\Sales\Api\Data\OrderInterface;
 
 /**
  * Class ReturnProcessor
+ *
+ * @api
  */
 class ReturnProcessor
 {

--- a/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
@@ -8,7 +8,6 @@ namespace Magento\Ui\Model\Export;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Ui\Component\MassAction\Filter;
 
 /**
@@ -17,7 +16,7 @@ use Magento\Ui\Component\MassAction\Filter;
 class ConvertToCsv
 {
     /**
-     * @var WriteInterface
+     * @var DirectoryList
      */
     protected $directory;
 

--- a/app/code/Magento/Ui/Model/Export/ConvertToXml.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToXml.php
@@ -12,7 +12,6 @@ use Magento\Framework\Convert\Excel;
 use Magento\Framework\Convert\ExcelFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Ui\Component\MassAction\Filter;
 
 /**
@@ -21,7 +20,7 @@ use Magento\Ui\Component\MassAction\Filter;
 class ConvertToXml
 {
     /**
-     * @var WriteInterface
+     * @var DirectoryList
      */
     protected $directory;
 

--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -97,6 +97,16 @@ class Instance extends \Magento\Framework\Model\AbstractModel
     protected $_relatedCacheTypes;
 
     /**
+     * @var \Magento\Catalog\Model\Product\Type
+     */
+    protected $_productType;
+
+    /**
+     * @var \Magento\Widget\Model\Config\Reader
+     */
+    protected $_reader;
+
+    /**
      * @var \Magento\Framework\Escaper
      */
     protected $_escaper;

--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -22,6 +22,7 @@ use Magento\Framework\Serialize\Serializer\Json;
  * @method int getThemeId()
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  * @since 100.0.2
  */
 class Instance extends \Magento\Framework\Model\AbstractModel

--- a/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml
+++ b/app/code/Magento/Widget/Test/Unit/Model/_files/widget.xml
@@ -41,7 +41,7 @@
             </parameter>
             <parameter name="id_path" xsi:type="block" visible="true" required="true" sort_order="10">
                 <label translate="true">Product</label>
-                <block class="Magento\Backend\Block\Catalog\Product\Widget\Chooser">
+                <block class="Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser">
                     <data>
                         <item name="button" xsi:type="array">
                             <item name="open" xsi:type="string" translate="true">Select Product...</item>

--- a/app/code/Magento/Widget/Test/Unit/Model/_files/widget_config.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/_files/widget_config.php
@@ -48,7 +48,7 @@ return [
                 'type' => 'label',
                 '@' => ['type' => 'complex'],
                 'helper_block' => [
-                    'type' => \Magento\Backend\Block\Catalog\Product\Widget\Chooser::class,
+                    'type' => \Magento\Catalog\Block\Adminhtml\Product\Widget\Chooser::class,
                     'data' => ['button' => ['open' => 'Select Product...']],
                 ],
                 'visible' => '1',

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_with_shipping_and_invoice.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_with_shipping_and_invoice.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+use Magento\Sales\Model\Order\ShipmentFactory;
+
 require 'order.php';
 
 $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
@@ -36,4 +39,10 @@ $invoice->register();
 
 $order->setIsInProcess(true);
 
-$transaction->addObject($invoice)->addObject($order)->save();
+$items = [];
+foreach ($order->getItems() as $orderItem) {
+    $items[$orderItem->getId()] = $orderItem->getQtyOrdered();
+}
+$shipment = $objectManager->get(ShipmentFactory::class)->create($order, $items);
+
+$transaction->addObject($invoice)->addObject($shipment)->addObject($order)->save();

--- a/lib/internal/Magento/Framework/App/Test/Unit/Language/DictionaryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Language/DictionaryTest.php
@@ -52,7 +52,7 @@ class DictionaryTest extends \PHPUnit\Framework\TestCase
         }
 
         $file = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\File\ReadInterface::class);
-        for ($i = 0; $i < count($data); $i++) {
+        for ($i = 0, $iMax = count($data); $i < $iMax; $i++) {
             $file->expects($this->at($i))->method('readCsv')->will($this->returnValue($data[$i]));
         }
         $file->expects($this->at($i))->method('readCsv')->will($this->returnValue(false));

--- a/lib/internal/Magento/Framework/Archive.php
+++ b/lib/internal/Magento/Framework/Archive.php
@@ -96,7 +96,7 @@ class Archive
     {
         $archivers = $this->_getArchivers($destination);
         $interimSource = '';
-        for ($i = 0; $i < count($archivers); $i++) {
+        for ($i = 0, $iMax = count($archivers); $i < $iMax; $i++) {
             if ($i == count($archivers) - 1) {
                 $packed = $destination;
             } else {

--- a/lib/internal/Magento/Framework/Filesystem/Io/AbstractIo.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/AbstractIo.php
@@ -80,7 +80,7 @@ abstract class AbstractIo implements IoInterface
         $pathParts = explode("/", $pathTokP);
         $realPathParts = [];
 
-        for ($i = 0, $realPathParts = []; $i < count($pathParts); $i++) {
+        for ($i = 0, $realPathParts = [], $iMax = count($pathParts); $i < $iMax; $i++) {
             if ($pathParts[$i] == '.') {
                 continue;
             } elseif ($pathParts[$i] == '..') {

--- a/lib/internal/Magento/Framework/Filter/Template.php
+++ b/lib/internal/Magento/Framework/Filter/Template.php
@@ -313,7 +313,7 @@ class Template implements \Zend_Filter_Interface
         $stackVars = $tokenizer->tokenize();
         $result = $default;
         $last = 0;
-        for ($i = 0; $i < count($stackVars); $i++) {
+        for ($i = 0, $iMax = count($stackVars); $i < $iMax; $i++) {
             if ($i == 0 && isset($this->templateVars[$stackVars[$i]['name']])) {
                 // Getting of template value
                 $stackVars[$i]['variable'] = & $this->templateVars[$stackVars[$i]['name']];

--- a/lib/internal/Magento/Framework/Profiler/Driver/Standard/Stat.php
+++ b/lib/internal/Magento/Framework/Profiler/Driver/Standard/Stat.php
@@ -200,7 +200,7 @@ class Stat
 
         $prevTimerId = $timerIds[0];
         $result = [$prevTimerId];
-        for ($i = 1; $i < count($timerIds); $i++) {
+        for ($i = 1, $iMax = count($timerIds); $i < $iMax; $i++) {
             $timerId = $timerIds[$i];
             /* Skip already added timer */
             if (!$timerId) {
@@ -209,7 +209,7 @@ class Stat
             /* Loop over all timers that need to be closed under previous timer */
             while (strpos($timerId, $prevTimerId . Profiler::NESTING_SEPARATOR) !== 0) {
                 /* Add to result all timers nested in the previous timer */
-                for ($j = $i + 1; $j < count($timerIds); $j++) {
+                for ($j = $i + 1, $jMax = count($timerIds); $j < $jMax; $j++) {
                     if (strpos($timerIds[$j], $prevTimerId . Profiler::NESTING_SEPARATOR) === 0) {
                         $result[] = $timerIds[$j];
                         /* Mark timer as already added */

--- a/lib/internal/Magento/Framework/System/Ftp.php
+++ b/lib/internal/Magento/Framework/System/Ftp.php
@@ -58,7 +58,7 @@ class Ftp
         $dir = explode("/", $path);
         $path = "";
         $ret = true;
-        for ($i = 0; $i < count($dir); $i++) {
+        for ($i = 0, $iMax = count($dir); $i < $iMax; $i++) {
             $path .= "/" . $dir[$i];
             if (!@ftp_chdir($this->_conn, $path)) {
                 @ftp_chdir($this->_conn, "/");

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -31,7 +31,7 @@ class Html extends AbstractAdapter
 
         $results = [];
         preg_match_all(Filter::CONSTRUCTION_PATTERN, $data, $results, PREG_SET_ORDER);
-        for ($i = 0; $i < count($results); $i++) {
+        for ($i = 0, $iMax = count($results); $i < $iMax; $i++) {
             if ($results[$i][1] === Filter::TRANS_DIRECTIVE_NAME) {
                 $directive = [];
                 if (preg_match(Filter::TRANS_DIRECTIVE_REGEX, $results[$i][2], $directive) !== 1) {
@@ -43,7 +43,7 @@ class Html extends AbstractAdapter
         }
 
         preg_match_all(self::HTML_FILTER, $data, $results, PREG_SET_ORDER);
-        for ($i = 0; $i < count($results); $i++) {
+        for ($i = 0, $iMax = count($results); $i < $iMax; $i++) {
             if (!empty($results[$i]['value'])) {
                 $this->_addPhrase($results[$i]['value']);
             }

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Js.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Js.php
@@ -22,7 +22,7 @@ class Js extends AbstractAdapter
             $fileRow = fgets($fileHandle, 4096);
             $results = [];
             preg_match_all('/mage\.__\(\s*([\'"])(.*?[^\\\])\1.*?[),]/', $fileRow, $results, PREG_SET_ORDER);
-            for ($i = 0; $i < count($results); $i++) {
+            for ($i = 0, $iMax = count($results); $i < $iMax; $i++) {
                 if (isset($results[$i][2])) {
                     $quote = $results[$i][1];
                     $this->_addPhrase($quote . $results[$i][2] . $quote, $lineNumber);
@@ -30,7 +30,7 @@ class Js extends AbstractAdapter
             }
 
             preg_match_all('/\\$t\(\s*([\'"])(.*?[^\\\])\1.*?[),]/', $fileRow, $results, PREG_SET_ORDER);
-            for ($i = 0; $i < count($results); $i++) {
+            for ($i = 0, $iMax = count($results); $i < $iMax; $i++) {
                 if (isset($results[$i][2])) {
                     $quote = $results[$i][1];
                     $this->_addPhrase($quote . $results[$i][2] . $quote, $lineNumber);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15619
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Incorrect PHPdoc causes warnings in IDE.

Changes applied:

1. Changed the return type for **setQty** method to the type it actually returns.
2. Removed the hint for newer thrown LocalizedException in PHPDocs of **register** and **setQty** methods.


### Fixed Issues
1. magento/magento2#13992: Incorrect phpdoc should be Shipment\Item not Invoice\Item


### Manual testing scenarios
1. This is not necessary, this just resolves warnings in the IDE. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
