### PR TITLE
[Backport] Declare module namespace before template path name

### DIFF
--- a/app/code/Magento/Captcha/Block/Captcha/DefaultCaptcha.php
+++ b/app/code/Magento/Captcha/Block/Captcha/DefaultCaptcha.php
@@ -13,7 +13,7 @@ class DefaultCaptcha extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'default.phtml';
+    protected $_template = 'Magento_Captcha::default.phtml';
 
     /**
      * @var string

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/AssignProducts.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/AssignProducts.php
@@ -13,7 +13,7 @@ class AssignProducts extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'catalog/category/edit/assign_products.phtml';
+    protected $_template = 'Magento_Catalog::catalog/category/edit/assign_products.phtml';
 
     /**
      * @var \Magento\Catalog\Block\Adminhtml\Category\Tab\Product

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -29,7 +29,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     /**
      * @var string
      */
-    protected $_template = 'catalog/category/tree.phtml';
+    protected $_template = 'Magento_Catalog::catalog/category/tree.phtml';
 
     /**
      * @var \Magento\Backend\Model\Auth\Session

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Widget/Chooser.php
@@ -24,7 +24,7 @@ class Chooser extends \Magento\Catalog\Block\Adminhtml\Category\Tree
      *
      * @var string
      */
-    protected $_template = 'catalog/category/widget/tree.phtml';
+    protected $_template = 'Magento_Catalog::catalog/category/widget/tree.phtml';
 
     /**
      * @return void

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main.php
@@ -22,7 +22,7 @@ class Main extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/main.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/main.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Group.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Group.php
@@ -14,5 +14,5 @@ class Group extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/main/tree/group.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/main/tree/group.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Add.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Add.php
@@ -18,7 +18,7 @@ class Add extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/toolbar/add.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/toolbar/add.phtml';
 
     /**
      * @return AbstractBlock

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Main.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Toolbar/Main.php
@@ -20,7 +20,7 @@ class Main extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/toolbar/main.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/toolbar/main.phtml';
 
     /**
      * @return $this

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Composite/Configure.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Composite/Configure.php
@@ -22,7 +22,7 @@ class Configure extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/composite/configure.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/composite/configure.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
@@ -17,7 +17,7 @@ class Edit extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Alerts.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Alerts.php
@@ -18,7 +18,7 @@ class Alerts extends \Magento\Backend\Block\Widget\Tab
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/tab/alert.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/tab/alert.phtml';
 
     /**
      * @return $this

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Inventory.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Inventory.php
@@ -15,7 +15,7 @@ class Inventory extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/tab/inventory.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/tab/inventory.phtml';
 
     /**
      * @var \Magento\Framework\Module\Manager

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options.php
@@ -16,7 +16,7 @@ class Options extends Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options.phtml';
 
     /**
      * @return Widget

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -38,7 +38,7 @@ class Option extends Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/option.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/option.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Date.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Date.php
@@ -16,5 +16,5 @@ class Date extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Typ
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/date.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/date.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/File.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/File.php
@@ -16,5 +16,5 @@ class File extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Typ
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/file.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/file.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Select.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Select.php
@@ -16,7 +16,7 @@ class Select extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\T
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/select.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/select.phtml';
 
     /**
      * Class constructor

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Text.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Type/Text.php
@@ -16,5 +16,5 @@ class Text extends \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Typ
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/options/type/text.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/options/type/text.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Price/Tier.php
@@ -13,7 +13,7 @@ class Tier extends Group\AbstractGroup
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/price/tier.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/price/tier.phtml';
 
     /**
      * Retrieve list of initial customer groups

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Websites.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Websites.php
@@ -21,7 +21,7 @@ class Websites extends \Magento\Backend\Block\Store\Switcher
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/websites.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/edit/websites.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -23,7 +23,7 @@ class Content extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/helper/gallery.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/helper/gallery.phtml';
 
     /**
      * @var \Magento\Catalog\Model\Product\Media\Config

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Widget/Chooser/Container.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Widget/Chooser/Container.php
@@ -18,5 +18,5 @@ class Container extends Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/widget/chooser/container.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/widget/chooser/container.phtml';
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Rss/Grid/Link.php
@@ -13,7 +13,7 @@ class Link extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rss/grid/link.phtml';
+    protected $_template = 'Magento_Catalog::rss/grid/link.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\UrlBuilderInterface

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
@@ -83,7 +83,7 @@ class Toolbar extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'product/list/toolbar.phtml';
+    protected $_template = 'Magento_Catalog::product/list/toolbar.phtml';
 
     /**
      * Catalog config

--- a/app/code/Magento/Catalog/Block/Product/View/Additional.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Additional.php
@@ -25,7 +25,7 @@ class Additional extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'product/view/additional.phtml';
+    protected $_template = 'Magento_Catalog::product/view/additional.phtml';
 
     /**
      * @return array

--- a/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
@@ -51,7 +51,7 @@ class Conditions extends Template implements RendererInterface
     /**
      * @var string
      */
-    protected $_template = 'product/widget/conditions.phtml';
+    protected $_template = 'Magento_Catalog::product/widget/conditions.phtml';
 
     /**
      * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory

--- a/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
@@ -51,7 +51,7 @@ class Conditions extends Template implements RendererInterface
     /**
      * @var string
      */
