### PR TITLE
[Forwardport 2.3] magento/magento2#15505: Interceptor class methods do not support nullable return types

### DIFF
--- a/lib/internal/Magento/Framework/Code/Generator/Method/ReturnTypeResolver.php
+++ b/lib/internal/Magento/Framework/Code/Generator/Method/ReturnTypeResolver.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Method return type resolver
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Code\Generator\Method;
+
+class ReturnTypeResolver
+{
+    /**
+     * Retrieve return type info.
+     *
+     * @param \ReflectionMethod $method
+     *
+     * @return null|string
+     */
+    public function getReturnType(\ReflectionMethod $method)
+    {
+        $returnType = method_exists($method, 'getReturnType')
+            ? $method->getReturnType()
+            : null;
+
+        if ($returnType !== null) {
+            $returnType = $this->getReturnTypeName($returnType, $method);
+        }
+
+        return $returnType;
+    }
+
+    /**
+     * Retrieve return type name.
+     *
+     * @param \ReflectionType $returnType
+     * @param \ReflectionMethod $methodReflection
+     * @return string
+     */
+    private function getReturnTypeName(\ReflectionType $returnType, \ReflectionMethod $methodReflection) : string
+    {
+        if (method_exists($returnType, 'getName')) {
+            $returnTypeName = ($returnType->allowsNull() ? '?' : '') .
+                $this->expandLiteralType($returnType->getName(), $methodReflection);
+        } else {
+            $returnTypeName = $this->expandLiteralType((string) $returnType, $methodReflection);
+        }
+
+        return $returnTypeName;
+    }
+
+    /**
+     * Return literal type name.
+     *
+     * @param string $literalReturnType
+     * @param \ReflectionMethod $methodReflection
+     *
+     * @return string
+     */
+    private function expandLiteralType($literalReturnType, \ReflectionMethod $methodReflection)
+    {
+        $returnType = $literalReturnType;
+
+        if (strtolower($literalReturnType) == 'self') {
+            $returnType = $methodReflection->getDeclaringClass()->getName();
+        }
+
+        if (strtolower($literalReturnType) == 'parent') {
+            $returnType = $methodReflection->getDeclaringClass()->getParentClass()->getName();
+        }
+
+        return $returnType;
+    }
+}

--- a/lib/internal/Magento/Framework/Code/Generator/Method/ReturnTypeResolver.php
+++ b/lib/internal/Magento/Framework/Code/Generator/Method/ReturnTypeResolver.php
@@ -5,6 +5,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Code\Generator\Method;
 
 class ReturnTypeResolver
@@ -16,7 +18,7 @@ class ReturnTypeResolver
      *
      * @return null|string
      */
