### PR TITLE
Insecure 'uniqid(...)' usage (Insufficient Entropy Vulnerability)

### DIFF
--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/TunnelTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/TunnelTest.php
@@ -46,7 +46,7 @@ class TunnelTest extends \PHPUnit\Framework\TestCase
 
     public function testTunnelAction()
     {
-        $fixture = uniqid();
+        $fixture = uniqid('', true);
         $this->_request->expects($this->at(0))
             ->method('getParam')
             ->with('ga')
@@ -113,7 +113,7 @@ class TunnelTest extends \PHPUnit\Framework\TestCase
 
     public function testTunnelAction503()
     {
-        $fixture = uniqid();
+        $fixture = uniqid('', true);
         $this->_request->expects($this->at(0))
             ->method('getParam')
             ->with('ga')

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/create/items/renderer.phtml
@@ -186,7 +186,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/view/items/renderer.phtml
@@ -113,7 +113,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/create/items/renderer.phtml
@@ -172,7 +172,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/view/items/renderer.phtml
@@ -114,7 +114,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['protoype'], function(){
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
@@ -183,7 +183,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/create/items/renderer.phtml
@@ -80,7 +80,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/view/items/renderer.phtml
@@ -75,7 +75,7 @@
                     <?php else: ?>
                         <?= $block->truncateString($option['value'], 55, '', $_remainder) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                            ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                             <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -217,7 +217,7 @@ class ListProduct extends AbstractProduct implements IdentityInterface
         $block = $this->getToolbarFromLayout();
 
         if (!$block) {
-            $block = $this->getLayout()->createBlock($this->_defaultToolbarBlock, uniqid(microtime()));
+            $block = $this->getLayout()->createBlock($this->_defaultToolbarBlock, uniqid(microtime(), true));
         }
 
         return $block;

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -479,7 +479,7 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
                 ->getMock();
             $productMock->expects($this->once())->method('load');
             $productMock->expects($this->atLeastOnce())->method('getId')->willReturn($i);
-            $productMock->expects($this->atLeastOnce())->method('getSku')->willReturn($i . uniqid());
+            $productMock->expects($this->atLeastOnce())->method('getSku')->willReturn($i . uniqid('', true));
             $productMocks[] = $productMock;
         }
 

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
@@ -9,7 +9,7 @@
 ?>
 
 <?php
-$_htmlId = $block->getHtmlId() ? $block->getHtmlId() : '_' . uniqid();
+$_htmlId = $block->getHtmlId() ? $block->getHtmlId() : '_' . uniqid('', true);
 $_colspan = $block->isAddAfter() ? 2 : 1;
 ?>
 

--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -801,7 +801,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel
      */
     public function getRandomConfirmationKey()
     {
-        return md5(uniqid());
+        return md5(uniqid('', true));
     }
 
     /**

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/creditmemo/name.phtml
@@ -21,7 +21,7 @@
             <?php else: ?>
                 <?= $block->truncateString($_option['value'], 55, '', $_remainder) ?>
                 <?php if ($_remainder):?>
-                    ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                    ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                     <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/invoice/name.phtml
@@ -21,7 +21,7 @@
             <?php else: ?>
                 <?= $block->truncateString($_option['value'], 55, '', $_remainder) ?>
                 <?php if ($_remainder):?>
-                    ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                    ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                     <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/name.phtml
@@ -24,7 +24,7 @@
             <?php else: ?>
                 <?= $block->truncateString($_option['value'], 55, '', $_remainder) ?>
                 <?php if ($_remainder):?>
-                    ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
+                    ... <span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_remainder ?></span>
                     <script>
 require(['prototype'], function(){
 

--- a/app/code/Magento/ImportExport/Model/Export/Adapter/AbstractAdapter.php
+++ b/app/code/Magento/ImportExport/Model/Export/Adapter/AbstractAdapter.php
@@ -50,7 +50,7 @@ abstract class AbstractAdapter
     ) {
         $this->_directoryHandle = $filesystem->getDirectoryWrite($destinationDirectoryCode);
         if (!$destination) {
-            $destination = uniqid('importexport_');
+            $destination = uniqid('importexport_', true);
             $this->_directoryHandle->touch($destination);
         }
         if (!is_string($destination)) {

--- a/app/code/Magento/Integration/Test/Unit/Model/Oauth/ConsumerTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Oauth/ConsumerTest.php
@@ -110,8 +110,8 @@ class ConsumerTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->validDataArray = [
-            'key' => md5(uniqid()),
-            'secret' => md5(uniqid()),
+            'key' => md5(uniqid('', true)),
+            'secret' => md5(uniqid('', true)),
             'callback_url' => 'http://example.com/callback',
             'rejected_callback_url' => 'http://example.com/rejectedCallback'
         ];

--- a/app/code/Magento/Paypal/Model/Report/Settlement.php
+++ b/app/code/Magento/Paypal/Model/Report/Settlement.php
@@ -250,7 +250,7 @@ class Settlement extends \Magento\Framework\Model\AbstractModel
         $fetched = 0;
         $listing = $this->_filterReportsList($connection->rawls());
         foreach ($listing as $filename => $attributes) {
-            $localCsv = 'PayPal_STL_' . uniqid(\Magento\Framework\Math\Random::getRandomNumber()) . time() . '.csv';
+            $localCsv = 'PayPal_STL_' . uniqid(\Magento\Framework\Math\Random::getRandomNumber(), true) . time() . '.csv';
             if ($connection->read($filename, $this->_tmpDirectory->getAbsolutePath($localCsv))) {
                 if (!$this->_tmpDirectory->isWritable($localCsv)) {
                     throw new \Magento\Framework\Exception\LocalizedException(

--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
@@ -32,7 +32,7 @@
                         <?= /* @escapeNotVerified */ $block->getCustomizedOptionValue($_option) ?>
                     <?php else: ?>
                         <?php $_option = $block->getFormattedOption($_option['value']); ?>
-                        <?= /* @escapeNotVerified */ $_option['value'] ?><?php if (isset($_option['remainder']) && $_option['remainder']): ?><span id="<?= /* @escapeNotVerified */ $_dots = 'dots' . uniqid() ?>"> ...</span><span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid() ?>"><?= /* @escapeNotVerified */ $_option['remainder'] ?></span>
+                        <?= /* @escapeNotVerified */ $_option['value'] ?><?php if (isset($_option['remainder']) && $_option['remainder']): ?><span id="<?= /* @escapeNotVerified */ $_dots = 'dots' . uniqid('', true) ?>"> ...</span><span id="<?= /* @escapeNotVerified */ $_id = 'id' . uniqid('', true) ?>"><?= /* @escapeNotVerified */ $_option['remainder'] ?></span>
                             <script>
                                 require(['prototype'], function() {
                                     $('<?= /* @escapeNotVerified */ $_id ?>').hide();

--- a/app/code/Magento/Shipping/Model/Shipping/LabelGenerator.php
+++ b/app/code/Magento/Shipping/Model/Shipping/LabelGenerator.php
@@ -180,7 +180,7 @@ class LabelGenerator
 
         imageinterlace($image, 0);
         $tmpFileName = $directory->getAbsolutePath(
-            'shipping_labels_' . uniqid(\Magento\Framework\Math\Random::getRandomNumber()) . time() . '.png'
+            'shipping_labels_' . uniqid(\Magento\Framework\Math\Random::getRandomNumber(), true) . time() . '.png'
         );
         imagepng($image, $tmpFileName);
         $pdfImage = \Zend_Pdf_Image::imageWithPath($tmpFileName);

--- a/lib/internal/Magento/Framework/Data/Test/Unit/StructureTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/StructureTest.php
@@ -172,8 +172,8 @@ class StructureTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateGetHasElement()
     {
-        $data = [uniqid() => uniqid()];
-        $elementId = uniqid('id');
+        $data = [uniqid('', true) => uniqid('', true)];
+        $elementId = uniqid('id', true);
         $this->assertFalse($this->_structure->hasElement($elementId));
         $this->assertFalse($this->_structure->getElement($elementId));
 
@@ -188,7 +188,7 @@ class StructureTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateElementException()
     {
-        $elementId = uniqid('id');
+        $elementId = uniqid('id', true);
         $this->_structure->createElement($elementId, []);
         $this->_structure->createElement($elementId, []);
     }
@@ -219,7 +219,7 @@ class StructureTest extends \PHPUnit\Framework\TestCase
         $this->_populateSampleStructure();
         $this->assertFalse($this->_structure->getAttribute('two', 'non-existing'));
         $this->assertEquals('bar', $this->_structure->getAttribute('two', 'foo'));
-        $value = uniqid();
+        $value = uniqid('', true);
         $this->_structure->setAttribute('two', 'non-existing', $value)->setAttribute('two', 'foo', $value);
         $this->assertEquals($value, $this->_structure->getAttribute('two', 'non-existing'));
         $this->assertEquals($value, $this->_structure->getAttribute('two', 'foo'));

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -64,7 +64,7 @@ class Escaper
                     );
                     $allowedTags = array_diff($allowedTags, $this->notAllowedTags);
                 }
-                $wrapperElementId = uniqid();
+                $wrapperElementId = uniqid('', true);
                 $domDocument = new \DOMDocument('1.0', 'UTF-8');
                 set_error_handler(
                     function ($errorNumber, $errorString) {

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/AuthenticationTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/AuthenticationTest.php
@@ -80,7 +80,7 @@ class AuthenticationTest extends \PHPUnit\Framework\TestCase
                 'httpResponse' => $response
             ]
         );
-        $realm = uniqid();
+        $realm = uniqid('', true);
         $authentication->setAuthenticationFailed($realm);
         $headers = $response->getHeaders();
 

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -475,7 +475,7 @@ class Element extends \SimpleXMLElement
      */
     public function unsetSelf()
     {
-        $uniqueId = uniqid();
+        $uniqueId = uniqid('', true);
         $this['_unique_id'] = $uniqueId;
         $children = $this->getParent()->xpath('*');
         for ($i = count($children); $i > 0; $i--) {

--- a/lib/internal/Magento/Framework/Url/Test/Unit/DecoderTest.php
+++ b/lib/internal/Magento/Framework/Url/Test/Unit/DecoderTest.php
@@ -21,7 +21,7 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
         $decoder = new Decoder($urlBuilderMock);
         $encoder = new Encoder();
 
-        $data = uniqid();
+        $data = uniqid('', true);
         $result = $encoder->encode($data);
         $urlBuilderMock->expects($this->once())
             ->method('sessionUrlVar')

--- a/lib/internal/Magento/Framework/View/Design/Theme/Image.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/Image.php
@@ -132,7 +132,7 @@ class Image
         $image->backgroundColor([255, 255, 255]);
         $image->resize($imageWidth, $imageHeight);
 
-        $imageName = uniqid('preview_image_') . image_type_to_extension($image->getImageType());
+        $imageName = uniqid('preview_image_', true) . image_type_to_extension($image->getImageType());
         $image->save($this->themeImagePath->getImagePreviewDirectory(), $imageName);
         $this->theme->setPreviewImage($imageName);
         return $this;

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/AbstractBlockTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/AbstractBlockTest.php
@@ -145,7 +145,7 @@ class AbstractBlockTest extends \PHPUnit\Framework\TestCase
     public function testGetVar()
     {
         $config = $this->createPartialMock(View::class, ['getVarValue']);
-        $module = uniqid();
+        $module = uniqid('', true);
 
         $config->expects($this->any())
             ->method('getVarValue')

--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -199,7 +199,7 @@ class ErrorProcessor
      */
     protected function _critical(\Exception $exception)
     {
-        $reportId = uniqid("webapi-");
+        $reportId = uniqid("webapi-", true);
         $message = "Report ID: {$reportId}; Message: {$exception->getMessage()}";
         $code = $exception->getCode();
         $exception = new \Exception($message, $code, $exception);


### PR DESCRIPTION
### Description
Insecure 'uniqid(...)' usage (Insufficient Entropy Vulnerability)

More information, see documentation:

http://php.net/manual/en/function.uniqid.php

more_entropy (parameter): If set to TRUE, uniqid() will add additional entropy (using the combined linear congruential generator) at the end of the return value, which increases the likelihood that the result will be unique.

http://phpsecurity.readthedocs.io/en/latest/Insufficient-Entropy-For-Random-Values.html