### PR TITLE
1164: OnePageCheckoutOfflinePaymentMethodsTest rework to support MSI reservation mechanism.

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertMinicartEmpty.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertMinicartEmpty.php
@@ -27,6 +27,7 @@ class AssertMinicartEmpty extends AbstractConstraint
     public function processAssert(
         CmsIndex $cmsIndex
     ) {
+        $cmsIndex->open();
         \PHPUnit\Framework\Assert::assertEquals(
             self::TEXT_EMPTY_MINICART,
             $cmsIndex->getCartSidebarBlock()->getEmptyMessage(),

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/OnePageCheckoutOfflinePaymentMethodsTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/OnePageCheckoutOfflinePaymentMethodsTest.xml
@@ -19,7 +19,7 @@
             <data name="shipping/shipping_method" xsi:type="string">Fixed</data>
             <data name="payment/method" xsi:type="string">checkmo</data>
             <data name="configData" xsi:type="string">checkmo, disable_guest_checkout, disable_customer_redirect_after_logging</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
         </variation>
         <variation name="OnePageCheckoutUsingRegisterLink" summary="Customer is redirected to checkout on login if guest is disabled, flow with registration new Customer" ticketId="MAGETWO-49917">
             <data name="issue" xsi:type="string">MAGETWO-59816: Redirect works improperly in a browser incognito mode</data>
@@ -35,7 +35,7 @@
             <data name="shippingAddress/dataset" xsi:type="string">US_address_1_without_email</data>
             <data name="payment/method" xsi:type="string">checkmo</data>
             <data name="configData" xsi:type="string">checkmo, disable_guest_checkout, disable_customer_redirect_after_logging, enable_https_frontend_only</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
         </variation>
         <variation name="OnePageCheckoutTestVariation1" summary="Checkout as UK guest with virtual product and downloadable product using coupon for not logged in customers">
             <data name="tag" xsi:type="string">severity:S0</data>
@@ -51,7 +51,6 @@
             <data name="status" xsi:type="string">Pending</data>
             <data name="orderButtonsAvailable" xsi:type="string">Back, Send Email, Cancel, Hold, Invoice, Edit</data>
             <data name="configData" xsi:type="string">checkmo_specificcountry_gb</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderStatusIsCorrect" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
@@ -70,10 +69,10 @@
                 <item name="grandTotal" xsi:type="string">285.00</item>
             </data>
             <data name="payment/method" xsi:type="string">banktransfer</data>
-            <data name="status" xsi:type="string">Pending</data>
-            <data name="orderButtonsAvailable" xsi:type="string">Back, Send Email, Cancel, Hold, Ship, Invoice, Edit</data>
+            <data name="status" xsi:type="string">Processing</data>
+            <data name="orderButtonsAvailable" xsi:type="string">Back, Send Email, Cancel, Hold, Invoice, Edit</data>
             <data name="configData" xsi:type="string">banktransfer</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderStatusIsCorrect" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
@@ -93,10 +92,10 @@
                 <item name="grandTotal" xsi:type="string">375.00</item>
             </data>
             <data name="payment/method" xsi:type="string">banktransfer</data>
-            <data name="status" xsi:type="string">Pending</data>
-            <data name="orderButtonsAvailable" xsi:type="string">Back, Send Email, Cancel, Hold, Ship, Invoice, Edit</data>
+            <data name="status" xsi:type="string">Precessing</data>
+            <data name="orderButtonsAvailable" xsi:type="string">Back, Send Email, Cancel, Hold, Invoice, Edit</data>
             <data name="configData" xsi:type="string">banktransfer_specificcountry_gb, can_subtract_and_can_back_in_stock</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Catalog\Test\Constraint\AssertProductsOutOfStock" />
             <constraint name="Magento\Catalog\Test\Constraint\AssertProductsQtyAndStockStatusInAdminPanel" />
@@ -123,7 +122,7 @@
             <data name="billingCheckboxState" xsi:type="string">Yes</data>
             <data name="payment/method" xsi:type="string">checkmo</data>
             <data name="configData" xsi:type="string">checkmo</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal"/>
         </variation>
@@ -149,7 +148,7 @@
             <data name="refresh" xsi:type="boolean">true</data>
             <data name="payment/method" xsi:type="string">checkmo</data>
             <data name="configData" xsi:type="string">checkmo, freeshipping_minimum_order_amount_100</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderAddresses" />
@@ -168,7 +167,6 @@
             <data name="status" xsi:type="string">Pending</data>
             <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Hold, Invoice, Edit</data>
             <data name="configData" xsi:type="string">zero_subtotal_checkout</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderStatusIsCorrect" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
@@ -185,9 +183,9 @@
                 <item name="grandTotal" xsi:type="string">375</item>
             </data>
             <data name="payment/method" xsi:type="string">checkmo</data>
-            <data name="status" xsi:type="string">Pending</data>
+            <data name="status" xsi:type="string">Processing</data>
             <data name="orderButtonsAvailable" xsi:type="string">Back, Send Email, Cancel, Hold, Invoice, Edit</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertCartIsEmpty" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderStatusIsCorrect" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
@@ -208,7 +206,7 @@
                 <item name="grandTotal" xsi:type="string">565.00</item>
             </data>
             <data name="payment/method" xsi:type="string">checkmo</data>
-            <constraint name="Magento\Customer\Test\Constraint\AssertCustomerRedirectToDashboard" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
         </variation>
         <variation name="OnePageCheckoutTestVariation9" summary="One Page Checkout Products with different shipping/billing address and Tier Prices" ticketId="MAGETWO-42604">
@@ -225,7 +223,7 @@
             </data>
             <data name="payment/method" xsi:type="string">banktransfer</data>
             <data name="configData" xsi:type="string">banktransfer_specificcountry_gb</data>
-            <constraint name="Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Checkout\Test\Constraint\AssertMinicartEmpty" />
             <constraint name="Magento\Customer\Test\Constraint\AssertCustomerDefaultAddressFrontendAddressBook" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestStep/PlaceOrderStep.php
@@ -116,8 +116,8 @@ class PlaceOrderStep implements TestStepInterface
             $this->assertGrandTotalOrderReview->processAssert($this->checkoutOnepage, $this->prices['grandTotal']);
         }
         $this->checkoutOnepage->getPaymentBlock()->getSelectedPaymentMethodBlock()->clickPlaceOrder();
-        $this->assertOrderSuccessPlacedMessage->processAssert($this->checkoutOnepageSuccess);
         $orderId = $this->checkoutOnepageSuccess->getSuccessBlock()->getGuestOrderId();
+        $this->assertOrderSuccessPlacedMessage->processAssert($this->checkoutOnepageSuccess);
         $data = [
             'id' => $orderId,
             'entity_id' => ['products' => $this->products]

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestStep/PlaceOrderStep.php
@@ -11,6 +11,7 @@ use Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage;
 use Magento\Checkout\Test\Page\CheckoutOnepage;
 use Magento\Checkout\Test\Page\CheckoutOnepageSuccess;
 use Magento\Mtf\Fixture\FixtureFactory;
+use Magento\Mtf\ObjectManager;
 use Magento\Mtf\TestStep\TestStepInterface;
 use Magento\Sales\Test\Fixture\OrderInjectable;
 
@@ -78,31 +79,32 @@ class PlaceOrderStep implements TestStepInterface
     /**
      * @param CheckoutOnepage $checkoutOnepage
      * @param AssertGrandTotalOrderReview $assertGrandTotalOrderReview
-     * @param AssertOrderSuccessPlacedMessage $assertOrderSuccessPlacedMessage
      * @param CheckoutOnepageSuccess $checkoutOnepageSuccess
      * @param FixtureFactory $fixtureFactory
      * @param array $products
      * @param array $prices
      * @param OrderInjectable|null $order
+     * @param AssertOrderSuccessPlacedMessage $assertOrderSuccessPlacedMessage
      */
     public function __construct(
         CheckoutOnepage $checkoutOnepage,
         AssertGrandTotalOrderReview $assertGrandTotalOrderReview,
-        AssertOrderSuccessPlacedMessage $assertOrderSuccessPlacedMessage,
         CheckoutOnepageSuccess $checkoutOnepageSuccess,
         FixtureFactory $fixtureFactory,
         array $products = [],
         array $prices = [],
-        OrderInjectable $order = null
+        OrderInjectable $order = null,
+        AssertOrderSuccessPlacedMessage $assertOrderSuccessPlacedMessage = null
     ) {
         $this->checkoutOnepage = $checkoutOnepage;
         $this->assertGrandTotalOrderReview = $assertGrandTotalOrderReview;
-        $this->assertOrderSuccessPlacedMessage = $assertOrderSuccessPlacedMessage;
         $this->checkoutOnepageSuccess = $checkoutOnepageSuccess;
         $this->fixtureFactory = $fixtureFactory;
         $this->products = $products;
         $this->prices = $prices;
         $this->order = $order;
+        $this->assertOrderSuccessPlacedMessage = $assertOrderSuccessPlacedMessage
+            ?: ObjectManager::getInstance()->create(AssertOrderSuccessPlacedMessage::class);
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestStep/PlaceOrderStep.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestStep/PlaceOrderStep.php
@@ -7,6 +7,7 @@
 namespace Magento\Checkout\Test\TestStep;
 
 use Magento\Checkout\Test\Constraint\AssertGrandTotalOrderReview;
+use Magento\Checkout\Test\Constraint\AssertOrderSuccessPlacedMessage;
 use Magento\Checkout\Test\Page\CheckoutOnepage;
 use Magento\Checkout\Test\Page\CheckoutOnepageSuccess;
 use Magento\Mtf\Fixture\FixtureFactory;
@@ -31,6 +32,13 @@ class PlaceOrderStep implements TestStepInterface
      * @var AssertGrandTotalOrderReview
      */
     private $assertGrandTotalOrderReview;
+
+    /**
+     * Assert that order success message is correct.
+     *
+     * @var AssertOrderSuccessPlacedMessage
+     */
+    private $assertOrderSuccessPlacedMessage;
 
     /**
      * One page checkout success page.
@@ -70,6 +78,7 @@ class PlaceOrderStep implements TestStepInterface
     /**
      * @param CheckoutOnepage $checkoutOnepage
      * @param AssertGrandTotalOrderReview $assertGrandTotalOrderReview
+     * @param AssertOrderSuccessPlacedMessage $assertOrderSuccessPlacedMessage
      * @param CheckoutOnepageSuccess $checkoutOnepageSuccess
      * @param FixtureFactory $fixtureFactory
      * @param array $products
@@ -79,6 +88,7 @@ class PlaceOrderStep implements TestStepInterface
     public function __construct(
         CheckoutOnepage $checkoutOnepage,
         AssertGrandTotalOrderReview $assertGrandTotalOrderReview,
+        AssertOrderSuccessPlacedMessage $assertOrderSuccessPlacedMessage,
         CheckoutOnepageSuccess $checkoutOnepageSuccess,
         FixtureFactory $fixtureFactory,
         array $products = [],
@@ -87,6 +97,7 @@ class PlaceOrderStep implements TestStepInterface
     ) {
         $this->checkoutOnepage = $checkoutOnepage;
         $this->assertGrandTotalOrderReview = $assertGrandTotalOrderReview;
+        $this->assertOrderSuccessPlacedMessage = $assertOrderSuccessPlacedMessage;
         $this->checkoutOnepageSuccess = $checkoutOnepageSuccess;
         $this->fixtureFactory = $fixtureFactory;
         $this->products = $products;
@@ -105,6 +116,7 @@ class PlaceOrderStep implements TestStepInterface
             $this->assertGrandTotalOrderReview->processAssert($this->checkoutOnepage, $this->prices['grandTotal']);
         }
         $this->checkoutOnepage->getPaymentBlock()->getSelectedPaymentMethodBlock()->clickPlaceOrder();
+        $this->assertOrderSuccessPlacedMessage->processAssert($this->checkoutOnepageSuccess);
         $orderId = $this->checkoutOnepageSuccess->getSuccessBlock()->getGuestOrderId();
         $data = [
             'id' => $orderId,

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/etc/testcase.xml
@@ -38,7 +38,8 @@
         <step name="fillBillingInformation" module="Magento_Checkout" next="refreshPage" />
         <step name="refreshPage" module="Magento_Checkout" next="placeOrder" />
         <step name="placeOrder" module="Magento_Checkout" next="createCustomerAccount" />
-        <step name="createCustomerAccount" module="Magento_Checkout" />
+        <step name="createCustomerAccount" module="Magento_Checkout" next="createShipment" />
+        <step name="createShipment" module="Magento_Sales"/>
     </scenario>
     <scenario name="OnePageCheckoutJsValidationTest" firstStep="setupConfiguration">
         <step name="setupConfiguration" module="Magento_Config" next="createProducts" />

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Actions.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Actions.php
@@ -138,6 +138,16 @@ class Actions extends Block
     protected $confirmModal = '.confirm._show[data-role=modal]';
 
     /**
+     * Is shipment can be created.
+     *
+     * @return bool
+     */
+    public function canShip()
+    {
+        return $this->_rootElement->find($this->ship)->isVisible();
+    }
+
+    /**
      * Ship order.
      *
      * @return void

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateShipmentStep.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateShipmentStep.php
@@ -99,13 +99,21 @@ class CreateShipmentStep implements TestStepInterface
     {
         $this->orderIndex->open();
         $this->orderIndex->getSalesOrderGrid()->searchAndOpen(['id' => $this->order->getId()]);
-        $this->salesOrderView->getPageActions()->ship();
-        if (!empty($this->data)) {
-            $this->orderShipmentNew->getFormBlock()->fillData($this->data, $this->order->getEntityId()['products']);
+        $shipmentIds = [];
+        /**
+         * As this step is used in general scenarios and not all test cases has shippable items(ex: virtual product)
+         * we need to check, if it possible to create shipment for given order.
+         */
+        if ($this->salesOrderView->getPageActions()->canShip()) {
+            $this->salesOrderView->getPageActions()->ship();
+            if (!empty($this->data)) {
+                $this->orderShipmentNew->getFormBlock()->fillData($this->data, $this->order->getEntityId()['products']);
+            }
+            $this->orderShipmentNew->getFormBlock()->submit();
+            $shipmentIds = $this->getShipmentIds();
         }
-        $this->orderShipmentNew->getFormBlock()->submit();
 
-        return ['shipmentIds' => $this->getShipmentIds()];
+        return ['shipmentIds' => $shipmentIds];
     }
 
     /**


### PR DESCRIPTION

### Description
Add shipment step to OnePageCheckoutOfflinePaymentMethodsTest in order to support MSI reservation mechanism.

Standard magento behaviour - product quantity decreased immediately after place order, but with MSI quantity decreasing only after shipment created, as MSI introduces additional property for product as 'salable quantity'. And after order placement, 'salable quantity' decreasing, not quantity itself(more about reservation mechanism [here).](https://github.com/magento-engcom/msi/wiki/Reservations) Quantity decreasing only after shipment creation. So, in order to pass OnePageCheckoutOfflinePaymentMethodsTest with MSI, additional step with shipment creation should be added into test before assertions.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1164: Fix Functional Test Magento\Checkout\Test\TestCase\OnePageCheckoutOfflinePaymentMethodsTest::test with data set "OnePageCheckoutTestVariation7_0"

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. None.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