-    public function getReturnType(\ReflectionMethod $method)
+    public function getReturnType(\ReflectionMethod $method) : ?string
     {
         $returnType = method_exists($method, 'getReturnType')
             ? $method->getReturnType()
@@ -39,13 +41,11 @@ class ReturnTypeResolver
     private function getReturnTypeName(\ReflectionType $returnType, \ReflectionMethod $methodReflection) : string
     {
         if (method_exists($returnType, 'getName')) {
-            $returnTypeName = ($returnType->allowsNull() ? '?' : '') .
+            return ($returnType->allowsNull() ? '?' : '') .
                 $this->expandLiteralType($returnType->getName(), $methodReflection);
-        } else {
-            $returnTypeName = $this->expandLiteralType((string) $returnType, $methodReflection);
         }
 
-        return $returnTypeName;
+        return $this->expandLiteralType((string) $returnType, $methodReflection);
     }
 
     /**
@@ -56,7 +56,7 @@ class ReturnTypeResolver
      *
      * @return string
      */
-    private function expandLiteralType($literalReturnType, \ReflectionMethod $methodReflection)
+    private function expandLiteralType(string $literalReturnType, \ReflectionMethod $methodReflection) : string
     {
         $returnType = $literalReturnType;
 

--- a/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
+++ b/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
@@ -6,12 +6,48 @@
 
 namespace Magento\Framework\Interception\Code\Generator;
 
+use Magento\Framework\Code\Generator\DefinedClasses;
+use Magento\Framework\Code\Generator\Io;
+use Magento\Framework\Code\Generator\CodeGeneratorInterface;
+use Magento\Framework\Code\Generator\Method\ReturnTypeResolver;
+
 class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
 {
+
+    /**
+     * Result type resolver.
+     *
+     * @var ReturnTypeResolver
+     */
+    private $returnTypeResolver;
+
     /**
      * Entity type
      */
     const ENTITY_TYPE = 'interceptor';
+
+    /**
+     * Interceptor constructor.
+     *
+     * @param null|string $sourceClassName
+     * @param null|string $resultClassName
+     * @param Io $ioObject
+     * @param \Magento\Framework\Code\Generator\CodeGeneratorInterface $classGenerator
+     * @param DefinedClasses $definedClasses
+     * @param ReturnTypeResolver $returnTypeResolver
+     */
+    public function __construct(
+        $sourceClassName = null,
+        $resultClassName = null,
+        Io $ioObject = null,
+        CodeGeneratorInterface $classGenerator = null,
+        DefinedClasses $definedClasses = null,
+        ReturnTypeResolver $returnTypeResolver = null
+    ) {
+        parent::__construct($sourceClassName, $resultClassName, $ioObject, $classGenerator, $definedClasses);
+
+        $this->returnTypeResolver = $returnTypeResolver ?: new ReturnTypeResolver();
+    }
 
     /**
      * @param string $modelClassName
@@ -102,10 +138,7 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
             $parameters[] = $this->_getMethodParameterInfo($parameter);
         }
 
-        $returnType = $method->getReturnType();
-        $returnTypeValue = $returnType
-            ? ($returnType->allowsNull() ? '?' : '') .$returnType->getName()
-            : null;
+        $returnTypeValue = $this->returnTypeResolver->getReturnType($method);
         $methodInfo = [
             'name' => ($method->returnsReference() ? '& ' : '') . $method->getName(),
             'parameters' => $parameters,

--- a/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Proxy.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Proxy.php
@@ -7,8 +7,20 @@
  */
 namespace Magento\Framework\ObjectManager\Code\Generator;
 
+use Magento\Framework\Code\Generator\DefinedClasses;
+use Magento\Framework\Code\Generator\Io;
+use Magento\Framework\Code\Generator\CodeGeneratorInterface;
+use Magento\Framework\Code\Generator\Method\ReturnTypeResolver;
+
 class Proxy extends \Magento\Framework\Code\Generator\EntityAbstract
 {
+    /**
+     * Result type resolver.
+     *
+     * @var ReturnTypeResolver
+     */
+    private $returnTypeResolver;
+
     /**
      * Entity type
      */
@@ -18,6 +30,28 @@ class Proxy extends \Magento\Framework\Code\Generator\EntityAbstract
      * Marker interface
      */
     const NON_INTERCEPTABLE_INTERFACE = \Magento\Framework\ObjectManager\NoninterceptableInterface::class;
+
+    /**
+     * Interceptor constructor.
+     * @param string $sourceClassName
+     * @param string $resultClassName
+     * @param Io|null $ioObject
+     * @param CodeGeneratorInterface|null $classGenerator
+     * @param DefinedClasses|null $definedClasses
+     * @param ReturnTypeResolver|null $returnTypeResolver
+     */
+    public function __construct(
+        $sourceClassName = null,
+        $resultClassName = null,
+        Io $ioObject = null,
+        CodeGeneratorInterface $classGenerator = null,
+        DefinedClasses $definedClasses = null,
+        ReturnTypeResolver $returnTypeResolver = null
+    ) {
+        parent::__construct($sourceClassName, $resultClassName, $ioObject, $classGenerator, $definedClasses);
+
+        $this->returnTypeResolver = $returnTypeResolver ?: new ReturnTypeResolver();
+    }
 
     /**
      * @param string $modelClassName
@@ -160,10 +194,8 @@ class Proxy extends \Magento\Framework\Code\Generator\EntityAbstract
             $parameters[] = $this->_getMethodParameterInfo($parameter);
         }
 
-        $returnType = $method->getReturnType();
-        $returnTypeValue = $returnType
-            ? ($returnType->allowsNull() ? '?' : '') .$returnType->getName()
-            : null;
+        $returnTypeValue = $this->returnTypeResolver->getReturnType($method);
+
         $methodInfo = [
             'name' => $method->getName(),
             'parameters' => $parameters,

--- a/lib/internal/Magento/Framework/ObjectManager/Profiler/Code/Generator/Logger.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Profiler/Code/Generator/Logger.php
@@ -199,10 +199,14 @@ class Logger extends \Magento\Framework\Code\Generator\EntityAbstract
             }
         }
 
+        $returnType = $this->returnTypeResolver->getReturnType($method);
+
         $methodInfo = [
             'name' => $method->getName(),
             'parameters' => $parameters,
-            'body' => $body . "\nreturn \$this->_invoke('{$method->getName()}', \$args);",
+            'body' => $body . ($returnType === "void" ? "\n": "\nreturn ") .
+                "\$this->_invoke('{$method->getName()}', \$args);",
+            'returnType' => $returnType,
             'docblock' => [
                 'shortDescription' => '{@inheritdoc}',
             ],

--- a/lib/internal/Magento/Framework/ObjectManager/Profiler/Code/Generator/Logger.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Profiler/Code/Generator/Logger.php
@@ -6,12 +6,47 @@
  */
 namespace Magento\Framework\ObjectManager\Profiler\Code\Generator;
 
+use Magento\Framework\Code\Generator\DefinedClasses;
+use Magento\Framework\Code\Generator\Io;
+use Magento\Framework\Code\Generator\CodeGeneratorInterface;
+use Magento\Framework\Code\Generator\Method\ReturnTypeResolver;
+
 class Logger extends \Magento\Framework\Code\Generator\EntityAbstract
 {
     /**
      * Entity type
      */
     const ENTITY_TYPE = 'logger';
+
+    /**
+     * Result type resolver.
+     *
+     * @var ReturnTypeResolver
+     */
+    private $returnTypeResolver;
+
+    /**
+     * Logger constructor.
+     *
+     * @param null|string $sourceClassName
+     * @param null|string $resultClassName
+     * @param Io $ioObject
+     * @param \Magento\Framework\Code\Generator\CodeGeneratorInterface $classGenerator
+     * @param DefinedClasses $definedClasses
+     * @param ReturnTypeResolver $returnTypeResolver
+     */
+    public function __construct(
+        $sourceClassName = null,
+        $resultClassName = null,
+        Io $ioObject = null,
+        CodeGeneratorInterface $classGenerator = null,
+        DefinedClasses $definedClasses = null,
+        ReturnTypeResolver $returnTypeResolver = null
+    ) {
+        parent::__construct($sourceClassName, $resultClassName, $ioObject, $classGenerator, $definedClasses);
+
+        $this->returnTypeResolver = $returnTypeResolver ?: new ReturnTypeResolver();
+    }
 
     /**
      * @param string $modelClassName

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/ProxyTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/ProxyTest.php
@@ -30,6 +30,7 @@ class ProxyTest extends \PHPUnit\Framework\TestCase
                     $this->ioObjectMock,
                     null,
                     null,
+                    null,
                     $this->createMock(\Magento\Framework\Filesystem\FileResolver::class)
                 ]
             )


### PR DESCRIPTION
Code generation improvements.
### Description
Improve code generation for proxies, loggers and interceptors.
Forwardport of PR https://github.com/magento/magento2/pull/16337;
Partial refactoring for MAGETWO-89899:
- Fix return types like 'parent' and 'self';
- Add support of return types for loggers;
- Move logic to separated class, according to solid principles;

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15505: Interceptor class methods do not support nullable return types

### Manual testing scenarios
Steps to reproduce well described in related issue.
In additional, PR have impact on Logger and Proxies generation.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
