### PR TITLE
[Backport] Invoice grid shows wrong shipping & handling for partial items invoice. It shows order's shipping & handling instead if invoiced shipping& handling charge

### DIFF
--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -669,8 +669,8 @@
                 <item name="billing_address" xsi:type="object">BillingAddressAggregator</item>
                 <item name="shipping_address" xsi:type="object">ShippingAddressAggregator</item>
                 <item name="shipping_information" xsi:type="string">sales_order.shipping_description</item>
-                <item name="subtotal" xsi:type="string">sales_order.base_subtotal</item>
-                <item name="shipping_and_handling" xsi:type="string">sales_order.base_shipping_amount</item>
+                <item name="subtotal" xsi:type="string">sales_invoice.base_subtotal</item>
+                <item name="shipping_and_handling" xsi:type="string">sales_invoice.base_shipping_amount</item>
                 <item name="base_grand_total" xsi:type="string">sales_invoice.base_grand_total</item>
                 <item name="grand_total" xsi:type="string">sales_invoice.grand_total</item>
                 <item name="created_at" xsi:type="string">sales_invoice.created_at</item>


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/14795

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Magento Version : (2.1.6 | 2.2.0 | 2.2.2 | 2.2.3) (community-edition), (2.2.2 | 2.2.3) (enterprise-edition)
2. PHP : 7.0.24
3. MySQL : 5.7.21
4. Platform : MacOS High Sierra v10.13.4

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. Invoice grid shows wrong shipping & handling for partial items invoice. It shows order's shipping & handling instead if invoiced shipping& handling charge

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Place order with multiple taxable items and shipping charge
2. Generate separate invoice for each items and shipping charge should be covered in first invoice. (In short generate multiple invoices for same order with different items)
3. Do check value of **Shipping & Handling** column value in Invoice grid.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)