### PR TITLE
[Backport] #16079 translation possibility for moreButtonText

### DIFF
--- a/app/code/Magento/Swatches/i18n/en_US.csv
+++ b/app/code/Magento/Swatches/i18n/en_US.csv
@@ -35,3 +35,4 @@ Image,Image
 "Image Position","Image Position"
 "The value of Admin must be unique.","The value of Admin must be unique."
 "Description","Description"
+"More","More"

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -235,7 +235,7 @@ define([
             controlLabelId: '',
 
             // text for more button
-            moreButtonText: 'More',
+            moreButtonText: $t('More'),
 
             // Callback url for media
             mediaCallback: '',


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

Added translation possibility for moreButtonText

### Fixed Issues (if relevant)

1. magento/magento2#16079: Need information about translating issue (Magento Swatches Js)


### Manual testing scenarios
You need a Configurable Product with a Swatch Product Attribute in Attribute Set
Swatch attribute have color or image attached to each swatch attribute value
This Parent Product have more than three children configured with the Swatch Attribute
In configuration, you need to have in Catalog > Storefront > Swatches per Product defined to 2
In configuration, you need to have in Catalog > Storefront > Show Swatches in Product List defined to Yes
Swatches have "more" text that can be translated

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR:
https://github.com/magento/magento2/pull/16190