### PR TITLE
Changes: Removed the deprecated methods usage.

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Controller/Adminhtml/Export/GetFilter.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Controller/Adminhtml/Export/GetFilter.php
@@ -37,10 +37,10 @@ class GetFilter extends ExportController
                 );
                 return $resultLayout;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } else {
-            $this->messageManager->addError(__('Please correct the data sent.'));
+            $this->messageManager->addErrorMessage(__('Please correct the data sent.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Authorizenet/Block/Transparent/Iframe.php
+++ b/app/code/Magento/Authorizenet/Block/Transparent/Iframe.php
@@ -73,7 +73,7 @@ class Iframe extends TransparentIframe
     {
         $params = $this->getParams();
         if (isset($params['redirect_parent'])) {
-            $this->messageManager->addSuccess(__('You created the order.'));
+            $this->messageManager->addSuccessMessage(__('You created the order.'));
         }
     }
 }

--- a/app/code/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/Redirect.php
+++ b/app/code/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment/Redirect.php
@@ -121,7 +121,7 @@ class Redirect extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_getSession()->clearStorage();
             $directpostSession->removeCheckoutOrderIncrementId($redirectParams['x_invoice_num']);
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->clearStorage();
-            $this->messageManager->addSuccess(__('You created the order.'));
+            $this->messageManager->addSuccessMessage(__('You created the order.'));
         }
 
         if (!empty($redirectParams['error_msg'])) {

--- a/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
+++ b/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
@@ -160,7 +160,7 @@ class Authentication
             } else {
                 $this->_actionFlag->set('', \Magento\Framework\App\ActionInterface::FLAG_NO_DISPATCH, true);
                 $this->_response->setRedirect($this->_url->getCurrentUrl());
-                $this->messageManager->addError(__('Invalid Form Key. Please refresh the page.'));
+                $this->messageManager->addErrorMessage(__('Invalid Form Key. Please refresh the page.'));
                 $isRedirectNeeded = true;
             }
         }
@@ -205,7 +205,7 @@ class Authentication
             $this->_auth->login($username, $password);
         } catch (AuthenticationException $e) {
             if (!$request->getParam('messageSent')) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $request->setParam('messageSent', true);
                 $outputValue = false;
             }

--- a/app/code/Magento/Backend/Controller/Adminhtml/Auth/Logout.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Auth/Logout.php
@@ -16,7 +16,7 @@ class Logout extends \Magento\Backend\Controller\Adminhtml\Auth
     public function execute()
     {
         $this->_auth->logout();
-        $this->messageManager->addSuccess(__('You have logged out.'));
+        $this->messageManager->addSuccessMessage(__('You have logged out.'));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanImages.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanImages.php
@@ -28,11 +28,11 @@ class CleanImages extends \Magento\Backend\Controller\Adminhtml\Cache
         try {
             $this->_objectManager->create(\Magento\Catalog\Model\Product\Image::class)->clearCache();
             $this->_eventManager->dispatch('clean_catalog_images_cache_after');
-            $this->messageManager->addSuccess(__('The image cache was cleaned.'));
+            $this->messageManager->addSuccessMessage(__('The image cache was cleaned.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while clearing the image cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the image cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
@@ -32,7 +32,10 @@ class CleanMedia extends \Magento\Backend\Controller\Adminhtml\Cache
         } catch (LocalizedException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
+            $this->messageManager->addExceptionMessage(
+                $e,
+                __('An error occurred while clearing the JavaScript/CSS cache.')
+            );
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
@@ -28,11 +28,11 @@ class CleanMedia extends \Magento\Backend\Controller\Adminhtml\Cache
         try {
             $this->_objectManager->get(\Magento\Framework\View\Asset\MergeService::class)->cleanMergedJsCss();
             $this->_eventManager->dispatch('clean_media_cache_after');
-            $this->messageManager->addSuccess(__('The JavaScript/CSS cache has been cleaned.'));
+            $this->messageManager->addSuccessMessage(__('The JavaScript/CSS cache has been cleaned.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanStaticFiles.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanStaticFiles.php
@@ -26,7 +26,7 @@ class CleanStaticFiles extends \Magento\Backend\Controller\Adminhtml\Cache
     {
         $this->_objectManager->get(\Magento\Framework\App\State\CleanupFiles::class)->clearMaterializedViewFiles();
         $this->_eventManager->dispatch('clean_static_files_cache_after');
-        $this->messageManager->addSuccess(__('The static files cache has been cleaned.'));
+        $this->messageManager->addSuccessMessage(__('The static files cache has been cleaned.'));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushAll.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushAll.php
@@ -27,7 +27,7 @@ class FlushAll extends \Magento\Backend\Controller\Adminhtml\Cache
         foreach ($this->_cacheFrontendPool as $cacheFrontend) {
             $cacheFrontend->getBackend()->clean();
         }
-        $this->messageManager->addSuccess(__("You flushed the cache storage."));
+        $this->messageManager->addSuccessMessage(__("You flushed the cache storage."));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();
         return $resultRedirect->setPath('adminhtml/*');

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushSystem.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushSystem.php
@@ -27,7 +27,7 @@ class FlushSystem extends \Magento\Backend\Controller\Adminhtml\Cache
             $cacheFrontend->clean();
         }
         $this->_eventManager->dispatch('adminhtml_cache_flush_system');
-        $this->messageManager->addSuccess(__("The Magento cache storage has been flushed."));
+        $this->messageManager->addSuccessMessage(__("The Magento cache storage has been flushed."));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();
         return $resultRedirect->setPath('adminhtml/*');

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassDisable.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassDisable.php
@@ -67,12 +67,12 @@ class MassDisable extends \Magento\Backend\Controller\Adminhtml\Cache
             }
             if ($updatedTypes > 0) {
                 $this->_cacheState->persist();
-                $this->messageManager->addSuccess(__("%1 cache type(s) disabled.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) disabled.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while disabling cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while disabling cache.'));
         }
     }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassEnable.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassEnable.php
@@ -66,12 +66,12 @@ class MassEnable extends \Magento\Backend\Controller\Adminhtml\Cache
             }
             if ($updatedTypes > 0) {
                 $this->_cacheState->persist();
-                $this->messageManager->addSuccess(__("%1 cache type(s) enabled.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) enabled.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while enabling cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while enabling cache.'));
         }
     }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassRefresh.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassRefresh.php
@@ -37,12 +37,12 @@ class MassRefresh extends \Magento\Backend\Controller\Adminhtml\Cache
                 $updatedTypes++;
             }
             if ($updatedTypes > 0) {
-                $this->messageManager->addSuccess(__("%1 cache type(s) refreshed.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) refreshed.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while refreshing cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while refreshing cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
@@ -34,9 +34,9 @@ class RefreshStatistics extends \Magento\Reports\Controller\Adminhtml\Report\Sta
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate();
             }
-            $this->messageManager->addSuccess(__('We updated lifetime statistic.'));
+            $this->messageManager->addSuccessMessage(__('We updated lifetime statistic.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh lifetime statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh lifetime statistics.'));
             $this->logger->critical($e);
         }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Account/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Account/Save.php
@@ -76,12 +76,12 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Account
             $errors = $user->validate();
             if ($errors !== true && !empty($errors)) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addError($error);
+                    $this->messageManager->addErrorMessage($error);
                 }
             } else {
                 $user->save();
                 $user->sendNotificationEmailsIfRequired();
-                $this->messageManager->addSuccess(__('You saved the account.'));
+                $this->messageManager->addSuccessMessage(__('You saved the account.'));
             }
         } catch (UserLockedException $e) {
             $this->_auth->logout();
@@ -91,12 +91,12 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Account
         } catch (ValidatorException $e) {
             $this->messageManager->addMessages($e->getMessages());
             if ($e->getMessage()) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while saving account.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while saving account.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Delete.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Delete.php
@@ -19,11 +19,11 @@ class Delete extends \Magento\Backend\Controller\Adminhtml\System\Design
 
             try {
                 $design->delete();
-                $this->messageManager->addSuccess(__('You deleted the design change.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the design change.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __("You can't delete the design change."));
+                $this->messageManager->addExceptionMessage($e, __("You can't delete the design change."));
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Save.php
@@ -50,9 +50,9 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Design
             try {
                 $design->save();
                 $this->_eventManager->dispatch('theme_save_after');
-                $this->messageManager->addSuccess(__('You saved the design change.'));
+                $this->messageManager->addSuccessMessage(__('You saved the design change.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setDesignData($data);
                 return $resultRedirect->setPath('adminhtml/*/', ['id' => $design->getId()]);
             }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
@@ -103,12 +103,12 @@ abstract class Store extends Action
                 ->setType('db')
                 ->setPath($filesystem->getDirectoryRead(DirectoryList::VAR_DIR)->getAbsolutePath('backups'));
             $backupDb->createBackup($backup);
-            $this->messageManager->addSuccess(__('The database was backed up.'));
+            $this->messageManager->addSuccessMessage(__('The database was backed up.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return false;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('We can\'t create a backup right now. Please try again later.')
             );
@@ -125,7 +125,7 @@ abstract class Store extends Action
      */
     protected function _addDeletionNotice($typeTitle)
     {
-        $this->messageManager->addNotice(
+        $this->messageManager->addNoticeMessage(
             __(
                 'Deleting a %1 will not delete the information associated with the %1 (e.g. categories, products, etc.)'
                 . ', but the %1 will not be able to be restored. It is suggested that you create a database backup '

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroup.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroup.php
@@ -15,13 +15,13 @@ class DeleteGroup extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Group::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroupPost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroupPost.php
@@ -21,11 +21,11 @@ class DeleteGroupPost extends \Magento\Backend\Controller\Adminhtml\System\Store
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Group::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $model->getId()]);
         }
 
@@ -35,12 +35,12 @@ class DeleteGroupPost extends \Magento\Backend\Controller\Adminhtml\System\Store
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the store.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the store.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the store. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store. Please try again later.'));
         }
         return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStore.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStore.php
@@ -15,13 +15,13 @@ class DeleteStore extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Store::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store view cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store view cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
@@ -22,11 +22,11 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Store::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store view cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store view cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $model->getId()]);
         }
 
@@ -37,12 +37,12 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         try {
             $model->delete();
 
-            $this->messageManager->addSuccess(__('You deleted the store view.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the store view.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the store view. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store view. Please try again later.'));
         }
         return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
@@ -42,7 +42,10 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store view. Please try again later.'));
+            $this->messageManager->addExceptionMessage(
+                $e,
+                __('Unable to delete the store view. Please try again later.')
+            );
         }
         return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsite.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsite.php
@@ -15,13 +15,13 @@ class DeleteWebsite extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Website::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This website cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This website cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editWebsite', ['website_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsitePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsitePost.php
@@ -23,11 +23,11 @@ class DeleteWebsitePost extends \Magento\Backend\Controller\Adminhtml\System\Sto
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
         if (!$model) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This website cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This website cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editWebsite', ['website_id' => $model->getId()]);
         }
 
@@ -37,12 +37,12 @@ class DeleteWebsitePost extends \Magento\Backend\Controller\Adminhtml\System\Sto
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the website.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the website.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the website. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the website. Please try again later.'));
         }
         return $redirectResult->setPath('*/*/editWebsite', ['website_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/EditStore.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/EditStore.php
@@ -57,7 +57,7 @@ class EditStore extends \Magento\Backend\Controller\Adminhtml\System\Store
         if ($model->getId() || $this->_coreRegistry->registry('store_action') == 'add') {
             $this->_coreRegistry->register('store_data', $model);
             if ($this->_coreRegistry->registry('store_action') == 'edit' && $codeBase && !$model->isReadOnly()) {
-                $this->messageManager->addNotice($codeBase);
+                $this->messageManager->addNoticeMessage($codeBase);
             }
             $resultPage = $this->createPage();
             if ($this->_coreRegistry->registry('store_action') == 'add') {
@@ -71,7 +71,7 @@ class EditStore extends \Magento\Backend\Controller\Adminhtml\System\Store
             ));
             return $resultPage;
         } else {
-            $this->messageManager->addError($notExists);
+            $this->messageManager->addErrorMessage($notExists);
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             return $resultRedirect->setPath('adminhtml/*/');

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/Save.php
@@ -32,7 +32,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
         }
 
         $websiteModel->save();
-        $this->messageManager->addSuccess(__('You saved the website.'));
+        $this->messageManager->addSuccessMessage(__('You saved the website.'));
 
         return $postData;
     }
@@ -68,7 +68,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
             );
         }
         $storeModel->save();
-        $this->messageManager->addSuccess(__('You saved the store view.'));
+        $this->messageManager->addSuccessMessage(__('You saved the store view.'));
 
         return $postData;
     }
@@ -98,7 +98,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
             );
         }
         $groupModel->save();
-        $this->messageManager->addSuccess(__('You saved the store.'));
+        $this->messageManager->addSuccessMessage(__('You saved the store.'));
 
         return $postData;
     }
@@ -134,10 +134,10 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
                 $redirectResult->setPath('adminhtml/*/');
                 return $redirectResult;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_getSession()->setPostData($postData);
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while saving. Please review the error log.')
                 );

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
@@ -86,7 +86,7 @@ class CleanMediaTest extends \PHPUnit\Framework\TestCase
         $mergeService->expects($this->once())->method('cleanMergedJsCss');
 
         $messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The JavaScript/CSS cache has been cleaned.');
 
         $valueMap = [

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
@@ -76,7 +76,7 @@ class CleanStaticFilesTest extends \PHPUnit\Framework\TestCase
             ->with('clean_static_files_cache_after');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The static files cache has been cleaned.');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
@@ -156,7 +156,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['someCache']);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('These cache type(s) don\'t exist: someCache')
             ->willReturnSelf();
 
@@ -176,7 +176,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'An error occurred while disabling cache.')
             ->willReturnSelf();
 
@@ -216,7 +216,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->method('persist');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 cache type(s) disabled.')
             ->willReturnSelf();
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
@@ -156,7 +156,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['someCache']);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('These cache type(s) don\'t exist: someCache')
             ->willReturnSelf();
 
@@ -176,7 +176,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'An error occurred while enabling cache.')
             ->willReturnSelf();
 
@@ -216,7 +216,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->method('persist');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 cache type(s) enabled.')
             ->willReturnSelf();
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/RefreshStatisticsTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/RefreshStatisticsTest.php
@@ -107,7 +107,7 @@ class RefreshStatisticsTest extends \PHPUnit\Framework\TestCase
         $this->resultRedirectFactory->expects($this->any())->method('create')->willReturn($this->resultRedirect);
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('We updated lifetime statistic.'));
 
         $this->objectManager->expects($this->any())

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
@@ -221,7 +221,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         $this->_requestMock->setParams($requestParams);
 
-        $this->_messagesMock->expects($this->once())->method('addSuccess')->with($this->equalTo($testedMessage));
+        $this->_messagesMock->expects($this->once())->method('addSuccessMessage')->with($this->equalTo($testedMessage));
 
         $this->_controller->execute();
     }

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/Create.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/Create.php
@@ -82,7 +82,7 @@ class Create extends \Magento\Backup\Controller\Adminhtml\Index
 
             $backupManager->create();
 
-            $this->messageManager->addSuccess($successMessage);
+            $this->messageManager->addSuccessMessage($successMessage);
 
             $response->setRedirectUrl($this->getUrl('*/*/index'));
         } catch (\Magento\Framework\Backup\Exception\NotEnoughFreeSpace $e) {

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/MassDelete.php
@@ -49,13 +49,13 @@ class MassDelete extends \Magento\Backup\Controller\Adminhtml\Index
 
             $resultData->setIsSuccess(true);
             if ($allBackupsDeleted) {
-                $this->messageManager->addSuccess(__('You deleted the selected backup(s).'));
+                $this->messageManager->addSuccessMessage(__('You deleted the selected backup(s).'));
             } else {
                 throw new \Exception($deleteFailMessage);
             }
         } catch (\Exception $e) {
             $resultData->setIsSuccess(false);
-            $this->messageManager->addError($deleteFailMessage);
+            $this->messageManager->addErrorMessage($deleteFailMessage);
         }
 
         return $this->_redirect('backup/*/index');

--- a/app/code/Magento/Captcha/Observer/CheckContactUsFormObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckContactUsFormObserver.php
@@ -76,7 +76,7 @@ class CheckContactUsFormObserver implements ObserverInterface
             /** @var \Magento\Framework\App\Action\Action $controller */
             $controller = $observer->getControllerAction();
             if (!$captcha->isCorrect($this->captchaStringResolver->resolve($controller->getRequest(), $formId))) {
-                $this->messageManager->addError(__('Incorrect CAPTCHA.'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA.'));
                 $this->getDataPersistor()->set($formId, $controller->getRequest()->getPostValue());
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->redirect->redirect($controller->getResponse(), 'contact/index/index');

--- a/app/code/Magento/Captcha/Observer/CheckForgotpasswordObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckForgotpasswordObserver.php
@@ -69,7 +69,7 @@ class CheckForgotpasswordObserver implements ObserverInterface
             /** @var \Magento\Framework\App\Action\Action $controller */
             $controller = $observer->getControllerAction();
             if (!$captchaModel->isCorrect($this->captchaStringResolver->resolve($controller->getRequest(), $formId))) {
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->redirect->redirect($controller->getResponse(), '*/*/forgotpassword');
             }

--- a/app/code/Magento/Captcha/Observer/CheckUserCreateObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserCreateObserver.php
@@ -86,7 +86,7 @@ class CheckUserCreateObserver implements ObserverInterface
             /** @var \Magento\Framework\App\Action\Action $controller */
             $controller = $observer->getControllerAction();
             if (!$captchaModel->isCorrect($this->captchaStringResolver->resolve($controller->getRequest(), $formId))) {
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->_session->setCustomerFormData($controller->getRequest()->getPostValue());
                 $url = $this->_urlManager->getUrl('*/*/create', ['_nosecret' => true]);

--- a/app/code/Magento/Captcha/Observer/CheckUserEditObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserEditObserver.php
@@ -119,9 +119,9 @@ class CheckUserEditObserver implements ObserverInterface
                         'The account is locked. Please wait and try again or contact %1.',
                         $this->scopeConfig->getValue('contact/email/recipient_email')
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                 }
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->redirect->redirect($controller->getResponse(), '*/*/edit');
             }

--- a/app/code/Magento/Captcha/Observer/CheckUserForgotPasswordBackendObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserForgotPasswordBackendObserver.php
@@ -75,7 +75,7 @@ class CheckUserForgotPasswordBackendObserver implements ObserverInterface
                 ) {
                     $this->_session->setEmail((string)$controller->getRequest()->getPost('email'));
                     $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
-                    $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                    $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                     $controller->getResponse()->setRedirect(
                         $controller->getUrl('*/*/forgotpassword', ['_nosecret' => true])
                     );

--- a/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
@@ -142,7 +142,7 @@ class CheckUserLoginObserver implements ObserverInterface
                 } catch (NoSuchEntityException $e) {
                     //do nothing as customer existance is validated later in authenticate method
                 }
-                $this->messageManager->addError(__('Incorrect CAPTCHA'));
+                $this->messageManager->addErrorMessage(__('Incorrect CAPTCHA'));
                 $this->_actionFlag->set('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);
                 $this->_session->setUsername($login);
                 $beforeUrl = $this->_session->getBeforeAuthUrl();

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckContactUsFormObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckContactUsFormObserverTest.php
@@ -116,7 +116,7 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
         $this->helperMock->expects($this->any())
             ->method('getCaptcha')
             ->with($formId)->willReturn($this->captchaMock);
-        $this->sessionMock->expects($this->never())->method('addError');
+        $this->sessionMock->expects($this->never())->method('addErrorMessage');
 
         $this->checkContactUsFormObserver->execute(
             new \Magento\Framework\Event\Observer(['controller_action' => $controller])
@@ -163,7 +163,7 @@ class CheckContactUsFormObserverTest extends \PHPUnit\Framework\TestCase
             ->method('getCaptcha')
             ->with($formId)
             ->willReturn($this->captchaMock);
-        $this->messageManagerMock->expects($this->once())->method('addError')->with($warningMessage);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage')->with($warningMessage);
         $this->actionFlagMock->expects($this->once())
             ->method('set')
             ->with('', \Magento\Framework\App\Action\Action::FLAG_NO_DISPATCH, true);

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckForgotpasswordObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckForgotpasswordObserverTest.php
@@ -138,7 +138,7 @@ class CheckForgotpasswordObserverTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($this->_captcha)
         );
-        $this->_messageManager->expects($this->once())->method('addError')->with($warningMessage);
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($warningMessage);
         $this->_actionFlag->expects(
             $this->once()
         )->method(

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserCreateObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserCreateObserverTest.php
@@ -151,7 +151,7 @@ class CheckUserCreateObserverTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue($this->_captcha)
         );
-        $this->_messageManager->expects($this->once())->method('addError')->with($warningMessage);
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($warningMessage);
         $this->_actionFlag->expects(
             $this->once()
         )->method(

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserEditObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserEditObserverTest.php
@@ -146,7 +146,7 @@ class CheckUserEditObserverTest extends \PHPUnit\Framework\TestCase
 
         $message = __('The account is locked. Please wait and try again or contact %1.', $email);
         $this->messageManagerMock->expects($this->exactly(2))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->withConsecutive([$message], [__('Incorrect CAPTCHA')]);
 
         $this->actionFlagMock->expects($this->once())

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserLoginObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserLoginObserverTest.php
@@ -145,7 +145,7 @@ class CheckUserLoginObserverTest extends \PHPUnit\Framework\TestCase
             ->with($customerId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Incorrect CAPTCHA'));
 
         $this->actionFlagMock->expects($this->once())

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
@@ -44,12 +44,12 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Category
                 $this->_eventManager->dispatch('catalog_controller_category_delete', ['category' => $category]);
                 $this->_auth->getAuthStorage()->setDeletedPath($category->getPath());
                 $this->categoryRepository->delete($category);
-                $this->messageManager->addSuccess(__('You deleted the category.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the category.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while trying to delete the category.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while trying to delete the category.'));
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
@@ -54,7 +54,7 @@ abstract class Attribute extends Action
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
         }
 
         return !$error;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -192,7 +192,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_eventManager->dispatch('catalog_product_to_website_change', ['products' => $productIds]);
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) were updated.', count($this->attributeHelper->getProductIds()))
             );
 
@@ -205,9 +205,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_productPriceIndexerProcessor->reindexList($this->attributeHelper->getProductIds());
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
@@ -68,7 +68,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attr
             $response->setError(true);
             $response->setMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
@@ -21,23 +21,23 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             // entity type check
             $model->load($id);
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('We can\'t delete the attribute.'));
+                $this->messageManager->addErrorMessage(__('We can\'t delete the attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             try {
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the product attribute.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the product attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath(
                     'catalog/*/edit',
                     ['attribute_id' => $this->getRequest()->getParam('attribute_id')]
                 );
             }
         }
-        $this->messageManager->addError(__('We can\'t find an attribute to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find an attribute to delete.'));
         return $resultRedirect->setPath('catalog/*/');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
@@ -25,14 +25,14 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $model->load($id);
 
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This attribute no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This attribute no longer exists.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             // entity type check
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('This attribute cannot be edited.'));
+                $this->messageManager->addErrorMessage(__('This attribute cannot be edited.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -92,7 +92,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $attributeSet->setEntityTypeId($this->_entityTypeId)->load($setName, 'attribute_set_name');
             if ($attributeSet->getId()) {
                 $setName = $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($setName);
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('A "%1" attribute set name already exists. Create a new name and try again.', $setName)
                 );
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
@@ -43,11 +43,11 @@ class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
         $product = $this->productBuilder->build($this->getRequest());
         try {
             $newProduct = $this->productCopier->copy($product);
-            $this->messageManager->addSuccess(__('You duplicated the product.'));
+            $this->messageManager->addSuccessMessage(__('You duplicated the product.'));
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true, 'id' => $newProduct->getId()]);
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
@@ -52,12 +52,12 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product
         if (($productId && !$product->getEntityId())) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('This product doesn\'t exist.'));
+            $this->messageManager->addErrorMessage(__('This product doesn\'t exist.'));
             return $resultRedirect->setPath('catalog/*/');
         } elseif ($productId === 0) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('Invalid product id. Should be numeric value greater than 0'));
+            $this->messageManager->addErrorMessage(__('Invalid product id. Should be numeric value greater than 0'));
             return $resultRedirect->setPath('catalog/*/');
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
@@ -29,12 +29,12 @@ class Save extends \Magento\Backend\App\Action
         );
 
         if ($model->itemExists()) {
-            $this->messageManager->addError(__('A group with the same name already exists.'));
+            $this->messageManager->addErrorMessage(__('A group with the same name already exists.'));
         } else {
             try {
                 $model->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving this group.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving this group.'));
             }
         }
     }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -64,7 +64,7 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product
             $this->productRepository->delete($product);
             $productDeleted++;
         }
-        $this->messageManager->addSuccess(
+        $this->messageManager->addSuccessMessage(
             __('A total of %1 record(s) have been deleted.', $productDeleted)
         );
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
@@ -36,10 +36,10 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         $resultRedirect = $this->resultRedirectFactory->create();
         try {
             $this->attributeSetRepository->deleteById($setId);
-            $this->messageManager->addSuccess(__('The attribute set has been removed.'));
+            $this->messageManager->addSuccessMessage(__('The attribute set has been removed.'));
             $resultRedirect->setPath('catalog/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete this set right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete this set right now.'));
             $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -100,15 +100,15 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
                 $model->initFromSkeleton($this->getRequest()->getParam('skeleton_set'));
             }
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the attribute set.'));
+            $this->messageManager->addSuccessMessage(__('You saved the attribute set.'));
         } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong while saving the attribute set.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the attribute set.'));
             $hasError = true;
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
@@ -137,7 +137,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product
             $response->setError(true);
             $response->setMessages([$e->getMessage()]);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $layout = $this->layoutFactory->create();
             $layout->initMessages();
             $response->setError(true);

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Add.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Add.php
@@ -36,7 +36,7 @@ class Add extends \Magento\Catalog\Controller\Product\Compare
                 $productName = $this->_objectManager->get(
                     \Magento\Framework\Escaper::class
                 )->escapeHtml($product->getName());
-                $this->messageManager->addSuccess(__('You added product %1 to the comparison list.', $productName));
+                $this->messageManager->addSuccessMessage(__('You added product %1 to the comparison list.', $productName));
                 $this->_eventManager->dispatch('catalog_product_compare_add_product', ['product' => $product]);
             }
 

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Add.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Add.php
@@ -36,7 +36,10 @@ class Add extends \Magento\Catalog\Controller\Product\Compare
                 $productName = $this->_objectManager->get(
                     \Magento\Framework\Escaper::class
                 )->escapeHtml($product->getName());
-                $this->messageManager->addSuccessMessage(__('You added product %1 to the comparison list.', $productName));
+                $this->messageManager->addSuccessMessage(
+                    __('You added product %1 to the comparison list.',
+                       $productName)
+                );
                 $this->_eventManager->dispatch('catalog_product_compare_add_product', ['product' => $product]);
             }
 

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
@@ -30,12 +30,12 @@ class Clear extends \Magento\Catalog\Controller\Product\Compare
 
         try {
             $items->clear();
-            $this->messageManager->addSuccess(__('You cleared the comparison list.'));
+            $this->messageManager->addSuccessMessage(__('You cleared the comparison list.'));
             $this->_objectManager->get(\Magento\Catalog\Helper\Product\Compare::class)->calculate();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong  clearing the comparison list.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong  clearing the comparison list.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
@@ -44,7 +44,7 @@ class Remove extends \Magento\Catalog\Controller\Product\Compare
                     $item->delete();
                     $productName = $this->_objectManager->get(\Magento\Framework\Escaper::class)
                         ->escapeHtml($product->getName());
-                    $this->messageManager->addSuccess(
+                    $this->messageManager->addSuccessMessage(
                         __('You removed product %1 from the comparison list.', $productName)
                     );
                     $this->_eventManager->dispatch(

--- a/app/code/Magento/Catalog/Controller/Product/View.php
+++ b/app/code/Magento/Catalog/Controller/Product/View.php
@@ -83,7 +83,7 @@ class View extends \Magento\Catalog\Controller\Product
             }
             if ($specifyOptions) {
                 $notice = $product->getTypeInstance()->getSpecifyOptionMessage();
-                $this->messageManager->addNotice($notice);
+                $this->messageManager->addNoticeMessage($notice);
             }
             if ($this->getRequest()->isAjax()) {
                 $this->getResponse()->representJson(

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/SaveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/SaveTest.php
@@ -394,7 +394,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $categoryMock->expects($this->once())
             ->method('save');
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the category.'));
         $categoryMock->expects($this->at(1))
             ->method('getId')

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/EditTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/EditTest.php
@@ -94,7 +94,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         $messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->setMethods([])
             ->disableOriginalConstructor()->getMock();
-        $messageManager->expects($this->any())->method('addError')->willReturn(true);
+        $messageManager->expects($this->any())->method('addErrorMessage')->willReturn(true);
         $this->context = $this->getMockBuilder(\Magento\Backend\App\Action\Context::class)
             ->setMethods(['getRequest', 'getObjectManager', 'getMessageManager', 'getResultRedirectFactory'])
             ->disableOriginalConstructor()->getMock();

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/SaveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Action/Attribute/SaveTest.php
@@ -250,8 +250,8 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ['inventory', [], [7]],
         ]));
 
-        $this->messageManager->expects($this->never())->method('addError');
-        $this->messageManager->expects($this->never())->method('addException');
+        $this->messageManager->expects($this->never())->method('addErrorMessage');
+        $this->messageManager->expects($this->never())->method('addExceptionMessage');
 
         $this->object->execute();
     }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
