### PR TITLE
fix icon color variable naming

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_CatalogSearch/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_CatalogSearch/web/css/source/_module.less
@@ -36,9 +36,9 @@
             @_icon-font-content: @icon-search,
             @_icon-font-size: 35px,
             @_icon-font-line-height: 33px,
-            @_icon-font-color: @minicart-icons-color,
-            @_icon-font-color-hover: @minicart-icons-color-hover,
-            @_icon-font-color-active: @minicart-icons-color-hover,
+            @_icon-font-color: @header-icons-color,
+            @_icon-font-color-hover: @header-icons-color-hover,
+            @_icon-font-color-active: @header-icons-color-hover,
             @_icon-font-text-hide: true
             );
             display: inline-block;

--- a/app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less
@@ -37,9 +37,9 @@
             @_icon-font-size: 22px,
             @_icon-font-line-height: 28px,
             @_icon-font-margin: 0 @indent__s 0 0,
-            @_icon-font-color: @minicart-icons-color,
-            @_icon-font-color-hover: @minicart-icons-color-hover,
-            @_icon-font-color-active: @minicart-icons-color-hover,
+            @_icon-font-color: @header-icons-color,
+            @_icon-font-color-hover: @header-icons-color-hover,
+            @_icon-font-color-active: @header-icons-color-hover,
             @_icon-font-text-hide: true
             );
             display: inline-block;


### PR DESCRIPTION
Search icon should not be defined by minicart icon colors and header icon variables should used instead. 

### Description
Changed search icon to use header icons color variables

### Fixed Issues (if relevant)


### Manual testing scenarios
visually nothing changed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
