### PR TITLE
Fix issues with setup:install command if scopes are defined in config.php

### DIFF
--- a/app/code/Magento/Store/Model/Config/Processor/Fallback.php
+++ b/app/code/Magento/Store/Model/Config/Processor/Fallback.php
@@ -85,13 +85,8 @@ class Fallback implements PostProcessorInterface
      */
     public function process(array $data)
     {
-        if ($this->deploymentConfig->isDbAvailable()) {//read only from db
-            $this->storeData = $this->storeResource->readAllStores();
-            $this->websiteData = $this->websiteResource->readAllWebsites();
-        } else {
-            $this->storeData = $this->scopes->get('stores');
-            $this->websiteData = $this->scopes->get('websites');
-        }
+        $this->storeData = $this->scopes->get('stores');
+        $this->websiteData = $this->scopes->get('websites');
 
         $defaultConfig = isset($data['default']) ? $data['default'] : [];
         $result = [

--- a/setup/src/Magento/Setup/Console/Command/InstallCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/InstallCommand.php
@@ -145,10 +145,11 @@ class InstallCommand extends AbstractSetupCommand
         $installer = $this->installerFactory->create($consoleLogger);
         $installer->install($input->getOptions());
 
-        $importConfigCommand = $this->getApplication()->find(ConfigImportCommand::COMMAND_NAME);
-        $arrayInput = new ArrayInput([]);
-        $arrayInput->setInteractive($input->isInteractive());
-        $importConfigCommand->run($arrayInput, $output);
+        $configImportCommand = 'bin/magento ' . ConfigImportCommand::COMMAND_NAME;
+        if (!$input->isInteractive()) {
+            $configImportCommand .= ' --no-interaction';
+        }
+        passthru($configImportCommand);
     }
 
     /**


### PR DESCRIPTION
# Preconditions

* Core Magento, no additional modules
* Tested on 2.2-develop with PHP 7.0 and 2.3-develop with PHP 7.1

# Steps to reproduce

Create `app/etc/config.php` with the following:

- Default store name different than "default". For example "custom"
- One extra store
- run `bin/magento setup:install`

```
return [
    'modules' => [
       /* All core modules enabled */
      ...
    ],
    'scopes' => [
        'websites' => [
            'admin' => [
                'website_id' => '0',
                'code' => 'admin',
                'name' => 'Admin',
                'sort_order' => '0',
                'default_group_id' => '0',
                'is_default' => '0'
            ],
            'base' => [
                'website_id' => '1',
                'code' => 'base',
                'name' => 'Main Website',
                'sort_order' => '0',
                'default_group_id' => '1',
                'is_default' => '1'
            ]
        ],
        'groups' => [
            [
                'group_id' => '0',
                'website_id' => '0',
                'code' => 'default',
                'name' => 'Default',
                'root_category_id' => '0',
                'default_store_id' => '0'
            ],
            [
                'group_id' => '1',
                'website_id' => '1',
                'code' => 'main_website_store',
                'name' => 'Main Website Store',
                'root_category_id' => '2',
                'default_store_id' => '1'
            ]
        ],
        'stores' => [
            'admin' => [
                'store_id' => '0',
                'code' => 'admin',
                'website_id' => '0',
                'group_id' => '0',
                'name' => 'Admin',
                'sort_order' => '0',
                'is_active' => '1'
            ],
            'custom' => [
                'store_id' => '1',
                'code' => 'custom',
                'website_id' => '1',
                'group_id' => '1',
                'name' => 'Default Store View',
                'sort_order' => '0',
                'is_active' => '1'
            ],
            'extra' => [
                'store_id' => '3',
                'code' => 'extra',
                'website_id' => '1',
                'group_id' => '1',
                'name' => 'Extra Store',
                'sort_order' => '1',
                'is_active' => '1'
            ]
        ]
    ]
];
```

# Expected result
Magento being installed and additional store created

# Actual result

## First Error
```
[Progress: 405 / 754]
Module 'Magento_Payment':
[Progress: 406 / 754]
Module 'Magento_CatalogRule':
Installing data... Upgrading data...
[Progress: 407 / 754]
Module 'Magento_CatalogSearch':
Installing data...

  [LogicException]
  There is no such engine:
```

### Reason

- `Magento_CatalogSearch` setup scripts calls `scopeConfig->getValue()` on store scope in one of his internal methods. This requests the value for the default store set in `config.php` which in this example will be `custom`
- Store values are retrieved in the `Fallback` class from DB instead of from the `config.php`:

```
// app/code/Magento/Store/Model/Config/Processor/Fallback.php
public function process(array $data)
{
    if ($this->deploymentConfig->isDbAvailable()) {//read only from db
        $this->storeData = $this->storeResource->readAllStores();
        $this->websiteData = $this->websiteResource->readAllWebsites();
    }
}
```

As we can see, list of stores is here retrieved from the database, where our `custom` store does not exists yet. 

### Solution
- [Code changes in app/code/Magento/Store/Model/Config/Processor/Fallback.php](https://github.com/magento/magento2/pull/16317/files#diff-5dec7e10285c9a96cf5b40b06ece36c0)
- Retrieve lists of stores always from `scopes` object. If I am not wrong, this object contains the list of stores from `config.php` or from the Database if they are not defined in `config.php`

## Second Error
After fixing the previous error, if we try to run `setup:install` again, we get another error at the end.

```
[SUCCESS]: Magento installation complete.
[SUCCESS]: Magento Admin URI: /admin
Processing configurations data from configuration file...

Import failed: Requested store is not found

```

### Reason

- After creating the new `extra` Store, the method `Magento\Store\Model\StoreManager::reinitStores()` is executed. This method calls `$this->scopeConfig->clean()`. Which will first clean the `scopes`.
- When cleaning the scopes, they are also loaded again because one `logging` submethod is calling `scopeConfig->getValue()`.
- When loading the scopes again, the list of stores is different on different objects. 

```
// Magento\Store\App\Config\Type\Scopes
public function get($path = '')
{
    if (null === $this->data) {
        $this->data = new DataObject($this->source->get());
    }
}
```

`$this-data` contains the list of scopes. On `storeRepository` object, this list is still the old one without the new store added.

### Solution

Option 1:
- The right solution will be to clear the `storeRepository` object and `Magento\Config\App\Config\Type\System` before the `Magento\Store\App\Config\Type\Scopes` -> That is not possible however because another race condition is trigger when the `System` is cleared before the `Scopes`

Option 2:
- Do not call `scopeConfig->getValue()` during the `Magento\Store\App\Config\Type\Scopes` to check whether the logs are enabled.

Option 3:
- Execute `app:config:import` in a new thread, where the objects are all clean.
- That is the actual solution of this PR because I did not manage to find a better way after 10 hours working on it. See [Changes on setup/src/Magento/Setup/Console/Command/InstallCommand.php](https://github.com/magento/magento2/pull/16317/files#diff-5dec7e10285c9a96cf5b40b06ece36c0)

## Fixed Issues
1. [#15686](https://github.com/magento/magento2/issues/15686)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