@@ -25,14 +25,14 @@ class ApplyRules extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
             $ruleJob->applyAll();
 
             if ($ruleJob->hasSuccess()) {
-                $this->messageManager->addSuccess($ruleJob->getSuccess());
+                $this->messageManager->addSuccessMessage($ruleJob->getSuccess());
                 $this->_objectManager->create(\Magento\CatalogRule\Model\Flag::class)->loadSelf()->setState(0)->save();
             } elseif ($ruleJob->hasError()) {
-                $this->messageManager->addError($errorMessage . ' ' . $ruleJob->getError());
+                $this->messageManager->addErrorMessage($errorMessage . ' ' . $ruleJob->getError());
             }
         } catch (\Exception $e) {
             $this->_objectManager->create(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError($errorMessage);
+            $this->messageManager->addErrorMessage($errorMessage);
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php
@@ -25,13 +25,13 @@ class Delete extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 $ruleRepository->deleteById($id);
 
                 $this->_objectManager->create(\Magento\CatalogRule\Model\Flag::class)->loadSelf()->setState(1)->save();
-                $this->messageManager->addSuccess(__('You deleted the rule.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rule.'));
                 $this->_redirect('catalog_rule/*/');
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete this rule right now. Please review the log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -39,7 +39,7 @@ class Delete extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a rule to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a rule to delete.'));
         $this->_redirect('catalog_rule/*/');
     }
 }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php
@@ -24,7 +24,7 @@ class Edit extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
             try {
                 $model = $ruleRepository->get($id);
             } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 $this->_redirect('catalog_rule/*');
                 return;
             }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -68,7 +68,7 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 $validateResult = $model->validateData(new \Magento\Framework\DataObject($data));
                 if ($validateResult !== true) {
                     foreach ($validateResult as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                     $this->_getSession()->setPageData($data);
                     $this->dataPersistor->set('catalog_rule', $data);
@@ -88,7 +88,7 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
 
                 $ruleRepository->save($model);
 
-                $this->messageManager->addSuccess(__('You saved the rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rule.'));
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setPageData(false);
                 $this->dataPersistor->clear('catalog_rule');
 
@@ -111,9 +111,9 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 }
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Something went wrong while saving the rule data. Please review the error log.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/CatalogRule/Observer/AddDirtyRulesNotice.php
+++ b/app/code/Magento/CatalogRule/Observer/AddDirtyRulesNotice.php
@@ -37,7 +37,7 @@ class AddDirtyRulesNotice implements ObserverInterface
         $dirtyRules = $observer->getData('dirty_rules');
         if (!empty($dirtyRules)) {
             if ($dirtyRules->getState()) {
-                $this->messageManager->addNotice($observer->getData('message'));
+                $this->messageManager->addNoticeMessage($observer->getData('message'));
             }
         }
     }

--- a/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
+++ b/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
@@ -103,7 +103,7 @@ class Attribute
 
         if ($disabledRulesCount) {
             $this->ruleProductProcessor->markIndexerAsInvalid();
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __(
                     'You disabled %1 Catalog Price Rules based on "%2" attribute.',
                     $disabledRulesCount,

--- a/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
@@ -49,7 +49,7 @@ class AddDirtyRulesNoticeTest extends \PHPUnit\Framework\TestCase
         $eventObserverMock->expects($this->at(0))->method('getData')->with('dirty_rules')->willReturn($flagMock);
         $flagMock->expects($this->once())->method('getState')->willReturn(1);
         $eventObserverMock->expects($this->at(1))->method('getData')->with('message')->willReturn($message);
-        $this->messageManagerMock->expects($this->once())->method('addNotice')->with($message);
+        $this->messageManagerMock->expects($this->once())->method('addNoticeMessage')->with($message);
         $this->observer->execute($eventObserverMock);
     }
 }

--- a/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
+++ b/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
@@ -54,7 +54,7 @@ class Result extends \Magento\Framework\App\Action\Action
             $this->_view->loadLayout();
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $defaultUrl = $this->_urlFactory->create()
                 ->addQueryParams($this->getRequest()->getQueryValue())
                 ->getUrl('*/*/');

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Delete.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Delete.php
@@ -16,20 +16,20 @@ class Delete extends \Magento\CheckoutAgreements\Controller\Adminhtml\Agreement
         $id = (int)$this->getRequest()->getParam('id');
         $model = $this->_objectManager->get(\Magento\CheckoutAgreements\Model\Agreement::class)->load($id);
         if (!$model->getId()) {
-            $this->messageManager->addError(__('This condition no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This condition no longer exists.'));
             $this->_redirect('checkout/*/');
             return;
         }
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the condition.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the condition.'));
             $this->_redirect('checkout/*/');
             return;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Something went wrong  while deleting this condition.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong  while deleting this condition.'));
         }
 
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Edit.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Edit.php
@@ -20,7 +20,7 @@ class Edit extends \Magento\CheckoutAgreements\Controller\Adminhtml\Agreement
         if ($id) {
             $agreementModel->load($id);
             if (!$agreementModel->getId()) {
-                $this->messageManager->addError(__('This condition no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This condition no longer exists.'));
                 $this->_redirect('checkout/*/');
                 return;
             }

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Save.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement/Save.php
@@ -22,18 +22,18 @@ class Save extends \Magento\CheckoutAgreements\Controller\Adminhtml\Agreement
                 $validationResult = $model->validateData(new \Magento\Framework\DataObject($postData));
                 if ($validationResult !== true) {
                     foreach ($validationResult as $message) {
-                        $this->messageManager->addError($message);
+                        $this->messageManager->addErrorMessage($message);
                     }
                 } else {
                     $model->save();
-                    $this->messageManager->addSuccess(__('You saved the condition.'));
+                    $this->messageManager->addSuccessMessage(__('You saved the condition.'));
                     $this->_redirect('checkout/*/');
                     return;
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving this condition.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving this condition.'));
             }
 
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setAgreementData($postData);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
@@ -26,18 +26,18 @@ class Delete extends \Magento\Cms\Controller\Adminhtml\Block
                 $model->load($id);
                 $model->delete();
                 // display success message
-                $this->messageManager->addSuccess(__('You deleted the block.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the block.'));
                 // go to grid
                 return $resultRedirect->setPath('*/*/');
             } catch (\Exception $e) {
                 // display error message
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 // go back to edit form
                 return $resultRedirect->setPath('*/*/edit', ['block_id' => $id]);
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find a block to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a block to delete.'));
         // go to grid
         return $resultRedirect->setPath('*/*/');
     }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Edit.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Edit.php
@@ -42,7 +42,7 @@ class Edit extends \Magento\Cms\Controller\Adminhtml\Block
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This block no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This block no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/MassDelete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/MassDelete.php
@@ -60,7 +60,7 @@ class MassDelete extends \Magento\Backend\App\Action
             $block->delete();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been deleted.', $collectionSize));
+        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been deleted.', $collectionSize));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Delete.php
@@ -35,7 +35,7 @@ class Delete extends \Magento\Backend\App\Action
                 $title = $model->getTitle();
                 $model->delete();
                 // display success message
-                $this->messageManager->addSuccess(__('The page has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The page has been deleted.'));
                 // go to grid
                 $this->_eventManager->dispatch(
                     'adminhtml_cmspage_on_delete',
@@ -48,13 +48,13 @@ class Delete extends \Magento\Backend\App\Action
                     ['title' => $title, 'status' => 'fail']
                 );
                 // display error message
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 // go back to edit form
                 return $resultRedirect->setPath('*/*/edit', ['page_id' => $id]);
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find a page to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a page to delete.'));
         // go to grid
         return $resultRedirect->setPath('*/*/');
     }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Edit.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Edit.php
@@ -76,7 +76,7 @@ class Edit extends \Magento\Backend\App\Action
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This page no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This page no longer exists.'));
                 /** \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDelete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDelete.php
@@ -59,7 +59,7 @@ class MassDelete extends \Magento\Backend\App\Action
             $page->delete();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been deleted.', $collectionSize));
+        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been deleted.', $collectionSize));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDisable.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDisable.php
@@ -59,7 +59,7 @@ class MassDisable extends \Magento\Backend\App\Action
             $item->save();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been disabled.', $collection->getSize()));
+        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been disabled.', $collection->getSize()));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDisable.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassDisable.php
@@ -59,7 +59,10 @@ class MassDisable extends \Magento\Backend\App\Action
             $item->save();
         }
 
-        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been disabled.', $collection->getSize()));
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 record(s) have been disabled.',
+               $collection->getSize())
+        );
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassEnable.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassEnable.php
@@ -59,7 +59,7 @@ class MassEnable extends \Magento\Backend\App\Action
             $item->save();
         }
 
-        $this->messageManager->addSuccess(__('A total of %1 record(s) have been enabled.', $collection->getSize()));
+        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been enabled.', $collection->getSize()));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/MassEnable.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/MassEnable.php
@@ -59,7 +59,10 @@ class MassEnable extends \Magento\Backend\App\Action
             $item->save();
         }
 
-        $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been enabled.', $collection->getSize()));
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 record(s) have been enabled.',
+               $collection->getSize())
+        );
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
@@ -119,7 +119,7 @@ class PostDataProcessor
         foreach ($data as $field => $value) {
             if (in_array($field, array_keys($requiredFields)) && $value == '') {
                 $errorNo = false;
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('To apply changes you should fill in hidden required "%1" field', $requiredFields[$field])
                 );
             }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Index.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Index.php
@@ -39,7 +39,7 @@ class Index extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images
         try {
             $this->_objectManager->get(\Magento\Cms\Helper\Wysiwyg\Images::class)->getCurrentPath();
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
         $this->_initAction();
         /** @var \Magento\Framework\View\Result\Layout $resultLayout */

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/DeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/DeleteTest.php
@@ -134,10 +134,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->with($this->blockId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You deleted the block.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -154,10 +154,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t find a block to delete.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -181,10 +181,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception(__($errorMsg)));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMsg);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/EditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/EditTest.php
@@ -139,7 +139,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('This block no longer exists.'));
 
         $this->resultRedirectFactoryMock->expects($this->atLeastOnce())

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/MassDeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/MassDeleteTest.php
@@ -68,9 +68,9 @@ class MassDeleteTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been deleted.', $deletedBlocksCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/DeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/DeleteTest.php
@@ -124,10 +124,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->method('delete');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The page has been deleted.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->eventManagerMock->expects($this->once())
             ->method('dispatch')
@@ -151,10 +151,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t find a page to delete.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -195,10 +195,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMsg);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/EditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/EditTest.php
@@ -139,7 +139,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('This page no longer exists.'));
 
         $this->resultRedirectFactoryMock->expects($this->atLeastOnce())

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDeleteTest.php
@@ -68,9 +68,9 @@ class MassDeleteTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been deleted.', $deletedPagesCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDisableTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassDisableTest.php
@@ -67,9 +67,9 @@ class MassDisableTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been disabled.', $disabledPagesCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassEnableTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/MassEnableTest.php
@@ -67,9 +67,9 @@ class MassEnableTest extends AbstractMassActionTest
             ->willReturn(new \ArrayIterator($collection));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) have been enabled.', $enabledPagesCount));
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Cms/Test/Unit/Controller/Page/PostDataProcessorTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Page/PostDataProcessorTest.php
@@ -65,7 +65,7 @@ class PostDataProcessorTest extends \PHPUnit\Framework\TestCase
             'title' => ''
         ];
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('To apply changes you should fill in hidden required "%1" field', 'Page Title'));
 
         $this->assertFalse($this->postDataProcessor->validateRequireEntry($postData));

--- a/app/code/Magento/Config/Controller/Adminhtml/System/Config/Save.php
+++ b/app/code/Magento/Config/Controller/Adminhtml/System/Config/Save.php
@@ -163,14 +163,14 @@ class Save extends AbstractConfig
                 'configData' => $configData,
                 'request' => $this->getRequest()
             ]);
-            $this->messageManager->addSuccess(__('You saved the configuration.'));
+            $this->messageManager->addSuccessMessage(__('You saved the configuration.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $messages = explode("\n", $e->getMessage());
             foreach ($messages as $message) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while saving this configuration:') . ' ' . $e->getMessage()
             );

--- a/app/code/Magento/Config/Test/Unit/Controller/Adminhtml/System/Config/SaveTest.php
+++ b/app/code/Magento/Config/Test/Unit/Controller/Adminhtml/System/Config/SaveTest.php
@@ -148,7 +148,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     public function testIndexActionWithAllowedSection()
     {
         $this->_sectionCheckerMock->expects($this->any())->method('isSectionAllowed')->will($this->returnValue(true));
-        $this->messageManagerMock->expects($this->once())->method('addSuccess')->with('You saved the configuration.');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage')->with('You saved the configuration.');
 
         $groups = ['some_key' => 'some_value'];
         $requestParamMap = [

--- a/app/code/Magento/Config/Test/Unit/Controller/Adminhtml/System/Config/SaveTest.php
+++ b/app/code/Magento/Config/Test/Unit/Controller/Adminhtml/System/Config/SaveTest.php
@@ -147,8 +147,12 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
     public function testIndexActionWithAllowedSection()
     {
-        $this->_sectionCheckerMock->expects($this->any())->method('isSectionAllowed')->will($this->returnValue(true));
-        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage')->with('You saved the configuration.');
+        $this->_sectionCheckerMock->expects($this->any())
+            ->method('isSectionAllowed')
+            ->will($this->returnValue(true));
+        $this->messageManagerMock->expects($this->once())
+            ->method('addSuccessMessage')
+            ->with('You saved the configuration.');
 
         $groups = ['some_key' => 'some_value'];
         $requestParamMap = [

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/FetchRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/FetchRates.php
@@ -40,18 +40,18 @@ class FetchRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Cur
             $errors = $importModel->getMessages();
             if (sizeof($errors) > 0) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addWarning($error);
+                    $this->messageManager->addWarningMessage($error);
                 }
-                $this->messageManager->addWarning(
+                $this->messageManager->addWarningMessage(
                     __('Click "Save" to apply the rates we found.')
                 );
             } else {
-                $this->messageManager->addSuccess(__('Click "Save" to apply the rates we found.'));
+                $this->messageManager->addSuccessMessage(__('Click "Save" to apply the rates we found.'));
             }
 
             $backendSession->setRates($rates);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -26,7 +26,7 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
                         )->getNumber($value));
                         $data[$currencyCode][$currencyTo] = $value;
                         if ($value == 0) {
-                            $this->messageManager->addWarning(
+                            $this->messageManager->addWarningMessage(
                                 __('Please correct the input data for "%1 => %2" rate.', $currencyCode, $currencyTo)
                             );
                         }
@@ -34,9 +34,9 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
                 }
 
                 $this->_objectManager->create(\Magento\Directory\Model\Currency::class)->saveRates($data);
-                $this->messageManager->addSuccess(__('All valid rates have been saved.'));
+                $this->messageManager->addSuccessMessage(__('All valid rates have been saved.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol/Save.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol/Save.php
@@ -27,9 +27,9 @@ class Save extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Currencys
         try {
             $this->_objectManager->create(\Magento\CurrencySymbol\Model\System\Currencysymbol::class)
                 ->setCurrencySymbolsData($symbolsDataArray);
-            $this->messageManager->addSuccess(__('You applied the custom currency symbols.'));
+            $this->messageManager->addSuccessMessage(__('You applied the custom currency symbols.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/CurrencySymbol/Test/Unit/Controller/Adminhtml/System/Currencysymbol/SaveTest.php
+++ b/app/code/Magento/CurrencySymbol/Test/Unit/Controller/Adminhtml/System/Currencysymbol/SaveTest.php
@@ -128,7 +128,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->filterManagerMock);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You applied the custom currency symbols.'));
 
         $this->action->execute();

--- a/app/code/Magento/Customer/Controller/Account/Confirm.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirm.php
@@ -163,13 +163,13 @@ class Confirm extends \Magento\Customer\Controller\AbstractAccount
                 $metadata->setPath('/');
                 $this->getCookieManager()->deleteCookie('mage-cache-sessid', $metadata);
             }
-            $this->messageManager->addSuccess($this->getSuccessMessage());
+            $this->messageManager->addSuccessMessage($this->getSuccessMessage());
             $resultRedirect->setUrl($this->getSuccessRedirect());
             return $resultRedirect;
         } catch (StateException $e) {
-            $this->messageManager->addException($e, __('This confirmation key is invalid or has expired.'));
+            $this->messageManager->addExceptionMessage($e, __('This confirmation key is invalid or has expired.'));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('There was an error confirming the account'));
+            $this->messageManager->addExceptionMessage($e, __('There was an error confirming the account'));
         }
 
         $url = $this->urlModel->getUrl('*/*/index', ['_secure' => true]);

--- a/app/code/Magento/Customer/Controller/Account/Confirmation.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirmation.php
@@ -91,11 +91,11 @@ class Confirmation extends \Magento\Customer\Controller\AbstractAccount
                     $email,
                     $this->storeManager->getStore()->getWebsiteId()
                 );
-                $this->messageManager->addSuccess(__('Please check your email for confirmation key.'));
+                $this->messageManager->addSuccessMessage(__('Please check your email for confirmation key.'));
             } catch (InvalidTransitionException $e) {
-                $this->messageManager->addSuccess(__('This email does not require confirmation.'));
+                $this->messageManager->addSuccessMessage(__('This email does not require confirmation.'));
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Wrong email.'));
+                $this->messageManager->addExceptionMessage($e, __('Wrong email.'));
                 $resultRedirect->setPath('*/*/*', ['email' => $email, '_secure' => true]);
                 return $resultRedirect;
             }

--- a/app/code/Magento/Customer/Controller/Account/CreatePassword.php
+++ b/app/code/Magento/Customer/Controller/Account/CreatePassword.php
@@ -78,7 +78,7 @@ class CreatePassword extends \Magento\Customer\Controller\AbstractAccount
                 return $resultPage;
             }
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Your password reset link has expired.'));
+            $this->messageManager->addErrorMessage(__('Your password reset link has expired.'));
             /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('*/*/forgotpassword');

--- a/app/code/Magento/Customer/Controller/Account/CreatePost.php
+++ b/app/code/Magento/Customer/Controller/Account/CreatePost.php
@@ -326,7 +326,7 @@ class CreatePost extends \Magento\Customer\Controller\AbstractAccount
             if ($confirmationStatus === AccountManagementInterface::ACCOUNT_CONFIRMATION_REQUIRED) {
                 $email = $this->customerUrl->getEmailConfirmationUrl($customer->getEmail());
                 // @codingStandardsIgnoreStart
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __(
                         'You must confirm your account. Please check your email for the confirmation link or <a href="%1">click here</a> for a new link.',
                         $email
@@ -337,7 +337,7 @@ class CreatePost extends \Magento\Customer\Controller\AbstractAccount
                 $resultRedirect->setUrl($this->_redirect->success($url));
             } else {
                 $this->session->setCustomerDataAsLoggedIn($customer);
-                $this->messageManager->addSuccess($this->getSuccessMessage());
+                $this->messageManager->addSuccessMessage($this->getSuccessMessage());
                 $requestedRedirect = $this->accountRedirect->getRedirectCookie();
                 if (!$this->scopeConfig->getValue('customer/startup/redirect_dashboard') && $requestedRedirect) {
                     $resultRedirect->setUrl($this->_redirect->success($requestedRedirect));
@@ -361,16 +361,16 @@ class CreatePost extends \Magento\Customer\Controller\AbstractAccount
                 $url
             );
             // @codingStandardsIgnoreEnd
-            $this->messageManager->addError($message);
+            $this->messageManager->addErrorMessage($message);
         } catch (InputException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             foreach ($e->getErrors() as $error) {
-                $this->messageManager->addError($this->escaper->escapeHtml($error->getMessage()));
+                $this->messageManager->addErrorMessage($this->escaper->escapeHtml($error->getMessage()));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t save the customer.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t save the customer.'));
         }
 
         $this->session->setCustomerFormData($this->getRequest()->getPostValue());

--- a/app/code/Magento/Customer/Controller/Account/EditPost.php
+++ b/app/code/Magento/Customer/Controller/Account/EditPost.php
@@ -163,10 +163,10 @@ class EditPost extends \Magento\Customer\Controller\AbstractAccount
                     $isPasswordChanged
                 );
                 $this->dispatchSuccessEvent($customerCandidateDataObject);
-                $this->messageManager->addSuccess(__('You saved the account information.'));
+                $this->messageManager->addSuccessMessage(__('You saved the account information.'));
                 return $resultRedirect->setPath('customer/account');
             } catch (InvalidEmailOrPasswordException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (UserLockedException $e) {
                 $message = __(
                     'The account sign-in was incorrect or your account is disabled temporarily. '
@@ -174,17 +174,17 @@ class EditPost extends \Magento\Customer\Controller\AbstractAccount
                 );
                 $this->session->logout();
                 $this->session->start();
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
                 return $resultRedirect->setPath('customer/account/login');
             } catch (InputException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 foreach ($e->getErrors() as $error) {
-                    $this->messageManager->addError($error->getMessage());
+                    $this->messageManager->addErrorMessage($error->getMessage());
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t save the customer.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t save the customer.'));
             }
 
             $this->session->setCustomerFormData($this->getRequest()->getPostValue());

--- a/app/code/Magento/Customer/Controller/Account/LoginPost.php
+++ b/app/code/Magento/Customer/Controller/Account/LoginPost.php
@@ -172,34 +172,34 @@ class LoginPost extends \Magento\Customer\Controller\AbstractAccount
                         'This account is not confirmed. <a href="%1">Click here</a> to resend confirmation email.',
                         $value
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (UserLockedException $e) {
                     $message = __(
                         'The account sign-in was incorrect or your account is disabled temporarily. '
                         . 'Please wait and try again later.'
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (AuthenticationException $e) {
                     $message = __(
                         'The account sign-in was incorrect or your account is disabled temporarily. '
                         . 'Please wait and try again later.'
                     );
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (LocalizedException $e) {
                     $message = $e->getMessage();
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                     $this->session->setUsername($login['username']);
                 } catch (\Exception $e) {
                     // PA DSS violation: throwing or logging an exception here can disclose customer password
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __('An unspecified error occurred. Please contact us for assistance.')
                     );
                 }
             } else {
-                $this->messageManager->addError(__('A login and a password are required.'));
+                $this->messageManager->addErrorMessage(__('A login and a password are required.'));
             }
         }
 

--- a/app/code/Magento/Customer/Controller/Account/ResetPasswordPost.php
+++ b/app/code/Magento/Customer/Controller/Account/ResetPasswordPost.php
@@ -75,12 +75,12 @@ class ResetPasswordPost extends \Magento\Customer\Controller\AbstractAccount
         $passwordConfirmation = (string)$this->getRequest()->getPost('password_confirmation');
 
         if ($password !== $passwordConfirmation) {
-            $this->messageManager->addError(__("New Password and Confirm New Password values didn't match."));
+            $this->messageManager->addErrorMessage(__("New Password and Confirm New Password values didn't match."));
             $resultRedirect->setPath('*/*/createPassword', ['id' => $customerId, 'token' => $resetPasswordToken]);
             return $resultRedirect;
         }
         if (iconv_strlen($password) <= 0) {
-            $this->messageManager->addError(__('Please enter a new password.'));
+            $this->messageManager->addErrorMessage(__('Please enter a new password.'));
             $resultRedirect->setPath('*/*/createPassword', ['id' => $customerId, 'token' => $resetPasswordToken]);
             return $resultRedirect;
         }
@@ -91,16 +91,16 @@ class ResetPasswordPost extends \Magento\Customer\Controller\AbstractAccount
             $this->accountManagement->resetPassword($customerEmail, $resetPasswordToken, $password);
             $this->session->unsRpToken();
             $this->session->unsRpCustomerId();
-            $this->messageManager->addSuccess(__('You updated your password.'));
+            $this->messageManager->addSuccessMessage(__('You updated your password.'));
             $resultRedirect->setPath('*/*/login');
             return $resultRedirect;
         } catch (InputException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             foreach ($e->getErrors() as $error) {
-                $this->messageManager->addError($error->getMessage());
+                $this->messageManager->addErrorMessage($error->getMessage());
             }
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Something went wrong while saving the new password.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while saving the new password.'));
         }
         $resultRedirect->setPath('*/*/createPassword', ['id' => $customerId, 'token' => $resetPasswordToken]);
         return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Address/Delete.php
+++ b/app/code/Magento/Customer/Controller/Address/Delete.php
@@ -20,12 +20,12 @@ class Delete extends \Magento\Customer\Controller\Address
                 $address = $this->_addressRepository->getById($addressId);
                 if ($address->getCustomerId() === $this->_getSession()->getCustomerId()) {
                     $this->_addressRepository->deleteById($addressId);
-                    $this->messageManager->addSuccess(__('You deleted the address.'));
+                    $this->messageManager->addSuccessMessage(__('You deleted the address.'));
                 } else {
-                    $this->messageManager->addError(__('We can\'t delete the address right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t delete the address right now.'));
                 }
             } catch (\Exception $other) {
-                $this->messageManager->addException($other, __('We can\'t delete the address right now.'));
+                $this->messageManager->addExceptionMessage($other, __('We can\'t delete the address right now.'));
             }
         }
         return $this->resultRedirectFactory->create()->setPath('*/*/index');

--- a/app/code/Magento/Customer/Controller/Address/FormPost.php
+++ b/app/code/Magento/Customer/Controller/Address/FormPost.php
@@ -197,17 +197,17 @@ class FormPost extends \Magento\Customer\Controller\Address
         try {
             $address = $this->_extractAddress();
             $this->_addressRepository->save($address);
-            $this->messageManager->addSuccess(__('You saved the address.'));
+            $this->messageManager->addSuccessMessage(__('You saved the address.'));
             $url = $this->_buildUrl('*/*/index', ['_secure' => true]);
             return $this->resultRedirectFactory->create()->setUrl($this->_redirect->success($url));
         } catch (InputException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             foreach ($e->getErrors() as $error) {
-                $this->messageManager->addError($error->getMessage());
+                $this->messageManager->addErrorMessage($error->getMessage());
             }
         } catch (\Exception $e) {
             $redirectUrl = $this->_buildUrl('*/*/index');
-            $this->messageManager->addException($e, __('We can\'t save the address.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t save the address.'));
         }
 
         $url = $redirectUrl;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
