### PR TITLE
array_push(...) calls behaving as '$array[] = ...', $array[] = works faster than invoking functions in PHP

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -394,9 +394,9 @@ class AttributeMerger
         ]];
         foreach ($countryOptions as $countryOption) {
             if (empty($countryOption['value']) || in_array($countryOption['value'], $this->topCountryCodes)) {
-                array_push($headOptions, $countryOption);
+                $headOptions[] = $countryOption;
             } else {
-                array_push($tailOptions, $countryOption);
+                $tailOptions[] = $countryOption;
             }
         }
         return array_merge($headOptions, $tailOptions);

--- a/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
@@ -141,9 +141,9 @@ class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutP
         ]];
         foreach ($countryOptions as $countryOption) {
             if (empty($countryOption['value']) || in_array($countryOption['value'], $topCountryCodes)) {
-                array_push($headOptions, $countryOption);
+                $headOptions[] = $countryOption;
             } else {
-                array_push($tailOptions, $countryOption);
+                $tailOptions[] = $countryOption;
             }
         }
         return array_merge($headOptions, $tailOptions);

--- a/app/code/Magento/Deploy/Package/Processor/PreProcessor/Less.php
+++ b/app/code/Magento/Deploy/Package/Processor/PreProcessor/Less.php
@@ -188,7 +188,7 @@ class Less implements ProcessorInterface
             if (!isset($this->map[$filePath])) {
                 $this->map[$filePath] = [];
             }
-            array_push($this->map[$filePath], $resolvedMapPath);
+            $this->map[$filePath][] = $resolvedMapPath;
             $this->buildMap($resolvedMapPath, $packagePath, $contentType);
         };
         if ($content) {

--- a/app/code/Magento/ImportExport/Model/Report/Csv.php
+++ b/app/code/Magento/ImportExport/Model/Report/Csv.php
@@ -77,7 +77,7 @@ class Csv implements ReportProcessorInterface
         $outputCsv = $this->createOutputCsvModel($outputFileName);
 
         $columnsName = $sourceCsv->getColNames();
-        array_push($columnsName, self::REPORT_ERROR_COLUMN_NAME);
+        $columnsName[] = self::REPORT_ERROR_COLUMN_NAME;
         $outputCsv->setHeaderCols($columnsName);
 
         foreach ($sourceCsv as $rowNum => $rowData) {

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -2022,7 +2022,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         foreach ($this->getMessages() as $message) {
             /* @var $error \Magento\Framework\Message\AbstractMessage */
             if ($message->getType() == \Magento\Framework\Message\MessageInterface::TYPE_ERROR) {
-                array_push($errors, $message);
+                $errors[] = $message;
             }
         }
         return $errors;

--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -508,7 +508,7 @@ class Validator extends \Magento\Framework\Model\AbstractModel
             foreach ($items as $itemKey => $itemValue) {
                 if ($rule->getActions()->validate($itemValue)) {
                     unset($items[$itemKey]);
-                    array_push($itemsSorted, $itemValue);
+                    $itemsSorted[] = $itemValue;
                 }
             }
         }

--- a/lib/internal/Magento/Framework/Webapi/Rest/Response/FieldsFilter.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Response/FieldsFilter.php
@@ -106,9 +106,9 @@ class FieldsFilter
             }
             switch ($filterString[$position]) {
                 case '[':
-                    array_push($parent, $currentElement);
+                    $parent[] = $currentElement;
                     // push current field in stack and initialize current
-                    array_push($stack, $current);
+                    $stack[] = $current;
                     $current = [];
                     break;
 

--- a/setup/src/Magento/Setup/Module/Dependency/Circular.php
+++ b/setup/src/Magento/Setup/Module/Dependency/Circular.php
@@ -118,7 +118,7 @@ class Circular
             return;
         }
         $this->circularDependencies[$path] = $modules;
-        array_push($modules, array_shift($modules));
+        $modules[] = array_shift($modules);
         $this->buildCircular($modules);
     }
 
@@ -133,7 +133,7 @@ class Circular
         $dependenciesByModule = [];
         foreach ($circularDependencies as $circularDependency) {
             $module = $circularDependency[0];
-            array_push($circularDependency, $module);
+            $circularDependency[] = $module;
             $dependenciesByModule[$module][] = $circularDependency;
         }
 

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlInterceptorScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlInterceptorScanner.php
@@ -42,9 +42,9 @@ class XmlInterceptorScanner implements ScannerInterface
             $attributes = $entityNode->attributes;
             $type = $attributes->getNamedItem('type');
             if ($type !== null) {
-                array_push($output, $type->nodeValue);
+                $output[] = $type->nodeValue;
             } else {
-                array_push($output, $attributes->getNamedItem('name')->nodeValue);
+                $output[] = $attributes->getNamedItem('name')->nodeValue;
             }
         }
         return $output;
@@ -80,7 +80,7 @@ class XmlInterceptorScanner implements ScannerInterface
                 $this->_handleControllerClassName($entityName);
             }
             if (class_exists($entityName) || interface_exists($entityName)) {
-                array_push($filteredEntities, $entityName . '\\Interceptor');
+                $filteredEntities[] = $entityName . '\\Interceptor';
             }
         }
         return $filteredEntities;

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlScanner.php
@@ -72,7 +72,7 @@ class XmlScanner implements ScannerInterface
             }
             if (false === $isClassExists) {
                 if (class_exists($entityName) || interface_exists($entityName)) {
-                    array_push($filteredEntities, $className);
+                    $filteredEntities[] = $className;
                 } else {
                     $this->_log->add(
                         \Magento\Setup\Module\Di\Compiler\Log\Log::CONFIGURATION_ERROR,


### PR DESCRIPTION
### Description
array_push(...) calls behaving as '$array[] = ...', $array[] = works faster than invoking functions in PHP

See note in PHP documentation:

http://php.net/manual/en/function.array-push.php

Note: If you use array_push() to add one element to the array, it's better to use $array[] = because in that way there is no overhead of calling a function. 