### PR TITLE
Removed unused $required param from \Magento\GroupedProduct\Model\Product\Type\Grouped::getChildrenIds()

### DIFF
--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -165,12 +165,11 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
      * )
      *
      * @param int $parentId
-     * @param bool $required
      * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getChildrenIds($parentId, $required = true)
+    public function getChildrenIds($parentId)
     {
         return $this->productLinks->getChildrenIds(
             $parentId,


### PR DESCRIPTION
Removed unused $required param from \Magento\GroupedProduct\Model\Product\Type\Grouped::getChildrenIds()
![image](https://user-images.githubusercontent.com/10281408/41835021-c09b3be8-785e-11e8-9261-3af5f998b01d.png)
