### PR TITLE
Save configurable product options after validation error

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -147,13 +147,13 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
                 $this->messageManager->addExceptionMessage($e);
-                $data = $this->persistMediaData($product, $data);
+                $data = isset($product) ? $this->persistMediaData($product, $data) : $data;
                 $this->getDataPersistor()->set('catalog_product', $data);
                 $redirectBack = $productId ? true : 'new';
             } catch (\Exception $e) {
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
                 $this->messageManager->addErrorMessage($e->getMessage());
-                $data = $this->persistMediaData($product, $data);
+                $data = isset($product) ? $this->persistMediaData($product, $data) : $data;
                 $this->getDataPersistor()->set('catalog_product', $data);
                 $redirectBack = $productId ? true : 'new';
             }

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
@@ -407,15 +407,17 @@ define([
          *   - associated_product_ids_serialized.
          */
         serializeData: function () {
-            this.source.data['configurable-matrix-serialized'] =
-                JSON.stringify(this.source.data['configurable-matrix']);
+            if (this.source.data['configurable-matrix']) {
+                this.source.data['configurable-matrix-serialized'] =
+                    JSON.stringify(this.source.data['configurable-matrix']);
+                delete this.source.data['configurable-matrix'];
+            }
 
-            delete this.source.data['configurable-matrix'];
-
-            this.source.data['associated_product_ids_serialized'] =
-                JSON.stringify(this.source.data['associated_product_ids']);
-
-            delete this.source.data['associated_product_ids'];
+            if (this.source.data['associated_product_ids']) {
+                this.source.data['associated_product_ids_serialized'] =
+                    JSON.stringify(this.source.data['associated_product_ids']);
+                delete this.source.data['associated_product_ids'];
+            }
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
1. Fix issue with configurable product save.
2. Improve fix for issue #7372 - cover edge case.

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13177: Can't save attributes on a configurable product 
2. magento/magento2#7372: Product images gets removed from "Images And Videos" after validation alert.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
#### Pre-conditions
1. Created configurable product with the options

#### Steps to reproduce
1. Go to Admin Panel. 
2. Go to Product Edit form of Configurable product.
3. Remove value from 'Name' attribute and press 'Save'.
4. See js validation error.
5. Fill 'Name' attribute and press 'Save'.

#### Expected result
1. Product was saved

#### Actual result
1. Magento report will be shown.
3. After page reload, you will see session message **'Warning: array_filter() expects parameter 1 to be array, string given invendor/magento/module-configurable-product/Controller/Adminhtml/Product/Initialization/Helper/Plugin/Configurable.php on line 145**


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
