### PR TITLE
13633 - Fixes missed parameter "componentType" for "cms_page_columns" component

### DIFF
--- a/app/code/Magento/Cms/Ui/Component/DataProvider.php
+++ b/app/code/Magento/Cms/Ui/Component/DataProvider.php
@@ -83,6 +83,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
                     'arguments' => [
                         'data' => [
                             'config' => [
+                                'componentType' => 'columns',
                                 'editorConfig' => [
                                     'enabled' => false
                                 ]


### PR DESCRIPTION
### Description
Adds componentType to prepareMetadata() method in app/code/Magento/Cms/Ui/Component/DataProvider.php

### Fixed Issues (if relevant)
1. magento/magento2#13633: The configuration parameter "componentType" is a required for "cms_page_columns" component.

### Manual testing scenarios
1. Create admin user with role with access only to Content -> Elements -> Blocks
2. Login as this user
3. Go to Content -> Blocks
4. Blocks Grid will be showed instead of exception

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
