### PR TITLE
#6942 added check for page layout loaded from cache

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
@@ -275,10 +275,10 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($handles, $this->_model->getHandles());
         $expectedResult = <<<XML
 <body>
-   <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+   <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_one.phtml"/>
 </body>
 <body>
-   <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+   <block class="Magento\Framework\View\Element\Template" template="Magento_Framework::fixture_template_two.phtml"/>
 </body>
 
 XML;

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
@@ -273,7 +273,16 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         $handles = ['fixture_handle_one', 'fixture_handle_two'];
         $this->_model->load($handles);
         $this->assertEquals($handles, $this->_model->getHandles());
-        $this->assertEquals(self::FIXTURE_LAYOUT_XML, $this->_model->asString());
+        $expectedResult = <<<XML
+<body>
+   <block class="Magento\Framework\View\Element\Template" template="fixture_template_one.phtml"/>
+</body>
+<body>
+   <block class="Magento\Framework\View\Element\Template" template="fixture_template_two.phtml"/>
+</body>
+
+XML;
+        $this->assertEquals($expectedResult, $this->_model->asString());
     }
 
     public function testLoadDbApp()

--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -428,9 +428,10 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
         $cacheId = $this->getCacheId();
         $cacheIdPageLayout = $cacheId . '_' . self::PAGE_LAYOUT_CACHE_SUFFIX;
         $result = $this->_loadCache($cacheId);
-        if ($result) {
+        $pageLayoutResult = $this->_loadCache($cacheIdPageLayout);
+        if ($result && $pageLayoutResult) {
             $this->addUpdate($result);
-            $this->pageLayout = $this->_loadCache($cacheIdPageLayout);
+            $this->pageLayout = $pageLayoutResult;
             foreach ($this->getHandles() as $handle) {
                 $this->allHandles[$handle] = $this->handleProcessed;
             }


### PR DESCRIPTION
This is the 2.2-develop version of https://github.com/magento/magento2/pull/14129. Description copied below.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Under heavy traffic, some pages will become broken because the HTML `<head>` is not present. The only remedy is to disable layout cache.
When layout updates are loaded from cache, it's assumed that page layout will be loaded from cache as well. The problem is that when Redis reaches its maxmemory setting (as it might under heavy traffic), it will begin evicting keys. So if the page layout key is evicted while the layout key is not, the bug occurs. To fix this bug, we have to check for a successful load of both layout and page layout from the cache.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6942 (Title is wrong, but issue is real)

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install Magento with Redis cache (I used db 0 for sessions, 1 for cache, 2 for FPC).
2. Navigate to a page not cached by FPC (I used customer/account/login).
3. Delete the page layout cache key in Redis. (Found by doing a var_dump of $cacheIdPageLayout in Magento\Framework\View\Model\Layout\Merge::load).
4. Refresh the page and behold the headlessness of your broken page.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