@@ -131,14 +131,14 @@ class InvalidateToken extends \Magento\Customer\Controller\Adminhtml\Index
         if ($customerId = $this->getRequest()->getParam('customer_id')) {
             try {
                 $this->tokenService->revokeCustomerAccessToken($customerId);
-                $this->messageManager->addSuccess(__('You have revoked the customer\'s tokens.'));
+                $this->messageManager->addSuccessMessage(__('You have revoked the customer\'s tokens.'));
                 $resultRedirect->setPath('customer/index/edit', ['id' => $customerId, '_current' => true]);
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $resultRedirect->setPath('customer/index/edit', ['id' => $customerId, '_current' => true]);
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find a customer to revoke.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find a customer to revoke.'));
             $resultRedirect->setPath('customer/index/index');
         }
         return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/Delete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/Delete.php
@@ -23,12 +23,12 @@ class Delete extends \Magento\Customer\Controller\Adminhtml\Group
         if ($id) {
             try {
                 $this->groupRepository->deleteById($id);
-                $this->messageManager->addSuccess(__('You deleted the customer group.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the customer group.'));
             } catch (NoSuchEntityException $e) {
-                $this->messageManager->addError(__('The customer group no longer exists.'));
+                $this->messageManager->addErrorMessage(__('The customer group no longer exists.'));
                 return $resultRedirect->setPath('customer/*/');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('customer/group/edit', ['id' => $id]);
             }
         }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
@@ -89,10 +89,10 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Group
 
                 $this->groupRepository->save($customerGroup);
 
-                $this->messageManager->addSuccess(__('You saved the customer group.'));
+                $this->messageManager->addSuccessMessage(__('You saved the customer group.'));
                 $resultRedirect->setPath('customer/group');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 if ($customerGroup != null) {
                     $this->storeCustomerGroupDataToSession(
                         $this->dataObjectProcessor->buildOutputDataArray(

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index.php
@@ -311,7 +311,7 @@ abstract class Index extends \Magento\Backend\App\Action
     protected function actUponMultipleCustomers(callable $singleAction, $customerIds)
     {
         if (!is_array($customerIds)) {
-            $this->messageManager->addError(__('Please select customer(s).'));
+            $this->messageManager->addErrorMessage(__('Please select customer(s).'));
             return 0;
         }
         $customersUpdated = 0;
@@ -320,7 +320,7 @@ abstract class Index extends \Magento\Backend\App\Action
                 $singleAction($customerId);
                 $customersUpdated++;
             } catch (\Exception $exception) {
-                $this->messageManager->addError($exception->getMessage());
+                $this->messageManager->addErrorMessage($exception->getMessage());
             }
         }
         return $customersUpdated;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/AbstractMassAction.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/AbstractMassAction.php
@@ -64,7 +64,7 @@ abstract class AbstractMassAction extends \Magento\Backend\App\Action
             $collection = $this->filter->getCollection($this->collectionFactory->create());
             return $this->massAction($collection);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
@@ -20,7 +20,7 @@ class Delete extends \Magento\Customer\Controller\Adminhtml\Index
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addError(__('Customer could not be deleted.'));
+            $this->messageManager->addErrorMessage(__('Customer could not be deleted.'));
             return $resultRedirect->setPath('customer/index');
         }
 
@@ -28,9 +28,9 @@ class Delete extends \Magento\Customer\Controller\Adminhtml\Index
         if (!empty($customerId)) {
             try {
                 $this->_customerRepository->deleteById($customerId);
-                $this->messageManager->addSuccess(__('You deleted the customer.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the customer.'));
             } catch (\Exception $exception) {
-                $this->messageManager->addError($exception->getMessage());
+                $this->messageManager->addErrorMessage($exception->getMessage());
             }
         }
 

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Edit.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Edit.php
@@ -42,7 +42,7 @@ class Edit extends \Magento\Customer\Controller\Adminhtml\Index
                     //do nothing
                 }
             } catch (NoSuchEntityException $e) {
-                $this->messageManager->addException($e, __('Something went wrong while editing the customer.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while editing the customer.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 $resultRedirect->setPath('customer/*/index');
                 return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassAssignGroup.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassAssignGroup.php
@@ -56,7 +56,7 @@ class MassAssignGroup extends AbstractMassAction
         }
 
         if ($customersUpdated) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', $customersUpdated));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', $customersUpdated));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
@@ -51,7 +51,7 @@ class MassDelete extends AbstractMassAction
         }
 
         if ($customersDeleted) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were deleted.', $customersDeleted));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were deleted.', $customersDeleted));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassSubscribe.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassSubscribe.php
@@ -64,7 +64,7 @@ class MassSubscribe extends AbstractMassAction
         }
 
         if ($customersUpdated) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', $customersUpdated));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', $customersUpdated));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassUnsubscribe.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassUnsubscribe.php
@@ -64,7 +64,7 @@ class MassUnsubscribe extends AbstractMassAction
         }
 
         if ($customersUpdated) {
-            $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', $customersUpdated));
+            $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', $customersUpdated));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
@@ -31,7 +31,7 @@ class ResetPassword extends \Magento\Customer\Controller\Adminhtml\Index
                 \Magento\Customer\Model\AccountManagement::EMAIL_REMINDER,
                 $customer->getWebsiteId()
             );
-            $this->messageManager->addSuccess(__('The customer will receive an email with a link to reset password.'));
+            $this->messageManager->addSuccessMessage(__('The customer will receive an email with a link to reset password.'));
         } catch (NoSuchEntityException $exception) {
             $resultRedirect->setPath('customer/index');
             return $resultRedirect;
@@ -44,7 +44,7 @@ class ResetPassword extends \Magento\Customer\Controller\Adminhtml\Index
         } catch (SecurityViolationException $exception) {
             $this->messageManager->addErrorMessage($exception->getMessage());
         } catch (\Exception $exception) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $exception,
                 __('Something went wrong while resetting customer password.')
             );

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
@@ -31,7 +31,9 @@ class ResetPassword extends \Magento\Customer\Controller\Adminhtml\Index
                 \Magento\Customer\Model\AccountManagement::EMAIL_REMINDER,
                 $customer->getWebsiteId()
             );
-            $this->messageManager->addSuccessMessage(__('The customer will receive an email with a link to reset password.'));
+            $this->messageManager->addSuccessMessage(
+                __('The customer will receive an email with a link to reset password.')
+            );
         } catch (NoSuchEntityException $exception) {
             $resultRedirect->setPath('customer/index');
             return $resultRedirect;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -261,7 +261,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                 $this->_getSession()->unsCustomerFormData();
                 // Done Saving customer, finish save action
                 $this->_coreRegistry->register(RegistryConstants::CURRENT_CUSTOMER_ID, $customerId);
-                $this->messageManager->addSuccess(__('You saved the customer.'));
+                $this->messageManager->addSuccessMessage(__('You saved the customer.'));
                 $returnToEdit = (bool)$this->getRequest()->getParam('back', false);
             } catch (\Magento\Framework\Validator\Exception $exception) {
                 $messages = $exception->getMessages();
@@ -285,7 +285,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                 $this->_getSession()->setCustomerFormData($originalRequestData);
                 $returnToEdit = true;
             } catch (\Exception $exception) {
-                $this->messageManager->addException($exception, __('Something went wrong while saving the customer.'));
+                $this->messageManager->addExceptionMessage($exception, __('Something went wrong while saving the customer.'));
                 $this->_getSession()->setCustomerFormData($originalRequestData);
                 $returnToEdit = true;
             }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -285,7 +285,10 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                 $this->_getSession()->setCustomerFormData($originalRequestData);
                 $returnToEdit = true;
             } catch (\Exception $exception) {
-                $this->messageManager->addExceptionMessage($exception, __('Something went wrong while saving the customer.'));
+                $this->messageManager->addExceptionMessage(
+                    $exception,
+                    __('Something went wrong while saving the customer.')
+                );
                 $this->_getSession()->setCustomerFormData($originalRequestData);
                 $returnToEdit = true;
             }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Locks/Unlock.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Locks/Unlock.php
@@ -58,7 +58,7 @@ class Unlock extends \Magento\Backend\App\Action
                 $this->getMessageManager()->addSuccess(__('Customer has been unlocked successfully.'));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
+++ b/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
@@ -255,7 +255,7 @@ class AfterAddressSaveObserver implements ObserverInterface
                 : (string)__('You will not be charged tax.');
         }
 
-        $this->messageManager->addSuccess(implode(' ', $message));
+        $this->messageManager->addSuccessMessage(implode(' ', $message));
 
         return $this;
     }
@@ -280,7 +280,7 @@ class AfterAddressSaveObserver implements ObserverInterface
             $message[] = (string)__('You will be charged tax.');
         }
 
-        $this->messageManager->addError(implode(' ', $message));
+        $this->messageManager->addErrorMessage(implode(' ', $message));
 
         return $this;
     }
@@ -307,7 +307,7 @@ class AfterAddressSaveObserver implements ObserverInterface
         $email = $this->scopeConfig->getValue('trans_email/ident_support/email', ScopeInterface::SCOPE_STORE);
         $message[] = (string)__('If you believe this is an error, please contact us at %1', $email);
 
-        $this->messageManager->addError(implode(' ', $message));
+        $this->messageManager->addErrorMessage(implode(' ', $message));
 
         return $this;
     }

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
@@ -205,7 +205,7 @@ class ConfirmTest extends \PHPUnit\Framework\TestCase
 
         $exception = new \Exception('Bad request.');
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($this->equalTo($exception), $this->equalTo('There was an error confirming the account'));
 
         $testUrl = 'http://example.com';
@@ -281,7 +281,7 @@ class ConfirmTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->willReturnSelf();
 
@@ -399,7 +399,7 @@ class ConfirmTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePasswordTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePasswordTest.php
@@ -209,7 +209,7 @@ class CreatePasswordTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Exception.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Your password reset link has expired.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/CreatePostTest.php
@@ -371,7 +371,7 @@ class CreatePostTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo($customerId));
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->will($this->returnSelf());
 
@@ -502,7 +502,7 @@ class CreatePostTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo($customerId));
 
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($this->stringContains($successMessage))
             ->will($this->returnSelf());
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/EditPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/EditPostTest.php
@@ -281,7 +281,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the account information.'))
             ->willReturnSelf();
 
@@ -359,7 +359,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage)
             ->willReturnSelf();
 
@@ -497,7 +497,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
                 ->willReturnSelf();
 
             $this->messageManager->expects($this->once())
-                ->method('addSuccess')
+                ->method('addSuccessMessage')
                 ->with(__('You saved the account information.'))
                 ->willReturnSelf();
 
@@ -772,7 +772,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
                 ->willThrowException($exception);
 
             $this->messageManager->expects($this->any())
-                ->method('addException')
+                ->method('addExceptionMessage')
                 ->with($exception, __('We can\'t save the customer.'))
                 ->willReturnSelf();
         }
@@ -783,7 +783,7 @@ class EditPostTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->any())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errors['message'])
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/LoginPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/LoginPostTest.php
@@ -222,7 +222,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
             ->willReturn([]);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('A login and a password are required.'))
             ->willReturnSelf();
 
@@ -551,7 +551,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
                     $url
                 );
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($message)
                     ->willReturnSelf();
 
@@ -563,7 +563,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
 
             case \Magento\Framework\Exception\AuthenticationException::class:
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with(
                         __(
                             'The account sign-in was incorrect or your account is disabled temporarily. '
@@ -580,7 +580,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
 
             case '\Exception':
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with(__('An unspecified error occurred. Please contact us for assistance.'))
                     ->willReturnSelf();
                 break;
@@ -591,7 +591,7 @@ class LoginPostTest extends \PHPUnit\Framework\TestCase
                     . 'Please wait and try again later.'
                 );
                 $this->messageManager->expects($this->once())
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($message)
                     ->willReturnSelf();
                 $this->session->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ResetPasswordPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ResetPasswordPostTest.php
@@ -126,7 +126,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             ->method('unsRpCustomerId');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You updated your password.'))
             ->willReturnSelf();
 
@@ -192,7 +192,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Exception.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Something went wrong while saving the new password.'))
             ->willReturnSelf();
 
@@ -261,7 +261,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\InputException(__('InputException.')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('InputException.'))
             ->willReturnSelf();
 
@@ -308,7 +308,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('New Password and Confirm New Password values didn\'t match.'))
             ->willReturnSelf();
 
@@ -355,7 +355,7 @@ class ResetPasswordPostTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Please enter a new password.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Address/DeleteTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Address/DeleteTest.php
@@ -146,7 +146,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->method('deleteById')
             ->with($addressId);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You deleted the address.'));
         $this->resultRedirect->expects($this->once())
             ->method('setPath')
@@ -183,11 +183,11 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(34);
         $exception = new \Exception('Exception');
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t delete the address right now.'))
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('We can\'t delete the address right now.'));
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Customer/Test/Unit/Controller/Address/FormPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Address/FormPostTest.php
@@ -549,7 +549,7 @@ class FormPostTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the address.'))
             ->willReturnSelf();
 
@@ -637,7 +637,7 @@ class FormPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new InputException(__('InputException')));
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('InputException')
             ->willReturnSelf();
 
@@ -700,7 +700,7 @@ class FormPostTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('We can\'t save the address.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Group/SaveTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Group/SaveTest.php
@@ -167,7 +167,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('save')
             ->with($this->group);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the customer group.'));
         $exception = new \Exception('Exception');
         $this->resultRedirect->expects($this->at(0))
@@ -175,7 +175,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with('customer/group')
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Exception');
         $this->dataObjectProcessorMock->expects($this->once())
             ->method('buildOutputDataArray')

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
@@ -312,7 +312,7 @@ class InlineEditTest extends \PHPUnit\Framework\TestCase
             ->with($this->customerData)
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('[Customer ID: 12] Exception message');
         $this->logger->expects($this->once())
             ->method('critical')
@@ -334,7 +334,7 @@ class InlineEditTest extends \PHPUnit\Framework\TestCase
             ->with($this->customerData)
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('[Customer ID: 12] We can\'t save the customer.');
         $this->logger->expects($this->once())
             ->method('critical')

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassAssignGroupTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassAssignGroupTest.php
@@ -157,7 +157,7 @@ class MassAssignGroupTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, $customerMock], [11, $customerMock], [12, $customerMock]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were updated.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -181,7 +181,7 @@ class MassAssignGroupTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassDeleteTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassDeleteTest.php
@@ -155,7 +155,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, true], [11, true], [12, true]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were deleted.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -179,7 +179,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassSubscribeTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassSubscribeTest.php
@@ -171,7 +171,7 @@ class MassSubscribeTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, true], [11, true], [12, true]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were updated.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -195,7 +195,7 @@ class MassSubscribeTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassUnsubscribeTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/MassUnsubscribeTest.php
@@ -171,7 +171,7 @@ class MassUnsubscribeTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[10, true], [11, true], [12, true]]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('A total of %1 record(s) were updated.', count($customersIds)));
 
         $this->resultRedirectMock->expects($this->any())
@@ -195,7 +195,7 @@ class MassUnsubscribeTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Some message.'));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Some message.');
 
         $this->massAction->execute();

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/SaveTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/SaveTest.php
@@ -574,7 +574,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with(RegistryConstants::CURRENT_CUSTOMER_ID, $customerId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the customer.'))
             ->willReturnSelf();
 
@@ -841,7 +841,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with(RegistryConstants::CURRENT_CUSTOMER_ID, $customerId);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the customer.'))
             ->willReturnSelf();
 
@@ -982,7 +982,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('register');
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->messageManagerMock->expects($this->once())
             ->method('addMessage')
@@ -1125,7 +1125,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('register');
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->messageManagerMock->expects($this->once())
             ->method('addMessage')
@@ -1269,10 +1269,10 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('register');
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('Something went wrong while saving the customer.'));
 
         $this->sessionMock->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Locks/UnlockTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Locks/UnlockTest.php
@@ -118,7 +118,7 @@ class UnlockTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('customer_id'))
             ->will($this->returnValue($customerId));
         $this->authenticationMock->expects($this->once())->method('unlock')->with($customerId);
-        $this->messageManagerMock->expects($this->once())->method('addSuccess');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
         $this->redirectMock->expects($this->once())
             ->method('setPath')
             ->with($this->equalTo('customer/index/edit'))
@@ -141,7 +141,7 @@ class UnlockTest extends \PHPUnit\Framework\TestCase
             ->method('unlock')
             ->with($customerId)
             ->willThrowException(new \Exception($phrase));
-        $this->messageManagerMock->expects($this->once())->method('addError');
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
         $this->controller->execute();
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Observer/AfterAddressSaveObserverTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Observer/AfterAddressSaveObserverTest.php
@@ -572,7 +572,7 @@ class AfterAddressSaveObserverTest extends \PHPUnit\Framework\TestCase
 
         if ($resultValidMessage) {
             $this->messageManager->expects($this->once())
-                ->method('addSuccess')
+                ->method('addSuccessMessage')
                 ->with($resultValidMessage)
                 ->willReturnSelf();
         }
@@ -582,7 +582,7 @@ class AfterAddressSaveObserverTest extends \PHPUnit\Framework\TestCase
                 ->with($vatId)
                 ->willReturn($vatId);
             $this->messageManager->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with($resultInvalidMessage)
                 ->willReturnSelf();
         }
@@ -592,7 +592,7 @@ class AfterAddressSaveObserverTest extends \PHPUnit\Framework\TestCase
                 ->with('trans_email/ident_support/email', ScopeInterface::SCOPE_STORE)
                 ->willReturn('admin@example.com');
             $this->messageManager->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with($resultErrorMessage)
                 ->willReturnSelf();
         }

--- a/app/code/Magento/Developer/Model/Config/Backend/AllowedIps.php
+++ b/app/code/Magento/Developer/Model/Config/Backend/AllowedIps.php
@@ -77,7 +77,7 @@ class AllowedIps extends \Magento\Framework\App\Config\Value
 
         $noticeMsg = implode(',', $noticeMsgArray);
         if (!empty($noticeMsgArray)) {
-            $this->messageManager->addNotice(
+            $this->messageManager->addNoticeMessage(
                 __(
                     __('The following invalid values cannot be saved: %values', ['values' => $noticeMsg])
                 )

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Link.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Link.php
@@ -125,7 +125,7 @@ class Link extends \Magento\Catalog\Controller\Adminhtml\Product\Edit
             try {
                 $this->_processDownload($resource, $resourceType);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
             }
         }
     }

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Sample.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Sample.php
@@ -54,7 +54,7 @@ class Sample extends \Magento\Downloadable\Controller\Adminhtml\Downloadable\Pro
             try {
                 $this->_processDownload($resource, $resourceType);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
             }
         }
     }

--- a/app/code/Magento/Downloadable/Controller/Download/Link.php
+++ b/app/code/Magento/Downloadable/Controller/Download/Link.php
@@ -44,7 +44,7 @@ class Link extends \Magento\Downloadable\Controller\Download
             'link_hash'
         );
         if (!$linkPurchasedItem->getId()) {
-            $this->messageManager->addNotice(__("We can't find the link you requested."));
+            $this->messageManager->addNoticeMessage(__("We can't find the link you requested."));
             return $this->_redirect('*/customer/products');
         }
         if (!$this->_objectManager->get(\Magento\Downloadable\Helper\Data::class)->getIsShareable($linkPurchasedItem)) {
@@ -65,7 +65,7 @@ class Link extends \Magento\Downloadable\Controller\Download
                 } else {
                     $notice = __('Please sign in to download your product.');
                 }
-                $this->messageManager->addNotice($notice);
+                $this->messageManager->addNoticeMessage($notice);
                 $session->authenticate();
                 $session->setBeforeAuthUrl(
                     $this->_objectManager->create(
@@ -84,7 +84,7 @@ class Link extends \Magento\Downloadable\Controller\Download
                 $linkPurchasedItem->getPurchasedId()
             );
             if ($linkPurchased->getCustomerId() != $customerId) {
-                $this->messageManager->addNotice(__("We can't find the link you requested."));
+                $this->messageManager->addNoticeMessage(__("We can't find the link you requested."));
                 return $this->_redirect('*/customer/products');
             }
         }
@@ -119,15 +119,15 @@ class Link extends \Magento\Downloadable\Controller\Download
                 $linkPurchasedItem->save();
                 exit(0);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
             }
         } elseif ($status == PurchasedLink::LINK_STATUS_EXPIRED) {
-            $this->messageManager->addNotice(__('The link has expired.'));
+            $this->messageManager->addNoticeMessage(__('The link has expired.'));
         } elseif ($status == PurchasedLink::LINK_STATUS_PENDING || $status == PurchasedLink::LINK_STATUS_PAYMENT_REVIEW
         ) {
-            $this->messageManager->addNotice(__('The link is not available.'));
+            $this->messageManager->addNoticeMessage(__('The link is not available.'));
         } else {
-            $this->messageManager->addError(__('Something went wrong while getting the requested content.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while getting the requested content.'));
         }
         return $this->_redirect('*/customer/products');
     }

--- a/app/code/Magento/Downloadable/Controller/Download/LinkSample.php
+++ b/app/code/Magento/Downloadable/Controller/Download/LinkSample.php
@@ -41,7 +41,7 @@ class LinkSample extends \Magento\Downloadable\Controller\Download
                 $this->_processDownload($resource, $resourceType);
                 exit(0);
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Sorry, there was an error getting requested content. Please contact the store owner.')
                 );
             }

--- a/app/code/Magento/Downloadable/Controller/Download/Sample.php
+++ b/app/code/Magento/Downloadable/Controller/Download/Sample.php
@@ -38,7 +38,7 @@ class Sample extends \Magento\Downloadable\Controller\Download
                 $this->_processDownload($resource, $resourceType);
                 exit(0);
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Sorry, there was an error getting requested content. Please contact the store owner.')
                 );
             }

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkSampleTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkSampleTest.php
@@ -146,7 +146,7 @@ class LinkSampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');
@@ -193,7 +193,7 @@ class LinkSampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
@@ -175,7 +175,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with("We can't find the link you requested.");
         $this->redirect->expects($this->once())->method('redirect')->with($this->response, '*/customer/products', []);
 
@@ -217,7 +217,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->product->expects($this->once())->method('getProductUrl')->willReturn('product_url');
         $this->product->expects($this->once())->method('getName')->willReturn('product_name');
         $this->messageManager->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('Please sign in to download your product or purchase <a href="product_url">product_name</a>.');
         $this->session->expects($this->once())->method('authenticate')->willReturn(true);
         $this->objectManager->expects($this->at(4))
@@ -266,7 +266,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->linkPurchased->expects($this->once())->method('load')->with('purchased_id')->willReturnSelf();
         $this->linkPurchased->expects($this->once())->method('getCustomerId')->willReturn('other_customer_id');
         $this->messageManager->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with("We can't find the link you requested.");
         $this->redirect->expects($this->once())->method('redirect')->with($this->response, '*/customer/products', []);
 
@@ -315,7 +315,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->linkPurchasedItem->expects($this->any())->method('setStatus')->with('expired')->willReturnSelf();
         $this->linkPurchasedItem->expects($this->any())->method('save')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Something went wrong while getting the requested content.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('redirect')->with($this->response, '*/customer/products', []);

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/SampleTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/SampleTest.php
@@ -146,7 +146,7 @@ class SampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');
@@ -189,7 +189,7 @@ class SampleTest extends \PHPUnit\Framework\TestCase
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->downloadHelper->expects($this->once())->method('output')->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Sorry, there was an error getting requested content. Please contact the store owner.')
             ->willReturnSelf();
         $this->redirect->expects($this->once())->method('getRedirectUrl')->willReturn('redirect_url');

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Delete.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Delete.php
@@ -22,21 +22,21 @@ class Delete extends \Magento\Email\Controller\Adminhtml\Email\Template
                 if (count($template->getSystemConfigPathsWhereCurrentlyUsed()) == 0) {
                     $template->delete();
                     // display success message
-                    $this->messageManager->addSuccess(__('You deleted the email template.'));
+                    $this->messageManager->addSuccessMessage(__('You deleted the email template.'));
                     $this->_objectManager->get(\Magento\Framework\App\ReinitableConfig::class)->reinit();
                     // go to grid
                     $this->_redirect('adminhtml/*/');
                     return;
                 }
                 // display error  message
-                $this->messageManager->addError(__('The email template is currently being used.'));
+                $this->messageManager->addErrorMessage(__('The email template is currently being used.'));
                 // redirect to edit form
                 $this->_redirect('adminhtml/*/edit', ['id' => $template->getId()]);
                 return;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete email template data right now. Please review log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -52,7 +52,7 @@ class Delete extends \Magento\Email\Controller\Adminhtml\Email\Template
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find an email template to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find an email template to delete.'));
         // go to grid
         $this->_redirect('adminhtml/*/');
     }

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Preview.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Preview.php
@@ -21,7 +21,7 @@ class Preview extends \Magento\Email\Controller\Adminhtml\Email\Template
             $this->_view->renderLayout();
             $this->getResponse()->setHeader('Content-Security-Policy', "script-src 'none'");
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred. The email template can not be opened for preview.'));
+            $this->messageManager->addErrorMessage(__('An error occurred. The email template can not be opened for preview.'));
             $this->_redirect('adminhtml/*/');
         }
     }

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Preview.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Preview.php
@@ -21,7 +21,9 @@ class Preview extends \Magento\Email\Controller\Adminhtml\Email\Template
             $this->_view->renderLayout();
             $this->getResponse()->setHeader('Content-Security-Policy', "script-src 'none'");
         } catch (\Exception $e) {
-            $this->messageManager->addErrorMessage(__('An error occurred. The email template can not be opened for preview.'));
+            $this->messageManager->addErrorMessage(
+                __('An error occurred. The email template can not be opened for preview.')
+            );
             $this->_redirect('adminhtml/*/');
         }
     }

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Save.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/Save.php
@@ -22,7 +22,7 @@ class Save extends \Magento\Email\Controller\Adminhtml\Email\Template
 
         $template = $this->_initTemplate('id');
         if (!$template->getId() && $id) {
-            $this->messageManager->addError(__('This email template no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This email template no longer exists.'));
             $this->_redirect('adminhtml/*/');
             return;
         }
@@ -55,7 +55,7 @@ class Save extends \Magento\Email\Controller\Adminhtml\Email\Template
 
             $template->save();
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData(false);
-            $this->messageManager->addSuccess(__('You saved the email template.'));
+            $this->messageManager->addSuccessMessage(__('You saved the email template.'));
             $this->_redirect('adminhtml/*');
         } catch (\Exception $e) {
             $this->_objectManager->get(
@@ -64,7 +64,7 @@ class Save extends \Magento\Email\Controller\Adminhtml\Email\Template
                 'email_template_form_data',
                 $request->getParams()
             );
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_forward('new');
         }
     }

