### PR TITLE
1163: CreateCreditMemoEntityTest rework to support MSI reservation mechanism.

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Sales/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/etc/testcase.xml
@@ -145,7 +145,8 @@
     <scenario name="CreateCreditMemoEntityTest" firstStep="setupConfiguration">
         <step name="setupConfiguration" module="Magento_Config" next="createOrder" />
         <step name="createOrder" module="Magento_Sales" next="createInvoice" />
-        <step name="createInvoice" module="Magento_Sales" next="createCreditMemo" />
+        <step name="createInvoice" module="Magento_Sales" next="createShipment" />
+        <step name="createShipment" module="Magento_Sales" next="createCreditMemo" />
         <step name="createCreditMemo" module="Magento_Sales" />
     </scenario>
 </config>


### PR DESCRIPTION
### Description
Add shipment step to CreateCreditMemoEntityTest in order to support MSI reservation mechanism.

Standard magento behaviour - product quantity decreased immediately after place order, but with MSI quantity decreasing only after shipment created, as MSI introduces additional property for product as 'salable quantity'. And after order placement, 'salable quantity' decreasing, not quantity itself(more about reservation mechanism [here).](https://github.com/magento-engcom/msi/wiki/Reservations) Quantity decreasing only after shipment creation. So, in order to pass CreateCreditMemoEntityTest with MSI, additional step with shipment creation should be added into test before assertions.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1163:Fix Functional Test Magento\Sales\Test\TestCase\CreateCreditMemoEntityTest::test with data set "CreateCreditMemoEntityTestVariation1_0"

### Manual testing scenarios
1. None.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
