### PR TITLE
[Forwardport2.3] Fix incorrect type hinting in PHPDocs

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Item.php
@@ -144,8 +144,7 @@ class Item extends AbstractModel implements ShipmentItemInterface
      * Declare qty
      *
      * @param float $qty
-     * @return \Magento\Sales\Model\Order\Shipment\Item
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return $this
      */
     public function setQty($qty)
     {
@@ -157,7 +156,6 @@ class Item extends AbstractModel implements ShipmentItemInterface
      * Applying qty to order item
      *
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function register()
     {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15619
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Incorrect PHPdoc causes warnings in IDE.

Changes applied:

1. Changed the return type for **setQty** method to the type it actually returns.
2. Removed the hint for newer thrown LocalizedException in PHPDocs of **register** and **setQty** methods.


### Fixed Issues
1. magento/magento2#13992: Incorrect phpdoc should be Shipment\Item not Invoice\Item


### Manual testing scenarios
1. This is not necessary, this just resolves warnings in the IDE. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
