### PR TITLE
getRegionHtmlSelect does not have configuration

### DIFF
--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,7 +158,7 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($value = null, $name = 'region', $state = 'state', $title = 'State/Province')
+    public function getRegionHtmlSelect($value = null, $name = 'region', $id = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
@@ -179,7 +179,7 @@ class Data extends \Magento\Framework\View\Element\Template
         )->setTitle(
             __($title)
         )->setId(
-            $state
+            $id
         )->setClass(
             'required-entry validate-state'
         )->setValue(

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,14 +158,15 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($defValue = null, $name = 'region', $stateId = 'state', $title = 'State/Province')
+    public function getRegionHtmlSelect($defValue = null, $name = 'region', 
+    $stateId = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
-	if ($defValue === null) {
-		$defValue = $this->getRegionId();
-	}
-		
+        if ($defValue === null) {
+            $defValue = $this->getRegionId();
+        }
+
         $cache = $this->_configCacheType->load($cacheKey);
         if ($cache) {
             $options = $this->getSerializer()->unserialize($cache);

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,7 +158,7 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($defValue = null, $name = 'region', $id = 'state', $title = 'State/Province')
+    public function getRegionHtmlSelect($defValue = null, $name = 'region', $stateId = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
@@ -180,7 +180,7 @@ class Data extends \Magento\Framework\View\Element\Template
         )->setTitle(
             __($title)
         )->setId(
-            $id
+            $stateId
         )->setClass(
             'required-entry validate-state'
         )->setValue(

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -101,40 +101,39 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect(
-        $defValue = null,
-        $name = 'region',
-        $stateId = 'state',
-        $title = 'State/Province'
-    ) {
+    public function getCountryHtmlSelect($defValue = null, $name = 'country_id', $id = 'country', $title = 'Country')
+    {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
-        $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
         if ($defValue === null) {
-            $defValue = $this->getRegionId();
+            $defValue = $this->getCountryId();
         }
+        $cacheKey = 'DIRECTORY_COUNTRY_SELECT_STORE_' . $this->_storeManager->getStore()->getCode();
         $cache = $this->_configCacheType->load($cacheKey);
         if ($cache) {
-            $options = $this->getSerializer()->unserialize($cache);
+            $options = unserialize($cache);
         } else {
-            $options = $this->getRegionCollection()->toOptionArray();
-            $this->_configCacheType->save($this->getSerializer()->serialize($options), $cacheKey);
+            $options = $this->getCountryCollection()
+                ->setForegroundCountries($this->getTopDestinations())
+                ->toOptionArray();
+            $this->_configCacheType->save(serialize($options), $cacheKey);
         }
         $html = $this->getLayout()->createBlock(
-            \Magento\Framework\View\Element\Html\Select::class
+            'Magento\Framework\View\Element\Html\Select'
         )->setName(
             $name
+        )->setId(
+            $id
         )->setTitle(
             __($title)
-        )->setId(
-            $stateId
-        )->setClass(
-            'required-entry validate-state'
         )->setValue(
-            intval($defValue)
+            $defValue
         )->setOptions(
             $options
+        )->setExtraParams(
+            'data-validate="{\'validate-select\':true}"'
         )->getHtml();
-        \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
+
+        \Magento\Framework\Profiler::stop('TEST: ' . __METHOD__);
         return $html;
     }
 

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,9 +158,10 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect(
+    public function getRegionHtmlSelect
+    (
         $defValue = null,
-        $name = 'region', 
+        $name = 'region',
         $stateId = 'state',
         $title = 'State/Province'
     )

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,7 +158,7 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($defValue = null,$name = 'region',$stateId = 'state',$title = 'State/Province')
+    public function getRegionHtmlSelect($defValue = null, $name = 'region', $stateId = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -101,65 +101,12 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getCountryHtmlSelect($defValue = null, $name = 'country_id', $id = 'country', $title = 'Country')
-    {
-        \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
-        if ($defValue === null) {
-            $defValue = $this->getCountryId();
-        }
-        $cacheKey = 'DIRECTORY_COUNTRY_SELECT_STORE_' . $this->_storeManager->getStore()->getCode();
-        $cache = $this->_configCacheType->load($cacheKey);
-        if ($cache) {
-            $options = unserialize($cache);
-        } else {
-            $options = $this->getCountryCollection()
-                ->setForegroundCountries($this->getTopDestinations())
-                ->toOptionArray();
-            $this->_configCacheType->save(serialize($options), $cacheKey);
-        }
-        $html = $this->getLayout()->createBlock(
-            'Magento\Framework\View\Element\Html\Select'
-        )->setName(
-            $name
-        )->setId(
-            $id
-        )->setTitle(
-            __($title)
-        )->setValue(
-            $defValue
-        )->setOptions(
-            $options
-        )->setExtraParams(
-            'data-validate="{\'validate-select\':true}"'
-        )->getHtml();
-
-        \Magento\Framework\Profiler::stop('TEST: ' . __METHOD__);
-        return $html;
-    }
-
-    /**
-     * @return \Magento\Directory\Model\ResourceModel\Region\Collection
-     */
-    public function getRegionCollection()
-    {
-        $collection = $this->getData('region_collection');
-        if ($collection === null) {
-            $collection = $this->_regionCollectionFactory->create()->addCountryFilter($this->getCountryId())->load();
-
-            $this->setData('region_collection', $collection);
-        }
-        return $collection;
-    }
-
-    /**
-     * @param null|string $defValue
-     * @param string $name
-     * @param string $id
-     * @param string $title
-     * @return string
-     */
-    public function getRegionHtmlSelect($defValue = null, $name = 'region', $stateId = 'state', $title = 'State/Province')
-    {
+    public function getRegionHtmlSelect(
+        $defValue = null,
+        $name = 'region',
+        $stateId = 'state',
+        $title = 'State/Province'
+    ) {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
         if ($defValue === null) {
@@ -184,6 +131,60 @@ class Data extends \Magento\Framework\View\Element\Template
             'required-entry validate-state'
         )->setValue(
             intval($defValue)
+        )->setOptions(
+            $options
+        )->getHtml();
+        \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
+        return $html;
+    }
+
+    /**
+     * @return \Magento\Directory\Model\ResourceModel\Region\Collection
+     */
+    public function getRegionCollection()
+    {
+        $collection = $this->getData('region_collection');
+        if ($collection === null) {
+            $collection = $this->_regionCollectionFactory->create()->addCountryFilter($this->getCountryId())->load();
+
+            $this->setData('region_collection', $collection);
+        }
+        return $collection;
+    }
+
+    /**
+     * @param null|string $defValue
+     * @param string $name
+     * @param string $id
+     * @param string $title
+     * @return string
+     */
+    public function getRegionHtmlSelect($value = null, $name = 'region', $state = 'state', $title = 'State/Province')
+    {
+        \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
+        $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
+        if ($value === null) {
+            $value = $this->getRegionId();
+        }
+        $cache = $this->_configCacheType->load($cacheKey);
+        if ($cache) {
+            $options = $this->getSerializer()->unserialize($cache);
+        } else {
+            $options = $this->getRegionCollection()->toOptionArray();
+            $this->_configCacheType->save($this->getSerializer()->serialize($options), $cacheKey);
+        }
+        $html = $this->getLayout()->createBlock(
+            \Magento\Framework\View\Element\Html\Select::class
+        )->setName(
+            $name
+        )->setTitle(
+            __($title)
+        )->setId(
+            $state
+        )->setClass(
+            'required-entry validate-state'
+        )->setValue(
+            intval($value)
         )->setOptions(
             $options
         )->getHtml();

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,13 +158,7 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect
-    (
-        $defValue = null,
-        $name = 'region',
-        $stateId = 'state',
-        $title = 'State/Province'
-    )
+    public function getRegionHtmlSelect($defValue = null,$name = 'region',$stateId = 'state',$title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -152,6 +152,10 @@ class Data extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * @param null|string $defValue
+     * @param string $name
+     * @param string $id
+     * @param string $title
      * @return string
      */
     public function getRegionHtmlSelect($defValue = null, $name = 'region', $id = 'state', $title = 'State/Province')

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -166,7 +166,6 @@ class Data extends \Magento\Framework\View\Element\Template
         if ($defValue === null) {
             $defValue = $this->getRegionId();
         }
-
         $cache = $this->_configCacheType->load($cacheKey);
         if ($cache) {
             $options = $this->getSerializer()->unserialize($cache);

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,8 +158,12 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($defValue = null, $name = 'region', 
-    $stateId = 'state', $title = 'State/Province')
+    public function getRegionHtmlSelect(
+        $defValue = null,
+        $name = 'region', 
+        $stateId = 'state',
+        $title = 'State/Province'
+    )
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,9 +158,10 @@ class Data extends \Magento\Framework\View\Element\Template
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
-		if ($defValue === null) {
-            $defValue = $this->getRegionId();
-        }
+	if ($defValue === null) {
+		$defValue = $this->getRegionId();
+	}
+		
         $cache = $this->_configCacheType->load($cacheKey);
         if ($cache) {
             $options = $this->getSerializer()->unserialize($cache);

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -154,29 +154,32 @@ class Data extends \Magento\Framework\View\Element\Template
     /**
      * @return string
      */
-    public function getRegionHtmlSelect()
+    public function getRegionHtmlSelect($defValue = null, $name = 'region', $id = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
+		if ($defValue === null) {
+            $defValue = $this->getRegionId();
+        }
         $cache = $this->_configCacheType->load($cacheKey);
         if ($cache) {
-            $options = unserialize($cache);
+            $options = $this->getSerializer()->unserialize($cache);
         } else {
             $options = $this->getRegionCollection()->toOptionArray();
-            $this->_configCacheType->save(serialize($options), $cacheKey);
+            $this->_configCacheType->save($this->getSerializer()->serialize($options), $cacheKey);
         }
         $html = $this->getLayout()->createBlock(
-            'Magento\Framework\View\Element\Html\Select'
+            \Magento\Framework\View\Element\Html\Select::class
         )->setName(
-            'region'
+            $name
         )->setTitle(
-            __('State/Province')
+            __($title)
         )->setId(
-            'state'
+            $id
         )->setClass(
             'required-entry validate-state'
         )->setValue(
-            intval($this->getRegionId())
+            intval($defValue)
         )->setOptions(
             $options
         )->getHtml();

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -93,6 +93,40 @@ class Data extends \Magento\Framework\View\Element\Template
         );
         return !empty($destinations) ? explode(',', $destinations) : [];
     }
+    
+    /**
+     * @deprecated
+     * @return string
+     */
+    public function getRegionHtmlSelect()
+    {
+        \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
+        $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
+        $cache = $this->_configCacheType->load($cacheKey);
+        if ($cache) {
+            $options = $this->getSerializer()->unserialize($cache);
+        } else {
+            $options = $this->getRegionCollection()->toOptionArray();
+            $this->_configCacheType->save($this->getSerializer()->serialize($options), $cacheKey);
+        }
+        $html = $this->getLayout()->createBlock(
+            \Magento\Framework\View\Element\Html\Select::class
+        )->setName(
+            'region'
+        )->setTitle(
+            __('State/Province')
+        )->setId(
+            'state'
+        )->setClass(
+            'required-entry validate-state'
+        )->setValue(
+            intval($this->getRegionId())
+        )->setOptions(
+            $options
+        )->getHtml();
+        \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
+        return $html;
+    }
 
     /**
      * @param null|string $defValue
@@ -151,6 +185,8 @@ class Data extends \Magento\Framework\View\Element\Template
         return $collection;
     }
 
+    
+    
     /**
      * @param null|string $defValue
      * @param string $name
@@ -158,7 +194,7 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($value = null, $name = 'region', $htmlId = 'state', $title = 'State/Province')
+    public function getRegionSelect($value = null, $name = 'region', $htmlId = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -185,8 +185,6 @@ class Data extends \Magento\Framework\View\Element\Template
         return $collection;
     }
 
-    
-    
     /**
      * @param null|string $defValue
      * @param string $name

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -158,7 +158,7 @@ class Data extends \Magento\Framework\View\Element\Template
      * @param string $title
      * @return string
      */
-    public function getRegionHtmlSelect($value = null, $name = 'region', $id = 'state', $title = 'State/Province')
+    public function getRegionHtmlSelect($value = null, $name = 'region', $htmlId = 'state', $title = 'State/Province')
     {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
@@ -179,7 +179,7 @@ class Data extends \Magento\Framework\View\Element\Template
         )->setTitle(
             __($title)
         )->setId(
-            $id
+            $htmlId
         )->setClass(
             'required-entry validate-state'
         )->setValue(


### PR DESCRIPTION
### Description

When i use the getRegionHtmlSelect function in custom module there is not way to pass argument for create region drop down.  This arguments available in getCountryHtmlSelect in same way need to implement in getRegionHtmlSelect .

### Fixed Issues 
magento/magento2#7491:Method does not have configuration

### Manual testing scenarios
1. Created the address from customer account. 
2. Created the Order.
3. Created and Edit the customer from admin with address details. 

### Contribution checklist
   [X] Pull request has a meaningful description of its purpose
   [X] All commits are accompanied by meaningful commit messages
   [ ] All new or changed code is covered with unit/integration tests 
  [ ] All automated tests passed successfully (all builds on Travis CI are green)

