### PR TITLE
Fix the special price expression.

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/DefaultPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/DefaultPrice.php
@@ -456,7 +456,7 @@ class DefaultPrice extends AbstractIndexer implements PriceInterface
         $specialFromExpr = "{$specialFrom} IS NULL OR {$specialFromDate} <= {$currentDate}";
         $specialToExpr = "{$specialTo} IS NULL OR {$specialToDate} >= {$currentDate}";
         $specialPriceExpr = $connection->getCheckSql(
-            "{$specialPrice} IS NOT NULL AND {$specialFromExpr} AND {$specialToExpr}",
+            "{$specialPrice} IS NOT NULL AND ({$specialFromExpr}) AND ({$specialToExpr})",
             $specialPrice,
             $maxUnsignedBigint
         );


### PR DESCRIPTION
### Description
The priority of "OR" is lower then "AND". That's why we have to add brackets around OR-expresstion.

### Fixed Issues (if relevant)
Without this fix, catalog_product_price generate incorrect price data.