### PR TITLE
Fixed backwards incompatible change to Transport variable event parameters

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -138,7 +138,7 @@ class OrderSender extends Sender
          */
         $this->eventManager->dispatch(
             'email_order_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
+            ['sender' => $this, 'transport' => $transportObject, 'transportObject' => $transportObject]
         );
 
         $this->templateContainer->setTemplateVars($transportObject->getData());


### PR DESCRIPTION
### Description
In PR#15040 the type of event parameter "transport" was incorrectly changed from type DataObject to Array(). This change corrects this back to DataObject.

### Fixed Issues (if relevant)
1. magento/magento2#10210: Transport variable can not be altered in email_invoice_set_template_vars_before Event

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