--- a/app/code/Magento/EncryptionKey/Controller/Adminhtml/Crypt/Key/Index.php
+++ b/app/code/Magento/EncryptionKey/Controller/Adminhtml/Crypt/Key/Index.php
@@ -21,7 +21,7 @@ class Index extends \Magento\EncryptionKey\Controller\Adminhtml\Crypt\Key
         /** @var \Magento\Framework\App\DeploymentConfig\Writer $writer */
         $writer = $this->_objectManager->get(\Magento\Framework\App\DeploymentConfig\Writer::class);
         if (!$writer->checkIfWritable()) {
-            $this->messageManager->addError(__('Deployment configuration file is not writable.'));
+            $this->messageManager->addErrorMessage(__('Deployment configuration file is not writable.'));
         }
 
         $this->_view->loadLayout();

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/Export.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/Export.php
@@ -62,13 +62,13 @@ class Export extends ExportController
                     $model->getContentType()
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                $this->messageManager->addError(__('Please correct the data sent value.'));
+                $this->messageManager->addErrorMessage(__('Please correct the data sent value.'));
             }
         } else {
-            $this->messageManager->addError(__('Please correct the data sent value.'));
+            $this->messageManager->addErrorMessage(__('Please correct the data sent value.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/GetFilter.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/GetFilter.php
@@ -33,10 +33,10 @@ class GetFilter extends ExportController
                 );
                 return $resultLayout;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } else {
-            $this->messageManager->addError(__('Please correct the data sent value.'));
+            $this->messageManager->addErrorMessage(__('Please correct the data sent value.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
@@ -89,7 +89,7 @@ class Download extends ImportController
         try {
             $fileContents = $this->sampleFileProvider->getFileContents($entityName);
         } catch (NoSuchEntityException $e) {
-            $this->messageManager->addError(__('There is no sample file for this entity.'));
+            $this->messageManager->addErrorMessage(__('There is no sample file for this entity.'));
 
             return $this->getResultRedirect();
         }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Index.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Index.php
@@ -17,7 +17,7 @@ class Index extends ImportController
      */
     public function execute()
     {
-        $this->messageManager->addNotice(
+        $this->messageManager->addNoticeMessage(
             $this->_objectManager->get(\Magento\ImportExport\Helper\Data::class)->getMaxUploadSizeMessage()
         );
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Validate.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Validate.php
@@ -59,7 +59,7 @@ class Validate extends ImportResultController
             $resultBlock->addError(__('The file was not uploaded.'));
             return $resultLayout;
         }
-        $this->messageManager->addError(__('Sorry, but the data is invalid or the file is not uploaded.'));
+        $this->messageManager->addErrorMessage(__('Sorry, but the data is invalid or the file is not uploaded.'));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $resultRedirect->setPath('adminhtml/*/index');

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Import/ValidateTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Import/ValidateTest.php
@@ -144,7 +144,7 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
             ]);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Sorry, but the data is invalid or the file is not uploaded.'));
 
         $this->assertEquals($resultRedirectMock, $this->validate->execute());
@@ -170,7 +170,7 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $resultBlock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('The file was not uploaded.'));
 
         $layoutMock = $this->getMockBuilder(\Magento\Framework\View\LayoutInterface::class)

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
@@ -17,7 +17,7 @@ class MassChangelog extends \Magento\Indexer\Controller\Adminhtml\Indexer
     {
         $indexerIds = $this->getRequest()->getParam('indexer_ids');
         if (!is_array($indexerIds)) {
-            $this->messageManager->addError(__('Please select indexers.'));
+            $this->messageManager->addErrorMessage(__('Please select indexers.'));
         } else {
             try {
                 foreach ($indexerIds as $indexerId) {
@@ -27,13 +27,13 @@ class MassChangelog extends \Magento\Indexer\Controller\Adminhtml\Indexer
                     )->get($indexerId);
                     $model->setScheduled(true);
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('%1 indexer(s) are in "Update by Schedule" mode.', count($indexerIds))
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __("We couldn't change indexer(s)' mode because of an error.")
                 );

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
@@ -17,7 +17,7 @@ class MassOnTheFly extends \Magento\Indexer\Controller\Adminhtml\Indexer
     {
         $indexerIds = $this->getRequest()->getParam('indexer_ids');
         if (!is_array($indexerIds)) {
-            $this->messageManager->addError(__('Please select indexers.'));
+            $this->messageManager->addErrorMessage(__('Please select indexers.'));
         } else {
             try {
                 foreach ($indexerIds as $indexerId) {
@@ -27,13 +27,13 @@ class MassOnTheFly extends \Magento\Indexer\Controller\Adminhtml\Indexer
                     )->get($indexerId);
                     $model->setScheduled(false);
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('%1 indexer(s) are in "Update on Save" mode.', count($indexerIds))
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __("We couldn't change indexer(s)' mode because of an error.")
                 );

--- a/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassChangelogTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassChangelogTest.php
@@ -181,7 +181,7 @@ class MassChangelogTest extends \PHPUnit\Framework\TestCase
 
         if (!is_array($indexerIds)) {
             $this->messageManager->expects($this->once())
-                ->method('addError')->with(__('Please select indexers.'))
+                ->method('addErrorMessage')->with(__('Please select indexers.'))
                 ->will($this->returnValue(1));
         } else {
             $this->objectManager->expects($this->any())
@@ -205,15 +205,15 @@ class MassChangelogTest extends \PHPUnit\Framework\TestCase
                     ->method('setScheduled')->with(true)->will($this->returnValue(1));
             }
 
-            $this->messageManager->expects($this->any())->method('addSuccess')->will($this->returnValue(1));
+            $this->messageManager->expects($this->any())->method('addSuccessMessage')->will($this->returnValue(1));
 
             if ($exception !== null) {
                 $this->messageManager
                     ->expects($this->exactly($expectsExceptionValues[2]))
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($exception->getMessage());
                 $this->messageManager->expects($this->exactly($expectsExceptionValues[1]))
-                    ->method('addException')
+                    ->method('addExceptionMessage')
                     ->with($exception, "We couldn't change indexer(s)' mode because of an error.");
             }
         }

--- a/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
@@ -184,7 +184,7 @@ class MassOnTheFlyTest extends \PHPUnit\Framework\TestCase
 
         if (!is_array($indexerIds)) {
             $this->messageManager->expects($this->once())
-                ->method('addError')->with(__('Please select indexers.'))
+                ->method('addErrorMessage')->with(__('Please select indexers.'))
                 ->will($this->returnValue(1));
         } else {
             $this->objectManager->expects($this->any())
@@ -208,14 +208,14 @@ class MassOnTheFlyTest extends \PHPUnit\Framework\TestCase
                     ->method('setScheduled')->with(false)->will($this->returnValue(1));
             }
 
-            $this->messageManager->expects($this->any())->method('addSuccess')->will($this->returnValue(1));
+            $this->messageManager->expects($this->any())->method('addSuccessMessage')->will($this->returnValue(1));
 
             if ($exception !== null) {
                 $this->messageManager->expects($this->exactly($expectsExceptionValues[2]))
-                    ->method('addError')
+                    ->method('addErrorMessage')
                     ->with($exception->getMessage());
                 $this->messageManager->expects($this->exactly($expectsExceptionValues[1]))
-                    ->method('addException')
+                    ->method('addExceptionMessage')
                     ->with($exception, "We couldn't change indexer(s)' mode because of an error.");
             }
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Delete.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Delete.php
@@ -26,7 +26,7 @@ class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
             if ($integrationId) {
                 $integrationData = $this->_integrationService->get($integrationId);
                 if ($this->_integrationData->isConfigType($integrationData)) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __(
                             "Uninstall the extension to remove integration '%1'.",
                             $this->escaper->escapeHtml($integrationData[Info::DATA_NAME])
@@ -36,14 +36,14 @@ class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
                 }
                 $integrationData = $this->_integrationService->delete($integrationId);
                 if (!$integrationData[Info::DATA_ID]) {
-                    $this->messageManager->addError(__('This integration no longer exists.'));
+                    $this->messageManager->addErrorMessage(__('This integration no longer exists.'));
                 } else {
                     //Integration deleted successfully, now safe to delete the associated consumer data
                     if (isset($integrationData[Info::DATA_CONSUMER_ID])) {
                         $this->_oauthService->deleteConsumer($integrationData[Info::DATA_CONSUMER_ID]);
                     }
                     $this->_registry->register(self::REGISTRY_KEY_CURRENT_INTEGRATION, $integrationData);
-                    $this->messageManager->addSuccess(
+                    $this->messageManager->addSuccessMessage(
                         __(
                             "The integration '%1' has been deleted.",
                             $this->escaper->escapeHtml($integrationData[Info::DATA_NAME])
@@ -51,10 +51,10 @@ class Delete extends \Magento\Integration\Controller\Adminhtml\Integration
                     );
                 }
             } else {
-                $this->messageManager->addError(__('Integration ID is not specified or is invalid.'));
+                $this->messageManager->addErrorMessage(__('Integration ID is not specified or is invalid.'));
             }
         } catch (IntegrationException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_logger->critical($e);
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Edit.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Edit.php
@@ -26,12 +26,12 @@ class Edit extends \Magento\Integration\Controller\Adminhtml\Integration
                 $integrationData = $this->_integrationService->get($integrationId)->getData();
                 $originalName = $this->escaper->escapeHtml($integrationData[Info::DATA_NAME]);
             } catch (IntegrationException $e) {
-                $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+                $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
                 $this->_redirect('*/*/');
                 return;
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
-                $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+                $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
                 $this->_redirect('*/*');
                 return;
             }
@@ -40,7 +40,7 @@ class Edit extends \Magento\Integration\Controller\Adminhtml\Integration
                 $integrationData = array_merge($integrationData, $restoredIntegration);
             }
         } else {
-            $this->messageManager->addError(__('Integration ID is not specified or is invalid.'));
+            $this->messageManager->addErrorMessage(__('Integration ID is not specified or is invalid.'));
             $this->_redirect('*/*/');
             return;
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Index.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Index.php
@@ -18,7 +18,7 @@ class Index extends \Magento\Integration\Controller\Adminhtml\Integration
         $unsecureIntegrationsCount = $this->_integrationCollection->addUnsecureUrlsFilter()->getSize();
         if ($unsecureIntegrationsCount > 0) {
             // @codingStandardsIgnoreStart
-            $this->messageManager->addNotice(__('Warning! Integrations not using HTTPS are insecure and potentially expose private or personally identifiable information')
+            $this->messageManager->addNoticeMessage(__('Warning! Integrations not using HTTPS are insecure and potentially expose private or personally identifiable information')
             // @codingStandardsIgnoreEnd
             );
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/PermissionsDialog.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/PermissionsDialog.php
@@ -23,17 +23,17 @@ class PermissionsDialog extends \Magento\Integration\Controller\Adminhtml\Integr
                 $integrationData = $this->_integrationService->get($integrationId)->getData();
                 $this->_registry->register(self::REGISTRY_KEY_CURRENT_INTEGRATION, $integrationData);
             } catch (IntegrationException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('*/*/');
                 return;
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
-                $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+                $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
                 $this->_redirect('*/*');
                 return;
             }
         } else {
-            $this->messageManager->addError(__('Integration ID is not specified or is invalid.'));
+            $this->messageManager->addErrorMessage(__('Integration ID is not specified or is invalid.'));
             $this->_redirect('*/*/');
             return;
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/Save.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/Save.php
@@ -68,19 +68,19 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
             );
             $this->_redirect('*');
         } catch (\Magento\Framework\Exception\AuthenticationException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_getSession()->setIntegrationData($this->getRequest()->getPostValue());
             $this->_redirectOnSaveError();
         } catch (IntegrationException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_getSession()->setIntegrationData($integrationData);
             $this->_redirectOnSaveError();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_redirectOnSaveError();
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_redirectOnSaveError();
         }
     }
@@ -114,12 +114,12 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
         try {
             $integrationData = $this->_integrationService->get($integrationId)->getData();
         } catch (IntegrationException $e) {
-            $this->messageManager->addError($this->escaper->escapeHtml($e->getMessage()));
+            $this->messageManager->addErrorMessage($this->escaper->escapeHtml($e->getMessage()));
             $this->_redirect('*/*/');
             return null;
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+            $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
             $this->_redirect('*/*');
             return null;
         }
@@ -163,7 +163,7 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
                 $integration = $this->_integrationService->update($integrationData);
             }
             if (!$this->getRequest()->isXmlHttpRequest()) {
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __(
                         'The integration \'%1\' has been saved.',
                         $this->escaper->escapeHtml($integration->getName())
@@ -179,7 +179,7 @@ class Save extends \Magento\Integration\Controller\Adminhtml\Integration
                 );
             }
         } else {
-            $this->messageManager->addError(__('The integration was not saved.'));
+            $this->messageManager->addErrorMessage(__('The integration was not saved.'));
         }
     }
 }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensDialog.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensDialog.php
@@ -27,7 +27,7 @@ class TokensDialog extends \Magento\Integration\Controller\Adminhtml\Integration
             "The integration '%1' has been activated.",
             $integrationName
         );
-        $this->messageManager->addSuccess($successMsg);
+        $this->messageManager->addSuccessMessage($successMsg);
     }
 
     /**
@@ -50,12 +50,12 @@ class TokensDialog extends \Magento\Integration\Controller\Adminhtml\Integration
                 $this->_integrationService->get($integrationId)->getData()
             );
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*');
             return;
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+            $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
             $this->_redirect('*/*');
             return;
         }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensExchange.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration/TokensExchange.php
@@ -28,7 +28,7 @@ class TokensExchange extends \Magento\Integration\Controller\Adminhtml\Integrati
             "Integration '%1' has been sent for activation.",
             $integrationName
         );
-        $this->messageManager->addNotice($msg);
+        $this->messageManager->addNoticeMessage($msg);
     }
 
     /**
@@ -72,12 +72,12 @@ class TokensExchange extends \Magento\Integration\Controller\Adminhtml\Integrati
             ];
             $this->getResponse()->representJson($this->jsonHelper->jsonEncode($result));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*');
             return;
         } catch (\Exception $e) {
             $this->_logger->critical($e);
-            $this->messageManager->addError(__('Internal error. Check exception log for details.'));
+            $this->messageManager->addErrorMessage(__('Internal error. Check exception log for details.'));
             $this->_redirect('*/*');
             return;
         }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/DeleteTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/DeleteTest.php
@@ -55,7 +55,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_translateModelMock = null;
         // verify success message
         $this->_messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The integration \'%1\' has been deleted.', $intData[Info::DATA_NAME]));
 
         $this->_escaper->expects($this->once())
@@ -88,7 +88,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_translateModelMock = null;
         // verify success message
         $this->_messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The integration \'%1\' has been deleted.', $intData[Info::DATA_NAME]));
 
         $this->_escaper->expects($this->once())
@@ -115,13 +115,13 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
             ->willReturn(true);
         // verify error message
         $this->_messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Uninstall the extension to remove integration \'%1\'.', $intData[Info::DATA_NAME]));
         $this->_integrationSvcMock->expects($this->never())->method('delete');
         // Use real translate model
         $this->_translateModelMock = null;
         // verify success message
-        $this->_messageManager->expects($this->never())->method('addSuccess');
+        $this->_messageManager->expects($this->never())->method('addSuccessMessage');
 
         $this->_escaper->expects($this->once())
             ->method('escapeHtml')
@@ -138,7 +138,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_translateModelMock = null;
         // verify error message
         $this->_messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Integration ID is not specified or is invalid.'));
 
         $this->integrationController->execute();
@@ -161,7 +161,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_integrationSvcMock->expects($this->once())
             ->method('delete')
             ->willThrowException($invalidIdException);
-        $this->_messageManager->expects($this->once())->method('addError');
+        $this->_messageManager->expects($this->once())->method('addErrorMessage');
 
         $this->integrationController->execute();
     }
@@ -183,7 +183,7 @@ class DeleteTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Int
         $this->_integrationSvcMock->expects($this->once())
             ->method('delete')
             ->willThrowException($invalidIdException);
-        $this->_messageManager->expects($this->never())->method('addError');
+        $this->_messageManager->expects($this->never())->method('addErrorMessage');
 
         $this->integrationController->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/EditTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/EditTest.php
@@ -61,7 +61,7 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'This integration no longer exists.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $this->_requestMock->expects($this->any())->method('getParam')->will($this->returnValue(self::INTEGRATION_ID));
         // put data in session, the magic function getFormData is called so, must match __call method name
         $this->_backendSessionMock->expects(
@@ -92,7 +92,7 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'Integration ID is not specified or is invalid.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $this->_verifyLoadAndRenderLayout();
         $integrationContr = $this->_createIntegrationController('Edit');
         $integrationContr->execute();
@@ -102,7 +102,7 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'Integration ID is not specified or is invalid.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $this->_controller = $this->_createIntegrationController('Edit');
         $this->_controller->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/EditTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/EditTest.php
@@ -61,7 +61,9 @@ class EditTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
     {
         $exceptionMessage = 'This integration no longer exists.';
         // verify the error
-        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())
+            ->method('addErrorMessage')
+            ->with($this->equalTo($exceptionMessage));
         $this->_requestMock->expects($this->any())->method('getParam')->will($this->returnValue(self::INTEGRATION_ID));
         // put data in session, the magic function getFormData is called so, must match __call method name
         $this->_backendSessionMock->expects(

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/SaveTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/SaveTest.php
@@ -56,7 +56,9 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             ->with(self::INTEGRATION_ID)
             ->will($this->throwException(new \Magento\Framework\Exception\LocalizedException(__($exceptionMessage))));
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())
+            ->method('addErrorMessage')
+            ->with($this->equalTo($exceptionMessage));
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/SaveTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/SaveTest.php
@@ -34,7 +34,7 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             ->will($this->returnValue($intData));
         // verify success message
         $this->_messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The integration \'%1\' has been saved.', $intData[Info::DATA_NAME]));
 
         $this->_escaper->expects($this->once())
@@ -56,7 +56,7 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             ->with(self::INTEGRATION_ID)
             ->will($this->throwException(new \Magento\Framework\Exception\LocalizedException(__($exceptionMessage))));
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -81,7 +81,7 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             ->method('escapeHtml')
             ->willReturnArgument(0);
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -174,7 +174,7 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
         // Use real translate model
         $this->_translateModelMock = null;
         // Verify success message
-        $this->_messageManager->expects($this->once())->method('addError')->with($exceptionMessage);
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($exceptionMessage);
         $integrationController = $this->_createIntegrationController('Save');
         $integrationController->execute();
     }
@@ -205,7 +205,7 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             ->willReturnArgument(0);
 
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }
@@ -277,7 +277,7 @@ class SaveTest extends \Magento\Integration\Test\Unit\Controller\Adminhtml\Integ
             ->will($this->throwException(new AuthenticationException(__($exceptionMessage))));
 
         // Verify error
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($exceptionMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($exceptionMessage));
         $integrationContr = $this->_createIntegrationController('Save');
         $integrationContr->execute();
     }

--- a/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/TokensExchangeTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Controller/Adminhtml/Integration/TokensExchangeTest.php
@@ -37,9 +37,9 @@ class TokensExchangeTest extends \Magento\Integration\Test\Unit\Controller\Admin
         $consumerMock->expects($this->once())->method('getId')->willReturn(1);
         $this->_oauthSvcMock->expects($this->once())->method('loadConsumer')->willReturn($consumerMock);
 
-        $this->_messageManager->expects($this->once())->method('addNotice');
-        $this->_messageManager->expects($this->never())->method('addError');
-        $this->_messageManager->expects($this->never())->method('addSuccess');
+        $this->_messageManager->expects($this->once())->method('addNoticeMessage');
+        $this->_messageManager->expects($this->never())->method('addErrorMessage');
+        $this->_messageManager->expects($this->never())->method('addSuccessMessage');
 
         $this->_viewMock->expects($this->once())->method('loadLayout');
         $this->_viewMock->expects($this->once())->method('renderLayout');

--- a/app/code/Magento/Multishipping/Controller/Checkout.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout.php
@@ -123,7 +123,7 @@ abstract class Checkout extends \Magento\Checkout\Controller\Action implements
                 \Magento\Multishipping\Helper\Data::class
             )->isMultishippingCheckoutAvailable()) {
                 $error = $this->_getCheckout()->getMinimumAmountError();
-                $this->messageManager->addError($error);
+                $this->messageManager->addErrorMessage($error);
                 $this->getResponse()->setRedirect($this->_getHelper()->getCartUrl());
                 $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
                 return parent::dispatch($request);
@@ -170,7 +170,7 @@ abstract class Checkout extends \Magento\Checkout\Controller\Action implements
     {
         if (!$this->_getCheckout()->validateMinimumAmount()) {
             $error = $this->_getCheckout()->getMinimumAmountError();
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->_forward('backToAddresses');
             return false;
         }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Addresses.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Addresses.php
@@ -28,7 +28,7 @@ class Addresses extends \Magento\Multishipping\Controller\Checkout
         $this->_getState()->setActiveStep(State::STEP_SELECT_ADDRESSES);
         if (!$this->_getCheckout()->validateMinimumAmount()) {
             $message = $this->_getCheckout()->getMinimumAmountDescription();
-            $this->messageManager->addNotice($message);
+            $this->messageManager->addNoticeMessage($message);
         }
         $this->_view->loadLayout();
         $this->_view->renderLayout();

--- a/app/code/Magento/Multishipping/Controller/Checkout/AddressesPost.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/AddressesPost.php
@@ -36,10 +36,10 @@ class AddressesPost extends \Magento\Multishipping\Controller\Checkout
                 $this->_getCheckout()->setShippingItemsInformation($shipToInfo);
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/addresses');
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Data saving problem'));
+            $this->messageManager->addExceptionMessage($e, __('Data saving problem'));
             $this->_redirect('*/*/addresses');
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Overview.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Overview.php
@@ -42,11 +42,11 @@ class Overview extends \Magento\Multishipping\Controller\Checkout
             $this->_view->loadLayout();
             $this->_view->renderLayout();
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/billing');
         } catch (\Exception $e) {
             $this->_objectManager->get(LoggerInterface::class)->critical($e);
-            $this->messageManager->addException($e, __('We cannot open the overview page.'));
+            $this->messageManager->addExceptionMessage($e, __('We cannot open the overview page.'));
             $this->_redirect('*/*/billing');
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/OverviewPost.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/OverviewPost.php
@@ -89,7 +89,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
 
         try {
             if (!$this->agreementsValidator->isValid(array_keys($this->getRequest()->getPost('agreement', [])))) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Please agree to all Terms and Conditions before placing the order.')
                 );
                 $this->_redirect('*/*/billing');
@@ -119,7 +119,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
         } catch (PaymentException $e) {
             $message = $e->getMessage();
             if (!empty($message)) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $this->_redirect('*/*/billing');
         } catch (\Magento\Checkout\Exception $e) {
@@ -131,7 +131,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
                 'multi-shipping'
             );
             $this->_getCheckout()->getCheckoutSession()->clearQuote();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/cart');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->_objectManager->get(
@@ -141,7 +141,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
                 $e->getMessage(),
                 'multi-shipping'
             );
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/billing');
         } catch (\Exception $e) {
             $this->logger->critical($e);
@@ -156,7 +156,7 @@ class OverviewPost extends \Magento\Multishipping\Controller\Checkout
             } catch (\Exception $e) {
                 $this->logger->error($e->getMessage());
             }
-            $this->messageManager->addError(__('Order place error'));
+            $this->messageManager->addErrorMessage(__('Order place error'));
             $this->_redirect('*/*/billing');
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/ShippingPost.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/ShippingPost.php
@@ -26,7 +26,7 @@ class ShippingPost extends \Magento\Multishipping\Controller\Checkout
             $this->_getState()->setCompleteStep(State::STEP_SHIPPING);
             $this->_redirect('*/*/billing');
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('*/*/shipping');
         }
     }

--- a/app/code/Magento/NewRelicReporting/Model/Observer/CheckConfig.php
+++ b/app/code/Magento/NewRelicReporting/Model/Observer/CheckConfig.php
@@ -58,7 +58,7 @@ class CheckConfig implements ObserverInterface
         if ($this->config->isNewRelicEnabled()) {
             if (!$this->newRelicWrapper->isExtensionInstalled()) {
                 $this->config->disableModule();
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __(
                         'The New Relic integration requires the newrelic-php5 agent, which is not installed. More 
                         information on installing the agent is available <a target="_blank" href="%1">here</a>.',

--- a/app/code/Magento/NewRelicReporting/Test/Unit/Model/Observer/CheckConfigTest.php
+++ b/app/code/Magento/NewRelicReporting/Test/Unit/Model/Observer/CheckConfigTest.php
@@ -120,7 +120,7 @@ class CheckConfigTest extends \PHPUnit\Framework\TestCase
         $this->config->expects($this->once())
             ->method('disableModule');
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->model->execute($eventObserver);
     }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Grid.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Grid.php
@@ -28,7 +28,7 @@ class Grid extends \Magento\Newsletter\Controller\Adminhtml\Problem
                 $collection->walk('unsubscribe');
             }
 
-            $this->messageManager->addSuccess(__('We unsubscribed the people you identified.'));
+            $this->messageManager->addSuccessMessage(__('We unsubscribed the people you identified.'));
         }
 
         if ($this->getRequest()->getParam('_delete')) {
@@ -43,7 +43,7 @@ class Grid extends \Magento\Newsletter\Controller\Adminhtml\Problem
                 $collection->walk('delete');
             }
 
-            $this->messageManager->addSuccess(__('The problems you identified have been deleted.'));
+            $this->messageManager->addSuccessMessage(__('The problems you identified have been deleted.'));
         }
         $this->_view->loadLayout(false);
         $this->_view->getLayout()->getMessagesBlock()->setMessages($this->messageManager->getMessages(true));

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Queue/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Queue/Save.php
@@ -80,13 +80,13 @@ class Save extends \Magento\Newsletter\Controller\Adminhtml\Queue
 
             $queue->save();
 
-            $this->messageManager->addSuccess(__('You saved the newsletter queue.'));
+            $this->messageManager->addSuccessMessage(__('You saved the newsletter queue.'));
             $this->_getSession()->setFormData(false);
             $this->_getSession()->unsPreviewData();
 
             $this->_redirect('*/*');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $id = $this->getRequest()->getParam('id');
             if ($id) {
                 $this->_redirect('*/*/edit', ['id' => $id]);

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
@@ -28,7 +28,10 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
                     );
                     $subscriber->delete();
                 }
-                $this->messageManager->addSuccessMessage(__('Total of %1 record(s) were deleted.', count($subscribersIds)));
+                $this->messageManager->addSuccessMessage(
+                    __('Total of %1 record(s) were deleted.',
+                       count($subscribersIds))
+                );
             } catch (\Exception $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());
             }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
@@ -17,7 +17,7 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
     {
         $subscribersIds = $this->getRequest()->getParam('subscriber');
         if (!is_array($subscribersIds)) {
-            $this->messageManager->addError(__('Please select one or more subscribers.'));
+            $this->messageManager->addErrorMessage(__('Please select one or more subscribers.'));
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
@@ -28,9 +28,9 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
                     );
                     $subscriber->delete();
                 }
-                $this->messageManager->addSuccess(__('Total of %1 record(s) were deleted.', count($subscribersIds)));
+                $this->messageManager->addSuccessMessage(__('Total of %1 record(s) were deleted.', count($subscribersIds)));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -28,7 +28,10 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
                     );
                     $subscriber->unsubscribe();
                 }
-                $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', count($subscribersIds)));
+                $this->messageManager->addSuccessMessage(
+                    __('A total of %1 record(s) were updated.',
+                       count($subscribersIds))
+                );
             } catch (\Exception $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());
             }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -17,7 +17,7 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
     {
         $subscribersIds = $this->getRequest()->getParam('subscriber');
         if (!is_array($subscribersIds)) {
-            $this->messageManager->addError(__('Please select one or more subscribers.'));
+            $this->messageManager->addErrorMessage(__('Please select one or more subscribers.'));
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
@@ -28,9 +28,9 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
                     );
                     $subscriber->unsubscribe();
                 }
-                $this->messageManager->addSuccess(__('A total of %1 record(s) were updated.', count($subscribersIds)));
+                $this->messageManager->addSuccessMessage(__('A total of %1 record(s) were updated.', count($subscribersIds)));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Delete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Delete.php
@@ -23,12 +23,12 @@ class Delete extends \Magento\Newsletter\Controller\Adminhtml\Template
         if ($template->getId()) {
             try {
                 $template->delete();
-                $this->messageManager->addSuccess(__('The newsletter template has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The newsletter template has been deleted.'));
                 $this->_getSession()->setFormData(false);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t delete this template right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t delete this template right now.'));
             }
         }
         $this->_redirect('*/template');

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Template/Save.php
@@ -62,16 +62,16 @@ class Save extends \Magento\Newsletter\Controller\Adminhtml\Template
 
             $template->save();
 
-            $this->messageManager->addSuccess(__('The newsletter template has been saved.'));
+            $this->messageManager->addSuccessMessage(__('The newsletter template has been saved.'));
             $this->_getSession()->setFormData(false);
             $this->_getSession()->unsPreviewData();
             $this->_redirect('*/template');
             return;
         } catch (LocalizedException $e) {
-            $this->messageManager->addError(nl2br($e->getMessage()));
+            $this->messageManager->addErrorMessage(nl2br($e->getMessage()));
             $this->_getSession()->setData('newsletter_template_form_data', $this->getRequest()->getParams());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong while saving this template.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving this template.'));
             $this->_getSession()->setData('newsletter_template_form_data', $this->getRequest()->getParams());
         }
 

--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -68,7 +68,7 @@ class Save extends \Magento\Newsletter\Controller\Manage
 
         $customerId = $this->_customerSession->getCustomerId();
         if ($customerId === null) {
-            $this->messageManager->addError(__('Something went wrong while saving your subscription.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while saving your subscription.'));
         } else {
             try {
                 $customer = $this->customerRepository->getById($customerId);
@@ -77,13 +77,13 @@ class Save extends \Magento\Newsletter\Controller\Manage
                 $this->customerRepository->save($customer);
                 if ((boolean)$this->getRequest()->getParam('is_subscribed', false)) {
                     $this->subscriberFactory->create()->subscribeCustomerById($customerId);
-                    $this->messageManager->addSuccess(__('We saved the subscription.'));
+                    $this->messageManager->addSuccessMessage(__('We saved the subscription.'));
                 } else {
                     $this->subscriberFactory->create()->unsubscribeCustomerById($customerId);
-                    $this->messageManager->addSuccess(__('We removed the subscription.'));
+                    $this->messageManager->addSuccessMessage(__('We removed the subscription.'));
                 }
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving your subscription.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving your subscription.'));
             }
         }
         $this->_redirect('customer/account/');

