### PR TITLE
5730: fixed hardcoded sort order on the search page, added new config

### DIFF
--- a/app/code/Magento/Catalog/Model/Config.php
+++ b/app/code/Magento/Catalog/Model/Config.php
@@ -17,6 +17,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 class Config extends \Magento\Eav\Model\Config
 {
     const XML_PATH_LIST_DEFAULT_SORT_BY = 'catalog/frontend/default_sort_by';
+    const XML_PATH_SEARCH_LIST_DEFAULT_SORT_BY = 'catalog/search/default_sort_by';
 
     /**
      * @var mixed
@@ -492,5 +493,21 @@ class Config extends \Magento\Eav\Model\Config
     public function getProductListDefaultSortBy($store = null)
     {
         return $this->_scopeConfig->getValue(self::XML_PATH_LIST_DEFAULT_SORT_BY, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
+    }
+
+    /**
+     * Retrieve Search Product List Default Sort By
+     *
+     * @param mixed $store
+     * @return string
+     */
+    public function getSearchProductListDefaultSortBy($store = null)
+    {
+        $configValue = $this->_scopeConfig->getValue(
+            self::XML_PATH_SEARCH_LIST_DEFAULT_SORT_BY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+        return $configValue ? $configValue : 'relevance';
     }
 }

--- a/app/code/Magento/CatalogSearch/Block/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Result.php
@@ -9,9 +9,11 @@ use Magento\Catalog\Block\Product\ListProduct;
 use Magento\Catalog\Model\Layer\Resolver as LayerResolver;
 use Magento\CatalogSearch\Helper\Data;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Search\Model\QueryFactory;
+use Magento\Catalog\Model\Config;
 
 /**
  * Product search result block
@@ -48,10 +50,16 @@ class Result extends Template
     private $queryFactory;
 
     /**
+     * @var Config
+     */
+    private $catalogConfig;
+
+    /**
      * @param Context $context
      * @param LayerResolver $layerResolver
      * @param Data $catalogSearchData
      * @param QueryFactory $queryFactory
+     * @param Config $catalogConfig
      * @param array $data
      */
     public function __construct(
@@ -59,11 +67,13 @@ class Result extends Template
         LayerResolver $layerResolver,
         Data $catalogSearchData,
         QueryFactory $queryFactory,
-        array $data = []
+        array $data = [],
+        Config $catalogConfig = null
     ) {
         $this->catalogLayer = $layerResolver->get();
         $this->catalogSearchData = $catalogSearchData;
         $this->queryFactory = $queryFactory;
+        $this->catalogConfig = $catalogConfig ?: ObjectManager::getInstance()->get(Config::class);
         parent::__construct($context, $data);
     }
 
@@ -143,7 +153,7 @@ class Result extends Template
         )->setDefaultDirection(
             'desc'
         )->setDefaultSortBy(
-            'relevance'
+            $this->catalogConfig->getSearchProductListDefaultSortBy($category->getStoreId())
         );
 
         return $this;

--- a/app/code/Magento/CatalogSearch/Block/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Result.php
@@ -59,8 +59,8 @@ class Result extends Template
      * @param LayerResolver $layerResolver
      * @param Data $catalogSearchData
      * @param QueryFactory $queryFactory
-     * @param Config $catalogConfig
      * @param array $data
+     * @param Config|null $catalogConfig
      */
     public function __construct(
         Context $context,

--- a/app/code/Magento/CatalogSearch/Model/Config/Source/ListSort.php
+++ b/app/code/Magento/CatalogSearch/Model/Config/Source/ListSort.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogSearch\Model\Config\Source;
+
+use Magento\Catalog\Model\Config;
+use Magento\Framework\Option\ArrayInterface;
+
+/**
+ * @inheritdoc
+ */
+class ListSort implements ArrayInterface
+{
+    /**
+     * @var Config
+     */
+    private $catalogConfig;
+
+    /**
+     * @param Config $catalogConfig
+     */
+    public function __construct(Config $catalogConfig)
+    {
+        $this->catalogConfig = $catalogConfig;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toOptionArray()
+    {
+        $options[] = [
+            'label' => __('Relevance'),
+            'value' => 'relevance'
+        ];
+        foreach ($this->catalogConfig->getAttributesUsedForSortBy() as $attribute) {
+            $options[] = [
+                'label' => __($attribute['frontend_label']),
+                'value' => $attribute['attribute_code']
+            ];
+        }
+
+        return $options;
+    }
+}

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
@@ -32,6 +32,10 @@
                     <comment>Number of popular search terms to be cached for faster response. Use “0” to cache all results after a term is searched for the second time.</comment>
                     <validate>validate-digits</validate>
                 </field>
+                <field id="default_sort_by" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Product Listing Sort by</label>
+                    <source_model>Magento\CatalogSearch\Model\Config\Source\ListSort</source_model>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
### Description
Added new option in `admin -> stores -> configuration -> catalog -> catalog -> catalog search -> Product Listing Sort by` for setting a default sort order for search results page instead hardcoded string literal `relevance`.

### Fixed Issues (if relevant)
1. magento/magento2#5730: Changing sort order in admin doesn't work for catalog search

### Manual testing scenarios
1. Login to Magento store admin
2. Navigate to `Stores->Configuration->Catalog->Catalog->Catalog Search`
3. Change Product Listing Sort by to Price
4. Clear Cache
5. Go to Magento store frontend and search by keyword
6. Verify that default sorting is the one set in admin