### PR TITLE
Accurately return the current page set even if it is greater than the number of pages

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -240,11 +240,9 @@ class Collection implements \IteratorAggregate, \Countable, ArrayInterface, Coll
     {
         if ($this->_curPage + $displacement < 1) {
             return 1;
-        } elseif ($this->_curPage + $displacement > $this->getLastPageNumber()) {
-            return $this->getLastPageNumber();
-        } else {
-            return $this->_curPage + $displacement;
         }
+
+        return $this->_curPage + $displacement;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Test/Unit/CollectionTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/CollectionTest.php
@@ -98,7 +98,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testGetCurPage()
     {
         $this->_model->setCurPage(10);
-        $this->assertEquals(1, $this->_model->getCurPage());
+        $this->assertEquals(10, $this->_model->getCurPage());
     }
 
     public function testPossibleFlowWithItem()


### PR DESCRIPTION
### Description
If you are working with a paginated collection and set the current page to an integer greater than the total number of pages, the code defaults to the last page, overriding the value that was set by the user.

This has logic implications and has caused some pain with some integrations in my experience, specially when it comes to integrations with 3rd party systems using the Rest API. 3rd party system sometimes traverse pages until there is no more records returned, they generally don't expect the application to keep returning the last page forever as the current page increases.

I feel 2.3 is a great opportunity to introduce this change, I have patched several projects myself but it would be great if this is fixed in the Magento project itself with this PR.

I understand the current code was done on purpose and it seems like it is trying to be nice by not letting you request an offset page, however it comes down to logic, page 5 of 5 is not equal to page 7 of 5 and therefore the result set must not be equal either. 
 
This would potentially be backwards incompatible, but if there is an opportunity to merge this any time soon, it is 2.3.

### Manual testing scenarios

Using the Rest API to fetch products using the pagination, keep increasing the current page you want to fetch and once this is greater than the last page, the last page of records will be returned instead of an empty set as expected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

Some test in the Magento/Framework/Locale module are not passing but are unrelated to this work.