### PR TITLE
Fix zero price simple failed to resolve as default

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Pricing/Price/ConfigurablePriceResolver.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Price/ConfigurablePriceResolver.php
@@ -64,7 +64,7 @@ class ConfigurablePriceResolver implements PriceResolverInterface
 
         foreach ($this->lowestPriceOptionsProvider->getProducts($product) as $subProduct) {
             $productPrice = $this->priceResolver->resolvePrice($subProduct);
-            $price = $price ? min($price, $productPrice) : $productPrice;
+            $price = isset($price) ? min($price, $productPrice) : $productPrice;
         }
 
         return (float)$price;

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Price/ConfigurablePriceResolverTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Price/ConfigurablePriceResolverTest.php
@@ -100,6 +100,28 @@ class ConfigurablePriceResolverTest extends \PHPUnit\Framework\TestCase
                 ],
                 $expectedPrice = 5.00,
             ],
+            'Single variants at price null (null), should return 0.00 (float)' => [
+                $variantPrices = [
+                    null,
+                ],
+                $expectedPrice = 0.00,
+            ],
+            'Multiple variants at price 0, 10, 20, should return 0.00 (float)' => [
+                $variantPrices = [
+                    0,
+                    10,
+                    20,
+                ],
+                $expectedPrice = 0.00,
+            ],
+            'Multiple variants at price 10, 0, 20, should return 0.00 (float)' => [
+                $variantPrices = [
+                    10,
+                    0,
+                    20,
+                ],
+                $expectedPrice = 0.00,
+            ],
         ];
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Price/ConfigurablePriceResolverTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Price/ConfigurablePriceResolverTest.php
@@ -55,24 +55,31 @@ class ConfigurablePriceResolverTest extends \PHPUnit\Framework\TestCase
      * situation: one product is supplying the price, which could be a price of zero (0)
      *
      * @dataProvider resolvePriceDataProvider
+     *
+     * @param $variantPrices
+     * @param $expectedPrice
      */
-    public function testResolvePrice($expectedValue)
+    public function testResolvePrice($variantPrices, $expectedPrice)
     {
-        $price = $expectedValue;
-
         $product = $this->getMockBuilder(
             \Magento\Catalog\Model\Product::class
         )->disableOriginalConstructor()->getMock();
 
         $product->expects($this->never())->method('getSku');
 
-        $this->lowestPriceOptionsProvider->expects($this->once())->method('getProducts')->willReturn([$product]);
-        $this->priceResolver->expects($this->once())
-            ->method('resolvePrice')
-            ->with($product)
-            ->willReturn($price);
+        $products = array_map(function () {
+            return $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+        }, $variantPrices);
 
-        $this->assertEquals($expectedValue, $this->resolver->resolvePrice($product));
+        $this->lowestPriceOptionsProvider->expects($this->once())->method('getProducts')->willReturn($products);
+        $this->priceResolver
+            ->method('resolvePrice')
+            ->willReturnOnConsecutiveCalls(...$variantPrices);
+
+        $actualPrice = $this->resolver->resolvePrice($product);
+        self::assertSame($expectedPrice, $actualPrice);
     }
 
     /**
@@ -81,8 +88,18 @@ class ConfigurablePriceResolverTest extends \PHPUnit\Framework\TestCase
     public function resolvePriceDataProvider()
     {
         return [
-            'price of zero' => [0.00],
-            'price of five' => [5],
+            'Single variant at price 0.00 (float), should return 0.00 (float)' => [
+                $variantPrices = [
+                    0.00,
+                ],
+                $expectedPrice = 0.00,
+            ],
+            'Single variant at price 5 (integer), should return 5.00 (float)' => [
+                $variantPrices = [
+                    5,
+                ],
+                $expectedPrice = 5.00,
+            ],
         ];
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When two simple products of a configurable have different prices, the lowest price simple product is expected to resolve as the default price showing on product detail page.

If one of the simple products has price=0, it will fail to resolve as default.

Notice that it is an edge case having price=0 product. It probably is still worth fixing.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Can't find any related issues at the moment

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set up a configurable with two simple products. One simple have price at £3, another at £0
2. The simple products with *LOWER* product id must be at £0
3. Go to product detail page of the configurable

Expected result: Default price rendered as £0
Actual result: Default price rendered as £3

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
