### PR TITLE
[Forwardport] Fixed syntax for before-after operators in less files

### DIFF
--- a/app/code/Magento/Catalog/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/menu.xml
@@ -12,7 +12,6 @@
         <add id="Magento_Catalog::catalog_categories" title="Categories" translate="title" module="Magento_Catalog" sortOrder="20" parent="Magento_Catalog::inventory" action="catalog/category/" resource="Magento_Catalog::categories"/>
         <add id="Magento_Catalog::catalog_attributes_attributes" title="Product" translate="title" module="Magento_Catalog" sortOrder="30" parent="Magento_Backend::stores_attributes" action="catalog/product_attribute/" resource="Magento_Catalog::attributes_attributes"/>
         <add id="Magento_Catalog::catalog_attributes_sets" title="Attribute Set" translate="title" module="Magento_Catalog" sortOrder="40" parent="Magento_Backend::stores_attributes" action="catalog/product_set/" resource="Magento_Catalog::sets"/>
-
         <add id="Magento_Catalog::inventory" title="Inventory" translate="title" module="Magento_Catalog" sortOrder="10" parent="Magento_Catalog::catalog" dependsOnModule="Magento_Catalog" resource="Magento_Catalog::catalog"/>
     </menu>
 </config>

--- a/app/design/adminhtml/Magento/backend/web/app/setup/styles/less/lib/forms/_checkbox-radio.less
+++ b/app/design/adminhtml/Magento/backend/web/app/setup/styles/less/lib/forms/_checkbox-radio.less
@@ -87,7 +87,7 @@
 .form-el-checkbox {
     &:checked {
         + .form-label {
-            &::before {
+            &:before {
                 content: @checkbox-icon__content;
                 font-family: @icons__font-family;
             }

--- a/app/design/adminhtml/Magento/backend/web/app/updater/styles/less/components/_data-grid.less
+++ b/app/design/adminhtml/Magento/backend/web/app/updater/styles/less/components/_data-grid.less
@@ -22,8 +22,8 @@
     vertical-align: middle;
     width: @component-indicator__size;
 
-    &::before,
-    &::after {
+    &:before,
+    &:after {
         background: @color-white;
         display: block;
         opacity: 0;
@@ -32,7 +32,7 @@
         visibility: hidden;
     }
 
-    &::before {
+    &:before {
         border: 1px solid @color-gray68;
         border-radius: 1px;
         box-shadow: 0 0 2px rgba(0,0,0,.4);
@@ -43,7 +43,7 @@
         padding: 4px 5px;
     }
 
-    &::after {
+    &:after {
         border-color: darken(@color-gray68, 8);
         border-style: solid;
         border-width: 1px 0 0 1px;
@@ -56,8 +56,8 @@
     }
 
     &:hover {
-        &::before,
-        &::after {
+        &:before,
+        &:after {
             opacity: 1;
             transition: opacity .2s linear;
             visibility: visible;

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_authentication.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_authentication.less
@@ -94,7 +94,7 @@
                 padding-top: @indent__xl;
                 position: relative;
 
-                &::before {
+                &:before {
                     .lib-css(height, @block-auth__or-label__size);
                     .lib-css(line-height, @block-auth__or-label__size - 2px);
                     .lib-css(margin, -(@block-auth__or-label__size/2 + 1px) 0 0 -(@block-auth__or-label__size / 2));
@@ -212,7 +212,7 @@
                 margin: 0;
                 padding: @indent__s 0 0 @indent__xl;
 
-                &::before {
+                &:before {
                     left: 0;
                     top: 50%;
                 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16181
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed syntax for **before-after** operators in less files.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
