### PR TITLE
Magento_Sales integration tests: Fix addresses in order_list fixture

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
@@ -54,6 +54,14 @@ foreach ($orders as $orderData) {
     $order = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
         \Magento\Sales\Model\Order::class
     );
+
+    // Reset addresses
+    $billingAddress = $objectManager->create(\Magento\Sales\Model\Order\Address::class, ['data' => $addressData]);
+    $billingAddress->setAddressType('billing');
+
+    $shippingAddress = clone $billingAddress;
+    $shippingAddress->setId(null)->setAddressType('shipping');
+
     $order
         ->setData($orderData)
         ->addItem($orderItem)

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
@@ -8,10 +8,10 @@ use Magento\Sales\Model\Order;
 
 require 'order.php';
 /** @var Order $order */
-/** @var  Order\Payment $payment */
-/** @var  Order\Item $orderItem */
-/** @var  Order\Address $billingAddress */
-/** @var  Order\Address $shippingAddress */
+/** @var Order\Payment $payment */
+/** @var Order\Item $orderItem */
+/** @var Order\Address $billingAddress */
+/** @var Order\Address $shippingAddress */
 $orders = [
     [
         'increment_id' => '100000002',
@@ -58,6 +58,6 @@ foreach ($orders as $orderData) {
         ->setData($orderData)
         ->addItem($orderItem)
         ->setBillingAddress($billingAddress)
-        ->setBillingAddress($shippingAddress)
+        ->setShippingAddress($shippingAddress)
         ->save();
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
@@ -6,6 +6,7 @@
 
 use Magento\Sales\Model\Order;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\Address as OrderAddress;
 
 require 'order.php';
 /** @var Order $order */
@@ -59,20 +60,19 @@ foreach ($orders as $orderData) {
 
     // Reset addresses
     /** @var Order\Address $billingAddress */
-    $billingAddress = $objectManager->create(\Magento\Sales\Model\Order\Address::class, ['data' => $addressData]);
+    $billingAddress = $objectManager->create(OrderAddress::class, ['data' => $addressData]);
     $billingAddress->setAddressType('billing');
 
-    /** @var Order\Address $shippingAddress */
-    $shippingAddress = $objectManager->create(\Magento\Sales\Model\Order\Address::class, ['data' => $addressData]);
-    $shippingAddress->setAddressType('shipping');
+    $shippingAddress = clone $billingAddress;
+    $shippingAddress->setId(null)->setAddressType('shipping');
 
     $order
         ->setData($orderData)
         ->addItem($orderItem)
-        ->setBillingAddress($billingAddress)
-        ->setShippingAddress($shippingAddress)
         ->setCustomerIsGuest(true)
-        ->setCustomerEmail('customer@null.com');
+        ->setCustomerEmail('customer@null.com')
+        ->setBillingAddress($billingAddress)
+        ->setShippingAddress($shippingAddress);
 
     $orderRepository->save($order);
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
@@ -5,6 +5,7 @@
  */
 
 use Magento\Sales\Model\Order;
+use Magento\Sales\Api\OrderRepositoryInterface;
 
 require 'order.php';
 /** @var Order $order */
@@ -47,6 +48,8 @@ $orders = [
     ],
 ];
 
+/** @var OrderRepositoryInterface $orderRepository */
+$orderRepository = $objectManager->create(OrderRepositoryInterface::class);
 /** @var array $orderData */
 foreach ($orders as $orderData) {
     /** @var $order \Magento\Sales\Model\Order */
@@ -60,13 +63,16 @@ foreach ($orders as $orderData) {
     $billingAddress->setAddressType('billing');
 
     /** @var Order\Address $shippingAddress */
-    $shippingAddress = clone $billingAddress;
-    $shippingAddress->setId(null)->setAddressType('shipping');
+    $shippingAddress = $objectManager->create(\Magento\Sales\Model\Order\Address::class, ['data' => $addressData]);
+    $shippingAddress->setAddressType('shipping');
 
     $order
         ->setData($orderData)
         ->addItem($orderItem)
         ->setBillingAddress($billingAddress)
         ->setShippingAddress($shippingAddress)
-        ->save();
+        ->setCustomerIsGuest(true)
+        ->setCustomerEmail('customer@null.com');
+
+    $orderRepository->save($order);
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_list.php
@@ -10,8 +10,7 @@ require 'order.php';
 /** @var Order $order */
 /** @var Order\Payment $payment */
 /** @var Order\Item $orderItem */
-/** @var Order\Address $billingAddress */
-/** @var Order\Address $shippingAddress */
+/** @var array $addressData Data for creating addresses for the orders. */
 $orders = [
     [
         'increment_id' => '100000002',
@@ -56,9 +55,11 @@ foreach ($orders as $orderData) {
     );
 
     // Reset addresses
+    /** @var Order\Address $billingAddress */
     $billingAddress = $objectManager->create(\Magento\Sales\Model\Order\Address::class, ['data' => $addressData]);
     $billingAddress->setAddressType('billing');
 
+    /** @var Order\Address $shippingAddress */
     $shippingAddress = clone $billingAddress;
     $shippingAddress->setId(null)->setAddressType('shipping');
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Addresses are broken in the order_list.php integration test fixture.

Instead of setting billing address twice, set both billing address and shipping address.
Reset $billingAddress and $shippingAddress variables with newly created Address objects. Otherwise trying to access the order's address data gives an error. (e.g. 'Call to a member function on null' when trying to use $order->getBillingAddress()->getFirstname())

Additionally, improve code style slightly.

I don't think this affects the present integration tests that use this fixture, but when you try to use this fixture in a test that does use the addresses, it will not work.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

None.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Create an integration test that uses order_list fixture
2. Create order in the test
3. Call $order->getShipppingAddress()->getFirstname()

Without the fix, you will get a 'Call to a member function on null' error.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
