### PR TITLE
MSI-1411: Add new rule to copy paste detector blacklist to avoid cove…

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/common.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/common.txt
@@ -201,3 +201,4 @@ IntegrationConfig.php
 setup/performance-toolkit/aggregate-report
 Magento/MessageQueue/Setup
 Magento/Elasticsearch/Elasticsearch5
+Test/_files


### PR DESCRIPTION
### Description
In the MSI modules all fixtures for tests are in `<Module_Name>/Test/_data` which is different from Magento current implementations.
In order to avoid falling copy paste detector tests on the fixtures has been added a new rule to the blacklist.

### Fixed Issues (if relevant)
Static test falling

PS. It's very important for MSI ;)
