### PR TITLE
Fixed issue : Trim whitespace on SKU when saving product #16572

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php
@@ -28,6 +28,9 @@ class AttributeFilter
     public function prepareProductAttributes(Product $product, array $productData, array $useDefaults): array
     {
         $attributeList = $product->getAttributes();
+        
+        $productData['sku'] = trim($productData['sku']);
+        
         foreach ($productData as $attributeCode => $attributeValue) {
             if ($this->isAttributeShouldNotBeUpdated($product, $useDefaults, $attributeCode, $attributeValue)) {
                 unset($productData[$attributeCode]);

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilter.php
@@ -28,7 +28,7 @@ class AttributeFilter
     public function prepareProductAttributes(Product $product, array $productData, array $useDefaults): array
     {
         $attributeList = $product->getAttributes();
-        
+
         $productData['sku'] = trim($productData['sku']);
         
         foreach ($productData as $attributeCode => $attributeValue) {

--- a/app/code/Magento/ConfigurableProduct/Model/Product/VariationHandler.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/VariationHandler.php
@@ -92,6 +92,7 @@ class VariationHandler
         $productsData = $this->duplicateImagesForVariations($productsData);
         foreach ($productsData as $simpleProductData) {
             $newSimpleProduct = $this->productFactory->create();
+            $simpleProductData['sku'] = trim($simpleProductData['sku']);
             if (isset($simpleProductData['configurable_attribute'])) {
                 $configurableAttribute = json_decode($simpleProductData['configurable_attribute'], true);
                 unset($simpleProductData['configurable_attribute']);

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
@@ -88,7 +88,7 @@ define([
          * @param {Function} getSectionValue
          */
         calculate: function (variations, getSectionValue) {
-            var productSku = this.variationsComponent().getProductValue('sku'),
+            var productSku = this.variationsComponent().getProductValue('sku').trim(),
                 productPrice = this.variationsComponent().getProductPrice(),
                 productWeight = this.variationsComponent().getProductValue('weight'),
                 productName = this.variationsComponent().getProductValue('name'),


### PR DESCRIPTION
### Description
Strip whitespace from the beginning and end of SKU while saving product in admin.

### Fixed Issues
1. magento/magento2#16572: Trim whitespace on SKU when saving product

### Manual testing scenarios
1. Added new product with sku having whitespaces in beginning, at the end and at both the beginning and the end.
2. Updated product with sku having whitespaces in beginning, at the end and at both the beginning and the end.