--- a/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Confirm.php
@@ -23,12 +23,12 @@ class Confirm extends \Magento\Newsletter\Controller\Subscriber
 
             if ($subscriber->getId() && $subscriber->getCode()) {
                 if ($subscriber->confirm($code)) {
-                    $this->messageManager->addSuccess(__('Your subscription has been confirmed.'));
+                    $this->messageManager->addSuccessMessage(__('Your subscription has been confirmed.'));
                 } else {
-                    $this->messageManager->addError(__('This is an invalid subscription confirmation code.'));
+                    $this->messageManager->addErrorMessage(__('This is an invalid subscription confirmation code.'));
                 }
             } else {
-                $this->messageManager->addError(__('This is an invalid subscription ID.'));
+                $this->messageManager->addErrorMessage(__('This is an invalid subscription ID.'));
             }
         }
 

--- a/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
@@ -135,17 +135,17 @@ class NewAction extends \Magento\Newsletter\Controller\Subscriber
 
                 $status = $this->_subscriberFactory->create()->subscribe($email);
                 if ($status == \Magento\Newsletter\Model\Subscriber::STATUS_NOT_ACTIVE) {
-                    $this->messageManager->addSuccess(__('The confirmation request has been sent.'));
+                    $this->messageManager->addSuccessMessage(__('The confirmation request has been sent.'));
                 } else {
-                    $this->messageManager->addSuccess(__('Thank you for your subscription.'));
+                    $this->messageManager->addSuccessMessage(__('Thank you for your subscription.'));
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('There was a problem with the subscription: %1', $e->getMessage())
                 );
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong with the subscription.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong with the subscription.'));
             }
         }
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl());

--- a/app/code/Magento/Newsletter/Controller/Subscriber/Unsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/Unsubscribe.php
@@ -20,11 +20,11 @@ class Unsubscribe extends \Magento\Newsletter\Controller\Subscriber
         if ($id && $code) {
             try {
                 $this->_subscriberFactory->create()->load($id)->setCheckCode($code)->unsubscribe();
-                $this->messageManager->addSuccess(__('You unsubscribed.'));
+                $this->messageManager->addSuccessMessage(__('You unsubscribed.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addException($e, $e->getMessage());
+                $this->messageManager->addExceptionMessage($e, $e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while unsubscribing you.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while unsubscribing you.'));
             }
         }
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl());

--- a/app/code/Magento/Newsletter/Test/Unit/Controller/Manage/SaveTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Controller/Manage/SaveTest.php
@@ -105,9 +105,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('redirect')
             ->with($this->responseMock, 'customer/account/', []);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->action->execute();
     }
 
@@ -123,9 +123,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('redirect')
             ->with($this->responseMock, 'customer/account/', []);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Something went wrong while saving your subscription.');
         $this->action->execute();
     }
@@ -154,9 +154,9 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('redirect')
             ->with($this->responseMock, 'customer/account/', []);
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Something went wrong while saving your subscription.');
         $this->action->execute();
     }

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Express/PlaceOrderTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Express/PlaceOrderTest.php
@@ -147,7 +147,7 @@ class PlaceOrderTest extends \Magento\Paypal\Test\Unit\Controller\ExpressTest
                 ->with($redirectUrl);
         } else {
             $this->messageManager->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with('User Message');
             $this->_expectRedirect('checkout/cart');
         }

--- a/app/code/Magento/Persistent/Controller/Index/ExpressCheckout.php
+++ b/app/code/Magento/Persistent/Controller/Index/ExpressCheckout.php
@@ -20,7 +20,7 @@ class ExpressCheckout extends Index
      */
     public function execute()
     {
-        $this->messageManager->addNotice(__('Your shopping cart has been updated with new prices.'));
+        $this->messageManager->addNoticeMessage(__('Your shopping cart has been updated with new prices.'));
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $resultRedirect->setPath('checkout/cart');

--- a/app/code/Magento/Persistent/Observer/PreventExpressCheckoutObserver.php
+++ b/app/code/Magento/Persistent/Observer/PreventExpressCheckoutObserver.php
@@ -81,7 +81,7 @@ class PreventExpressCheckoutObserver implements ObserverInterface
             return;
         }
 
-        $this->messageManager->addNotice(__('To check out, please sign in using your email address.'));
+        $this->messageManager->addNoticeMessage(__('To check out, please sign in using your email address.'));
         $customerBeforeAuthUrl = $this->_url->getUrl('persistent/index/expressCheckout');
 
         $this->_expressRedirectHelper->redirectLogin($controllerAction, $customerBeforeAuthUrl);

--- a/app/code/Magento/ProductAlert/Controller/Add/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Price.php
@@ -89,9 +89,9 @@ class Price extends AddController
                         ->getWebsiteId()
                 );
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the alert subscription.'));
+            $this->messageManager->addSuccessMessage(__('You saved the alert subscription.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('There are not enough parameters.'));
+            $this->messageManager->addErrorMessage(__('There are not enough parameters.'));
             if ($this->isInternal($backUrl)) {
                 $resultRedirect->setUrl($backUrl);
             } else {
@@ -99,7 +99,7 @@ class Price extends AddController
             }
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Add/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Stock.php
@@ -62,13 +62,13 @@ class Stock extends AddController
                         ->getWebsiteId()
                 );
             $model->save();
-            $this->messageManager->addSuccess(__('Alert subscription has been saved.'));
+            $this->messageManager->addSuccessMessage(__('Alert subscription has been saved.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('There are not enough parameters.'));
+            $this->messageManager->addErrorMessage(__('There are not enough parameters.'));
             $resultRedirect->setUrl($backUrl);
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Price.php
@@ -67,13 +67,13 @@ class Price extends UnsubscribeController
                 $model->delete();
             }
 
-            $this->messageManager->addSuccess(__('You deleted the alert subscription.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the alert subscription.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__("The product wasn't found. Verify the product and try again."));
+            $this->messageManager->addErrorMessage(__("The product wasn't found. Verify the product and try again."));
             $resultRedirect->setPath('customer/account/');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/PriceAll.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/PriceAll.php
@@ -23,9 +23,9 @@ class PriceAll extends UnsubscribeController
                         ->getStore()
                         ->getWebsiteId()
                 );
-            $this->messageManager->addSuccess(__('You will no longer receive price alerts for this product.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive price alerts for this product.'));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to update the alert subscription.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to update the alert subscription.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
@@ -65,13 +65,13 @@ class Stock extends UnsubscribeController
             if ($model->getId()) {
                 $model->delete();
             }
-            $this->messageManager->addSuccess(__('You will no longer receive stock alerts for this product.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive stock alerts for this product.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('The product was not found.'));
+            $this->messageManager->addErrorMessage(__('The product was not found.'));
             $resultRedirect->setPath('customer/account/');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/StockAll.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/StockAll.php
@@ -23,9 +23,9 @@ class StockAll extends UnsubscribeController
                         ->getStore()
                         ->getWebsiteId()
                 );
-            $this->messageManager->addSuccess(__('You will no longer receive stock alerts.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive stock alerts.'));
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to update the alert subscription.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to update the alert subscription.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/AbstractReport.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/AbstractReport.php
@@ -157,7 +157,7 @@ abstract class AbstractReport extends \Magento\Backend\App\Action
         $refreshStatsLink = $this->getUrl('reports/report_statistics');
         $directRefreshLink = $this->getUrl('reports/report_statistics/refreshRecent', ['code' => $refreshCode]);
 
-        $this->messageManager->addNotice(
+        $this->messageManager->addNoticeMessage(
             __(
                 'Last updated: %1. To refresh last day\'s <a href="%2">statistics</a>, ' .
                 'click <a href="%3">here</a>.',

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Viewed.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Viewed.php
@@ -42,9 +42,9 @@ class Viewed extends \Magento\Reports\Controller\Adminhtml\Report\Product
 
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('An error occurred while showing the product views report. Please review the log and try again.')
             );
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
@@ -20,11 +20,11 @@ class RefreshLifetime extends \Magento\Reports\Controller\Adminhtml\Report\Stati
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate();
             }
-            $this->messageManager->addSuccess(__('You refreshed lifetime statistics.'));
+            $this->messageManager->addSuccessMessage(__('You refreshed lifetime statistics.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh lifetime statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh lifetime statistics.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshRecent.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshRecent.php
@@ -25,11 +25,11 @@ class RefreshRecent extends \Magento\Reports\Controller\Adminhtml\Report\Statist
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate($date);
             }
-            $this->messageManager->addSuccess(__('Recent statistics have been updated.'));
+            $this->messageManager->addSuccessMessage(__('Recent statistics have been updated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh recent statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh recent statistics.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Product/ViewedTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Product/ViewedTest.php
@@ -190,7 +190,7 @@ class ViewedTest extends \Magento\Reports\Test\Unit\Controller\Adminhtml\Report\
 
         $this->messageManagerMock
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorText);
 
         $logMock
@@ -217,7 +217,7 @@ class ViewedTest extends \Magento\Reports\Test\Unit\Controller\Adminhtml\Report\
 
         $this->messageManagerMock
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorText);
 
         $this->menuBlockMock

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Delete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Delete.php
@@ -21,7 +21,7 @@ class Delete extends ProductController
         try {
             $this->reviewFactory->create()->setId($reviewId)->aggregate()->delete();
 
-            $this->messageManager->addSuccess(__('The review has been deleted.'));
+            $this->messageManager->addSuccessMessage(__('The review has been deleted.'));
             if ($this->getRequest()->getParam('ret') == 'pending') {
                 $resultRedirect->setPath('review/*/pending');
             } else {
@@ -29,9 +29,9 @@ class Delete extends ProductController
             }
             return $resultRedirect;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong  deleting this review.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong  deleting this review.'));
         }
 
         return $resultRedirect->setPath('review/*/edit/', ['id' => $reviewId]);

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassDelete.php
@@ -18,20 +18,20 @@ class MassDelete extends ProductController
     {
         $reviewsIds = $this->getRequest()->getParam('reviews');
         if (!is_array($reviewsIds)) {
-            $this->messageManager->addError(__('Please select review(s).'));
+            $this->messageManager->addErrorMessage(__('Please select review(s).'));
         } else {
             try {
                 foreach ($reviewsIds as $reviewId) {
                     $model = $this->reviewFactory->create()->load($reviewId);
                     $model->delete();
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been deleted.', count($reviewsIds))
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while deleting these records.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while deleting these records.'));
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassDelete.php
@@ -31,7 +31,10 @@ class MassDelete extends ProductController
             } catch (LocalizedException $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addExceptionMessage($e, __('Something went wrong while deleting these records.'));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __('Something went wrong while deleting these records.')
+                );
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassUpdateStatus.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassUpdateStatus.php
@@ -18,7 +18,7 @@ class MassUpdateStatus extends ProductController
     {
         $reviewsIds = $this->getRequest()->getParam('reviews');
         if (!is_array($reviewsIds)) {
-            $this->messageManager->addError(__('Please select review(s).'));
+            $this->messageManager->addErrorMessage(__('Please select review(s).'));
         } else {
             try {
                 $status = $this->getRequest()->getParam('status');
@@ -26,13 +26,13 @@ class MassUpdateStatus extends ProductController
                     $model = $this->reviewFactory->create()->load($reviewId);
                     $model->setStatusId($status)->save()->aggregate();
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been updated.', count($reviewsIds))
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while updating these review(s).')
                 );

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/MassVisibleIn.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/MassVisibleIn.php
@@ -18,7 +18,7 @@ class MassVisibleIn extends ProductController
     {
         $reviewsIds = $this->getRequest()->getParam('reviews');
         if (!is_array($reviewsIds)) {
-            $this->messageManager->addError(__('Please select review(s).'));
+            $this->messageManager->addErrorMessage(__('Please select review(s).'));
         } else {
             try {
                 $stores = $this->getRequest()->getParam('stores');
@@ -27,13 +27,13 @@ class MassVisibleIn extends ProductController
                     $model->setSelectStores($stores);
                     $model->save();
                 }
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('A total of %1 record(s) have been updated.', count($reviewsIds))
                 );
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while updating these review(s).')
                 );

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Post.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Post.php
@@ -49,7 +49,7 @@ class Post extends ProductController
 
                 $review->aggregate();
 
-                $this->messageManager->addSuccess(__('You saved the review.'));
+                $this->messageManager->addSuccessMessage(__('You saved the review.'));
                 if ($this->getRequest()->getParam('ret') == 'pending') {
                     $resultRedirect->setPath('review/*/pending');
                 } else {
@@ -57,9 +57,9 @@ class Post extends ProductController
                 }
                 return $resultRedirect;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while saving this review.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving this review.'));
             }
         }
         $resultRedirect->setPath('review/*/');

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
@@ -22,7 +22,7 @@ class Save extends ProductController
         if (($data = $this->getRequest()->getPostValue()) && ($reviewId = $this->getRequest()->getParam('id'))) {
             $review = $this->reviewFactory->create()->load($reviewId);
             if (!$review->getId()) {
-                $this->messageManager->addError(__('The review was removed by another user or does not exist.'));
+                $this->messageManager->addErrorMessage(__('The review was removed by another user or does not exist.'));
             } else {
                 try {
                     $review->addData($data)->save();
@@ -51,11 +51,11 @@ class Save extends ProductController
 
                     $review->aggregate();
 
-                    $this->messageManager->addSuccess(__('You saved the review.'));
+                    $this->messageManager->addSuccessMessage(__('You saved the review.'));
                 } catch (LocalizedException $e) {
-                    $this->messageManager->addError($e->getMessage());
+                    $this->messageManager->addErrorMessage($e->getMessage());
                 } catch (\Exception $e) {
-                    $this->messageManager->addException($e, __('Something went wrong while saving this review.'));
+                    $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving this review.'));
                 }
             }
 

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
@@ -55,7 +55,10 @@ class Save extends ProductController
                 } catch (LocalizedException $e) {
                     $this->messageManager->addErrorMessage($e->getMessage());
                 } catch (\Exception $e) {
-                    $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving this review.'));
+                    $this->messageManager->addExceptionMessage(
+                        $e,
+                        __('Something went wrong while saving this review.')
+                    );
                 }
             }
 

--- a/app/code/Magento/Review/Controller/Adminhtml/Rating/Delete.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Rating/Delete.php
@@ -22,9 +22,9 @@ class Delete extends RatingController
                 /** @var \Magento\Review\Model\Rating $model */
                 $model = $this->_objectManager->create(\Magento\Review\Model\Rating::class);
                 $model->load($this->getRequest()->getParam('id'))->delete();
-                $this->messageManager->addSuccess(__('You deleted the rating.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rating.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $resultRedirect->setPath('review/rating/edit', ['id' => $this->getRequest()->getParam('id')]);
                 return $resultRedirect;
             }

--- a/app/code/Magento/Review/Controller/Adminhtml/Rating/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Rating/Save.php
@@ -57,10 +57,10 @@ class Save extends RatingController
                     }
                 }
 
-                $this->messageManager->addSuccess(__('You saved the rating.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rating.'));
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setRatingData(false);
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)
                     ->setRatingData($this->getRequest()->getPostValue());
                 $resultRedirect->setPath('review/rating/edit', ['id' => $this->getRequest()->getParam('id')]);

--- a/app/code/Magento/Review/Controller/Product/Post.php
+++ b/app/code/Magento/Review/Controller/Product/Post.php
@@ -62,19 +62,19 @@ class Post extends ProductController
                     }
 
                     $review->aggregate();
-                    $this->messageManager->addSuccess(__('You submitted your review for moderation.'));
+                    $this->messageManager->addSuccessMessage(__('You submitted your review for moderation.'));
                 } catch (\Exception $e) {
                     $this->reviewSession->setFormData($data);
-                    $this->messageManager->addError(__('We can\'t post your review right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t post your review right now.'));
                 }
             } else {
                 $this->reviewSession->setFormData($data);
                 if (is_array($validate)) {
                     foreach ($validate as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                 } else {
-                    $this->messageManager->addError(__('We can\'t post your review right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t post your review right now.'));
                 }
             }
         }

--- a/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
+++ b/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
@@ -299,7 +299,7 @@ class PostTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->review->expects($this->once())->method('aggregate')
             ->willReturnSelf();
-        $this->messageManager->expects($this->once())->method('addSuccess')
+        $this->messageManager->expects($this->once())->method('addSuccessMessage')
             ->with(__('You submitted your review for moderation.'))
             ->willReturnSelf();
         $this->reviewSession->expects($this->once())->method('getRedirectUrl')

--- a/app/code/Magento/Sales/Controller/AbstractController/Reorder.php
+++ b/app/code/Magento/Sales/Controller/AbstractController/Reorder.php
@@ -59,13 +59,13 @@ abstract class Reorder extends Action\Action
                 $cart->addOrderItem($item);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 if ($this->_objectManager->get(\Magento\Checkout\Model\Session::class)->getUseNotice(true)) {
-                    $this->messageManager->addNotice($e->getMessage());
+                    $this->messageManager->addNoticeMessage($e->getMessage());
                 } else {
-                    $this->messageManager->addError($e->getMessage());
+                    $this->messageManager->addErrorMessage($e->getMessage());
                 }
                 return $resultRedirect->setPath('*/*/history');
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t add this item to your shopping cart right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t add this item to your shopping cart right now.'));
                 return $resultRedirect->setPath('checkout/cart');
             }
         }

--- a/app/code/Magento/Sales/Controller/AbstractController/Reorder.php
+++ b/app/code/Magento/Sales/Controller/AbstractController/Reorder.php
@@ -65,7 +65,10 @@ abstract class Reorder extends Action\Action
                 }
                 return $resultRedirect->setPath('*/*/history');
             } catch (\Exception $e) {
-                $this->messageManager->addExceptionMessage($e, __('We can\'t add this item to your shopping cart right now.'));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __('We can\'t add this item to your shopping cart right now.')
+                );
                 return $resultRedirect->setPath('checkout/cart');
             }
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Email.php
@@ -33,7 +33,7 @@ class Email extends \Magento\Backend\App\Action
         $this->_objectManager->create(\Magento\Sales\Api\CreditmemoManagementInterface::class)
             ->notify($creditmemoId);
 
-        $this->messageManager->addSuccess(__('You sent the message.'));
+        $this->messageManager->addSuccessMessage(__('You sent the message.'));
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath('sales/order_creditmemo/view', ['creditmemo_id' => $creditmemoId]);
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Email.php
@@ -57,7 +57,7 @@ abstract class Email extends \Magento\Backend\App\Action
             \Magento\Sales\Api\InvoiceManagementInterface::class
         )->notify($invoice->getEntityId());
 
-        $this->messageManager->addSuccess(__('You sent the message.'));
+        $this->messageManager->addSuccessMessage(__('You sent the message.'));
         return $this->resultRedirectFactory->create()->setPath(
             'sales/invoice/view',
             ['order_id' => $invoice->getOrder()->getId(), 'invoice_id' => $invoiceId]

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/View.php
@@ -79,7 +79,7 @@ abstract class View extends \Magento\Backend\App\Action
                 ->get($this->getRequest()->getParam('invoice_id'));
             $this->registry->register('current_invoice', $invoice);
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice capturing error'));
+            $this->messageManager->addErrorMessage(__('Invoice capturing error'));
             return false;
         }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order.php
@@ -154,11 +154,11 @@ abstract class Order extends \Magento\Backend\App\Action
         try {
             $order = $this->orderRepository->get($id);
         } catch (NoSuchEntityException $e) {
-            $this->messageManager->addError(__('This order no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This order no longer exists.'));
             $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
             return false;
         } catch (InputException $e) {
-            $this->messageManager->addError(__('This order no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This order no longer exists.'));
             $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
             return false;
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AbstractMassAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AbstractMassAction.php
@@ -61,7 +61,7 @@ abstract class AbstractMassAction extends \Magento\Backend\App\Action
             $collection = $this->filter->getCollection($this->collectionFactory->create());
             return $this->massAction($collection);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -114,12 +114,12 @@ class AddressSave extends Order
                         'order_id' => $address->getParentId()
                     ]
                 );
-                $this->messageManager->addSuccess(__('You updated the order address.'));
+                $this->messageManager->addSuccessMessage(__('You updated the order address.'));
                 return $resultRedirect->setPath('sales/*/view', ['order_id' => $address->getParentId()]);
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t update the order address right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t update the order address right now.'));
             }
             return $resultRedirect->setPath('sales/*/address', ['address_id' => $address->getId()]);
         } else {

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Cancel.php
@@ -24,18 +24,18 @@ class Cancel extends \Magento\Sales\Controller\Adminhtml\Order
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         if (!$this->isValidPostRequest()) {
-            $this->messageManager->addError(__('You have not canceled the item.'));
+            $this->messageManager->addErrorMessage(__('You have not canceled the item.'));
             return $resultRedirect->setPath('sales/*/');
         }
         $order = $this->_initOrder();
         if ($order) {
             try {
                 $this->orderManagement->cancel($order->getEntityId());
-                $this->messageManager->addSuccess(__('You canceled the order.'));
+                $this->messageManager->addSuccessMessage(__('You canceled the order.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('You have not canceled the item.'));
+                $this->messageManager->addErrorMessage(__('You have not canceled the item.'));
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             }
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create.php
@@ -317,7 +317,7 @@ abstract class Create extends \Magento\Backend\App\Action
                 }
             }
             if (!$isApplyDiscount) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __(
                         '"%1" coupon code was not applied. Do not apply discount is selected for item(s)',
                         $this->escaper->escapeHtml($couponCode)
@@ -325,14 +325,14 @@ abstract class Create extends \Magento\Backend\App\Action
                 );
             } else {
                 if ($this->_getQuote()->getCouponCode() !== $couponCode) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __(
                             'The "%1" coupon code isn\'t valid. Verify the code and try again.',
                             $this->escaper->escapeHtml($couponCode)
                         )
                     );
                 } else {
-                    $this->messageManager->addSuccess(__('The coupon code has been accepted.'));
+                    $this->messageManager->addSuccessMessage(__('The coupon code has been accepted.'));
                 }
             }
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/LoadBlock.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/LoadBlock.php
@@ -55,10 +55,10 @@ class LoadBlock extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_initSession()->_processData();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->_reloadQuote();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_reloadQuote();
-            $this->messageManager->addException($e, $e->getMessage());
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
         }
 
         $asJson = $request->getParam('json');

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create/Save.php
@@ -49,7 +49,7 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Create
                 ->createOrder();
 
             $this->_getSession()->clearStorage();
-            $this->messageManager->addSuccess(__('You created the order.'));
+            $this->messageManager->addSuccessMessage(__('You created the order.'));
             if ($this->_authorization->isAllowed('Magento_Sales::actions_view')) {
                 $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
             } else {
@@ -59,7 +59,7 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_getOrderCreateModel()->saveQuote();
             $message = $e->getMessage();
             if (!empty($message)) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $resultRedirect->setPath('sales/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
@@ -67,11 +67,11 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Create
             $this->_getSession()->setCustomerId($this->_getSession()->getQuote()->getCustomerId());
             $message = $e->getMessage();
             if (!empty($message)) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $resultRedirect->setPath('sales/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Order saving error: %1', $e->getMessage()));
+            $this->messageManager->addExceptionMessage($e, __('Order saving error: %1', $e->getMessage()));
             $resultRedirect->setPath('sales/*/');
         }
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Cancel.php
@@ -47,11 +47,11 @@ class Cancel extends \Magento\Backend\App\Action
                     \Magento\Sales\Api\CreditmemoManagementInterface::class
                 );
                 $creditmemoManagement->cancel($creditmemoId);
-                $this->messageManager->addSuccess(__('The credit memo has been canceled.'));
+                $this->messageManager->addSuccessMessage(__('The credit memo has been canceled.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Credit memo has not been canceled.'));
+                $this->messageManager->addErrorMessage(__('Credit memo has not been canceled.'));
             }
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('sales/*/view', ['creditmemo_id' => $creditmemoId]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
@@ -109,7 +109,7 @@ class Save extends \Magento\Backend\App\Action
                     $this->creditmemoSender->send($creditmemo);
                 }
 
-                $this->messageManager->addSuccess(__('You created the credit memo.'));
+                $this->messageManager->addSuccessMessage(__('You created the credit memo.'));
                 $this->_getSession()->getCommentText(true);
                 $resultRedirect->setPath('sales/order/view', ['order_id' => $creditmemo->getOrderId()]);
                 return $resultRedirect;
@@ -119,11 +119,11 @@ class Save extends \Magento\Backend\App\Action
                 return $resultForward;
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_getSession()->setFormData($data);
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError(__('We can\'t save the credit memo right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t save the credit memo right now.'));
         }
         $resultRedirect->setPath('sales/*/new', ['_current' => true]);
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/VoidAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/VoidAction.php
@@ -64,11 +64,11 @@ class VoidAction extends Action
                     $transactionSave->addObject($creditmemo->getInvoice());
                 }
                 $transactionSave->save();
-                $this->messageManager->addSuccess(__('You voided the credit memo.'));
+                $this->messageManager->addSuccessMessage(__('You voided the credit memo.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t void the credit memo.'));
+                $this->messageManager->addErrorMessage(__('We can\'t void the credit memo.'));
             }
             $resultRedirect = $this->resultRedirectFactory->create();
             $resultRedirect->setPath('sales/*/view', ['creditmemo_id' => $creditmemo->getId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/CreditmemoLoader.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/CreditmemoLoader.php
@@ -138,7 +138,7 @@ class CreditmemoLoader extends DataObject
          * Check order existing
          */
         if (!$order->getId()) {
-            $this->messageManager->addError(__('The order no longer exists.'));
+            $this->messageManager->addErrorMessage(__('The order no longer exists.'));
             return false;
         }
 
@@ -146,7 +146,7 @@ class CreditmemoLoader extends DataObject
          * Check creditmemo create availability
          */
         if (!$order->canCreditmemo()) {
-            $this->messageManager->addError(__('We can\'t create credit memo for the order.'));
+            $this->messageManager->addErrorMessage(__('We can\'t create credit memo for the order.'));
             return false;
         }
         return true;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Start.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Start.php
@@ -36,10 +36,10 @@ class Start extends \Magento\Sales\Controller\Adminhtml\Order\Create\Start
                 $resultRedirect->setPath('sales/order/');
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, $e->getMessage());
+            $this->messageManager->addExceptionMessage($e, $e->getMessage());
             $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         }
         return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Email.php
