### PR TITLE
Magento sometimes doesn't select the correct store if the scope code is null

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -34,7 +34,7 @@ class ScopeCodeResolver
      * Resolve scope code
      *
      * @param string $scopeType
-     * @param string $scopeCode
+     * @param string|null $scopeCode
      * @return string
      */
     public function resolve($scopeType, $scopeCode)
@@ -47,6 +47,9 @@ class ScopeCodeResolver
         ) {
             $scopeResolver = $this->scopeResolverPool->get($scopeType);
             $resolverScopeCode = $scopeResolver->getScope($scopeCode);
+            if ($scopeCode === null) {
+                $scopeCode = $resolverScopeCode->getCode();
+            }
         } else {
             $resolverScopeCode = $scopeCode;
         }


### PR DESCRIPTION
Description:
The method `resolve()` of the class `Magento/framework/App/Config/ScopeCodeResolver` doesn't select the correct store if the `$scopeCode` parameter in null on multi-store sites. In this case the value is retrieved with the wrong `$scopeCode` value.

Preconditions:
Magento v. 2.2.x or 2.3dev

Expected result:
The site switch to correct store in any cases.

Current result:
When the resolve method is called with null value then the `resolvedScopeCodes[$scopeType]` array gets an entry with null key wich has the resolved scope as value. If then the scope is switched and the resolve method is again called with null value then the value returned is not correct. This has been seen happening by us randomly in store language resolution.

Proposed solution:
If the store code of the method `resolve()` is called with a `null` `scopeCode` parameter then the `scopeCode` is changed after its evaluation so that the `resolvedScopeCodes[$scopeType]` array never has a null key value.