### PR TITLE
Modules sort order in config.php is being inconsistent #16116

### DIFF
--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -133,9 +133,11 @@ class Loader
         ksort($origList);
         $expanded = [];
         foreach ($origList as $moduleName => $value) {
+            $sequence = $this->expandSequence($origList, $moduleName);
+            asort($sequence);
             $expanded[] = [
                 'name' => $moduleName,
-                'sequence' => $this->expandSequence($origList, $moduleName),
+                'sequence' => $sequence,
             ];
         }
 


### PR DESCRIPTION
### Description
Modules sort order in config.php is being inconsistent when no changes being made and running setup:upgrade

### Fixed Issues
1. magento/magento2#16116: Modules sort order in config.php is being inconsistent when no changes being made;
2. magento/magento2#8479: Sequence of module load order should be deterministic.

### Manual testing scenarios
1. Install any Magento 2.*;
2. Run php bin/magento setup:upgrade;
3. Run cp app/etc/config.php app/etc/config.php_t1;
4. Run php bin/magento setup:upgrade again;
5. Run cp app/etc/config.php app/etc/config.php_t2;
6. Run diff app/etc/config.php_t1 app/etc/config.php_t2;
7. Check is there is/is no diff.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
