### PR TITLE
Add UpdatedAtListProvider to NotSyncedDataProvider for invoice grid

### DIFF
--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -120,6 +120,7 @@
         <arguments>
             <argument name="providers" xsi:type="array">
                 <item name="default" xsi:type="string">Magento\Sales\Model\ResourceModel\Provider\UpdatedIdListProvider</item>
+                <item name="updated_at" xsi:type="string">Magento\Sales\Model\ResourceModel\Provider\UpdatedAtListProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Invoice grid isn't updated when state is changed.

### Description
Invoice updates aren't updated in a grid. Regarding our use case: We create proforma invoices with their own increment ID (e.g. Concept #1), upon shipment we update update the increment ID to use the normal invoice sequence. These changes aren't picked up by the indexer because the `UpdatedAtListProvider` isn't used.

Issue should be reproducible using scenarios below.

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios
1. Enable async grid indexing.
2. Create order + invoice with state open.
3. Run the `sales_grid_order_invoice_async_insert`.
4. Invoice is added to grid.
5. Mark invoice paid.
6. Run the `sales_grid_order_invoice_async_insert`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
