### PR TITLE
Declare module namespace before template path name(Magento_Sales::order/history.phtml).

### DIFF
--- a/app/code/Magento/Sales/Block/Order/History.php
+++ b/app/code/Magento/Sales/Block/Order/History.php
@@ -19,7 +19,7 @@ class History extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/history.phtml';
+    protected $_template = 'Magento_Sales::order/history.phtml';
 
     /**
      * @var \Magento\Sales\Model\ResourceModel\Order\CollectionFactory


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When we override block history(Magento\Sales\Block\Order\History) to my custom module.
It throws an error and finding order/history.phtml in my custom module.
I tried to extend Block Magento\Sales\Block\Order\History from my custom module.

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'order/history.phtml' in module: 'Vendor_Module' block's name: 'sales.order.history'
```

### Fixed Issues (if relevant)
1. Declare module namespace before template path name.
`protected $_template = 'Magento_Sales::order/history.phtml';`

### Manual testing scenarios
1. I override history block
`<preference for="Magento\Sales\Block\Order\History" type="Vendor\Module\Block\Order\History" />`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)