@@ -25,11 +25,11 @@ class Email extends \Magento\Sales\Controller\Adminhtml\Order
         if ($order) {
             try {
                 $this->orderManagement->notify($order->getEntityId());
-                $this->messageManager->addSuccess(__('You sent the order email.'));
+                $this->messageManager->addSuccessMessage(__('You sent the order email.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t send the email order right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t send the email order right now.'));
                 $this->logger->critical($e);
             }
             return $this->resultRedirectFactory->create()->setPath(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Hold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Hold.php
@@ -23,18 +23,18 @@ class Hold extends \Magento\Sales\Controller\Adminhtml\Order
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         if (!$this->isValidPostRequest()) {
-            $this->messageManager->addError(__('You have not put the order on hold.'));
+            $this->messageManager->addErrorMessage(__('You have not put the order on hold.'));
             return $resultRedirect->setPath('sales/*/');
         }
         $order = $this->_initOrder();
         if ($order) {
             try {
                 $this->orderManagement->hold($order->getEntityId());
-                $this->messageManager->addSuccess(__('You put the order on hold.'));
+                $this->messageManager->addSuccessMessage(__('You put the order on hold.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('You have not put the order on hold.'));
+                $this->messageManager->addErrorMessage(__('You have not put the order on hold.'));
             }
             $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
             return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Cancel.php
@@ -31,11 +31,11 @@ class Cancel extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice
             )->addObject(
                 $invoice->getOrder()
             )->save();
-            $this->messageManager->addSuccess(__('You canceled the invoice.'));
+            $this->messageManager->addSuccessMessage(__('You canceled the invoice.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice canceling error'));
+            $this->messageManager->addErrorMessage(__('Invoice canceling error'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Capture.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Capture.php
@@ -33,11 +33,11 @@ class Capture extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoic
             )->addObject(
                 $invoice->getOrder()
             )->save();
-            $this->messageManager->addSuccess(__('The invoice has been captured.'));
+            $this->messageManager->addSuccessMessage(__('The invoice has been captured.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice capturing error'));
+            $this->messageManager->addErrorMessage(__('Invoice capturing error'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/NewAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/NewAction.php
@@ -112,10 +112,10 @@ class NewAction extends \Magento\Backend\App\Action
             $resultPage->getConfig()->getTitle()->prepend(__('New Invoice'));
             return $resultPage;
         } catch (\Magento\Framework\Exception\LocalizedException $exception) {
-            $this->messageManager->addError($exception->getMessage());
+            $this->messageManager->addErrorMessage($exception->getMessage());
             return $this->_redirectToOrder($orderId);
         } catch (\Exception $exception) {
-            $this->messageManager->addException($exception, 'Cannot create an invoice.');
+            $this->messageManager->addExceptionMessage($exception, 'Cannot create an invoice.');
             return $this->_redirectToOrder($orderId);
         }
     }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -118,7 +118,9 @@ class Save extends \Magento\Backend\App\Action
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addErrorMessage(__("The invoice can't be saved at this time. Please try again later."));
+            $this->messageManager->addErrorMessage(
+                __("The invoice can't be saved at this time. Please try again later.")
+            );
             return $resultRedirect->setPath('sales/order/index');
         }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -118,7 +118,7 @@ class Save extends \Magento\Backend\App\Action
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addError(__("The invoice can't be saved at this time. Please try again later."));
+            $this->messageManager->addErrorMessage(__("The invoice can't be saved at this time. Please try again later."));
             return $resultRedirect->setPath('sales/order/index');
         }
 
@@ -193,9 +193,9 @@ class Save extends \Magento\Backend\App\Action
             $transactionSave->save();
 
             if (!empty($data['do_shipment'])) {
-                $this->messageManager->addSuccess(__('You created the invoice and shipment.'));
+                $this->messageManager->addSuccessMessage(__('You created the invoice and shipment.'));
             } else {
-                $this->messageManager->addSuccess(__('The invoice has been created.'));
+                $this->messageManager->addSuccessMessage(__('The invoice has been created.'));
             }
 
             // send invoice/shipment emails
@@ -205,7 +205,7 @@ class Save extends \Magento\Backend\App\Action
                 }
             } catch (\Exception $e) {
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                $this->messageManager->addError(__('We can\'t send the invoice email right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t send the invoice email right now.'));
             }
             if ($shipment) {
                 try {
@@ -214,15 +214,15 @@ class Save extends \Magento\Backend\App\Action
                     }
                 } catch (\Exception $e) {
                     $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                    $this->messageManager->addError(__('We can\'t send the shipment right now.'));
+                    $this->messageManager->addErrorMessage(__('We can\'t send the shipment right now.'));
                 }
             }
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->getCommentText(true);
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__("The invoice can't be saved at this time. Please try again later."));
+            $this->messageManager->addErrorMessage(__("The invoice can't be saved at this time. Please try again later."));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         return $resultRedirect->setPath('sales/*/new', ['order_id' => $orderId]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/VoidAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/VoidAction.php
@@ -34,11 +34,11 @@ class VoidAction extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInv
             )->addObject(
                 $invoice->getOrder()
             )->save();
-            $this->messageManager->addSuccess(__('The invoice has been voided.'));
+            $this->messageManager->addSuccessMessage(__('The invoice has been voided.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Invoice voiding error'));
+            $this->messageManager->addErrorMessage(__('Invoice voiding error'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassCancel.php
@@ -61,13 +61,13 @@ class MassCancel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassA
         $countNonCancelOrder = $collection->count() - $countCancelOrder;
 
         if ($countNonCancelOrder && $countCancelOrder) {
-            $this->messageManager->addError(__('%1 order(s) cannot be canceled.', $countNonCancelOrder));
+            $this->messageManager->addErrorMessage(__('%1 order(s) cannot be canceled.', $countNonCancelOrder));
         } elseif ($countNonCancelOrder) {
-            $this->messageManager->addError(__('You cannot cancel the order(s).'));
+            $this->messageManager->addErrorMessage(__('You cannot cancel the order(s).'));
         }
 
         if ($countCancelOrder) {
-            $this->messageManager->addSuccess(__('We canceled %1 order(s).', $countCancelOrder));
+            $this->messageManager->addSuccessMessage(__('We canceled %1 order(s).', $countCancelOrder));
         }
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath($this->getComponentRefererUrl());

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassHold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassHold.php
@@ -62,13 +62,13 @@ class MassHold extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAct
         $countNonHoldOrder = $collection->count() - $countHoldOrder;
 
         if ($countNonHoldOrder && $countHoldOrder) {
-            $this->messageManager->addError(__('%1 order(s) were not put on hold.', $countNonHoldOrder));
+            $this->messageManager->addErrorMessage(__('%1 order(s) were not put on hold.', $countNonHoldOrder));
         } elseif ($countNonHoldOrder) {
-            $this->messageManager->addError(__('No order(s) were put on hold.'));
+            $this->messageManager->addErrorMessage(__('No order(s) were put on hold.'));
         }
 
         if ($countHoldOrder) {
-            $this->messageManager->addSuccess(__('You have put %1 order(s) on hold.', $countHoldOrder));
+            $this->messageManager->addSuccessMessage(__('You have put %1 order(s) on hold.', $countHoldOrder));
         }
 
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/MassUnhold.php
@@ -64,15 +64,15 @@ class MassUnhold extends AbstractMassAction
         $countNonUnHoldOrder = $collection->count() - $countUnHoldOrder;
 
         if ($countNonUnHoldOrder && $countUnHoldOrder) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('%1 order(s) were not released from on hold status.', $countNonUnHoldOrder)
             );
         } elseif ($countNonUnHoldOrder) {
-            $this->messageManager->addError(__('No order(s) were released from on hold status.'));
+            $this->messageManager->addErrorMessage(__('No order(s) were released from on hold status.'));
         }
 
         if ($countUnHoldOrder) {
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('%1 order(s) have been released from on hold status.', $countUnHoldOrder)
             );
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/PdfDocumentsMassAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/PdfDocumentsMassAction.php
@@ -27,7 +27,7 @@ abstract class PdfDocumentsMassAction extends \Magento\Sales\Controller\Adminhtm
             $collection = $this->filter->getCollection($this->getOrderCollection()->create());
             return $this->massAction($collection);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfcreditmemos.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfcreditmemos.php
@@ -82,7 +82,7 @@ class Pdfcreditmemos extends \Magento\Sales\Controller\Adminhtml\Order\PdfDocume
 
         $creditmemoCollection = $this->collectionFactory->create()->setOrderFilter(['in' => $collection->getAllIds()]);
         if (!$creditmemoCollection->getSize()) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
         return $this->fileFactory->create(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfdocs.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfdocs.php
@@ -134,7 +134,7 @@ class Pdfdocs extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassActi
         }
 
         if (empty($documents)) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfinvoices.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfinvoices.php
@@ -80,7 +80,7 @@ class Pdfinvoices extends \Magento\Sales\Controller\Adminhtml\Order\PdfDocuments
     {
         $invoicesCollection = $this->collectionFactory->create()->setOrderFilter(['in' => $collection->getAllIds()]);
         if (!$invoicesCollection->getSize()) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
         return $this->fileFactory->create(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfshipments.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Pdfshipments.php
@@ -84,7 +84,7 @@ class Pdfshipments extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMas
             ->create()
             ->setOrderFilter(['in' => $collection->getAllIds()]);
         if (!$shipmentsCollection->getSize()) {
-            $this->messageManager->addError(__('There are no printable documents related to selected orders.'));
+            $this->messageManager->addErrorMessage(__('There are no printable documents related to selected orders.'));
             return $this->resultRedirectFactory->create()->setPath($this->getComponentRefererUrl());
         }
         return $this->fileFactory->create(

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/ReviewPayment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/ReviewPayment.php
@@ -53,15 +53,15 @@ class ReviewPayment extends \Magento\Sales\Controller\Adminhtml\Order
                         throw new \Exception(sprintf('Action "%s" is not supported.', $action));
                 }
                 $this->orderRepository->save($order);
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             } else {
                 $resultRedirect->setPath('sales/*/');
                 return $resultRedirect;
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update the payment right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update the payment right now.'));
             $this->logger->critical($e);
         }
         $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getEntityId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/AssignPost.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/AssignPost.php
@@ -26,18 +26,18 @@ class AssignPost extends \Magento\Sales\Controller\Adminhtml\Order\Status
             if ($status && $status->getStatus()) {
                 try {
                     $status->assignState($state, $isDefault, $visibleOnFront);
-                    $this->messageManager->addSuccess(__('You assigned the order status.'));
+                    $this->messageManager->addSuccessMessage(__('You assigned the order status.'));
                     return $resultRedirect->setPath('sales/*/');
                 } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                    $this->messageManager->addError($e->getMessage());
+                    $this->messageManager->addErrorMessage($e->getMessage());
                 } catch (\Exception $e) {
-                    $this->messageManager->addException(
+                    $this->messageManager->addExceptionMessage(
                         $e,
                         __('Something went wrong while assigning the order status.')
                     );
                 }
             } else {
-                $this->messageManager->addError(__('We can\'t find this order status.'));
+                $this->messageManager->addErrorMessage(__('We can\'t find this order status.'));
             }
             return $resultRedirect->setPath('sales/*/assign');
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Edit.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Edit.php
@@ -48,7 +48,7 @@ class Edit extends \Magento\Sales\Controller\Adminhtml\Order\Status
             $resultPage->getConfig()->getTitle()->prepend(__('Edit Order Status'));
             return $resultPage;
         } else {
-            $this->messageManager->addError(__('We can\'t find this order status.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find this order status.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             return $resultRedirect->setPath('sales/');

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Save.php
@@ -40,7 +40,9 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Status
             $status = $this->_objectManager->create(\Magento\Sales\Model\Order\Status::class)->load($statusCode);
             // check if status exist
             if ($isNew && $status->getStatus()) {
-                $this->messageManager->addErrorMessage(__('We found another order status with the same order status code.'));
+                $this->messageManager->addErrorMessage(
+                    __('We found another order status with the same order status code.')
+                );
                 $this->_getSession()->setFormData($data);
                 return $resultRedirect->setPath('sales/*/new');
             }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Save.php
@@ -40,7 +40,7 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Status
             $status = $this->_objectManager->create(\Magento\Sales\Model\Order\Status::class)->load($statusCode);
             // check if status exist
             if ($isNew && $status->getStatus()) {
-                $this->messageManager->addError(__('We found another order status with the same order status code.'));
+                $this->messageManager->addErrorMessage(__('We found another order status with the same order status code.'));
                 $this->_getSession()->setFormData($data);
                 return $resultRedirect->setPath('sales/*/new');
             }
@@ -49,12 +49,12 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\Status
 
             try {
                 $status->save();
-                $this->messageManager->addSuccess(__('You saved the order status.'));
+                $this->messageManager->addSuccessMessage(__('You saved the order status.'));
                 return $resultRedirect->setPath('sales/*/');
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('We can\'t add the order status right now.')
                 );

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Unassign.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Unassign.php
@@ -18,17 +18,17 @@ class Unassign extends \Magento\Sales\Controller\Adminhtml\Order\Status
         if ($status) {
             try {
                 $status->unassignState($state);
-                $this->messageManager->addSuccess(__('You have unassigned the order status.'));
+                $this->messageManager->addSuccessMessage(__('You have unassigned the order status.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while unassigning the order.')
                 );
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find this order status.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find this order status.'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Unhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Unhold.php
@@ -23,7 +23,7 @@ class Unhold extends \Magento\Sales\Controller\Adminhtml\Order
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         if (!$this->isValidPostRequest()) {
-            $this->messageManager->addError(__('Can\'t unhold order.'));
+            $this->messageManager->addErrorMessage(__('Can\'t unhold order.'));
             return $resultRedirect->setPath('sales/*/');
         }
         $order = $this->_initOrder();
@@ -33,11 +33,11 @@ class Unhold extends \Magento\Sales\Controller\Adminhtml\Order
                     throw new \Magento\Framework\Exception\LocalizedException(__('Can\'t unhold order.'));
                 }
                 $this->orderManagement->unhold($order->getEntityId());
-                $this->messageManager->addSuccess(__('You released the order from holding status.'));
+                $this->messageManager->addSuccessMessage(__('You released the order from holding status.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('The order was not on hold.'));
+                $this->messageManager->addErrorMessage(__('The order was not on hold.'));
             }
             $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
             return $resultRedirect;

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/View.php
@@ -31,7 +31,7 @@ class View extends \Magento\Sales\Controller\Adminhtml\Order
                 $resultPage->getConfig()->getTitle()->prepend(__('Orders'));
             } catch (\Exception $e) {
                 $this->logger->critical($e);
-                $this->messageManager->addError(__('Exception occurred during order load'));
+                $this->messageManager->addErrorMessage(__('Exception occurred during order load'));
                 $resultRedirect->setPath('sales/order/index');
                 return $resultRedirect;
             }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/View/Giftmessage/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/View/Giftmessage/Save.php
@@ -18,9 +18,9 @@ class Save extends \Magento\Sales\Controller\Adminhtml\Order\View\Giftmessage
                 $this->getRequest()->getParam('giftmessage')
             )->saveAllInOrder();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Something went wrong while saving the gift message.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong while saving the gift message.'));
         }
 
         if ($this->getRequest()->getParam('type') == 'order_item') {

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/VoidPayment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/VoidPayment.php
@@ -21,11 +21,11 @@ class VoidPayment extends \Magento\Sales\Controller\Adminhtml\Order
                 // workaround for backwards compatibility
                 $order->getPayment()->void(new \Magento\Framework\DataObject());
                 $order->save();
-                $this->messageManager->addSuccess(__('The payment has been voided.'));
+                $this->messageManager->addSuccessMessage(__('The payment has been voided.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t void the payment right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t void the payment right now.'));
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             }
             $resultRedirect->setPath('sales/*/view', ['order_id' => $order->getId()]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
@@ -82,7 +82,7 @@ abstract class Transactions extends \Magento\Backend\App\Action
         );
 
         if (!$txn->getId()) {
-            $this->messageManager->addError(__('Please correct the transaction ID and try again.'));
+            $this->messageManager->addErrorMessage(__('Please correct the transaction ID and try again.'));
             $this->_actionFlag->set('', self::FLAG_NO_DISPATCH, true);
             return false;
         }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
@@ -38,11 +38,11 @@ class Fetch extends \Magento\Sales\Controller\Adminhtml\Transactions
                 ->setOrder($txn->getOrder())
                 ->importTransactionInfo($txn);
             $txn->save();
-            $this->messageManager->addSuccess(__('The transaction details have been updated.'));
+            $this->messageManager->addSuccessMessage(__('The transaction details have been updated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update the transaction details.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update the transaction details.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
 

--- a/app/code/Magento/Sales/Helper/Guest.php
+++ b/app/code/Magento/Sales/Helper/Guest.php
@@ -165,7 +165,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
             $this->coreRegistry->register('current_order', $order);
             return true;
         } catch (InputException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return $this->resultRedirectFactory->create()->setPath('sales/guest/form');
         }
     }

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1075,7 +1075,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             try {
                 $this->addProduct($productId, $config);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
                 return $e;
             }
@@ -2002,7 +2002,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             $logger = ObjectManager::getInstance()->get(LoggerInterface::class);
             foreach ($this->_errors as $error) {
                 $logger->error($error);
-                $this->messageManager->addError($error);
+                $this->messageManager->addErrorMessage($error);
             }
 
             throw new \Magento\Framework\Exception\LocalizedException(__('Validation is failed.'));

--- a/app/code/Magento/Sales/Model/AdminOrder/EmailSender.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/EmailSender.php
@@ -55,7 +55,7 @@ class EmailSender
             $this->orderSender->send($order);
         } catch (\Magento\Framework\Exception\MailException $exception) {
             $this->logger->critical($exception);
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __('You did not email your customer. Please check your email settings.')
             );
             return false;

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/EmailTest.php
@@ -147,7 +147,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->method('notify')
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the message.');
 
         $this->assertInstanceOf(

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Invoice/AbstractInvoice/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Invoice/AbstractInvoice/EmailTest.php
@@ -196,7 +196,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->with($invoiceId)
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the message.');
 
         $this->resultRedirectFactory->expects($this->atLeastOnce())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/CancelTest.php
@@ -117,7 +117,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('You have not canceled the item.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ProcessDataTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ProcessDataTest.php
@@ -226,7 +226,10 @@ class ProcessDataTest extends \PHPUnit\Framework\TestCase
         );
         $this->escaper->expects($this->once())->method('escapeHtml')->with($couponCode)->willReturn($couponCode);
 
-        $this->messageManager->expects($this->once())->method('addErrorMessage')->with($errorMessageManager)->willReturnSelf();
+        $this->messageManager->expects($this->once())
+            ->method('addErrorMessage')
+            ->with($errorMessageManager)
+            ->willReturnSelf();
 
         $this->resultForward->expects($this->once())
             ->method('forward')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ProcessDataTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ProcessDataTest.php
@@ -226,7 +226,7 @@ class ProcessDataTest extends \PHPUnit\Framework\TestCase
         );
         $this->escaper->expects($this->once())->method('escapeHtml')->with($couponCode)->willReturn($couponCode);
 
-        $this->messageManager->expects($this->once())->method('addError')->with($errorMessageManager)->willReturnSelf();
+        $this->messageManager->expects($this->once())->method('addErrorMessage')->with($errorMessageManager)->willReturnSelf();
 
         $this->resultForward->expects($this->once())
             ->method('forward')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/CancelTest.php
@@ -292,7 +292,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->method('cancel')
             ->with($creditmemoId);
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The credit memo has been canceled.');
         $this->resultRedirectFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
@@ -235,7 +235,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
      */
     protected function _setSaveActionExpectationForMageCoreException($data, $errorMessage)
     {
-        $this->_messageManager->expects($this->once())->method('addError')->with($this->equalTo($errorMessage));
+        $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($this->equalTo($errorMessage));
         $this->_sessionMock->expects($this->once())->method('setFormData')->with($this->equalTo($data));
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
@@ -335,7 +335,7 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->method('getInvoice')
             ->willReturn($invoiceMock);
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You voided the credit memo.');
         $this->resultRedirectFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/EmailTest.php
@@ -171,7 +171,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->with($orderId)
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the order email.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')
@@ -200,7 +200,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
                 )
             );
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('This order no longer exists.');
 
         $this->actionFlag->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/HoldTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/HoldTest.php
@@ -117,7 +117,7 @@ class HoldTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('You have not put the order on hold.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CancelTest.php
@@ -213,7 +213,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->method('save');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You canceled the invoice.');
 
         $this->invoiceRepository->expects($this->once())
@@ -295,7 +295,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->will($this->throwException($e));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())
@@ -343,7 +343,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
             ->will($this->throwException($e));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CaptureTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CaptureTest.php
@@ -223,7 +223,7 @@ class CaptureTest extends \PHPUnit\Framework\TestCase
             ->method('save');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The invoice has been captured.');
 
         $invoiceMock->expects($this->once())
@@ -304,7 +304,7 @@ class CaptureTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())
@@ -355,7 +355,7 @@ class CaptureTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message);
 
         $invoiceMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
@@ -122,7 +122,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with("The invoice can't be saved at this time. Please try again later.");
         $redirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
@@ -250,7 +250,7 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($transactionMock));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The invoice has been voided.');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
@@ -283,9 +283,9 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $resultForward = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Forward::class)
             ->disableOriginalConstructor()
@@ -334,7 +334,7 @@ class VoidActionTest extends \PHPUnit\Framework\TestCase
             ->willReturn($invoiceMock);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassCancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassCancelTest.php
@@ -201,11 +201,11 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
         $this->orderManagementMock->expects($this->at(1))->method('cancel')->with($order2id)->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('1 order(s) cannot be canceled.');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('We canceled 1 order(s).');
 
         $this->resultRedirectMock->expects($this->once())
@@ -251,7 +251,7 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
         $this->orderManagementMock->expects($this->atLeastOnce())->method('cancel')->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('You cannot cancel the order(s).');
 
         $this->resultRedirectMock->expects($this->once())
@@ -283,7 +283,7 @@ class MassCancelTest extends \PHPUnit\Framework\TestCase
         $this->orderManagementMock->expects($this->atLeastOnce())->method('cancel')->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Can not cancel');
 
         $this->massAction->execute();

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassHoldTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassHoldTest.php
@@ -196,11 +196,11 @@ class MassHoldTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('1 order(s) were not put on hold.');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You have put 1 order(s) on hold.');
 
         $this->resultRedirectMock->expects($this->once())
@@ -240,7 +240,7 @@ class MassHoldTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('No order(s) were put on hold.');
 
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassUnholdTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/MassUnholdTest.php
@@ -196,11 +196,11 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
         $this->orderManagementMock->expects($this->atLeastOnce())->method('unHold')->willReturn(true);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('1 order(s) were not released from on hold status.');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 order(s) have been released from on hold status.');
 
         $this->resultRedirectMock->expects($this->once())
@@ -239,7 +239,7 @@ class MassUnholdTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('No order(s) were released from on hold status.');
 
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ReviewPaymentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ReviewPaymentTest.php
@@ -137,7 +137,7 @@ class ReviewPaymentTest extends \PHPUnit\Framework\TestCase
         $this->paymentMock->expects($this->once())->method('update');
         $this->paymentMock->expects($this->any())->method('getIsTransactionApproved')->willReturn(true);
 
-        $this->messageManagerMock->expects($this->once())->method('addSuccess');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/UnholdTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/UnholdTest.php
@@ -117,7 +117,7 @@ class UnholdTest extends \PHPUnit\Framework\TestCase
             ->method('isPost')
             ->willReturn(false);
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Can\'t unhold order.');
         $this->resultRedirect->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ViewTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ViewTest.php
@@ -251,7 +251,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
             ->method('critical')
             ->with($exception);
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('Exception occurred during order load')
             ->willReturnSelf();
         $this->setPath('sales/order/index');
