### PR TITLE
Fix email sender

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
+++ b/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
@@ -110,6 +110,8 @@ class SenderBuilder
         $this->transportBuilder->setTemplateIdentifier($this->templateContainer->getTemplateId());
         $this->transportBuilder->setTemplateOptions($this->templateContainer->getTemplateOptions());
         $this->transportBuilder->setTemplateVars($this->templateContainer->getTemplateVars());
-        $this->transportBuilder->setFrom($this->identityContainer->getEmailIdentity(), $this->identityContainer->getStore()->getId());
+        $this->transportBuilder->setFrom(
+            $this->identityContainer->getEmailIdentity(),
+            $this->identityContainer->getStore()->getId());
     }
 }

--- a/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
+++ b/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
@@ -110,9 +110,6 @@ class SenderBuilder
         $this->transportBuilder->setTemplateIdentifier($this->templateContainer->getTemplateId());
         $this->transportBuilder->setTemplateOptions($this->templateContainer->getTemplateOptions());
         $this->transportBuilder->setTemplateVars($this->templateContainer->getTemplateVars());
-        $this->transportBuilderByStore->setFromByStore(
-            $this->identityContainer->getEmailIdentity(),
-            $this->identityContainer->getStore()->getId()
-        );
+        $this->transportBuilder->setFrom($this->identityContainer->getEmailIdentity(), $this->identityContainer->getStore()->getId());
     }
 }

--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -164,9 +164,9 @@ class TransportBuilder
      * @param string|array $from
      * @return $this
      */
-    public function setFrom($from)
+    public function setFrom($from, $store = null)
     {
-        $result = $this->_senderResolver->resolve($from);
+        $result = $this->_senderResolver->resolve($from, $store);
         $this->message->setFrom($result['email'], $result['name']);
         return $this;
     }


### PR DESCRIPTION
https://github.com/magento/magento2/issues/16355

### Preconditions
1.  Magento 2.2.4
2.  PhP 7.1
3.  Apache

### Steps to reproduce
1.  Set general store email addresses
2.  Set store specific email senders in Sales Emails
3. Send order/shipment/creditnota/invoice mail to customer

### Expected result
Email is sent from store email address

### Actual result
It sends from the mail server default mailadress

### Why

In vendor **\magento\module-sales\Model\Order\Email\SenderBuilder.php** the `configureEmailTemplate()` function as been changed.