### PR TITLE
Setting deploy mode to production with --skip-compilation flag should not clear generated code

### DIFF
--- a/setup/src/Magento/Setup/Console/CompilerPreparation.php
+++ b/setup/src/Magento/Setup/Console/CompilerPreparation.php
@@ -105,7 +105,6 @@ class CompilerPreparation
             'module:disable',
             'module:enable',
             'module:uninstall',
-            'deploy:mode:set'
         ];
     }
 


### PR DESCRIPTION
### Description

Changing the deploy mode to **production** using the `--skip-compilation` flag will remove the generated code in `generated/code/` and `generated/metadata/`.

The expected result is that `generated/code/` and `generated/metadata/` should not be cleared.

This was introduced in https://github.com/magento/magento2/commit/ea57b46e54161e2b61503092f18f208d2bb07899#diff-de930b059902896ae8ce118b11024cbaR108. It is safe to remove as the `deploy:mode:set` command will clear the folder when the `--skip-compilation` flag is not used.

### Manual testing scenarios
1. Make sure you are in developer mode: `php bin/magento deploy:mode:set developer`
2. `php bin/magento setup:di:compile`
3. `php bin/magento deploy:mode:set production --skip-compilation`
4. `ls -la generated/metadata/` should contain files