@@ -292,7 +292,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     protected function initOrderFail()
     {
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('This order no longer exists.')
             ->willReturnSelf();
         $this->actionFlagMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/PdfDocumentsMassActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/PdfDocumentsMassActionTest.php
@@ -88,7 +88,7 @@ class PdfDocumentsMassActionTest extends \PHPUnit\Framework\TestCase
             ->method('getCollection')
             ->with($this->orderCollectionMock)
             ->willThrowException($exception);
-        $this->messageManager->expects($this->once())->method('addError');
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
 
         $this->resultRedirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->controller->execute($exception);

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/EmailSenderTest.php
@@ -57,7 +57,7 @@ class EmailSenderTest extends \PHPUnit\Framework\TestCase
             ->method('send')
             ->willThrowException(new \Magento\Framework\Exception\MailException(__('test message')));
         $this->messageManagerMock->expects($this->once())
-            ->method('addWarning');
+            ->method('addWarningMessage');
         $this->loggerMock->expects($this->once())
             ->method('critical');
 

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Delete.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Delete.php
@@ -21,13 +21,13 @@ class Delete extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $model = $this->_objectManager->create(\Magento\SalesRule\Model\Rule::class);
                 $model->load($id);
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the rule.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rule.'));
                 $this->_redirect('sales_rule/*/');
                 return;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete the rule right now. Please review the log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -35,7 +35,7 @@ class Delete extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a rule to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a rule to delete.'));
         $this->_redirect('sales_rule/*/');
     }
 }

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Edit.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Edit.php
@@ -51,7 +51,7 @@ class Edit extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
         if ($id) {
             $model->load($id);
             if (!$model->getRuleId()) {
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 $this->_redirect('sales_rule/*');
                 return;
             }

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Generate.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Generate.php
@@ -64,7 +64,7 @@ class Generate extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
 
                 $couponCodes = $this->couponGenerator->generateCodes($data);
                 $generated = count($couponCodes);
-                $this->messageManager->addSuccess(__('%1 coupon(s) have been generated.', $generated));
+                $this->messageManager->addSuccessMessage(__('%1 coupon(s) have been generated.', $generated));
                 $this->_view->getLayout()->initMessages();
                 $result['messages'] = $this->_view->getLayout()->getMessagesBlock()->getGroupedHtml();
             } catch (\Magento\Framework\Exception\InputException $inputException) {

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
@@ -50,7 +50,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $validateResult = $model->validateData(new \Magento\Framework\DataObject($data));
                 if ($validateResult !== true) {
                     foreach ($validateResult as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                     $session->setPageData($data);
                     $this->_redirect('sales_rule/*/edit', ['id' => $model->getId()]);
@@ -82,7 +82,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $session->setPageData($model->getData());
 
                 $model->save();
-                $this->messageManager->addSuccess(__('You saved the rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rule.'));
                 $session->setPageData(false);
                 if ($this->getRequest()->getParam('back')) {
                     $this->_redirect('sales_rule/*/edit', ['id' => $model->getId()]);
@@ -91,7 +91,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 $this->_redirect('sales_rule/*/');
                 return;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $id = (int)$this->getRequest()->getParam('rule_id');
                 if (!empty($id)) {
                     $this->_redirect('sales_rule/*/edit', ['id' => $id]);
@@ -100,7 +100,7 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote
                 }
                 return;
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Something went wrong while saving the rule data. Please review the error log.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/SalesRule/Observer/CheckSalesRulesAvailability.php
+++ b/app/code/Magento/SalesRule/Observer/CheckSalesRulesAvailability.php
@@ -54,7 +54,7 @@ class CheckSalesRulesAvailability
         }
 
         if ($disabledRulesCount) {
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __(
                     '%1 Cart Price Rules based on "%2" attribute have been disabled.',
                     $disabledRulesCount,

--- a/app/code/Magento/SalesRule/Test/Unit/Controller/Adminhtml/Promo/Quote/GenerateTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Controller/Adminhtml/Promo/Quote/GenerateTest.php
@@ -143,7 +143,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
             ->with($requestData)
             ->willReturn(['some_data', 'some_data_2']);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
         $this->responseMock->expects($this->once())
             ->method('representJson')
             ->with();

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Delete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Delete.php
@@ -60,16 +60,16 @@ class Delete extends \Magento\Backend\App\Action
                 /** @var \Magento\Search\Model\SynonymGroup $synGroupModel */
                 $synGroupModel = $this->synGroupRepository->get($id);
                 $this->synGroupRepository->delete($synGroupModel);
-                $this->messageManager->addSuccess(__('The synonym group has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The synonym group has been deleted.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->logger->error($e);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('An error was encountered while performing delete operation.'));
+                $this->messageManager->addErrorMessage(__('An error was encountered while performing delete operation.'));
                 $this->logger->error($e);
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find a synonym group to delete.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find a synonym group to delete.'));
         }
 
         return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Delete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Delete.php
@@ -65,7 +65,9 @@ class Delete extends \Magento\Backend\App\Action
                 $this->messageManager->addErrorMessage($e->getMessage());
                 $this->logger->error($e);
             } catch (\Exception $e) {
-                $this->messageManager->addErrorMessage(__('An error was encountered while performing delete operation.'));
+                $this->messageManager->addErrorMessage(
+                    __('An error was encountered while performing delete operation.')
+                );
                 $this->logger->error($e);
             }
         } else {

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Edit.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Edit.php
@@ -66,7 +66,7 @@ class Edit extends \Magento\Backend\App\Action
 
         // 2. Initial checking
         if ($groupId && (!$synGroup->getGroupId())) {
-                $this->messageManager->addError(__('This synonyms group no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This synonyms group no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/MassDelete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/MassDelete.php
@@ -72,17 +72,17 @@ class MassDelete extends \Magento\Backend\App\Action
                 $this->synGroupRepository->delete($synonymGroup);
                 $deletedItems++;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
         if ($deletedItems != 0) {
             if ($collectionSize != $deletedItems) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Failed to delete %1 synonym group(s).', $collectionSize - $deletedItems)
                 );
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 synonym group(s) have been deleted.', $deletedItems)
             );
         }

--- a/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Save.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Synonyms/Save.php
@@ -59,7 +59,7 @@ class Save extends \Magento\Backend\App\Action
             $synGroup = $this->synGroupRepository->get($synGroupId);
 
             if (!$synGroup->getGroupId() && $synGroupId) {
-                $this->messageManager->addError(__('This synonym group no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This synonym group no longer exists.'));
                 return $resultRedirect->setPath('*/*/');
             }
 

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Delete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Delete.php
@@ -23,16 +23,16 @@ class Delete extends TermController
                 $model = $this->_objectManager->create(\Magento\Search\Model\Query::class);
                 $model->setId($id);
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the search.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the search.'));
                 $resultRedirect->setPath('search/*/');
                 return $resultRedirect;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $resultRedirect->setPath('search/*/edit', ['id' => $this->getRequest()->getParam('id')]);
                 return $resultRedirect;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a search term to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a search term to delete.'));
         $resultRedirect->setPath('search/*/');
         return $resultRedirect;
     }

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Edit.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Edit.php
@@ -43,7 +43,7 @@ class Edit extends TermController
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This search no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This search no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
                 $resultRedirect->setPath('search/*');

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/MassDelete.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/MassDelete.php
@@ -17,16 +17,16 @@ class MassDelete extends TermController
     {
         $searchIds = $this->getRequest()->getParam('search');
         if (!is_array($searchIds)) {
-            $this->messageManager->addError(__('Please select searches.'));
+            $this->messageManager->addErrorMessage(__('Please select searches.'));
         } else {
             try {
                 foreach ($searchIds as $searchId) {
                     $model = $this->_objectManager->create(\Magento\Search\Model\Query::class)->load($searchId);
                     $model->delete();
                 }
-                $this->messageManager->addSuccess(__('Total of %1 record(s) were deleted.', count($searchIds)));
+                $this->messageManager->addSuccessMessage(__('Total of %1 record(s) were deleted.', count($searchIds)));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Save.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Save.php
@@ -45,12 +45,12 @@ class Save extends TermController
                 $model->addData($data);
                 $model->setIsProcessed(0);
                 $model->save();
-                $this->messageManager->addSuccess(__('You saved the search term.'));
+                $this->messageManager->addSuccessMessage(__('You saved the search term.'));
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $this->proceedToEdit($data);
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('Something went wrong while saving the search query.'));
+                $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the search query.'));
                 return $this->proceedToEdit($data);
             }
         }

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Save.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Save.php
@@ -50,7 +50,10 @@ class Save extends TermController
                 $this->messageManager->addErrorMessage($e->getMessage());
                 return $this->proceedToEdit($data);
             } catch (\Exception $e) {
-                $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the search query.'));
+                $this->messageManager->addExceptionMessage(
+                    $e,
+                    __('Something went wrong while saving the search query.')
+                );
                 return $this->proceedToEdit($data);
             }
         }

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Synonyms/DeleteTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Synonyms/DeleteTest.php
@@ -107,10 +107,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         $this->repository->expects($this->once())->method('get')->with(10)->willReturn($this->synonymGroupMock);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The synonym group has been deleted.'));
 
-        $this->messageManagerMock->expects($this->never())->method('addError');
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
 
         $this->resultRedirectMock->expects($this->once())->method('setPath')->with('*/*/')->willReturnSelf();
 
@@ -124,10 +124,10 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t find a synonym group to delete.'));
         $this->messageManagerMock->expects($this->never())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/MassDeleteTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/MassDeleteTest.php
@@ -107,7 +107,7 @@ class MassDeleteTest extends \PHPUnit\Framework\TestCase
         $this->createQuery(0, 1);
         $this->createQuery(1, 2);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->will($this->returnSelf());
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/SaveTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/SaveTest.php
@@ -143,7 +143,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('getId')->willReturn(false);
         $this->query->expects($this->once())->method('load')->with($queryId);
 
-        $this->messageManager->expects($this->once())->method('addSuccess');
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -161,7 +161,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
         $this->query->expects($this->any())->method('getId')->willReturn($queryId);
 
-        $this->messageManager->expects($this->once())->method('addSuccess');
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -180,7 +180,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->any())->method('getId')->willReturn(false);
         $this->query->expects($this->once())->method('load')->with($queryId);
 
-        $this->messageManager->expects($this->once())->method('addSuccess');
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
 
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -199,7 +199,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
         $this->query->expects($this->any())->method('getId')->willReturn($anotherQueryId);
 
-        $this->messageManager->expects($this->once())->method('addError');
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
         $this->session->expects($this->once())->method('setPageData');
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
@@ -216,7 +216,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->query->expects($this->once())->method('setStoreId');
         $this->query->expects($this->once())->method('loadByQueryText')->willThrowException(new \Exception());
 
-        $this->messageManager->expects($this->once())->method('addException');
+        $this->messageManager->expects($this->once())->method('addExceptionMessage');
         $this->session->expects($this->once())->method('setPageData');
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());

--- a/app/code/Magento/Security/Controller/Adminhtml/Session/LogoutAll.php
+++ b/app/code/Magento/Security/Controller/Adminhtml/Session/LogoutAll.php
@@ -38,11 +38,11 @@ class LogoutAll extends \Magento\Backend\App\Action
     {
         try {
             $this->sessionsManager->logoutOtherUserSessions();
-            $this->messageManager->addSuccess(__('All other open sessions for this account were terminated.'));
+            $this->messageManager->addSuccessMessage(__('All other open sessions for this account were terminated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __("We couldn't logout because of an error."));
+            $this->messageManager->addExceptionMessage($e, __("We couldn't logout because of an error."));
         }
         $this->_redirect('*/*/activity');
     }

--- a/app/code/Magento/Security/Model/Plugin/Auth.php
+++ b/app/code/Magento/Security/Model/Plugin/Auth.php
@@ -43,7 +43,7 @@ class Auth
     {
         $this->sessionsManager->processLogin();
         if ($this->sessionsManager->getCurrentSession()->isOtherSessionsTerminated()) {
-            $this->messageManager->addWarning(__('All other open sessions for this account were terminated.'));
+            $this->messageManager->addWarningMessage(__('All other open sessions for this account were terminated.'));
         }
     }
 

--- a/app/code/Magento/Security/Model/Plugin/AuthSession.php
+++ b/app/code/Magento/Security/Model/Plugin/AuthSession.php
@@ -82,7 +82,7 @@ class AuthSession
                 $this->sessionsManager->getCurrentSession()->getStatus()
             );
         } elseif ($message = $this->sessionsManager->getLogoutReasonMessage()) {
-            $this->messageManager->addError($message);
+            $this->messageManager->addErrorMessage($message);
         }
 
         return $this;

--- a/app/code/Magento/Security/Model/Plugin/LoginController.php
+++ b/app/code/Magento/Security/Model/Plugin/LoginController.php
@@ -53,7 +53,7 @@ class LoginController
     {
         $logoutReasonCode = $this->securityCookie->getLogoutReasonCookie();
         if ($this->isLoginForm($login) && $logoutReasonCode >= 0) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 $this->sessionsManager->getLogoutReasonMessageByStatus($logoutReasonCode)
             );
             $this->securityCookie->deleteLogoutReasonCookie();

--- a/app/code/Magento/Security/Test/Unit/Controller/Adminhtml/Session/LogoutAllTest.php
+++ b/app/code/Magento/Security/Test/Unit/Controller/Adminhtml/Session/LogoutAllTest.php
@@ -132,12 +132,12 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
         $this->sessionsManager->expects($this->once())
             ->method('logoutOtherUserSessions');
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($successMessage);
         $this->messageManager->expects($this->never())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->messageManager->expects($this->never())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $this->responseMock->expects($this->once())
             ->method('setRedirect');
         $this->actionFlagMock->expects($this->once())
@@ -158,7 +158,7 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
             ->method('logoutOtherUserSessions')
             ->willThrowException(new LocalizedException($phrase));
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($phrase);
         $this->controller->execute();
     }
@@ -173,7 +173,7 @@ class LogoutAllTest extends \PHPUnit\Framework\TestCase
             ->method('logoutOtherUserSessions')
             ->willThrowException(new \Exception());
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with(new \Exception(), $phrase);
         $this->controller->execute();
     }

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthSessionTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthSessionTest.php
@@ -112,7 +112,7 @@ class AuthSessionTest extends \PHPUnit\Framework\TestCase
             ->willReturn($errorMessage);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage);
 
         $this->model->aroundProlong($this->authSessionMock, $proceed);

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthTest.php
@@ -94,7 +94,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             ->method('isOtherSessionsTerminated')
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addWarning')
+            ->method('addWarningMessage')
             ->with($warningMessage);
 
         $this->model->afterLogin($this->authMock);

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/LoginControllerTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/LoginControllerTest.php
@@ -103,7 +103,7 @@ class LoginControllerTest extends \PHPUnit\Framework\TestCase
             ->willReturn($errorMessage);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage);
 
         $this->securityCookieMock->expects($this->once())

--- a/app/code/Magento/SendFriend/Controller/Product/Send.php
+++ b/app/code/Magento/SendFriend/Controller/Product/Send.php
@@ -57,7 +57,7 @@ class Send extends \Magento\SendFriend\Controller\Product
         }
 
         if ($this->sendFriend->getMaxSendsToFriend() && $this->sendFriend->isExceedLimit()) {
-            $this->messageManager->addNotice(
+            $this->messageManager->addNoticeMessage(
                 __('You can\'t send messages more than %1 times an hour.', $this->sendFriend->getMaxSendsToFriend())
             );
         }

--- a/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
+++ b/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
@@ -91,23 +91,23 @@ class Sendmail extends \Magento\SendFriend\Controller\Product
             $validate = $this->sendFriend->validate();
             if ($validate === true) {
                 $this->sendFriend->send();
-                $this->messageManager->addSuccess(__('The link to a friend was sent.'));
+                $this->messageManager->addSuccessMessage(__('The link to a friend was sent.'));
                 $url = $product->getProductUrl();
                 $resultRedirect->setUrl($this->_redirect->success($url));
                 return $resultRedirect;
             } else {
                 if (is_array($validate)) {
                     foreach ($validate as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                 } else {
-                    $this->messageManager->addError(__('We found some problems with the data.'));
+                    $this->messageManager->addErrorMessage(__('We found some problems with the data.'));
                 }
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Some emails were not sent.'));
+            $this->messageManager->addExceptionMessage($e, __('Some emails were not sent.'));
         }
 
         // save form data

--- a/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendTest.php
+++ b/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendTest.php
@@ -128,7 +128,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addNotice');
+            ->method('addNoticeMessage');
 
         /** @var \Magento\Framework\View\Result\Page|\PHPUnit_Framework_MockObject_MockObject $pageMock */
         $pageMock = $this->getMockBuilder(\Magento\Framework\View\Result\Page::class)
@@ -217,7 +217,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
 
         $this->messageManagerMock->expects($this->never())
-            ->method('addNotice');
+            ->method('addNoticeMessage');
 
         /** @var \Magento\Framework\View\Result\Page|\PHPUnit_Framework_MockObject_MockObject $pageMock */
         $pageMock = $this->getMockBuilder(\Magento\Framework\View\Result\Page::class)
@@ -293,7 +293,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn(true);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with(__('You can\'t send messages more than %1 times an hour.', 11))
             ->willReturnSelf();
 

--- a/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendmailTest.php
+++ b/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendmailTest.php
@@ -216,7 +216,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('The link to a friend was sent.'))
             ->willReturnSelf();
 
@@ -338,7 +338,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Some error'))
             ->willReturnSelf();
 
@@ -465,7 +465,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We found some problems with the data.'))
             ->willReturnSelf();
 
@@ -592,7 +592,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Localized Exception.'))
             ->willReturnSelf();
 
@@ -720,7 +720,7 @@ class SendmailTest extends \PHPUnit\Framework\TestCase
             ->method('send');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, __('Some emails were not sent.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/CreateLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/CreateLabel.php
@@ -58,7 +58,7 @@ class CreateLabel extends \Magento\Backend\App\Action
             $shipment = $this->shipmentLoader->load();
             $this->labelGenerator->create($shipment, $this->_request);
             $shipment->save();
-            $this->messageManager->addSuccess(__('You created the shipping label.'));
+            $this->messageManager->addSuccessMessage(__('You created the shipping label.'));
             $response->setOk(true);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $response->setError(true);

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Email.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Email.php
@@ -57,12 +57,12 @@ class Email extends \Magento\Backend\App\Action
                 $this->_objectManager->create(\Magento\Shipping\Model\ShipmentNotifier::class)
                     ->notify($shipment);
                 $shipment->save();
-                $this->messageManager->addSuccess(__('You sent the shipment.'));
+                $this->messageManager->addSuccessMessage(__('You sent the shipment.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Cannot send shipment information.'));
+            $this->messageManager->addErrorMessage(__('Cannot send shipment information.'));
         }
 
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/MassPrintShippingLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/MassPrintShippingLabel.php
@@ -105,7 +105,7 @@ class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\A
             );
         }
 
-        $this->messageManager->addError(__('There are no shipping labels related to selected orders.'));
+        $this->messageManager->addErrorMessage(__('There are no shipping labels related to selected orders.'));
         return $this->resultRedirectFactory->create()->setPath('sales/order/');
     }
 }

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintLabel.php
@@ -74,7 +74,7 @@ class PrintLabel extends \Magento\Backend\App\Action
                     $pdf = new \Zend_Pdf();
                     $page = $this->labelGenerator->createPdfPageFromImageString($labelContent);
                     if (!$page) {
-                        $this->messageManager->addError(
+                        $this->messageManager->addErrorMessage(
                             __(
                                 'We don\'t recognize or support the file extension in this shipment: %1.',
                                 $shipment->getIncrementId()
@@ -93,10 +93,10 @@ class PrintLabel extends \Magento\Backend\App\Action
                 );
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError(__('An error occurred while creating shipping label.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while creating shipping label.'));
         }
         $this->_redirect(
             'adminhtml/order_shipment/view',

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
@@ -97,7 +97,7 @@ class Save extends \Magento\Backend\App\Action
         $formKeyIsValid = $this->_formKeyValidator->validate($this->getRequest());
         $isPost = $this->getRequest()->isPost();
         if (!$formKeyIsValid || !$isPost) {
-            $this->messageManager->addError(__('We can\'t save the shipment right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t save the shipment right now.'));
             return $resultRedirect->setPath('sales/order/index');
         }
 
@@ -135,7 +135,7 @@ class Save extends \Magento\Backend\App\Action
                 ->validate($shipment, [QuantityValidator::class]);
 
             if ($validationResult->hasMessages()) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __("Shipment Document Validation Error(s):\n" . implode("\n", $validationResult->getMessages()))
                 );
                 $this->_redirect('*/*/new', ['order_id' => $this->getRequest()->getParam('order_id')]);
@@ -159,7 +159,7 @@ class Save extends \Magento\Backend\App\Action
             $shipmentCreatedMessage = __('The shipment has been created.');
             $labelCreatedMessage = __('You created the shipping label.');
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 $isNeedCreateLabel ? $shipmentCreatedMessage . ' ' . $labelCreatedMessage : $shipmentCreatedMessage
             );
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->getCommentText(true);
@@ -168,7 +168,7 @@ class Save extends \Magento\Backend\App\Action
                 $responseAjax->setError(true);
                 $responseAjax->setMessage($e->getMessage());
             } else {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('*/*/new', ['order_id' => $this->getRequest()->getParam('order_id')]);
             }
         } catch (\Exception $e) {
@@ -177,7 +177,7 @@ class Save extends \Magento\Backend\App\Action
                 $responseAjax->setError(true);
                 $responseAjax->setMessage(__('An error occurred while creating shipping label.'));
             } else {
-                $this->messageManager->addError(__('Cannot save shipment.'));
+                $this->messageManager->addErrorMessage(__('Cannot save shipment.'));
                 $this->_redirect('*/*/new', ['order_id' => $this->getRequest()->getParam('order_id')]);
             }
         }

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
@@ -118,21 +118,21 @@ class ShipmentLoader extends DataObject
              * Check order existing
              */
             if (!$order->getId()) {
-                $this->messageManager->addError(__('The order no longer exists.'));
+                $this->messageManager->addErrorMessage(__('The order no longer exists.'));
                 return false;
             }
             /**
              * Check shipment is available to create separate from invoice
              */
             if ($order->getForcedShipmentWithInvoice()) {
-                $this->messageManager->addError(__('Cannot do shipment for the order separately from invoice.'));
+                $this->messageManager->addErrorMessage(__('Cannot do shipment for the order separately from invoice.'));
                 return false;
             }
             /**
              * Check shipment create availability
              */
             if (!$order->canShip()) {
-                $this->messageManager->addError(__('Cannot do shipment for the order.'));
+                $this->messageManager->addErrorMessage(__('Cannot do shipment for the order.'));
                 return false;
             }
 

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Shipment/MassPrintShippingLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Shipment/MassPrintShippingLabel.php
@@ -87,7 +87,7 @@ class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\A
             );
         }
 
-        $this->messageManager->addError(__('There are no shipping labels related to selected shipments.'));
+        $this->messageManager->addErrorMessage(__('There are no shipping labels related to selected shipments.'));
         return $this->resultRedirectFactory->create()->setPath('sales/shipment/');
     }
 }

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/CreateLabelTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/CreateLabelTest.php
@@ -155,7 +155,7 @@ class CreateLabelTest extends \PHPUnit\Framework\TestCase
             ->with($this->shipmentMock, $this->requestMock)
             ->will($this->returnValue(true));
         $this->shipmentMock->expects($this->once())->method('save')->will($this->returnSelf());
-        $this->messageManagerMock->expects($this->once())->method('addSuccess');
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
         $this->responseMock->expects($this->once())->method('representJson');
 
         $this->assertNull($this->controller->execute());

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/EmailTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/EmailTest.php
@@ -206,7 +206,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
             ->with($orderShipment)
             ->will($this->returnValue(true));
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You sent the shipment.');
         $path = '*/*/view';
         $arguments = ['shipment_id' => $shipmentId];

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/PrintLabelTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/PrintLabelTest.php
@@ -276,11 +276,11 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
             ->with($labelContent)
             ->will($this->returnValue(false));
         $this->messageManagerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(sprintf('We don\'t recognize or support the file extension in this shipment: %s.', $incrementId))
             ->will($this->throwException(new \Exception()));
         $this->messageManagerMock->expects($this->at(1))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('An error occurred while creating shipping label.')
             ->will($this->returnSelf());
         $this->objectManagerMock->expects($this->once())
@@ -306,7 +306,7 @@ class PrintLabelTest extends \PHPUnit\Framework\TestCase
         $this->shipmentLoaderMock->expects($this->once())
             ->method('load')
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
-        $this->messageManagerMock->expects($this->once())->method('addError')->will($this->returnSelf());
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage')->will($this->returnSelf());
         $this->redirectSection();
 
         $this->assertNull($this->controller->execute());

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/SaveTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/SaveTest.php
@@ -236,7 +236,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         if (!$formKeyIsValid || !$isPost) {
             $this->messageManager->expects($this->once())
-                ->method('addError');
+                ->method('addErrorMessage');
 
             $this->resultRedirect->expects($this->once())
                 ->method('setPath')

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Delete.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Delete.php
@@ -61,20 +61,20 @@ class Delete extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
                 }
                 $sitemap->delete();
                 // display success message
-                $this->messageManager->addSuccess(__('You deleted the sitemap.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the sitemap.'));
                 // go to grid
                 $this->_redirect('adminhtml/*/');
                 return;
             } catch (\Exception $e) {
                 // display error message
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 // go back to edit form
                 $this->_redirect('adminhtml/*/edit', ['sitemap_id' => $id]);
                 return;
             }
         }
         // display error message
-        $this->messageManager->addError(__('We can\'t find a sitemap to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a sitemap to delete.'));
         // go to grid
         $this->_redirect('adminhtml/*/');
     }

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Edit.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Edit.php
@@ -41,7 +41,7 @@ class Edit extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         if ($id) {
             $model->load($id);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This sitemap no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This sitemap no longer exists.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             }

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -25,16 +25,16 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             try {
                 $sitemap->generateXml();
 
-                $this->messageManager->addSuccess(
+                $this->messageManager->addSuccessMessage(
                     __('The sitemap "%1" has been generated.', $sitemap->getSitemapFilename())
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t generate the sitemap right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t generate the sitemap right now.'));
             }
         } else {
-            $this->messageManager->addError(__('We can\'t find a sitemap to generate.'));
+            $this->messageManager->addErrorMessage(__('We can\'t find a sitemap to generate.'));
         }
 
         // go to grid

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
@@ -30,7 +30,7 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             $validator->setPaths($helper->getValidPaths());
             if (!$validator->isValid($path)) {
                 foreach ($validator->getMessages() as $message) {
-                    $this->messageManager->addError($message);
+                    $this->messageManager->addErrorMessage($message);
                 }
                 // save data in session
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($data);
@@ -83,13 +83,13 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             // save the data
             $model->save();
             // display success message
-            $this->messageManager->addSuccess(__('You saved the sitemap.'));
+            $this->messageManager->addSuccessMessage(__('You saved the sitemap.'));
             // clear previously saved data from session
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData(false);
             return $model->getId();
         } catch (\Exception $e) {
             // display error message
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             // save data in session
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($data);
         }

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/DeleteTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/DeleteTest.php
@@ -83,7 +83,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         $this->requestMock->expects($this->any())->method('getParam')->with('sitemap_id')->willReturn(0);
         $this->responseMock->expects($this->once())->method('setRedirect');
         $this->messageManagerMock->expects($this->any())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t find a sitemap to delete.');
 
         $this->deleteController->execute();
@@ -107,7 +107,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         $this->sitemapFactoryMock->expects($this->once())->method('create')->willReturn($sitemapMock);
         $this->responseMock->expects($this->once())->method('setRedirect');
         $this->messageManagerMock->expects($this->any())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->deleteController->execute();
     }
@@ -142,7 +142,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
 
         $this->responseMock->expects($this->once())->method('setRedirect');
         $this->messageManagerMock->expects($this->any())
-            ->method('addSuccess');
+            ->method('addSuccessMessage');
 
         $this->deleteController->execute();
     }

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
@@ -154,7 +154,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([[$helperClass, $helper], [$sessionClass, $session]]);
 
         $this->messageManagerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->withConsecutive(
                 [$messages[0]],
                 [$messages[1]]

--- a/app/code/Magento/Store/Controller/Store/SwitchAction.php
+++ b/app/code/Magento/Store/Controller/Store/SwitchAction.php
@@ -86,7 +86,7 @@ class SwitchAction extends Action
         }
 
         if (isset($error)) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl());
             return;
         }

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/Delete.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/Delete.php
@@ -24,17 +24,17 @@ class Delete extends \Magento\Tax\Controller\Adminhtml\Rate
             try {
                 $this->_taxRateRepository->deleteById($rateId);
 
-                $this->messageManager->addSuccess(__('You deleted the tax rate.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the tax rate.'));
                 return $resultRedirect->setPath("*/*/");
             } catch (NoSuchEntityException $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete this rate because of an incorrect rate ID.')
                 );
                 return $resultRedirect->setPath("tax/*/");
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong deleting this rate.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong deleting this rate.'));
             }
 
             if ($this->getRequest()->getServer('HTTP_REFERER')) {

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate/Save.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate/Save.php
@@ -35,13 +35,13 @@ class Save extends \Magento\Tax\Controller\Adminhtml\Rate
                 $taxData = $this->_taxRateConverter->populateTaxRateData($ratePost);
                 $this->_taxRateRepository->save($taxData);
 
-                $this->messageManager->addSuccess(__('You saved the tax rate.'));
+                $this->messageManager->addSuccessMessage(__('You saved the tax rate.'));
                 return $resultRedirect->setPath('*/*/');
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setFormData($ratePost);
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
             return $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));
         }

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/Delete.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/Delete.php
@@ -20,15 +20,15 @@ class Delete extends \Magento\Tax\Controller\Adminhtml\Rule
         $ruleId = (int)$this->getRequest()->getParam('rule');
         try {
             $this->ruleService->deleteById($ruleId);
-            $this->messageManager->addSuccess(__('The tax rule has been deleted.'));
+            $this->messageManager->addSuccessMessage(__('The tax rule has been deleted.'));
             return $resultRedirect->setPath('tax/*/');
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $this->messageManager->addError(__('This rule no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
             return $resultRedirect->setPath('tax/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('Something went wrong deleting this tax rule.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong deleting this tax rule.'));
         }
 
         return $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/Edit.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/Edit.php
@@ -25,7 +25,7 @@ class Edit extends \Magento\Tax\Controller\Adminhtml\Rule
                 $pageTitle = sprintf("%s", $taxRule->getCode());
             } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
                 $backendSession->unsRuleData();
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
                 $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
                 return $resultRedirect->setPath('tax/*/');

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule/Save.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule/Save.php
@@ -24,16 +24,16 @@ class Save extends \Magento\Tax\Controller\Adminhtml\Rule
             try {
                 $taxRule = $this->ruleService->save($taxRule);
 
-                $this->messageManager->addSuccess(__('You saved the tax rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the tax rule.'));
 
                 if ($this->getRequest()->getParam('back')) {
                     return $resultRedirect->setPath('tax/*/edit', ['rule' => $taxRule->getId()]);
                 }
                 return $resultRedirect->setPath('tax/*/');
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t save this tax rule right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t save this tax rule right now.'));
             }
 
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setRuleData($postData);

--- a/app/code/Magento/Tax/Controller/Adminhtml/Tax/IgnoreTaxNotification.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Tax/IgnoreTaxNotification.php
@@ -46,7 +46,7 @@ class IgnoreTaxNotification extends \Magento\Tax\Controller\Adminhtml\Tax
                 $this->_objectManager->get(\Magento\Config\Model\ResourceModel\Config::class)
                     ->saveConfig($path, 1, ScopeConfigInterface::SCOPE_TYPE_DEFAULT, 0);
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
 

--- a/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate/ImportPost.php
+++ b/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate/ImportPost.php
@@ -25,14 +25,14 @@ class ImportPost extends \Magento\TaxImportExport\Controller\Adminhtml\Rate
                 );
                 $importHandler->importFromCsvFile($importRatesFile);
 
-                $this->messageManager->addSuccess(__('The tax rate has been imported.'));
+                $this->messageManager->addSuccessMessage(__('The tax rate has been imported.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Invalid file upload attempt'));
+                $this->messageManager->addErrorMessage(__('Invalid file upload attempt'));
             }
         } else {
-            $this->messageManager->addError(__('Invalid file upload attempt'));
+            $this->messageManager->addErrorMessage(__('Invalid file upload attempt'));
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Theme/Controller/Adminhtml/Design/Config/Save.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/Design/Config/Save.php
@@ -73,7 +73,7 @@ class Save extends Action
         try {
             $designConfigData = $this->configFactory->create($scope, $scopeId, $data);
             $this->designConfigRepository->save($designConfigData);
-            $this->messageManager->addSuccess(__('You saved the configuration.'));
+            $this->messageManager->addSuccessMessage(__('You saved the configuration.'));
 
             $this->dataPersistor->clear('theme_design_config');
 
@@ -86,10 +86,10 @@ class Save extends Action
         } catch (LocalizedException $e) {
             $messages = explode("\n", $e->getMessage());
             foreach ($messages as $message) {
-                $this->messageManager->addError(__('%1', $message));
+                $this->messageManager->addErrorMessage(__('%1', $message));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while saving this configuration:') . ' ' . $e->getMessage()
             );

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Delete.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Delete.php
@@ -37,12 +37,12 @@ class Delete extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
                     );
                 }
                 $theme->delete();
-                $this->messageManager->addSuccess(__('You deleted the theme.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the theme.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We cannot delete the theme.'));
+            $this->messageManager->addExceptionMessage($e, __('We cannot delete the theme.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCss.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCss.php
@@ -48,7 +48,7 @@ class DownloadCss extends \Magento\Theme\Controller\Adminhtml\System\Design\Them
                 DirectoryList::ROOT
             );
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('File not found: "%1".', $fileId));
+            $this->messageManager->addExceptionMessage($e, __('File not found: "%1".', $fileId));
             $this->getResponse()->setRedirect($this->_redirect->getRefererUrl());
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCustomCss.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCustomCss.php
@@ -44,7 +44,7 @@ class DownloadCustomCss extends \Magento\Theme\Controller\Adminhtml\System\Desig
                 );
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t find file.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t find file.'));
             $this->getResponse()->setRedirect($this->_redirect->getRefererUrl());
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Edit.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Edit.php
@@ -41,10 +41,10 @@ class Edit extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
             $this->_setActiveMenu('Magento_Theme::system_design_theme');
             $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_redirect('adminhtml/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We cannot find the theme.'));
