### PR TITLE
Remove reset data in AbstractSimpleObjectBuilder.php

### DIFF
--- a/lib/internal/Magento/Framework/Api/AbstractSimpleObjectBuilder.php
+++ b/lib/internal/Magento/Framework/Api/AbstractSimpleObjectBuilder.php
@@ -39,7 +39,7 @@ abstract class AbstractSimpleObjectBuilder implements SimpleBuilderInterface
     {
         $dataObjectType = $this->_getDataObjectType();
         $dataObject = $this->objectFactory->create($dataObjectType, ['data' => $this->data]);
-        $this->data = [];
+
         return $dataObject;
     }
 


### PR DESCRIPTION
### Description
Multiple call create() returns different value because data reset in create() method. Therefore its not easy to add some custom parameters in extension module.

### Fixed Issues (if relevant)
Nope.

### Manual testing scenarios
1. Add in after-plugin method some filters and recall create on SeatchCriteriaBuilder.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
