### PR TITLE
[fix] can send creditmemo email with grouped product

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Sales\Block\Order\Email\Items\Order;
 
+use Magento\Sales\Model\Order\Creditmemo\Item as CreditmemoItem;
+use Magento\Sales\Model\Order\Invoice\Item as InvoiceItem;
 use Magento\Sales\Model\Order\Item as OrderItem;
 
 /**
@@ -93,7 +95,7 @@ class DefaultOrder extends \Magento\Framework\View\Element\Template
     /**
      * Get the html for item price
      *
-     * @param OrderItem $item
+     * @param OrderItem|InvoiceItem|CreditmemoItem  $item
      * @return string
      */
     public function getItemPrice($item)

--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
@@ -96,7 +96,7 @@ class DefaultOrder extends \Magento\Framework\View\Element\Template
      * @param OrderItem $item
      * @return string
      */
-    public function getItemPrice(OrderItem $item)
+    public function getItemPrice($item)
     {
         $block = $this->getLayout()->getBlock('item_price');
         $block->setItem($item);

--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Sales\Block\Order\Email\Items\Order;
 
+use Magento\Sales\Model\AbstractModel;
 use Magento\Sales\Model\Order\Creditmemo\Item as CreditmemoItem;
 use Magento\Sales\Model\Order\Invoice\Item as InvoiceItem;
 use Magento\Sales\Model\Order\Item as OrderItem;
@@ -98,7 +99,7 @@ class DefaultOrder extends \Magento\Framework\View\Element\Template
      * @param OrderItem|InvoiceItem|CreditmemoItem  $item
      * @return string
      */
-    public function getItemPrice($item)
+    public function getItemPrice(AbstractModel $item)
     {
         $block = $this->getLayout()->getBlock('item_price');
         $block->setItem($item);


### PR DESCRIPTION
[fix] can send creditmemo email with grouped product

### Description
- Create an order with grouped product
- Make a creditmemo
- Send email

### Fixed Issues (if relevant)
You now receive the email.
```
[21-Jun-2018 10:37:43 UTC] PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Sales\Block\Order\Email\Items\Order\DefaultOrder::getItemPrice() must be an instance of Magento\Sales\Model\Order\Item, instance of Magento\Sales\Model\Order\Creditmemo\Item given, called in /var/www/html/vendor/magento/module-sales/view/frontend/templates/email/items/creditmemo/default.phtml on line 34 and defined in /var/www/html/vendor/magento/module-sales/Block/Order/Email/Items/Order/DefaultOrder.php:99
Stack trace:
#0 /var/www/html/vendor/magento/module-sales/view/frontend/templates/email/items/creditmemo/default.phtml(34): Magento\Sales\Block\Order\Email\Items\Order\DefaultOrder->getItemPrice(Object(Magento\Sales\Model\Order\Creditmemo\Item))
#1 /var/www/html/vendor/magento/framework/View/TemplateEngine/Php.php(59): include('/var/www/html/v...')
#2 /var/www/html/vendor/magento/framework/View/Element/Template.php(270): Magento\Framework\View\TemplateEngine\Php->render(Object(Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped), '/var/www/html/v...', Array)
#3 /var/www/html/vendor/magento/framework/View/Element/Template.php(300): Magento\Framework\View\Element\Template->fetchView('/var/www/html/v...')
#4 /var/www/html/vendor/magento/module-grouped-product/Block/Order/Email/Items/Order/Grouped.php(35): Magento\Framework\View\Element\Template->_toHtml()
#5 /var/www/html/vendor/magento/framework/View/Element/AbstractBlock.php(667): Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped->_toHtml()
#6 /var/www/html/vendor/magento/module-sales/Block/Items/AbstractItems.php(89): Magento\Framework\View\Element\AbstractBlock->toHtml()
#7 /var/www/html/vendor/magento/module-sales/view/frontend/templates/email/creditmemo/items.phtml(34): Magento\Sales\Block\Items\AbstractItems->getItemHtml(Object(Magento\Sales\Model\Order\Creditmemo\Item))
#8 /var/www/html/vendor/magento/framework/View/TemplateEngine/Php.php(59): include('/var/www/html/v...')
#9 /var/www/html/vendor/magento/framework/View/Element/Template.php(270): Magento\Framework\View\TemplateEngine\Php in /var/www/html/vendor/magento/module-sales/Block/Order/Email/Items/Order/DefaultOrder.php on line 99
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
