### PR TITLE
MAGETWO-61209: Backport - Fixed issue #7379 with mage/calendar when setting `numberOfM…

### DIFF
--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -236,11 +236,13 @@
                 firstDay = parseInt(this._get(inst, 'firstDay'), 10);
                 firstDay = isNaN(firstDay) ? 0 : firstDay;
 
-                for (row; row < numMonths[0]; row++) {
+                for (row = 0; row < numMonths[0]; row++) {
                     this.maxRows = 4;
 
-                    for (col; col < numMonths[1]; col++) {
+                    for (col = 0; col < numMonths[1]; col++) {
                         selectedDate = this._daylightSavingAdjust(new Date(drawYear, drawMonth, inst.selectedDay));
+
+                        calender = '';
 
                         if (isMultiMonth) {
                             calender += '<div class="ui-datepicker-group';
@@ -271,7 +273,7 @@
                         thead = showWeek ?
                             '<th class="ui-datepicker-week-col">' + this._get(inst, 'weekHeader') + '</th>' : '';
 
-                        for (dow; dow < 7; dow++) { // days of the week
+                        for (dow = 0; dow < 7; dow++) { // days of the week
                             day = (dow + firstDay) % 7;
                             thead += '<th' + ((dow + firstDay + 6) % 7 >= 5 ?
                                 ' class="ui-datepicker-week-end"' : '') + '>' +
@@ -289,7 +291,7 @@
                         this.maxRows = numRows;
                         printDate = this._daylightSavingAdjust(new Date(drawYear, drawMonth, 1 - leadDays));
 
-                        for (dRow; dRow < numRows; dRow++) { // create date picker rows
+                        for (dRow = 0; dRow < numRows; dRow++) { // create date picker rows
                             calender += '<tr>';
                             tbody = !showWeek ? '' : '<td class="ui-datepicker-week-col">' +
                             this._get(inst, 'calculateWeek')(printDate) + '</td>';


### PR DESCRIPTION
### Description
The full description of the issue and steps to reproduce are provided in #7379.
The same issue is reproduced on Magento 2.1, Magento 2.2 and Magento 2.3-develop

### Fixed Issues
1. magento/magento2#7379: Calendar widget (jQuery UI DatePicker) with numberOfMonths = 2 or more

### Manual testing scenarios
The easiest way to see the issue in action is to add a new field in the `Magento_Contact` form that is gonna use a calendar.

Field to add:
```
<div class="field availability">
  <label class="label" for="availability"><span><?= $block->escapeHtml(__('Availability')) ?></span></label>
   <div class="control">
       <input name="availability" id="availability" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>"
            value="<?= $block->escapeHtmlAttr($this->helper('Magento\Contact\Helper\Data')->getPostValue('availability')) ?>" class="input-text" type="text" />
  </div>
</div>
```

Initialize the calendar:
```
<script>
    require(['jquery', 'mage/calendar'], function($, calendar) {
       $('#availability').calendar({
           numberOfMonths: [1, 2]
       });
    });
</script>
```
You should see only 2 months displayed, like this:
![image](https://user-images.githubusercontent.com/13456702/41683263-c0665a74-74e2-11e8-9199-25ee3144cd20.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/16278