### PR TITLE
StockStatusSelectBuilder fix.

### DIFF
--- a/app/code/Magento/Bundle/Model/ResourceModel/Indexer/StockStatusSelectBuilder.php
+++ b/app/code/Magento/Bundle/Model/ResourceModel/Indexer/StockStatusSelectBuilder.php
@@ -7,8 +7,6 @@
 namespace Magento\Bundle\Model\ResourceModel\Indexer;
 
 use Magento\Framework\DB\Select;
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Model\Product\Attribute\Source\Status as ProductStatus;
 
 /**
  * Class StockStatusSelectBuilder
@@ -42,8 +40,6 @@ class StockStatusSelectBuilder
     public function buildSelect(Select $select)
     {
         $select = clone $select;
-        $metadata = $this->metadataPool->getMetadata(ProductInterface::class);
-        $linkField = $metadata->getLinkField();
 
         $select->reset(
             Select::COLUMNS
@@ -53,47 +49,10 @@ class StockStatusSelectBuilder
             ['o' => $this->resourceConnection->getTableName('catalog_product_bundle_stock_index')],
             'o.entity_id = e.entity_id AND o.website_id = cis.website_id AND o.stock_id = cis.stock_id',
             []
-        )->joinInner(
-            ['cpr' => $this->resourceConnection->getTableName('catalog_product_relation')],
-            'e.' . $linkField . ' = cpr.parent_id',
-            []
         )->columns(
             ['qty' => new \Zend_Db_Expr('0')]
         );
 
-        if ($metadata->getIdentifierField() === $metadata->getLinkField()) {
-            $select->joinInner(
-                ['cpei' => $this->resourceConnection->getTableName('catalog_product_entity_int')],
-                'cpr.child_id = cpei.' . $linkField
-                . ' AND cpei.attribute_id = ' . $this->getAttribute('status')->getId()
-                . ' AND cpei.value = ' . ProductStatus::STATUS_ENABLED,
-                []
-            );
-        } else {
-            $select->joinInner(
-                ['cpel' => $this->resourceConnection->getTableName('catalog_product_entity')],
-                'cpel.entity_id = cpr.child_id',
-                []
-            )->joinInner(
-                ['cpei' => $this->resourceConnection->getTableName('catalog_product_entity_int')],
-                'cpel.'. $linkField . ' = cpei.' . $linkField
-                . ' AND cpei.attribute_id = ' . $this->getAttribute('status')->getId()
-                . ' AND cpei.value = ' . ProductStatus::STATUS_ENABLED,
-                []
-            );
-        }
-
         return $select;
-    }
-
-    /**
-     * Retrieve catalog_product attribute instance by attribute code
-     *
-     * @param string $attributeCode
-     * @return \Magento\Catalog\Model\ResourceModel\Eav\Attribute
-     */
-    private function getAttribute($attributeCode)
-    {
-        return $this->eavConfig->getAttribute(\Magento\Catalog\Model\Product::ENTITY, $attributeCode);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Bundle/Model/ResourceModel/Indexer/StockStatusSelectBuilderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Model/ResourceModel/Indexer/StockStatusSelectBuilderTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Bundle\Model\ResourceModel\Indexer;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\CatalogInventory\Model\Indexer\Stock\Processor;
+use Magento\CatalogInventory\Model\ResourceModel\Stock\Status;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provide tests for StockStatusSelectBuilder indexer resource model.
+ */
+class StockStatusSelectBuilderTest extends TestCase
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $productCollectionFactory;
+
+    /**
+     * @var Processor
+     */
+    private $processor;
+
+    /**
+     * @var Status
+     */
+    private $stockStatus;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->processor = Bootstrap::getObjectManager()->get(Processor::class);
+        $this->productCollectionFactory = Bootstrap::getObjectManager()->create(CollectionFactory::class);
+        $this->stockStatus = Bootstrap::getObjectManager()->create(Status::class);
+    }
+
+    /**
+     * Check, bundle product without options will be returned in case "isFilterInStock" set to false.
+     *
+     * @magentoDataFixture Magento/Bundle/_files/empty_bundle_product.php
+     * @dataProvider buildSelectDataProvider
+     * @magentoDbIsolation disabled
+     * @magentoAppIsolation enabled
+     * @param bool $isFilterInStock
+     * @param int $resultCount
+     * @return void
+     */
+    public function testBuildSelect(bool $isFilterInStock, int $resultCount): void
+    {
+        $this->processor->reindexAll();
+        $productCollection = $this->productCollectionFactory->create();
+        $this->stockStatus->addStockDataToCollection($productCollection, $isFilterInStock);
+
+        $this->assertEquals($resultCount, $productCollection->getSize());
+    }
+
+    /**
+     * Provide test data for testBuildSelect().
+     *
+     * @return array
+     */
+    public function buildSelectDataProvider(): array
+    {
+        return [
+            [
+                'is_filter_in_stock' => true,
+                'resultCount' => 0,
+            ],
+            [
+                'is_filter_in_stock' => false,
+                'resultCount' => 1,
+            ],
+        ];
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Bundle/_files/empty_bundle_product.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/_files/empty_bundle_product.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+/** @var $objectManager \Magento\TestFramework\ObjectManager */
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+/** @var $product \Magento\Catalog\Model\Product */
+$product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+$product->setTypeId('bundle')
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Bundle Product')
+    ->setSku('bundle-product')
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->setStockData(['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1])
+    ->setPriceView(0)
+    ->setPriceType(0)
+    ->setShipmentType(1)
+    ->setWeightType(0)
+    ->setDescription('description')
+    ->setPrice(99);
+
+$productRepository->save($product);

--- a/dev/tests/integration/testsuite/Magento/Bundle/_files/empty_bundle_product_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/_files/empty_bundle_product_rollback.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+try {
+    $product = $productRepository->get('bundle-product', false, null, true);
+    $productRepository->delete($product);
+} catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+    //Product already removed
+}
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Currently, StockStatusSelectBuilder excludes all bundle product without any enabled child products, so enabled and "in stock" bundle products are absent in products collection after adding "in stock" filter to such collection.
So, such bundle products are not present in cataloginventory_stock_status table. This is an important issue for bundle products support in MSI project.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-engcom/msi#1398: Solve problem with \Magento\InventoryCatalog\Plugin\CatalogInventory\Model\ResourceModel\Stock\Status\AdaptAddStockDataToCollectionPlugin

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
