### PR TITLE
Fix bug where configurable attribute uses custom source model

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
@@ -43,11 +43,11 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
      */
     public function __construct(
         Attribute $attributeResource,
-        OptionProvider $attributeOptionProvider,
+        OptionProvider $optionProvider,
         EavAttributeResource $eavAttributeResource
     ) {
         $this->attributeResource = $attributeResource;
-        $this->attributeOptionProvider = $attributeOptionProvider;
+        $this->attributeOptionProvider = $optionProvider;
         $this->eavAttributeResource = $eavAttributeResource;
     }
 
@@ -117,7 +117,7 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
                 'attribute_option.option_id = entity_value.value and attribute_option.attribute_id = attribute.attribute_id',
                 []
             )->order(
-            'attribute_option.sort_order ASC'
+                'attribute_option.sort_order ASC'
             );
         }
 


### PR DESCRIPTION
### Description

When a configurable attribute uses a custom source model, the options
are not stored in the attribute_option table and therefore this table
must not be joined using an inner join when loading the configurable
options.

Inner joining this table is causing some options to not show on the front-end and back-end.

### Manual testing scenarios

This one is tricky to test in a vanilla installation because it requires a custom attribute using a custom source model but I will explain the scenario which made me run into this issue.

1. Create a custom flat entity for your store, eg. Fabric, which lives in its custom table and you can add records to it from the admin.

2. Create a new select attribute to be used in configurable products called fabric and set a custom source model to it, the custom module will load the options from the custom Fabric table.

3. Create a configurable product based on the fabric attribute and add simple products to it. Some of the options don't seem to associate with the product in the back-end and front-end even though link records are created in the catalog_attribute_super_link table.

The issue is that the table `attribute_option` is being inner joined in the query that loads the configurable options (simple products), but our custom attribute doesn't store its options in that table.

Moreover, some of the options might display even if they are not stored in that table, how is this possible? because our custom fabric ids might have the same id as options in the `attribute_option` table and the inner join looks at all the values in `attribute_option` table instead of just as the ones from the attribute in question.

This has been fixed as well for the scenario in which the `attribute_option` table must be joined (when the attribute uses the default table to store the options)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
