### PR TITLE
[FIX] dev:di:info duplicates plugin info

### DIFF
--- a/app/code/Magento/Developer/Model/Di/PluginList.php
+++ b/app/code/Magento/Developer/Model/Di/PluginList.php
@@ -143,6 +143,10 @@ class PluginList extends Interception\PluginList\PluginList
     {
         if ($methodTypes & $typeCode) {
             if (!array_key_exists($pluginInstance, $this->pluginList[$this->pluginTypeMapping[$typeCode]])) {
+                $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance] = [];
+            }
+
+            if (!in_array($pluginMethod, $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance])) {
                 $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance][] = $pluginMethod;
             }
         }

--- a/app/code/Magento/Developer/Model/Di/PluginList.php
+++ b/app/code/Magento/Developer/Model/Di/PluginList.php
@@ -143,9 +143,8 @@ class PluginList extends Interception\PluginList\PluginList
     {
         if ($methodTypes & $typeCode) {
             if (!array_key_exists($pluginInstance, $this->pluginList[$this->pluginTypeMapping[$typeCode]])) {
-                $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance] = [];
+                $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance][] = $pluginMethod;
             }
-            $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance][] = $pluginMethod ;
         }
     }
 }


### PR DESCRIPTION
### Description
Hello,

Looks like the execution of `dev:di:info` duplicates info about plugins by for the or the Preference if the same plugin class and its type were introduced in plugins by class name section.

For example, execute `php bin/magento dev:di:info "Magento\Sales\Model\Order"
` and the output result will be
![image](https://user-images.githubusercontent.com/5318512/42135988-42b6e238-7d5c-11e8-8a39-3c946e2cec1b.png)

with provided fix it will look like this

![image](https://user-images.githubusercontent.com/5318512/42135999-68476a54-7d5c-11e8-8c57-1c756442acee.png)

The problem is seems to be in this method: 
```php
    private function addPluginToList($pluginInstance, $pluginMethod, $methodTypes, $typeCode)
    {
        if ($methodTypes & $typeCode) {
            if (!array_key_exists($pluginInstance, $this->pluginList[$this->pluginTypeMapping[$typeCode]])) {
                $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance] = [];
            }
            $this->pluginList[$this->pluginTypeMapping[$typeCode]][$pluginInstance][] = $pluginMethod ;
        }
    }
```
It checks whether value exists in array or not. And if it exists it will be added +1 time. But it may logically to add an item once if it not exists.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
execute `dev:di:info` command for class and check "Plugins for the Preference:" section. Seems to have duplicated info.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
