### PR TITLE
[Backport] #8035 join extension attributes not added to orders

### DIFF
--- a/app/code/Magento/Sales/Model/OrderRepository.php
+++ b/app/code/Magento/Sales/Model/OrderRepository.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Sales\Model;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Sales\Model\ResourceModel\Order as Resource;
 use Magento\Sales\Model\ResourceModel\Metadata;
 use Magento\Sales\Model\Order\ShippingAssignmentBuilder;
@@ -16,6 +17,7 @@ use Magento\Sales\Api\Data\ShippingAssignmentInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Api\SortOrder;
+use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 
 /**
  * Repository class for @see OrderInterface
@@ -44,6 +46,11 @@ class OrderRepository implements \Magento\Sales\Api\OrderRepositoryInterface
     private $shippingAssignmentBuilder;
 
     /**
+     * @var JoinProcessorInterface
+     */
+    private $joinProcessor;
+
+    /**
      * OrderInterface[]
      *
      * @var array
@@ -55,13 +62,17 @@ class OrderRepository implements \Magento\Sales\Api\OrderRepositoryInterface
      *
      * @param Metadata $metadata
      * @param SearchResultFactory $searchResultFactory
+     * @param JoinProcessorInterface $joinProcessor
      */
     public function __construct(
         Metadata $metadata,
-        SearchResultFactory $searchResultFactory
+        SearchResultFactory $searchResultFactory,
+        JoinProcessorInterface $joinProcessor
     ) {
         $this->metadata = $metadata;
         $this->searchResultFactory = $searchResultFactory;
+        $this->joinProcessor = $joinProcessor
+         ?: ObjectManager::getInstance()->get(JoinProcessorInterface::class);
     }
 
     /**
@@ -116,6 +127,7 @@ class OrderRepository implements \Magento\Sales\Api\OrderRepositoryInterface
             );
         }
 
+        $this->joinProcessor->process($searchResult);
         $searchResult->setSearchCriteria($searchCriteria);
         $searchResult->setCurPage($searchCriteria->getCurrentPage());
         $searchResult->setPageSize($searchCriteria->getPageSize());
@@ -186,7 +198,7 @@ class OrderRepository implements \Magento\Sales\Api\OrderRepositoryInterface
 
     /**
      * Get the new OrderExtensionFactory for application code
-     * 
+     *
      * @return OrderExtensionFactory
      * @deprecated
      */

--- a/app/code/Magento/Sales/Model/OrderRepository.php
+++ b/app/code/Magento/Sales/Model/OrderRepository.php
@@ -62,12 +62,12 @@ class OrderRepository implements \Magento\Sales\Api\OrderRepositoryInterface
      *
      * @param Metadata $metadata
      * @param SearchResultFactory $searchResultFactory
-     * @param JoinProcessorInterface $joinProcessor
+     * @param JoinProcessorInterface|null $joinProcessor
      */
     public function __construct(
         Metadata $metadata,
         SearchResultFactory $searchResultFactory,
-        JoinProcessorInterface $joinProcessor
+        JoinProcessorInterface $joinProcessor = null
     ) {
         $this->metadata = $metadata;
         $this->searchResultFactory = $searchResultFactory;

--- a/dev/tests/api-functional/_files/Magento/TestModuleJoinDirectives/etc/extension_attributes.xml
+++ b/dev/tests/api-functional/_files/Magento/TestModuleJoinDirectives/etc/extension_attributes.xml
@@ -31,4 +31,15 @@
             </join>
         </attribute>
     </extension_attributes>
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+      <attribute code="orderApiTestAttribute" type="Magento\User\Api\Data\UserInterface">
+        <join reference_table="admin_user"
+              join_on_field="store_id"
+              reference_field="user_id"
+                >
+            <field>firstname</field>
+            <field>lastname</field>
+            <field>email</field>
+      </attribute>
+    </extension_attributes>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This is a backport fix of issue #8035 for Magento 2.1 - join extension attributes not added to orders within the Magento API

### Fixed Issues (if relevant)
1. magento/magento2#8035: Join extension attributes not added to order (fixed in 2.2 - this pull backports the fix to 2.1)

### Manual testing scenarios
1. Add extension attributes to the Magento\Sales\Api\Data\OrderInterface - that use a table join
2. Query the order listing to - confirming the extension_attributes appear alongside the order data

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
