### PR TITLE
Trim email address in newsletter, forgot password, checkout login and email to a friend form

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
@@ -22,7 +22,8 @@
                        type="email"
                        data-bind="
                             textInput: email,
-                            hasFocus: emailFocused"
+                            hasFocus: emailFocused,
+                            mageInit: {'mage/trim-input':{}}"
                        name="username"
                        data-validate="{required:true, 'validate-email':true}"
                        id="customer-email" />

--- a/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
@@ -20,7 +20,7 @@
         <div class="field email required">
             <label for="email_address" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" alt="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmailValue()) ?>" data-validate="{required:true, 'validate-email':true}">
+                <input type="email" name="email" alt="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmailValue()) ?>" data-mage-init='{"mage/trim-input":{}}' data-validate="{required:true, 'validate-email':true}">
             </div>
         </div>
         <?= $block->getChildHtml('form_additional_info') ?>

--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -23,6 +23,7 @@
                 <div class="control">
                     <input name="email" type="email" id="newsletter"
                                 placeholder="<?= $block->escapeHtmlAttr(__('Enter your email address')) ?>"
+                                data-mage-init='{"mage/trim-input":{}}'
                                 data-validate="{required:true, 'validate-email':true}"/>
                 </div>
             </div>

--- a/app/code/Magento/SendFriend/view/frontend/templates/send.phtml
+++ b/app/code/Magento/SendFriend/view/frontend/templates/send.phtml
@@ -35,6 +35,7 @@
             <div class="control">
                 <input name="recipients[email][<%- data._index_ %>]" title="<?= $block->escapeHtmlAttr(__('Email')) ?>"
                        id="recipients-email<%- data._index_ %>" type="email" class="input-text"
+                       data-mage-init='{"mage/trim-input":{}}'
                        data-validate="{required:true, 'validate-email':true}"/>
             </div>
         </div>
@@ -72,7 +73,8 @@
             <label for="sender-email" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
                 <input name="sender[email]" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>" id="sender-email" type="text" class="input-text"
+                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>" id="sender-email" type="email" class="input-text"
+                       data-mage-init='{"mage/trim-input":{}}'
                        data-validate="{required:true, 'validate-email':true}"/>
             </div>
         </div>

--- a/app/code/Magento/Theme/view/frontend/web/js/row-builder.js
+++ b/app/code/Magento/Theme/view/frontend/web/js/row-builder.js
@@ -144,7 +144,7 @@ define([
 
             $(tmpl).appendTo(row);
 
-            $(this.options.rowContainer).append(row);
+            $(this.options.rowContainer).append(row).trigger('contentUpdated');
 
             row.addClass(this.options.additionalRowClass);
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Related to issue: #6058 

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Trim email address by remove leading or trailing space on following forms.
- Newsletter
- Checkout login
- Forgot your password
- Email to a Friend

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6058: IE11 user login email validation fails if field has leading or trailing space

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open forgot your password page in Firefox or IE browser.
2. Try to add space before entering an email address in the Email field.
3. Copy `" johndoe@domain.com "` and paste in the Email field. It will automatically remove leading or trailing space.
4. Check same on the footer newsletter form
5. Check same by adding a product to cart and go to checkout page without login. Check an Email Address field under the Shipping Address section.
6. After login, go to the product view page and go to Email to a Friend form. Check an Email field under Sender and Invitee sections.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
