### PR TITLE
[Backport] Declare module namespace before template path name(Magento_Sales::order/creditmemo.phtml).

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Block/Order/Creditmemo.php
@@ -17,7 +17,7 @@ class Creditmemo extends \Magento\Sales\Block\Order\Creditmemo\Items
     /**
      * @var string
      */
-    protected $_template = 'order/creditmemo.phtml';
+    protected $_template = 'Magento_Sales::order/creditmemo.phtml';
 
     /**
      * @var \Magento\Framework\App\Http\Context


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16481
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When we override block creditmemo(Magento\Sales\Block\Order\Creditmemo) to my custom module.
It throws an error and finding order/creditmemo.phtml in my custom module.
I tried to extend Block Magento\Sales\Block\Order\Creditmemo from my custom module.

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'order/creditmemo.phtml' in module: 'Vendor_Module' block's name: 'sales.order.creditmemo'
```

### Fixed Issues (if relevant)
1. Declare module namespace before template path name.
`protected $_template = 'Magento_Sales::order/creditmemo.phtml';`

### Manual testing scenarios
1. I override creditmemo block
<preference for="Magento\Sales\Block\Order\Creditmemo" type="Vendor\Module\Block\Order\Creditmemo" />

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
