### PR TITLE
Remove unnecessary translation of HTML tags

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Config/YearRange.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Form/Renderer/Config/YearRange.php
@@ -32,10 +32,9 @@ class YearRange extends Field
 
         $from = $element->setValue(isset($values[0]) ? $values[0] : null)->getElementHtml();
         $to = $element->setValue(isset($values[1]) ? $values[1] : null)->getElementHtml();
-        return __(
-            '<label class="label"><span>from</span></label>'
-        ) . $from . __(
-            '<label class="label"><span>to</span></label>'
-        ) . $to;
+        return '<label class="label"><span>' . __('from') . '</span></label>'
+        . $from .
+        '<label class="label"><span>' . __('to') . '</span></label>'
+        . $to;
     }
 }

--- a/app/code/Magento/Catalog/i18n/en_US.csv
+++ b/app/code/Magento/Catalog/i18n/en_US.csv
@@ -13,8 +13,8 @@ Position,Position
 Day,Day
 Month,Month
 Year,Year
-"<label class=""label""><span>from</span></label>","<label class=""label""><span>from</span></label>"
-"<label class=""label""><span>to</span></label>","<label class=""label""><span>to</span></label>"
+from,from
+to,to
 [GLOBAL],[GLOBAL]
 [WEBSITE],[WEBSITE]
 "[STORE VIEW]","[STORE VIEW]"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
There is no need to translate string with HTML tags like `<label>` and `<span>`, instead translate only string value.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. N/A


### Manual testing scenarios
1. N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
