### PR TITLE
$block->getTotals() is not countable

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Totalbar.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Totalbar.php
@@ -50,7 +50,7 @@ class Totalbar extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
      *
      * @return array
      */
-    protected function getTotals()
+    public function getTotals()
     {
         return $this->_totals;
     }


### PR DESCRIPTION
### Description

Fix issue where $block->getTotals() is not countable in Magento/Sales/view/adminhtml/templates/order/totalbar.php
getTotals() is set to protected in block not allowing template to access the method.

### Manual testing scenarios

1. Setup check payment method.
2. Place order on frontend. 
3. Attempt to process invoice in backend.
4. Unable to process invoice because of PHP error. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
