### PR TITLE
[update] enhance performance on large catalog

### DIFF
--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -178,26 +178,26 @@ class UpgradeData implements UpgradeDataInterface
      */
     public function fillQuoteAddressIdInSalesOrderAddress(ModuleDataSetupInterface $setup)
     {
-        $salesOrderAddressTable = $setup->getTable('sales_order_address');
+        $addressTable = $setup->getTable('sales_order_address');
         $updateOrderAddress = $setup->getConnection()
             ->select()
             ->joinInner(
                 ['sales_order' => $setup->getTable('sales_order')],
-                $salesOrderAddressTable . '.parent_id = sales_order.entity_id',
+                $addressTable . '.parent_id = sales_order.entity_id',
                 ['quote_address_id' => 'quote_address.address_id']
             )
             ->joinInner(
                 ['quote_address' => $setup->getTable('quote_address')],
                 'sales_order.quote_id = quote_address.quote_id 
-                AND ' . $salesOrderAddressTable . '.address_type = quote_address.address_type',
+                AND ' . $addressTable . '.address_type = quote_address.address_type',
                 []
             )
             ->where(
-                $salesOrderAddressTable . '.quote_address_id IS NULL'
+                $addressTable . '.quote_address_id IS NULL'
             );
         $updateOrderAddress = $setup->getConnection()->updateFromSelect(
             $updateOrderAddress,
-            $salesOrderAddressTable
+            $addressTable
         );
         $setup->getConnection()->query($updateOrderAddress);
     }

--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -173,31 +173,30 @@ class UpgradeData implements UpgradeDataInterface
 
     /**
      * Fill quote_address_id in table sales_order_address if it is empty.
+     *
+     * @param ModuleDataSetupInterface $setup
      */
-    public function fillQuoteAddressIdInSalesOrderAddress()
+    public function fillQuoteAddressIdInSalesOrderAddress(ModuleDataSetupInterface $setup)
     {
-        $addressCollection = $this->addressCollectionFactory->create();
-        $addressCollection->addFieldToFilter('quote_address_id', ['null' => true]);
-        
-        /** @var \Magento\Sales\Model\Order\Address $orderAddress */
-        foreach ($addressCollection as $orderAddress) {
-            $orderId = $orderAddress->getParentId();
-            $addressType = $orderAddress->getAddressType();
-
-            /** @var \Magento\Sales\Model\Order $order */
-            $order = $this->orderFactory->create()->load($orderId);
-            $quoteId = $order->getQuoteId();
-            $quote = $this->quoteFactory->create()->load($quoteId);
-
-            if ($addressType == \Magento\Sales\Model\Order\Address::TYPE_SHIPPING) {
-                $quoteAddressId = $quote->getShippingAddress()->getId();
-                $orderAddress->setData('quote_address_id', $quoteAddressId);
-            } elseif ($addressType == \Magento\Sales\Model\Order\Address::TYPE_BILLING) {
-                $quoteAddressId = $quote->getBillingAddress()->getId();
-                $orderAddress->setData('quote_address_id', $quoteAddressId);
-            }
-
-            $orderAddress->save();
-        }
+        $updateOrderAddress = $setup->getConnection()
+            ->select()
+            ->joinInner(
+                ['sales_order' => $setup->getTable('sales_order')],
+                'sales_order_address.parent_id = sales_order.entity_id',
+                ['quote_address_id' => 'quote_address.address_id']
+            )
+            ->joinInner(
+                ['quote_address' => $setup->getTable('quote_address')],
+                'sales_order.quote_id = quote_address.quote_id AND sales_order_address.address_type = quote_address.address_type',
+                []
+            )
+            ->where(
+                'sales_order_address.quote_address_id IS NULL'
+            );
+        $updateOrderAddress = $setup->getConnection()->updateFromSelect(
+            $updateOrderAddress,
+            $setup->getTable('sales_order_address')
+        );
+        $setup->getConnection()->query($updateOrderAddress);
     }
 }

--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -178,25 +178,26 @@ class UpgradeData implements UpgradeDataInterface
      */
     public function fillQuoteAddressIdInSalesOrderAddress(ModuleDataSetupInterface $setup)
     {
+        $salesOrderAddressTable = $setup->getTable('sales_order_address');
         $updateOrderAddress = $setup->getConnection()
             ->select()
             ->joinInner(
                 ['sales_order' => $setup->getTable('sales_order')],
-                'sales_order_address.parent_id = sales_order.entity_id',
+                $salesOrderAddressTable . '.parent_id = sales_order.entity_id',
                 ['quote_address_id' => 'quote_address.address_id']
             )
             ->joinInner(
                 ['quote_address' => $setup->getTable('quote_address')],
                 'sales_order.quote_id = quote_address.quote_id 
-                AND sales_order_address.address_type = quote_address.address_type',
+                AND ' . $salesOrderAddressTable . '.address_type = quote_address.address_type',
                 []
             )
             ->where(
-                'sales_order_address.quote_address_id IS NULL'
+                $salesOrderAddressTable . '.quote_address_id IS NULL'
             );
         $updateOrderAddress = $setup->getConnection()->updateFromSelect(
             $updateOrderAddress,
-            $setup->getTable('sales_order_address')
+            $salesOrderAddressTable
         );
         $setup->getConnection()->query($updateOrderAddress);
     }

--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -187,7 +187,8 @@ class UpgradeData implements UpgradeDataInterface
             )
             ->joinInner(
                 ['quote_address' => $setup->getTable('quote_address')],
-                'sales_order.quote_id = quote_address.quote_id AND sales_order_address.address_type = quote_address.address_type',
+                'sales_order.quote_id = quote_address.quote_id 
+                AND sales_order_address.address_type = quote_address.address_type',
                 []
             )
             ->where(


### PR DESCRIPTION
### Description
On Magento update, if you have a big number of order (>100k for my case), you can't pass *setup:upgrade* step.
Instead of using Magento collection, it's a direct SQL request.
### Manual testing scenarios
Upgrade Magento from 2.2.2 to 2.2.5.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
