### PR TITLE
Update mini-cart checkout translations

### DIFF
--- a/app/code/Magento/Checkout/i18n/en_US.csv
+++ b/app/code/Magento/Checkout/i18n/en_US.csv
@@ -178,3 +178,6 @@ Payment,Payment
 "Thank you for your purchase!","Thank you for your purchase!"
 "Password", "Password"
 "Something went wrong while saving the page. Please refresh the page and try again.","Something went wrong while saving the page. Please refresh the page and try again."
+"Item in Cart","Item in Cart"
+"Items in Cart","Items in Cart"
+"Close","Close"


### PR DESCRIPTION
### Description
Add missing translations found in https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios
1. Install language pack other than English.
2. Check translations in mini cart.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)