### PR TITLE
[Forwardport] Coupon API not working for guest user

### DIFF
--- a/app/code/Magento/Quote/Model/CouponManagement.php
+++ b/app/code/Magento/Quote/Model/CouponManagement.php
@@ -55,6 +55,9 @@ class CouponManagement implements CouponManagementInterface
         if (!$quote->getItemsCount()) {
             throw new NoSuchEntityException(__('The "%1" Cart doesn\'t contain products.', $cartId));
         }
+        if (!$quote->getStoreId()) {
+            throw new NoSuchEntityException(__('Cart isn\'t assigned to correct store'));
+        }
         $quote->getShippingAddress()->setCollectShippingRates(true);
 
         try {

--- a/app/code/Magento/Quote/Test/Unit/Model/CouponManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/CouponManagementTest.php
@@ -47,6 +47,7 @@ class CouponManagementTest extends \PHPUnit\Framework\TestCase
                 'save',
                 'getShippingAddress',
                 'getCouponCode',
+                'getStoreId',
                 '__wakeup'
             ]);
         $this->quoteAddressMock = $this->createPartialMock(\Magento\Quote\Model\Quote\Address::class, [
@@ -98,6 +99,9 @@ class CouponManagementTest extends \PHPUnit\Framework\TestCase
         $cartId = 33;
         $couponCode = '153a-ABC';
 
+        $this->storeMock->expects($this->any())->method('getId')->will($this->returnValue(1));
+        $this->quoteMock->expects($this->once())->method('getStoreId')->willReturn($this->returnValue(1));
+
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getActive')->with($cartId)->will($this->returnValue($this->quoteMock));
         $this->quoteMock->expects($this->once())->method('getItemsCount')->will($this->returnValue(12));
@@ -125,6 +129,9 @@ class CouponManagementTest extends \PHPUnit\Framework\TestCase
         $cartId = 33;
         $couponCode = '153a-ABC';
 
+        $this->storeMock->expects($this->any())->method('getId')->will($this->returnValue(1));
+        $this->quoteMock->expects($this->once())->method('getStoreId')->willReturn($this->returnValue(1));
+
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getActive')->with($cartId)->will($this->returnValue($this->quoteMock));
         $this->quoteMock->expects($this->once())->method('getItemsCount')->will($this->returnValue(12));
@@ -143,6 +150,9 @@ class CouponManagementTest extends \PHPUnit\Framework\TestCase
     {
         $cartId = 33;
         $couponCode = '153a-ABC';
+
+        $this->storeMock->expects($this->any())->method('getId')->will($this->returnValue(1));
+        $this->quoteMock->expects($this->once())->method('getStoreId')->willReturn($this->returnValue(1));
 
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getActive')->with($cartId)->will($this->returnValue($this->quoteMock));


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15320

<!--- Provide a general summary of the Pull Request in the Title above -->
issue/14056 - Coupon API not working for guest user
https://github.com/magento/magento2/issues/14056

### Description
This is a forward **port** for the following PR: https://github.com/magento/magento2/pull/15320
<!--- Provide a description of the changes proposed in the pull request -->
I think everything is fine with the code. Reason is that programmers don't use API properly. With 1 step when cart is being created it's already wrong because quote doesn't contain proper store id. When cart is being added by API it has store id 0. So instead of adding by 

/rest/V1/guest-carts  (which is standard in swagger)

we should use

/rest/default/V1/guest-carts

By using store code in URL we provide store id to quote. 

Then coupon code added by API works like charm.

So reason is some kind of ignorance. We've decided to provide better validation message while adding coupon code to inform programmer that he has wrong quote and that problem is rather there.

I think that some example would be useful in API documentation to show how to use API properly.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14056: Coupon API not working for guest user

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create guest cart by API
2. Add product to cart by API
3. Create coupon and rule in admin panel
4. Add coupon to cart by API
5. See exception "Coupon code is not valid"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
