### PR TITLE
[Backport #16458] Add missing showInStore attributes

### DIFF
--- a/app/code/Magento/Braintree/etc/adminhtml/system.xml
+++ b/app/code/Magento/Braintree/etc/adminhtml/system.xml
@@ -44,7 +44,7 @@
                         <comment>http://docs.magento.com/m2/ce/user_guide/payment/braintree.html</comment>
                         <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Hint</frontend_model>
                     </group>
-                    <group id="braintree_required" translate="label" showInDefault="1" showInWebsite="1" sortOrder="5">
+                    <group id="braintree_required" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="5">
                         <comment><![CDATA[<a href="https://www.braintreegateway.com/login" target="_blank">Click here to login to your existing Braintree account</a>. Or to setup a new account and accept payments on your website, <a href="https://apply.braintreegateway.com/signup/us" target="_blank">click here to signup for a Braintree account</a>.<br><br>Powered by <a href="https://www.braintreepayments.com/features/hosted-fields" target="_blank">Braintree v.zero with Hosted Fields</a> latest technology. Hosted Fields are small, transparent iframes that replace the sensitive credit card inputs in your checkout flow - helping you meet the latest data security requirements while ensuring your customization doesn't suffer. <a href="https://www.braintreepayments.com/features/hosted-fields" target="_blank">Find out more</a>.]]></comment>
                         <label>Basic Braintree Settings</label>
                         <attribute type="expanded">1</attribute>
@@ -78,7 +78,7 @@
                             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                         </field>
                     </group>
-                    <group id="braintree_advanced" translate="label" showInDefault="1" showInWebsite="1" sortOrder="20">
+                    <group id="braintree_advanced" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="20">
                         <label>Advanced Braintree Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="braintree_cc_vault_title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -126,7 +126,7 @@
                             <config_path>payment/braintree/sort_order</config_path>
                         </field>
                     </group>
-                    <group id="braintree_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="30">
+                    <group id="braintree_country_specific" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="30">
                         <label>Country Specific Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -147,7 +147,7 @@
                             <config_path>payment/braintree/countrycreditcard</config_path>
                         </field>
                     </group>
-                    <group id="braintree_paypal" translate="label" showInDefault="1" showInWebsite="1" sortOrder="40">
+                    <group id="braintree_paypal" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="40">
                         <label>PayPal through Braintree</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -216,7 +216,7 @@
                             <config_path>payment/braintree_paypal/skip_order_review</config_path>
                         </field>
                     </group>
-                    <group id="braintree_3dsecure" translate="label" showInDefault="1" showInWebsite="1" sortOrder="41">
+                    <group id="braintree_3dsecure" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="41">
                         <label>3D Secure Verification Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="verify_3dsecure" translate="label" type="select" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -240,7 +240,7 @@
                             <config_path>payment/braintree/verify_specific_countries</config_path>
                         </field>
                     </group>
-                    <group id="braintree_dynamic_descriptor" translate="label" showInDefault="1" showInWebsite="1" sortOrder="50">
+                    <group id="braintree_dynamic_descriptor" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="50">
                         <label>Dynamic Descriptors</label>
                         <comment><![CDATA[Dynamic descriptors are sent on a per-transaction basis and define what will appear on your customers credit card statements for a specific purchase.
                             The clearer the description of your product, the less likely customers will issue chargebacks due to confusion or non-recognition.


### PR DESCRIPTION
### Description
This PR as a backport for https://github.com/magento/magento2/pull/16458

Add missing `showInStore` attributes on Braintree configuration as there are some values that are changeable on store view (title, descriptors, merchant name override) and are not accessible from store view level due to the missing store view level permission for the containing group.

Braintree configuration offers the possibility to change following fields on store view level:
* Basic Braintree Settings => Title
* PayPal through Braintree => Title
* PayPal through Braintree => Override Merchant Name
* Dynamic Descriptors => Name
* Dynamic Descriptors => Phone
* Dynamic Descriptors => URL

All the fields are correctly shown in default config and on website level, but when changing to storeview, nothing is shown at all when expanding Braintree section.

### Fixed Issues (if relevant)
-

### Manual testing scenarios
1. Go to Stores => Configuration => Sales => Payment Methods
2. Click "Configure" next to "Braintree" under "Recommended Solutions"
3. All groups are shown
4. Switch from "Default Config" to a random Store View
5. Repeat step 2 - no groups are shown

After applying the PR, the above mentioned fields in their respective groups are shown.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/16458