### PR TITLE
FIX for apparently random API failures while using array types

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -523,7 +523,7 @@ class TypeProcessor
         if ($type == 'array') {
             // try to determine class, if it's array of objects
             $docBlock = $param->getDeclaringFunction()->getDocBlock();
-            $pattern = "/\@param\s+([\w\\\_]+\[\])\s+\\\${$param->getName()}\n/";
+            $pattern = "/\@param\s+([\w\\\_]+\[\])\s+\\\${$param->getName()}[\n\r]/";
             $matches = [];
             if (preg_match($pattern, $docBlock->getContents(), $matches)) {
                 return $matches[1];


### PR DESCRIPTION
### Description
Magento2 web-api is based on the Interface doctype, but if the developer is using CR+LF end-of-line, the `\Magento\Framework\Reflection\TypeProcessor` class is not able to determine the class name on array types.

This was caused by a wrong regex non including `\r` in `\Magento\Framework\Reflection\TypeProcessor::getParamType`.

**Additional note:** Magento 2.2-develop seems to be not affected by this.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
