### PR TITLE
Fix of invalid price for integer currencies when amount less than group size

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -128,7 +128,6 @@ class Format implements \Magento\Framework\Locale\FormatInterface
         } else {
             $group = strrpos($format, '.');
         }
-        $integerRequired = strpos($format, '.') - strpos($format, '0');
 
         $result = [
             //TODO: change interface
@@ -138,7 +137,7 @@ class Format implements \Magento\Framework\Locale\FormatInterface
             'decimalSymbol' => $decimalSymbol,
             'groupSymbol' => $groupSymbol,
             'groupLength' => $group,
-            'integerRequired' => $integerRequired,
+            'integerRequired' => $totalPrecision == 0,
         ];
 
         return $result;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This is backported magento/magento2#16588 and related to magento/magento2#15909.

After correct fixes in magento/magento2#15909 (magento/magento2#15540) client-side formatting starts corrupt prices in currencies without minor units if price amount is less then number group size (usually equal to 3 numbers).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#11717: Wrong price amount on a product page

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
STR:
1. Install Magento
2. Set USD as a base currency
3. Set JPY as display currency (it also should be enabled as available currency)
4. Add product with price 0.01 USD
5. Add currency rate as 110 JPY for 1 USD
6. Open product page

AC: price 0,001 is displayed (wrongly added 0 to have group separator visible)

ER: price 1 is displayed (no decimal part, no preceding 0)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