+            $this->messageManager->addErrorMessage(__('We cannot find the theme.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             $this->_redirect('adminhtml/*/');
         }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Save.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Save.php
@@ -65,15 +65,15 @@ class Save extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
                 );
                 $customization->delete($removeJsFiles);
                 $singleFile->update($theme, $customCssData);
-                $this->messageManager->addSuccess(__('You saved the theme.'));
+                $this->messageManager->addSuccessMessage(__('You saved the theme.'));
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->_getSession()->setThemeData($themeData);
             $this->_getSession()->setThemeCustomCssData($customCssData);
             $redirectBack = true;
         } catch (\Exception $e) {
-            $this->messageManager->addError('The theme was not saved');
+            $this->messageManager->addErrorMessage('The theme was not saved');
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $redirectBack

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/Design/Config/SaveTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/Design/Config/SaveTest.php
@@ -138,7 +138,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->method('save')
             ->with($this->designConfig);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('You saved the configuration.'));
         $this->dataPersistor->expects($this->once())
             ->method('clear')
@@ -194,7 +194,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with($this->designConfig)
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('Exception message')));
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('Exception message')->render());
 
         $this->dataPersistor->expects($this->once())
@@ -249,7 +249,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with($this->designConfig)
             ->willThrowException($exception);
         $this->messageManager->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'Something went wrong while saving this configuration: Exception message');
 
         $this->dataPersistor->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DeleteTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DeleteTest.php
@@ -141,7 +141,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->method('isVirtual')
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->willReturnSelf();
         $this->resultFactory->expects($this->once())
             ->method('create')
@@ -215,7 +215,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->with($path)
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $this->objectManager->expects($this->once())
             ->method('get')
             ->with(\Psr\Log\LoggerInterface::class)
@@ -258,7 +258,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             ->with($path)
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
 
         $this->assertInstanceOf(\Magento\Framework\Controller\Result\Redirect::class, $this->controller->execute());
     }

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCssTest.php
@@ -235,7 +235,7 @@ class DownloadCssTest extends \PHPUnit\Framework\TestCase
             ->method('getId')
             ->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $logger->expects($this->once())
             ->method('critical');
         $this->redirect->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCustomCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCustomCssTest.php
@@ -205,7 +205,7 @@ class DownloadCustomCssTest extends \PHPUnit\Framework\TestCase
             ->with($themeId)
             ->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $logger->expects($this->once())
             ->method('critical');
         $this->redirect->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/EditTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/EditTest.php
@@ -48,7 +48,7 @@ class EditTest extends \Magento\Theme\Test\Unit\Controller\Adminhtml\System\Desi
             ->with(\Magento\Framework\View\Design\ThemeInterface::class)
             ->willReturn($theme);
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->session->expects($this->once())
             ->method('setIsUrlNotice')
             ->with(true);
@@ -114,7 +114,7 @@ class EditTest extends \Magento\Theme\Test\Unit\Controller\Adminhtml\System\Desi
             ->willReturn($logger);
 
         $this->messageManager->expects($this->once())
-            ->method('addError');
+            ->method('addErrorMessage');
         $this->session->expects($this->once())
             ->method('setIsUrlNotice')
             ->with(true);

--- a/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Delete.php
+++ b/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Delete.php
@@ -18,9 +18,9 @@ class Delete extends \Magento\UrlRewrite\Controller\Adminhtml\Url\Rewrite
         if ($this->_getUrlRewrite()->getId()) {
             try {
                 $this->_getUrlRewrite()->delete();
-                $this->messageManager->addSuccess(__('You deleted the URL rewrite.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the URL rewrite.'));
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __('We can\'t delete URL Rewrite right now.'));
+                $this->messageManager->addExceptionMessage($e, __('We can\'t delete URL Rewrite right now.'));
                 $this->_redirect('adminhtml/*/edit/', ['id' => $this->_getUrlRewrite()->getId()]);
                 return;
             }

--- a/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Save.php
+++ b/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite/Save.php
@@ -168,14 +168,14 @@ class Save extends \Magento\UrlRewrite\Controller\Adminhtml\Url\Rewrite
                 $this->_handleCmsPageUrlRewrite($model);
                 $model->save();
 
-                $this->messageManager->addSuccess(__('The URL Rewrite has been saved.'));
+                $this->messageManager->addSuccessMessage(__('The URL Rewrite has been saved.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $session->setUrlRewriteData($data);
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('An error occurred while saving the URL rewrite. Please try to save again.')
                 );

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
@@ -83,17 +83,17 @@ class Forgotpassword extends \Magento\User\Controller\Adminhtml\Auth
                     return $resultRedirect->setPath('admin');
                 }
                 // @codingStandardsIgnoreStart
-                $this->messageManager->addSuccess(__('We\'ll email you a link to reset your password.'));
+                $this->messageManager->addSuccessMessage(__('We\'ll email you a link to reset your password.'));
                 // @codingStandardsIgnoreEnd
                 $this->getResponse()->setRedirect(
                     $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
                 );
                 return;
             } else {
-                $this->messageManager->addError(__('Please correct this email address:'));
+                $this->messageManager->addErrorMessage(__('Please correct this email address:'));
             }
         } elseif (!empty($params)) {
-            $this->messageManager->addError(__('Please enter an email address.'));
+            $this->messageManager->addErrorMessage(__('Please enter an email address.'));
         }
         $this->_view->loadLayout();
         $this->_view->renderLayout();

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPassword.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPassword.php
@@ -31,7 +31,7 @@ class ResetPassword extends \Magento\User\Controller\Adminhtml\Auth
 
             $this->_view->renderLayout();
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Your password reset link has expired.'));
+            $this->messageManager->addErrorMessage(__('Your password reset link has expired.'));
             $this->_redirect('adminhtml/auth/forgotpassword', ['_nosecret' => true]);
             return;
         }

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -25,7 +25,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
         try {
             $this->_validateResetPasswordLinkToken($userId, $passwordResetToken);
         } catch (\Exception $exception) {
-            $this->messageManager->addError(__('Your password reset link has expired.'));
+            $this->messageManager->addErrorMessage(__('Your password reset link has expired.'));
             $this->getResponse()->setRedirect(
                 $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
             );
@@ -43,7 +43,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
             $errors = $user->validate();
             if ($errors !== true && !empty($errors)) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addError($error);
+                    $this->messageManager->addErrorMessage($error);
                     $this->_redirect(
                         'adminhtml/auth/resetpassword',
                         ['_nosecret' => true, '_query' => ['id' => $userId, 'token' => $passwordResetToken]]
@@ -51,7 +51,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
                 }
             } else {
                 $user->save();
-                $this->messageManager->addSuccess(__('You updated your password.'));
+                $this->messageManager->addSuccessMessage(__('You updated your password.'));
                 $this->getResponse()->setRedirect(
                     $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
                 );

--- a/app/code/Magento/User/Controller/Adminhtml/Locks/MassUnlock.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Locks/MassUnlock.php
@@ -30,7 +30,7 @@ class MassUnlock extends \Magento\User\Controller\Adminhtml\Locks
                 $this->getMessageManager()->addSuccess(__('Unlocked %1 user(s).', $affectedUsers));
             }
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/User/Controller/Adminhtml/User/Delete.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Delete.php
@@ -23,7 +23,7 @@ class Delete extends \Magento\User\Controller\Adminhtml\User
 
         if ($userId) {
             if ($currentUser->getId() == $userId) {
-                $this->messageManager->addError(__('You cannot delete your own account.'));
+                $this->messageManager->addErrorMessage(__('You cannot delete your own account.'));
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $userId]);
                 return;
             }
@@ -39,16 +39,16 @@ class Delete extends \Magento\User\Controller\Adminhtml\User
                 $model = $this->_userFactory->create();
                 $model->setId($userId);
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the user.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the user.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $this->getRequest()->getParam('user_id')]);
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a user to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a user to delete.'));
         $this->_redirect('adminhtml/*/');
     }
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Edit.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Edit.php
@@ -22,7 +22,7 @@ class Edit extends \Magento\User\Controller\Adminhtml\User
         if ($userId) {
             $model->load($userId);
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This user no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This user no longer exists.'));
                 $this->_redirect('adminhtml/*/');
                 return;
             }

--- a/app/code/Magento/User/Controller/Adminhtml/User/InvalidateToken.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/InvalidateToken.php
@@ -45,16 +45,16 @@ class InvalidateToken extends \Magento\User\Controller\Adminhtml\User
         if ($userId = $this->getRequest()->getParam('user_id')) {
             try {
                 $this->tokenService->revokeAdminAccessToken($userId);
-                $this->messageManager->addSuccess(__('You have revoked the user\'s tokens.'));
+                $this->messageManager->addSuccessMessage(__('You have revoked the user\'s tokens.'));
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $userId]);
                 return;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_redirect('adminhtml/*/edit', ['user_id' => $userId]);
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a user to revoke.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a user to revoke.'));
         $this->_redirect('adminhtml/*');
     }
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role/Delete.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role/Delete.php
@@ -24,15 +24,15 @@ class Delete extends \Magento\User\Controller\Adminhtml\User\Role
         $currentUser = $this->_userFactory->create()->setId($this->_authSession->getUser()->getId());
 
         if (in_array($rid, $currentUser->getRoles())) {
-            $this->messageManager->addError(__('You cannot delete self-assigned roles.'));
+            $this->messageManager->addErrorMessage(__('You cannot delete self-assigned roles.'));
             return $resultRedirect->setPath('adminhtml/*/editrole', ['rid' => $rid]);
         }
 
         try {
             $this->_initRole()->delete();
-            $this->messageManager->addSuccess(__('You deleted the role.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the role.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while deleting this role.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while deleting this role.'));
         }
 
         return $resultRedirect->setPath("*/*/");

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role/SaveRole.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role/SaveRole.php
@@ -86,7 +86,7 @@ class SaveRole extends \Magento\User\Controller\Adminhtml\User\Role
 
         $role = $this->_initRole('role_id');
         if (!$role->getId() && $rid) {
-            $this->messageManager->addError(__('This role no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This role no longer exists.'));
             return $resultRedirect->setPath('adminhtml/*/');
         }
 
@@ -110,7 +110,7 @@ class SaveRole extends \Magento\User\Controller\Adminhtml\User\Role
             foreach ($roleUsers as $nRuid) {
                 $this->_addUserToRole($nRuid, $role->getId());
             }
-            $this->messageManager->addSuccess(__('You saved the role.'));
+            $this->messageManager->addSuccessMessage(__('You saved the role.'));
         } catch (UserLockedException $e) {
             $this->_auth->logout();
             $this->getSecurityCookie()->setLogoutReasonCookie(
@@ -118,14 +118,14 @@ class SaveRole extends \Magento\User\Controller\Adminhtml\User\Role
             );
             return $resultRedirect->setPath('*');
         } catch (\Magento\Framework\Exception\AuthenticationException $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('The password entered for the current user is invalid. Verify the password and try again.')
             );
             return $this->saveDataToSessionAndRedirect($role, $this->getRequest()->getPostValue(), $resultRedirect);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while saving this role.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while saving this role.'));
         }
 
         return $resultRedirect->setPath('*/*/');

--- a/app/code/Magento/User/Controller/Adminhtml/User/Save.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Save.php
@@ -51,7 +51,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
         /** @var $model \Magento\User\Model\User */
         $model = $this->_userFactory->create()->load($userId);
         if ($userId && $model->isObjectNew()) {
-            $this->messageManager->addError(__('This user no longer exists.'));
+            $this->messageManager->addErrorMessage(__('This user no longer exists.'));
             $this->_redirect('adminhtml/*/');
             return;
         }
@@ -89,7 +89,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
 
             $model->sendNotificationEmailsIfRequired();
 
-            $this->messageManager->addSuccess(__('You saved the user.'));
+            $this->messageManager->addSuccessMessage(__('You saved the user.'));
             $this->_getSession()->setUserData(false);
             $this->_redirect('adminhtml/*/');
         } catch (UserLockedException $e) {
@@ -99,7 +99,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
             );
             $this->_redirect('adminhtml/*/');
         } catch (\Magento\Framework\Exception\AuthenticationException $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('The password entered for the current user is invalid. Verify the password and try again.')
             );
             $this->redirectToEdit($model, $data);
@@ -109,7 +109,7 @@ class Save extends \Magento\User\Controller\Adminhtml\User
             $this->redirectToEdit($model, $data);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             if ($e->getMessage()) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
             $this->redirectToEdit($model, $data);
         }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Validate.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Validate.php
@@ -34,7 +34,7 @@ class Validate extends \Magento\User\Controller\Adminhtml\User
 
         if ($errors !== true && !empty($errors)) {
             foreach ($errors as $error) {
-                $this->messageManager->addError($error);
+                $this->messageManager->addErrorMessage($error);
             }
             $response->setError(1);
             $this->_view->getLayout()->initMessages();

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Delete.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Delete.php
@@ -21,9 +21,9 @@ class Delete extends \Magento\Variable\Controller\Adminhtml\System\Variable
         if ($variable->getId()) {
             try {
                 $variable->delete();
-                $this->messageManager->addSuccess(__('You deleted the custom variable.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the custom variable.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('adminhtml/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Save.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Save.php
@@ -31,7 +31,7 @@ class Save extends \Magento\Variable\Controller\Adminhtml\System\Variable
             $variable->setData($data);
             try {
                 $variable->save();
-                $this->messageManager->addSuccess(__('You saved the custom variable.'));
+                $this->messageManager->addSuccessMessage(__('You saved the custom variable.'));
                 if ($back) {
                     $resultRedirect->setPath(
                         'adminhtml/*/edit',
@@ -42,7 +42,7 @@ class Save extends \Magento\Variable\Controller\Adminhtml\System\Variable
                 }
                 return $resultRedirect;
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('adminhtml/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Validate.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable/Validate.php
@@ -25,7 +25,7 @@ class Validate extends \Magento\Variable\Controller\Adminhtml\System\Variable
         $variable->addData($this->getRequest()->getPost('variable'));
         $result = $variable->validate();
         if ($result instanceof \Magento\Framework\Phrase) {
-            $this->messageManager->addError($result->getText());
+            $this->messageManager->addErrorMessage($result->getText());
             $layout = $this->layoutFactory->create();
             $layout->initMessages();
             $response->setError(true);

--- a/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
@@ -146,7 +146,7 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
 
         if ($result instanceof \Magento\Framework\Phrase) {
             $this->messageManagerMock->expects($this->once())
-                ->method('addError')
+                ->method('addErrorMessage')
                 ->with($result->getText());
             $this->layoutMock->expects($this->once())
                 ->method('initMessages');

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
@@ -104,7 +104,7 @@ abstract class Instance extends \Magento\Backend\App\Action
         if ($instanceId) {
             $widgetInstance->load($instanceId)->setCode($code);
             if (!$widgetInstance->getId()) {
-                $this->messageManager->addError(__('Please specify a correct widget.'));
+                $this->messageManager->addErrorMessage(__('Please specify a correct widget.'));
                 return false;
             }
         } else {

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Delete.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Delete.php
@@ -19,9 +19,9 @@ class Delete extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
         if ($widgetInstance) {
             try {
                 $widgetInstance->delete();
-                $this->messageManager->addSuccess(__('The widget instance has been deleted.'));
+                $this->messageManager->addSuccessMessage(__('The widget instance has been deleted.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         }
         $this->_redirect('adminhtml/*/');

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Save.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Save.php
@@ -33,7 +33,7 @@ class Save extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
         );
         try {
             $widgetInstance->save();
-            $this->messageManager->addSuccess(__('The widget instance has been saved.'));
+            $this->messageManager->addSuccessMessage(__('The widget instance has been saved.'));
             if ($this->getRequest()->getParam('back', false)) {
                 $this->_redirect(
                     'adminhtml/*/edit',
@@ -44,7 +44,7 @@ class Save extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
             }
             return;
         } catch (\Exception $exception) {
-            $this->messageManager->addError($exception->getMessage());
+            $this->messageManager->addErrorMessage($exception->getMessage());
             $this->_logger->critical($exception);
             $this->_redirect('adminhtml/*/edit', ['_current' => true]);
             return;

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Validate.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance/Validate.php
@@ -20,7 +20,7 @@ class Validate extends \Magento\Widget\Controller\Adminhtml\Widget\Instance
         $widgetInstance = $this->_initWidgetInstance();
         $result = $widgetInstance->validate();
         if ($result !== true && is_string($result)) {
-            $this->messageManager->addError($result);
+            $this->messageManager->addErrorMessage($result);
             $this->_view->getLayout()->initMessages();
             $response->setError(true);
             $response->setHtmlMessage($this->_view->getLayout()->getMessagesBlock()->getGroupedHtml());

--- a/app/code/Magento/Wishlist/Controller/Index/Cart.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Cart.php
@@ -183,7 +183,7 @@ class Cart extends \Magento\Wishlist\Controller\AbstractIndex
                     'You added %1 to your shopping cart.',
                     $this->escaper->escapeHtml($item->getProduct()->getName())
                 );
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             }
 
             if ($this->cartHelper->getShouldRedirectToCart()) {
@@ -195,12 +195,12 @@ class Cart extends \Magento\Wishlist\Controller\AbstractIndex
                 }
             }
         } catch (ProductException $e) {
-            $this->messageManager->addError(__('This product(s) is out of stock.'));
+            $this->messageManager->addErrorMessage(__('This product(s) is out of stock.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addNotice($e->getMessage());
+            $this->messageManager->addNoticeMessage($e->getMessage());
             $redirectUrl = $configureUrl;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t add the item to the cart right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t add the item to the cart right now.'));
         }
 
         $this->helper->calculate();

--- a/app/code/Magento/Wishlist/Controller/Index/Configure.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Configure.php
@@ -102,11 +102,11 @@ class Configure extends \Magento\Wishlist\Controller\AbstractIndex
 
             return $resultPage;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('*');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t configure the product right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t configure the product right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
             $resultRedirect->setPath('*');
             return $resultRedirect;

--- a/app/code/Magento/Wishlist/Controller/Index/Remove.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Remove.php
@@ -68,11 +68,11 @@ class Remove extends \Magento\Wishlist\Controller\AbstractIndex
             $item->delete();
             $wishlist->save();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError(
+            $this->messageManager->addErrorMessage(
                 __('We can\'t delete the item from Wish List right now because of an error: %1.', $e->getMessage())
             );
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete the item from the Wish List right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete the item from the Wish List right now.'));
         }
 
         $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();

--- a/app/code/Magento/Wishlist/Controller/Index/Send.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Send.php
@@ -164,7 +164,7 @@ class Send extends \Magento\Wishlist\Controller\AbstractIndex
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
             $this->wishlistSession->setSharingForm($this->getRequest()->getPostValue());
             $resultRedirect->setPath('*/*/share');
             return $resultRedirect;
@@ -230,12 +230,12 @@ class Send extends \Magento\Wishlist\Controller\AbstractIndex
             $this->inlineTranslation->resume();
 
             $this->_eventManager->dispatch('wishlist_share', ['wishlist' => $wishlist]);
-            $this->messageManager->addSuccess(__('Your wish list has been shared.'));
+            $this->messageManager->addSuccessMessage(__('Your wish list has been shared.'));
             $resultRedirect->setPath('*/*', ['wishlist_id' => $wishlist->getId()]);
             return $resultRedirect;
         } catch (\Exception $e) {
             $this->inlineTranslation->resume();
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $this->wishlistSession->setSharingForm($this->getRequest()->getPostValue());
             $resultRedirect->setPath('*/*/share');
             return $resultRedirect;

--- a/app/code/Magento/Wishlist/Controller/Index/Update.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Update.php
@@ -101,7 +101,7 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
                         $item->delete();
                     } catch (\Exception $e) {
                         $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                        $this->messageManager->addError(__('We can\'t delete item from Wish List right now.'));
+                        $this->messageManager->addErrorMessage(__('We can\'t delete item from Wish List right now.'));
                     }
                 }
 
@@ -113,7 +113,7 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
                     $item->setDescription($description)->setQty($qty)->save();
                     $updatedItems++;
                 } catch (\Exception $e) {
-                    $this->messageManager->addError(
+                    $this->messageManager->addErrorMessage(
                         __(
                             'Can\'t save description %1',
                             $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($description)
@@ -128,7 +128,7 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex
                     $wishlist->save();
                     $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
                 } catch (\Exception $e) {
-                    $this->messageManager->addError(__('Can\'t update wish list'));
+                    $this->messageManager->addErrorMessage(__('Can\'t update wish list'));
                 }
             }
 

--- a/app/code/Magento/Wishlist/Controller/Index/UpdateItemOptions.php
+++ b/app/code/Magento/Wishlist/Controller/Index/UpdateItemOptions.php
@@ -85,7 +85,7 @@ class UpdateItemOptions extends \Magento\Wishlist\Controller\AbstractIndex
         }
 
         if (!$product || !$product->isVisibleInCatalog()) {
-            $this->messageManager->addError(__('We can\'t specify a product.'));
+            $this->messageManager->addErrorMessage(__('We can\'t specify a product.'));
             $resultRedirect->setPath('*/');
             return $resultRedirect;
         }
@@ -114,11 +114,11 @@ class UpdateItemOptions extends \Magento\Wishlist\Controller\AbstractIndex
             $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
 
             $message = __('%1 has been updated in your Wish List.', $product->getName());
-            $this->messageManager->addSuccess($message);
+            $this->messageManager->addSuccessMessage($message);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t update your Wish List right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t update your Wish List right now.'));
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }
         $resultRedirect->setPath('*/*', ['wishlist_id' => $wishlist->getId()]);

--- a/app/code/Magento/Wishlist/Controller/Shared/Cart.php
+++ b/app/code/Magento/Wishlist/Controller/Shared/Cart.php
@@ -103,19 +103,19 @@ class Cart extends \Magento\Framework\App\Action\Action
                     'You added %1 to your shopping cart.',
                     $this->escaper->escapeHtml($item->getProduct()->getName())
                 );
-                $this->messageManager->addSuccess($message);
+                $this->messageManager->addSuccessMessage($message);
             }
 
             if ($this->cartHelper->getShouldRedirectToCart()) {
                 $redirectUrl = $this->cartHelper->getCartUrl();
             }
         } catch (ProductException $e) {
-            $this->messageManager->addError(__('This product(s) is out of stock.'));
+            $this->messageManager->addErrorMessage(__('This product(s) is out of stock.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addNotice($e->getMessage());
+            $this->messageManager->addNoticeMessage($e->getMessage());
             $redirectUrl = $item->getProductUrl();
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t add the item to the cart right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t add the item to the cart right now.'));
         }
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Wishlist/Controller/WishlistProvider.php
+++ b/app/code/Magento/Wishlist/Controller/WishlistProvider.php
@@ -85,10 +85,10 @@ class WishlistProvider implements WishlistProviderInterface
                 );
             }
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return false;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t create the Wish List right now.'));
+            $this->messageManager->addExceptionMessage($e, __('We can\'t create the Wish List right now.'));
             return false;
         }
         $this->wishlist = $wishlist;

--- a/app/code/Magento/Wishlist/Model/ItemCarrier.php
+++ b/app/code/Magento/Wishlist/Model/ItemCarrier.php
@@ -182,7 +182,7 @@ class ItemCarrier
 
         if ($messages) {
             foreach ($messages as $message) {
-                $this->messageManager->addError($message);
+                $this->messageManager->addErrorMessage($message);
             }
             $redirectUrl = $indexUrl;
         }
@@ -192,7 +192,7 @@ class ItemCarrier
             try {
                 $wishlist->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('We can\'t update the Wish List right now.'));
+                $this->messageManager->addErrorMessage(__('We can\'t update the Wish List right now.'));
                 $redirectUrl = $indexUrl;
             }
 
@@ -202,7 +202,7 @@ class ItemCarrier
                 $products[] = '"' . $product->getName() . '"';
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('%1 product(s) have been added to shopping cart: %2.', count($addedProducts), join(', ', $products))
             );
 

--- a/app/code/Magento/Wishlist/Observer/AddToCart.php
+++ b/app/code/Magento/Wishlist/Observer/AddToCart.php
@@ -105,7 +105,7 @@ class AddToCart implements ObserverInterface
             $this->checkoutSession->setWishlistPendingUrls($urls);
             $this->checkoutSession->setWishlistPendingMessages($messages);
 
-            $this->messageManager->addError($message);
+            $this->messageManager->addErrorMessage($message);
 
             $observer->getEvent()->getResponse()->setRedirect($url);
             $this->checkoutSession->setNoCartRedirect(true);

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
@@ -566,7 +566,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productName);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('You added '  . $productName . ' to your shopping cart.', null)
             ->willReturnSelf();
 
@@ -735,7 +735,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new ProductException(__('Test Phrase')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('This product(s) is out of stock.', null)
             ->willReturnSelf();
 
@@ -901,7 +901,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('message', null)
             ->willReturnSelf();
 
@@ -1073,7 +1073,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('message')));
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addNotice')
+            ->method('addNoticeMessage')
             ->with('message', null)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
@@ -270,7 +270,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t delete the item from Wish List right now because of an error: Message.')
             ->willReturn(true);
 
@@ -355,7 +355,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t delete the item from the Wish List right now.')
             ->willReturn(true);
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
@@ -343,7 +343,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturn($postValue);
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($errorMessage)
             ->willReturnSelf();
 
@@ -501,7 +501,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception($exceptionMessage));
 
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($exceptionMessage)
             ->willReturnSelf();
 
@@ -685,7 +685,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('Your wish list has been shared.'))
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
@@ -249,7 +249,7 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t specify a product.')
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())
@@ -294,7 +294,7 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->never())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t specify a product.')
             ->willReturn(true);
 
@@ -433,12 +433,12 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('Test name has been updated in your Wish List.', null)
             ->willThrowException(new \Magento\Framework\Exception\LocalizedException(__('error-message')));
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('error-message', null)
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())
@@ -572,12 +572,12 @@ class UpdateItemOptionsTest extends \PHPUnit\Framework\TestCase
 
         $this->messageManager
             ->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('Test name has been updated in your Wish List.', null)
             ->willThrowException($exception);
         $this->messageManager
             ->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('We can\'t update your Wish List right now.', null)
             ->willReturn(true);
         $this->resultRedirectMock->expects($this->once())

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Shared/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Shared/CartTest.php
@@ -266,7 +266,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
 
         $successMessage = __('You added %1 to your shopping cart.', $productName);
         $this->messageManager->expects($this->any())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with($successMessage)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
@@ -228,7 +228,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productTwoName);
 
         $this->managerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('%1 product(s) have been added to shopping cart: %2.', 1, '"' . $productTwoName . '"'), null)
             ->willReturnSelf();
 
@@ -431,12 +431,12 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productTwoName);
 
         $this->managerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('%1 for "%2".', 'Localized Exception', $productTwoName), null)
             ->willReturnSelf();
 
         $this->managerMock->expects($this->at(1))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(
                 __(
                     'We couldn\'t add the following product(s) to the shopping cart: %1.',
@@ -580,7 +580,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->with($exception, []);
 
         $this->managerMock->expects($this->at(0))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t add this item to your shopping cart right now.'), null)
             ->willReturnSelf();
 
@@ -603,7 +603,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception());
 
         $this->managerMock->expects($this->at(1))
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with(__('We can\'t update the Wish List right now.'), null)
             ->willReturnSelf();
 
@@ -615,7 +615,7 @@ class ItemCarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($productTwoName);
 
         $this->managerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('%1 product(s) have been added to shopping cart: %2.', 1, '"' . $productOneName . '"'), null)
             ->willReturnSelf();
 

--- a/app/code/Magento/Wishlist/Test/Unit/Observer/AddToCartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Observer/AddToCartTest.php
@@ -167,7 +167,7 @@ class AddToCartTest extends \PHPUnit\Framework\TestCase
             ->with([])
             ->willReturnSelf();
         $this->messageManager->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with($message)
             ->willReturnSelf();
         $event->expects($this->once())


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
In this commit the usage of deprecated methods from `Magento\Framework\Message\Manager` were removed.

Example:

Rather than use:

`$this->messageManager->addSuccess($message)`

Now is using:

`$this->messageManager->addSuccessMessage($message)`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No issue was solved in this pull request.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
It's a general scenario.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
