### PR TITLE
Resolve meta asset urls in additional meta assets

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -120,6 +120,11 @@ class Config
     ];
 
     /**
+     * @var array
+     */
+    protected $additionalMetaAssets = ['msapplication-TileImage'];
+
+    /**
      * @var \Magento\Framework\App\State
      */
     private $areaResolver;
@@ -474,6 +479,31 @@ class Config
             implode(' ', $bodyClasses)
         );
         return $this;
+    }
+
+    /**
+     * Retrieve the additional meta assets
+     *
+     * @return array
+     */
+    public function getAdditionalMetaAssets()
+    {
+        return $this->additionalMetaAssets;
+    }
+
+    /**
+     * Adjust metadata content url
+     *
+     * @param string $content
+     * @return string $content
+     */
+    public function getMetaAssetUrl($content)
+    {
+        $parsed = parse_url($content);
+        if (empty($parsed['scheme'])) {
+            return $this->assetRepo->getUrl($content);
+        }
+        return $content;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -139,6 +139,9 @@ class Renderer implements RendererInterface
         if (method_exists($this->pageConfig, $method)) {
             $content = $this->pageConfig->$method();
         }
+        if ($content && in_array($name, $this->pageConfig->getAdditionalMetaAssets())) {
+            $content = $this->pageConfig->getMetaAssetUrl($content);
+        }
         return $content;
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
@@ -171,6 +171,11 @@ class RendererTest extends \PHPUnit\Framework\TestCase
             ->method('getMetadata')
             ->will($this->returnValue($metadata));
 
+        $this->pageConfigMock
+            ->expects($this->any())
+            ->method('getAdditionalMetaAssets')
+            ->will($this->returnValue(['msapplication-TileImage']));
+
         $this->assertEquals($expected, $this->renderer->renderMetadata());
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
@@ -369,6 +369,20 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test-class', $this->model->getElementAttribute('body', 'class'));
     }
 
+    public function testGetMetaAssetUrlWithUrlInContent()
+    {
+        $this->assetRepo->expects($this->never())->method('getUrl');
+        $this->assertEquals('http://test.com/image.png', $this->model->getMetaAssetUrl('http://test.com/image.png'));
+    }
+
+    public function testGetMetaAssetUrlWithoutUrlInContent()
+    {
+        $this->assetRepo->expects($this->once())->method('getUrl')->with('image.png')->will(
+            $this->returnValue('http://test.com/image.png')
+        );
+        $this->assertEquals('http://test.com/image.png', $this->model->getMetaAssetUrl('image.png'));
+    }
+
     /**
      * @param string $elementType
      * @param string $attribute


### PR DESCRIPTION
### Description
It is currently not possible to additional meta assets (e.g. a msapplication-TileImage) to the <head> as the image path of this assets are not resolved, since this meta value uses the `content` attribute instead of `src` or `href` and is used to specify the path for the tile images for Windows devices.

This pull requests fixes this behavior and resolves the url for the defined meta assets. The meta key `msapplication-TileImage` was added by default since it is a very common meta asset.

### Fixed Issues (if relevant)
1. magento/magento2#5023: It is not possible to add MS tile image meta via default_head_blocks.xml

### Manual testing scenarios
1. Open `default_head_blocks.xml` of your theme.
2. Add additional meta asset image, e.g. *msapplication-TileImage* like this: `<meta name="msapplication-TileImage" content="images/favicons/default/mstile-144x144.png"/>`
3. If you inspect the rendered html code of the generated page, the asset url will now be resolved and the image will be found.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
