### PR TITLE
[Backport] Submitting search form (mini) with enter key fires event handlers bound by jquery twice

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -207,6 +207,7 @@ define([
                     break;
                 case $.ui.keyCode.ENTER:
                     this.searchForm.trigger('submit');
+                    e.preventDefault();
                     break;
                 case $.ui.keyCode.DOWN:
                     if (this.responseList.indexList) {


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15340

### Description
When submitting the search form in the header with the enter key on the keyboard, event handlers that were bound to the form submit (through jQuery) are fired twice. 

### Fixed Issues (if relevant)
1. magento/magento2#13793: Submitting search form (mini) with enter key fires event handlers bound by jquery twice

### Manual testing scenarios
1. Create a javascript which adds an event handler to the form submit
2. $('#search_mini_form').on('submit', function(e) {
    console.log('listening for form submit');
});
3. Submit the search form in the header with a value by pressing the enter button

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