-    protected $_template = 'Magento_Catalog::product/widget/conditions.phtml';
+    protected $_template = 'Magento_CatalogWidget::product/widget/conditions.phtml';
 
     /**
      * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory

--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Attribute/NewAttribute/Product/Created.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Attribute/NewAttribute/Product/Created.php
@@ -16,7 +16,7 @@ class Created extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/new/created.phtml';
+    protected $_template = 'Magento_ConfigurableProduct::catalog/product/attribute/new/created.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config.php
@@ -18,7 +18,7 @@ class Config extends Widget implements TabInterface
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/edit/super/config.phtml';
+    protected $_template = 'Magento_ConfigurableProduct::catalog/product/edit/super/config.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency.php
@@ -20,7 +20,7 @@ class Currency extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'system/currency/rates.phtml';
+    protected $_template = 'Magento_CurrencySymbol::system/currency/rates.phtml';
 
     /**
      * Prepare layout

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
@@ -16,7 +16,7 @@ class Matrix extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'system/currency/rate/matrix.phtml';
+    protected $_template = 'Magento_CurrencySymbol::system/currency/rate/matrix.phtml';
 
     /**
      * @var \Magento\Directory\Model\CurrencyFactory

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Services.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Services.php
@@ -16,7 +16,7 @@ class Services extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'system/currency/rate/services.phtml';
+    protected $_template = 'Magento_CurrencySymbol::system/currency/rate/services.phtml';
 
     /**
      * @var \Magento\Directory\Model\Currency\Import\Source\ServiceFactory

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Newsletter.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Newsletter.php
@@ -17,7 +17,7 @@ class Newsletter extends \Magento\Backend\Block\Widget\Form\Generic implements T
     /**
      * @var string
      */
-    protected $_template = 'tab/newsletter.phtml';
+    protected $_template = 'Magento_Customer::tab/newsletter.phtml';
 
     /**
      * @var \Magento\Newsletter\Model\SubscriberFactory

--- a/app/code/Magento/Customer/Block/Adminhtml/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Sales/Order/Address/Form/Renderer/Vat.php
@@ -24,7 +24,7 @@ class Vat extends \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element
     /**
      * @var string
      */
-    protected $_template = 'sales/order/create/address/form/renderer/vat.phtml';
+    protected $_template = 'Magento_Customer::sales/order/create/address/form/renderer/vat.phtml';
 
     /**
      * @var \Magento\Framework\Json\EncoderInterface

--- a/app/code/Magento/Customer/Block/Newsletter.php
+++ b/app/code/Magento/Customer/Block/Newsletter.php
@@ -20,7 +20,7 @@ class Newsletter extends \Magento\Customer\Block\Account\Dashboard
     /**
      * @var string
      */
-    protected $_template = 'form/newsletter.phtml';
+    protected $_template = 'Magento_Customer::form/newsletter.phtml';
 
     /**
      * @return bool

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -33,7 +33,7 @@ class Downloadable extends Widget implements TabInterface
     /**
      * @var string
      */
-    protected $_template = 'product/edit/downloadable.phtml';
+    protected $_template = 'Magento_Downloadable::product/edit/downloadable.phtml';
 
     /**
      * Accordion block id

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -30,7 +30,7 @@ class Links extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'product/edit/downloadable/links.phtml';
+    protected $_template = 'Magento_Downloadable::product/edit/downloadable/links.phtml';
 
     /**
      * Downloadable file

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -22,7 +22,7 @@ class Samples extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'product/edit/downloadable/samples.phtml';
+    protected $_template = 'Magento_Downloadable::product/edit/downloadable/samples.phtml';
 
     /**
      * Downloadable file

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -17,5 +17,5 @@ class Js extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'attribute/edit/js.phtml';
+    protected $_template = 'Magento_Eav::attribute/edit/js.phtml';
 }

--- a/app/code/Magento/Email/Block/Adminhtml/Template.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template.php
@@ -22,7 +22,7 @@ class Template extends \Magento\Backend\Block\Template implements \Magento\Backe
      *
      * @var string
      */
-    protected $_template = 'template/list.phtml';
+    protected $_template = 'Magento_Email::template/list.phtml';
 
     /**
      * @var \Magento\Backend\Block\Widget\Button\ButtonList

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Edit.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Edit.php
@@ -42,7 +42,7 @@ class Edit extends Widget implements ContainerInterface
      *
      * @var string
      */
-    protected $_template = 'template/edit.phtml';
+    protected $_template = 'Magento_Email::template/edit.phtml';
 
     /**
      * @var \Magento\Framework\Json\EncoderInterface

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -33,7 +33,7 @@ class Inline extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'inline.phtml';
+    protected $_template = 'Magento_GiftMessage::inline.phtml';
 
     /**
      * Gift message message

--- a/app/code/Magento/LayeredNavigation/Block/Navigation/State.php
+++ b/app/code/Magento/LayeredNavigation/Block/Navigation/State.php
@@ -18,7 +18,7 @@ class State extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'layer/state.phtml';
+    protected $_template = 'Magento_LayeredNavigation::layer/state.phtml';
 
     /**
      * Catalog layer


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16515
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When we override any core block to any custom module, It throws an error because it tries to find template file in the custom module if we do not declare module namespace before template path.
I tried to extend Block Magento\Sales\Block\Order\Creditmemo from my custom module.

`1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'form/newsletter.phtml' in module: 'Vendor_Module'`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Declare module namespace before template path name.
For example: `protected $_template = 'Magento_Customer::form/newsletter.phtml';`

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Override any block file which content static template file path

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
