### PR TITLE
Improved invoice PDF generation flow

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/PrintAction.php
@@ -48,7 +48,7 @@ abstract class PrintAction extends \Magento\Backend\App\Action
      */
     public function execute()
     {
-        $invoiceId = $this->getRequest()->getParam('invoice_id');
+        $invoiceId = (int) $this->getRequest()->getParam('invoice_id');
         if ($invoiceId) {
             $invoice = $this->_objectManager->create(
                 \Magento\Sales\Api\InvoiceRepositoryInterface::class

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/PrintAction.php
@@ -55,13 +55,10 @@ abstract class PrintAction extends \Magento\Backend\App\Action
             )->get($invoiceId);
             if ($invoice) {
                 $pdf = $this->_objectManager->create(\Magento\Sales\Model\Order\Pdf\Invoice::class)->getPdf([$invoice]);
-                $date = $this->_objectManager->get(
-                    \Magento\Framework\Stdlib\DateTime\DateTime::class
-                )->date('Y-m-d_H-i-s');
                 return $this->_fileFactory->create(
-                    'invoice' . $date . '.pdf',
+                    "invoice_$invoiceId.pdf",
                     $pdf->render(),
-                    DirectoryList::VAR_DIR,
+                    DirectoryList::PDF,
                     'application/pdf'
                 );
             }

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/PrintActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/PrintActionTest.php
@@ -126,7 +126,6 @@ class PrintActionTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $pdfMock->expects($this->once())
             ->method('render');
-        $dateTimeMock = $this->createMock(\Magento\Framework\Stdlib\DateTime\DateTime::class);
 
         $invoiceRepository = $this->getMockBuilder(\Magento\Sales\Api\InvoiceRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -143,10 +142,7 @@ class PrintActionTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->with(\Magento\Sales\Model\Order\Pdf\Invoice::class)
             ->willReturn($pdfMock);
-        $this->objectManagerMock->expects($this->at(2))
-            ->method('get')
-            ->with(\Magento\Framework\Stdlib\DateTime\DateTime::class)
-            ->willReturn($dateTimeMock);
+
 
         $this->assertNull($this->controller->execute());
     }

--- a/lib/internal/Magento/Framework/App/Filesystem/DirectoryList.php
+++ b/lib/internal/Magento/Framework/App/Filesystem/DirectoryList.php
@@ -136,6 +136,11 @@ class DirectoryList extends \Magento\Framework\Filesystem\DirectoryList
     const GENERATED_METADATA = 'metadata';
 
     /**
+     * Relative directory key for generated PDFs
+     */
+    const PDF = 'pdf';
+
+    /**
      * {@inheritdoc}
      */
     public static function getDefaultConfig()
@@ -164,6 +169,7 @@ class DirectoryList extends \Magento\Framework\Filesystem\DirectoryList
             self::GENERATED => [parent::PATH => 'generated'],
             self::GENERATED_CODE => [parent::PATH => Io::DEFAULT_DIRECTORY],
             self::GENERATED_METADATA => [parent::PATH => 'generated/metadata'],
+            self::PDF => [parent::PATH => 'var/pdf'],
         ];
         return parent::getDefaultConfig() + $result;
     }


### PR DESCRIPTION
### Description
Currently, in an attempt to print an invoice from admin panel, the corresponding PDF file is generated directly in `var` directory of the Magento installation. Very often this approach leads to a mess in the `va`r directory if the invoice printing action takes place frequently during a day.

This PR brings a concept for two improvements:

- Invoice PDFs are being generated in the `var/pdf` directory so the `var` directory root is clean.
- The generated PDF does not include the timestamp in its name. There's no reason to keep a separate PDF for the same invoice over and over again. So once the "Print" action is performed on the same invoice more than once, the old PDF file is simply overwritten.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/3535
2. https://github.com/magento/magento2/issues/14517

### Manual testing scenarios
- Open an existing invoice in the admin panel.
- Click the "Print" button.
- You should have the invoice downloaded.
- You should have a copy of the invoice generated in the `var/pdf` directory instead of `var`.

- Click on the "Print" button once again
- The `var/pdf` directory should not contain an additional copy of the same invoice

The same issue is fare for shipments and credit memos. I'm going to address those parts in a separate PR or within a scope of this one. I just want to make sure that the proposed concept is fine and we are good to move forward.

Thank you