### PR TITLE
[Forwardport] Incorrect value NULL was passed to DataObject constructor. It caused …

### DIFF
--- a/app/code/Magento/Wishlist/Model/Item.php
+++ b/app/code/Magento/Wishlist/Model/Item.php
@@ -473,7 +473,7 @@ class Item extends AbstractModel implements ItemInterface
     public function getBuyRequest()
     {
         $option = $this->getOptionByCode('info_buyRequest');
-        $initialData = $option ? $this->serializer->unserialize($option->getValue()) : null;
+        $initialData = $option ? $this->serializer->unserialize($option->getValue()) : [];
 
         if ($initialData instanceof \Magento\Framework\DataObject) {
             $initialData = $initialData->getData();


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16220

…fatal error. Fixed it by passing an empty array instead

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This error can only be noticed when testing wishlist with browser console open. Section data request for wishlist fails and on further debugging the cause was "Invalid parameter null was passed to \Magento\Framework\DataObject array expected. "

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds on Travis CI are green)
