### PR TITLE
[Forwardport] Move breadcrumb json configuration to viewmodel

### DIFF
--- a/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
@@ -9,6 +9,7 @@ namespace Magento\Catalog\ViewModel\Product;
 
 use Magento\Catalog\Helper\Data;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
@@ -43,13 +44,13 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     public function __construct(
         Data $catalogData,
         ScopeConfigInterface $scopeConfig,
-        Json $json
+        Json $json = null
     ) {
         parent::__construct();
 
         $this->catalogData = $catalogData;
         $this->scopeConfig = $scopeConfig;
-        $this->json = $json;
+        $this->json = $json ?: ObjectManager::getInstance()->get(Json::class);
     }
 
     /**

--- a/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
@@ -10,6 +10,7 @@ namespace Magento\Catalog\ViewModel\Product;
 use Magento\Catalog\Helper\Data;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DataObject;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 
 /**
@@ -30,17 +31,25 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     private $scopeConfig;
 
     /**
+     * @var Json
+     */
+    private $json;
+
+    /**
      * @param Data $catalogData
      * @param ScopeConfigInterface $scopeConfig
+     * @param Json $json
      */
     public function __construct(
         Data $catalogData,
-        ScopeConfigInterface $scopeConfig
+        ScopeConfigInterface $scopeConfig,
+        Json $json
     ) {
         parent::__construct();
 
         $this->catalogData = $catalogData;
         $this->scopeConfig = $scopeConfig;
+        $this->json = $json;
     }
 
     /**
@@ -79,5 +88,21 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
         return $this->catalogData->getProduct() !== null
             ? $this->catalogData->getProduct()->getName()
             : '';
+    }
+
+    /**
+     * Returns breadcrumb json.
+     *
+     * @return string
+     */
+    public function getJsonConfiguration()
+    {
+        return $this->json->serialize([
+            'breadcrumbs' => [
+                'categoryUrlSuffix' => $this->getCategoryUrlSuffix(),
+                'userCategoryPathInUrl' => (int)$this->isCategoryUsedInProductUrl(),
+                'product' => $this->getProductName()
+            ]
+        ]);
     }
 }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
@@ -7,11 +7,4 @@
 /** @var \Magento\Catalog\ViewModel\Product\Breadcrumbs $viewModel */
 $viewModel = $block->getData('viewModel');
 ?>
-<div class="breadcrumbs" data-mage-init='{
-    "breadcrumbs": {
-        "categoryUrlSuffix": "<?= $block->escapeHtml($viewModel->getCategoryUrlSuffix()); ?>",
-        "useCategoryPathInUrl": <?= (int)$viewModel->isCategoryUsedInProductUrl(); ?>,
-        "product": "<?= $block->escapeHtml($block->escapeJs($viewModel->getProductName())); ?>"
-    }
-}'>
-</div>
+<div class="breadcrumbs" data-mage-init='<?= $viewModel->getJsonConfiguration() ?>'></div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml
@@ -7,4 +7,4 @@
 /** @var \Magento\Catalog\ViewModel\Product\Breadcrumbs $viewModel */
 $viewModel = $block->getData('viewModel');
 ?>
-<div class="breadcrumbs" data-mage-init='<?= $viewModel->getJsonConfiguration() ?>'></div>
+<div class="breadcrumbs" data-mage-init='<?= /* @escapeNotVerified */ $viewModel->getJsonConfiguration() ?>'></div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15521
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Move breadcrumb json configuration to viewmodel and serialize it using Magento json serializer
Tweak code motivated by a discussion in pull request #15162 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
