### PR TITLE
Fix for #8222

### DIFF
--- a/lib/web/mage/collapsible.js
+++ b/lib/web/mage/collapsible.js
@@ -110,7 +110,7 @@ define([
         _processState: function () {
             var anchor = window.location.hash,
                 isValid = $.mage.isValidSelector(anchor),
-                urlPath = window.location.pathname.replace('.', ''),
+                urlPath = window.location.pathname.replace(/\./g, ''),
                 state;
 
             this.stateKey = encodeURIComponent(urlPath + this.element.attr('id'));


### PR DESCRIPTION
### Description

The shipping and estimate tax form doesn't display the form with country, city, postcode fields.
The form is in the dom, but hidden.
~~~
jquery.storageapi.min.js:2 Uncaught TypeError: Cannot read property 'htmlblock-shipping' of null
~~~

### Fixed Issues 

1. magento/magento2#8222: Estimate Shipping and Tax Form not works due to js error in collapsible.js


### Manual testing scenarios
1. Open chrome dev console
2. run: './././'.replace('.', '')
3. run: './././'.replace(/\./g,'')
4. profit

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
