### PR TITLE
Fix for #14593

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -93,7 +93,9 @@ define([
 
                         /** @inheritdoc */
                         always: function (e) {
-                            e.stopImmediatePropagation();
+                            if (e && typeof e.stopImmediatePropagation === 'function') {
+                                e.stopImmediatePropagation();
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
### Description

#### Preconditions: 

Magento version 2.2.4 with luma theme

#### Step to reproduce:

 - Open chrome developer console
 - Add a product to the cart.
 - From the mini cart in the upper right click the trash icon.
 - A confirmation modal will open.
 - Press Esc button

#### Expected Result
- Close the confirm

#### Actual result
- js error

https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js#L96

~~~
Uncaught TypeError: Cannot read property 'stopImmediatePropagation' of undefined
~~~
![2018-06-21 15-50-01](https://user-images.githubusercontent.com/412612/41720145-cbfd9e28-756a-11e8-9c4a-1500171c3788.png)

### Fixed Issues 

1. magento/magento2#14593

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
