### PR TITLE
[Backport 2.2] Use the new json serializer which throws an error when failing

### DIFF
--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -38,7 +38,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
     protected $layoutProcessors;
 
     /**
-     * @var \Magento\Framework\Serialize\Serializer\Json
+     * @var \Magento\Framework\Serialize\Serializer\JsonHexTag
      */
     private $serializer;
 
@@ -48,7 +48,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
      * @param array $data
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param \Magento\Framework\Serialize\Serializer\JsonHexTag|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
@@ -57,7 +57,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
         array $data = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        \Magento\Framework\Serialize\Serializer\JsonHexTag $serializer = null
     ) {
         parent::__construct($context, $data);
         $this->formKey = $formKey;
@@ -66,7 +66,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+            ->get(\Magento\Framework\Serialize\Serializer\JsonHexTag::class);
     }
 
     /**
@@ -78,7 +78,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
             $this->jsLayout = $processor->process($this->jsLayout);
         }
 
-        return json_encode($this->jsLayout, JSON_HEX_TAG);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**
@@ -120,6 +120,6 @@ class Onepage extends \Magento\Framework\View\Element\Template
      */
     public function getSerializedCheckoutConfig()
     {
-        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+        return  $this->serializer->serialize($this->getCheckoutConfig());
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -35,7 +35,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $serializer;
+    private $serializerMock;
 
     protected function setUp()
     {
@@ -49,7 +49,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
             \Magento\Checkout\Block\Checkout\LayoutProcessorInterface::class
         );
 
-        $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->serializerMock = $this->createMock(\Magento\Framework\Serialize\Serializer\JsonHexTag::class);
 
         $this->model = new \Magento\Checkout\Block\Onepage(
             $contextMock,
@@ -57,7 +57,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
             $this->configProviderMock,
             [$this->layoutProcessorMock],
             [],
-            $this->serializer
+            $this->serializerMock
         );
     }
 
@@ -93,6 +93,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
         $processedLayout = ['layout' => ['processed' => true]];
         $jsonLayout = '{"layout":{"processed":true}}';
         $this->layoutProcessorMock->expects($this->once())->method('process')->with([])->willReturn($processedLayout);
+        $this->serializerMock->expects($this->once())->method('serialize')->willReturn($jsonLayout);
 
         $this->assertEquals($jsonLayout, $this->model->getJsLayout());
     }
@@ -101,6 +102,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
     {
         $checkoutConfig = ['checkout', 'config'];
         $this->configProviderMock->expects($this->once())->method('getConfig')->willReturn($checkoutConfig);
+        $this->serializerMock->expects($this->once())->method('serialize')->willReturn(json_encode($checkoutConfig));
 
         $this->assertEquals(json_encode($checkoutConfig), $this->model->getSerializedCheckoutConfig());
     }

--- a/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
+++ b/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Ui\TemplateEngine\Xhtml;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\View\Layout\Generator\Structure;
 use Magento\Framework\View\Element\UiComponentInterface;
 use Magento\Framework\View\TemplateEngine\Xhtml\Template;
@@ -43,24 +45,32 @@ class Result implements ResultInterface
     protected $logger;
 
     /**
+     * @var JsonHexTag
+     */
+    private $jsonSerializer;
+
+    /**
      * @param Template $template
      * @param CompilerInterface $compiler
      * @param UiComponentInterface $component
      * @param Structure $structure
      * @param LoggerInterface $logger
+     * @param JsonHexTag $jsonSerializer
      */
     public function __construct(
         Template $template,
         CompilerInterface $compiler,
         UiComponentInterface $component,
         Structure $structure,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        JsonHexTag $jsonSerializer = null
     ) {
         $this->template = $template;
         $this->compiler = $compiler;
         $this->component = $component;
         $this->structure = $structure;
         $this->logger = $logger;
+        $this->jsonSerializer = $jsonSerializer ?? ObjectManager::getInstance()->get(JsonHexTag::class);
     }
 
     /**
@@ -81,7 +91,7 @@ class Result implements ResultInterface
     public function appendLayoutConfiguration()
     {
         $layoutConfiguration = $this->wrapContent(
-            json_encode($this->structure->generate($this->component), JSON_HEX_TAG)
+            $this->jsonSerializer->serialize($this->structure->generate($this->component))
         );
         $this->template->append($layoutConfiguration);
     }

--- a/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php
+++ b/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\Serialize\Serializer;
+
+use Magento\Framework\Serialize\SerializerInterface;
+
+/**
+ * Serialize data to JSON, unserialize JSON encoded data
+ *
+ * @api
+ * @since 100.2.0
+ */
+class JsonHexTag extends Json implements SerializerInterface
+{
+    /**
+     * {@inheritDoc}
+     * @since 100.2.0
+     */
+    public function serialize($data): string
+    {
+        $result = json_encode($data, JSON_HEX_TAG);
+        if (false === $result) {
+            throw new \InvalidArgumentException('Unable to serialize value.');
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
Original Pull Request
#16154

### Description
Use the new serializer which throws an error when json_encoding fails.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14937: Javascript error thrown from uiComponent 'notification_area' if messages are malformed
2. Perhaps more

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
