### PR TITLE
Fix Date Range Filter Error In Admin

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
@@ -27,7 +27,8 @@ define([
                 },
                 date: {
                     component: 'Magento_Ui/js/form/element/date',
-                    dateFormat: 'MM/dd/YYYY'
+                    dateFormat: 'MM/dd/YYYY',
+                    inputDateFormat: 'MM/dd/YYYY'
                 },
                 text: {
                     component: 'Magento_Ui/js/form/element/abstract'


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fix for **Issue 13428:** Date range filter in admin ui grid displaying "Invalid date" after reload
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://github.com/magento/magento2/issues/13428
Date range filter in admin ui grid displaying "Invalid date" after reload
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13428:Date range filter in admin ui grid displaying "Invalid date" after reload
2. ...

### Manual testing scenarios
1. Create a new sales order, if there are no sales orders already
2. Go to the orders admin grid
3. Filter the grid by "Order Date"
4. After the grid has been filtered by the date range, reload/refresh the page

### Actual result
1. Date range is properly displayed in the "Active filters" area

### Previous result
1. Date range is displayed improperly, including an "Invalid date" message

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
