### PR TITLE
[Backport] Remove the timezone from the date when retrieving the current month from a UTC timestamp.

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
@@ -215,8 +215,11 @@ class Collection extends \Magento\Framework\Data\Collection
                 )
             );
         } else {
+            // Transform the start date to UTC whilst preserving the date. This is required as getTimestamp()
+            // is in UTC which may result in a different month from the original start date due to time zones.
+            $dateStartUtc = (new \DateTime())->createFromFormat('d-m-Y g:i:s', $dateStart->format('d-m-Y 00:00:00'));
             $interval['end'] = $this->_localeDate->convertConfigTimeToUtc(
-                $dateStart->format('Y-m-' . date('t', $dateStart->getTimestamp()) . ' 23:59:59')
+                $dateStart->format('Y-m-' . date('t', $dateStartUtc->getTimestamp()) . ' 23:59:59')
             );
         }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16492
Remove the timezone from the date when retrieving the current month from a UTC timestamp.

### Description
When viewing "Ordered Products Report" on a monthly basis, the date range used does not always include the last day of the month. The reason for this is because the method used to retrieve the number of days in a month converts the startDate of 2018-05-01 00:00:00 Australia/Adelaide 
into a UTC timestamp which changes the month. Therefore the timestamp needs to be retrieved from a datetime that is in UTC with the correct month specified.

The proposed solution in issue #15940 of using cal_days_in_month will not always work if PHP is compiled without calendar support.

### Fixed Issues
1. magento/magento2#15940: Wrong end of month at Reports for Europe/Berlin time zone if month contains 31 day

### Manual testing scenarios
Testing scenario provided in issue was used. Copied here for simplicity:

**Preconditions**
1. Set Timezone "Central European Standard Time (Europe/Berlin)" at the STORE->CONFIGURATION->GENERAL->General->Local options-> Timezone and save configuration
2. Create orders at 31-st day of a month which has this date (May will be used for example)

**Steps to reproduce**
1. Go to the Reports adminhtml menu "Products">"Ordered" grid
2. Select "From" - 01.05.2018
3. Select "To" - 31.05.2018
4. Select "Show by" - Month
5. Hit refresh

**Expected result**
Orders that were created at 31.05.2018 are in the grid

**Actual result**
Orders that were created at 31.05.2018 are NOT in the grid
