### PR TITLE
Create symlink to setup wizard con compile command to avoid 404 error when /pub directory is configured as root path

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -411,7 +411,7 @@ class DiCompileCommand extends Command
         $setupPath       = $this->directoryList->getPath(DirectoryList::ROOT) . '/' . DirectoryList::SETUP;
         $setupPublicPath = $this->directoryList->getPath(DirectoryList::PUB) . '/' . DirectoryList::SETUP;
         
-        if (!file_exists($setupPublicPath)) {
+        if (file_exists($setupPublicPath)) {
             $output->writeln('<info>Setup folder already exists in public.</info>');
             return;
         }

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -412,18 +412,20 @@ class DiCompileCommand extends Command
         $setupPublicPath = $this->directoryList->getPath(DirectoryList::PUB) . '/' . DirectoryList::SETUP;
         
         if (!file_exists($setupPublicPath)) {
-            $process = new Process('ln -s ' . $setupPath . ' ' . $setupPublicPath);
-            
-            $process->run();
-            if ($process->isSuccessful()) {
-                $output->writeln('<info>Generated symlink for setup in public.</info>');
-            } else {
-                $output->writeln('<error>' . trim($process->getErrorOutput()) . '</error>');
-                $output->writeln('<error>Failed to generate the symlink for setup.</error>');
-            }
-        } else {
             $output->writeln('<info>Setup folder already exists in public.</info>');
+            return;
         }
+        
+        $process = new Process('ln -s ' . $setupPath . ' ' . $setupPublicPath);
+            
+        $process->run();
+        if (!$process->isSuccessful()) {
+            $output->writeln('<error>' . trim($process->getErrorOutput()) . '</error>');
+            $output->writeln('<error>Failed to generate the symlink for setup.</error>');
+            return;
+        }
+            
+        $output->writeln('<info>Generated symlink for setup in public.</info>');
     }
 
 }

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -22,6 +22,7 @@ use Magento\Setup\Module\Di\App\Task\OperationInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Magento\Framework\Console\Cli;
+use Symfony\Component\Process\Process;
 
 /**
  * Command to run compile in single-tenant mode
@@ -136,6 +137,8 @@ class DiCompileCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->generateSetupFolderInPublic($output);
+        
         $errors = $this->checkEnvironment();
         if ($errors) {
             foreach ($errors as $line) {
@@ -400,4 +403,27 @@ class DiCompileCommand extends Command
 
         return $operations;
     }
+    
+    private function generateSetupFolderInPublic(OutputInterface $output)
+    {
+        $output->writeln('<info>Generating symlink for setup.</info>');
+        
+        $setupPath       = $this->directoryList->getPath(DirectoryList::ROOT) . '/' . DirectoryList::SETUP;
+        $setupPublicPath = $this->directoryList->getPath(DirectoryList::PUB) . '/' . DirectoryList::SETUP;
+        
+        if (!file_exists($setupPublicPath)) {
+            $process = new Process('ln -s ' . $setupPath . ' ' . $setupPublicPath);
+            
+            $process->run();
+            if ($process->isSuccessful()) {
+                $output->writeln('<info>Generated symlink for setup in public.</info>');
+            } else {
+                $output->writeln('<error>' . trim($process->getErrorOutput()) . '</error>');
+                $output->writeln('<error>Failed to generate the symlink for setup.</error>');
+            }
+        } else {
+            $output->writeln('<info>Setup folder already exists in public.</info>');
+        }
+    }
+
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
There are some issues related to the 404 error when entering on setup wizard page when /pub directory is configured as root path in apache or nginx.
With this fix, the compile command will create a symlink to setup.
Related: https://github.com/magento/magento2/search?q=wizard+404&unscoped_q=wizard+404&type=Issues
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14880: Magento 2.2.1 Web Setup Wizard problems - {{menuState.title}}
2. magento/magento2#7623: Web Setup Wizard not visible in backend (V.2.1.2)
3. magento/magento2#11892: Web Setup Wizard not visible in backend magento 2.1.9

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Configure Apache with Document Root pointing to mage_dir/pub
2. Enter Admin -> Setup Wizard
3. A 404 page appears

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
