### PR TITLE
[Forwardport] Declare module namespace before template path name(Magento_Sales::order/info.phtml).

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Info.php
+++ b/app/code/Magento/Sales/Block/Order/Info.php
@@ -23,7 +23,7 @@ class Info extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/info.phtml';
+    protected $_template = 'Magento_Sales::order/info.phtml';
 
     /**
      * Core registry


### PR DESCRIPTION
### Original pull request
#16206 
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When we override block info(Magento\Sales\Block\Order\Info) to my custom module.
It throws an error and finding `order/info.phtml` in my custom module.
I tried to extend Block Magento\Sales\Block\Order\Info from my custom module.
```
1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'order/info.phtml' in module: 'Vendor_Module' block's name: 'sales.order.info'
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Declare module namespace before template path name.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. I override info block
```
<preference for="Magento\Sales\Block\Order\Info"
				type="Vendor\Module\Block\Order\Info" />
```
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
