### PR TITLE
[2.2-develop] Refactor sales upgrade script for better performance

### DIFF
--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -174,30 +174,29 @@ class UpgradeData implements UpgradeDataInterface
     /**
      * Fill quote_address_id in table sales_order_address if it is empty.
      */
-    public function fillQuoteAddressIdInSalesOrderAddress()
+    public function fillQuoteAddressIdInSalesOrderAddress(ModuleDataSetupInterface $setup)
     {
-        $addressCollection = $this->addressCollectionFactory->create();
-        $addressCollection->addFieldToFilter('quote_address_id', ['null' => true]);
-        
-        /** @var \Magento\Sales\Model\Order\Address $orderAddress */
-        foreach ($addressCollection as $orderAddress) {
-            $orderId = $orderAddress->getParentId();
-            $addressType = $orderAddress->getAddressType();
+        $updateOrderAddress = $setup->getConnection()
+            ->select()
+            ->joinInner(
+                ['sales_order' => $setup->getTable('sales_order')],
+                'sales_order_address.parent_id = sales_order.entity_id',
+                ['quote_address_id' => 'quote_address.address_id']
+            )
+            ->joinInner(
+                ['quote_address' => $setup->getTable('quote_address')],
+                'sales_order.quote_id = quote_address.quote_id AND sales_order_address.address_type = quote_address.address_type',
+                []
+            )
+            ->where(
+                'sales_order_address.quote_address_id IS NULL'
+            );
 
-            /** @var \Magento\Sales\Model\Order $order */
-            $order = $this->orderFactory->create()->load($orderId);
-            $quoteId = $order->getQuoteId();
-            $quote = $this->quoteFactory->create()->load($quoteId);
+        $updateOrderAddress = $setup->getConnection()->updateFromSelect(
+            $updateOrderAddress,
+            $setup->getTable('sales_order_address')
+        );
 
-            if ($addressType == \Magento\Sales\Model\Order\Address::TYPE_SHIPPING) {
-                $quoteAddressId = $quote->getShippingAddress()->getId();
-                $orderAddress->setData('quote_address_id', $quoteAddressId);
-            } elseif ($addressType == \Magento\Sales\Model\Order\Address::TYPE_BILLING) {
-                $quoteAddressId = $quote->getBillingAddress()->getId();
-                $orderAddress->setData('quote_address_id', $quoteAddressId);
-            }
-
-            $orderAddress->save();
-        }
+        $setup->getConnection()->query($updateOrderAddress);
     }
 }

--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -185,7 +185,8 @@ class UpgradeData implements UpgradeDataInterface
             )
             ->joinInner(
                 ['quote_address' => $setup->getTable('quote_address')],
-                'sales_order.quote_id = quote_address.quote_id AND sales_order_address.address_type = quote_address.address_type',
+                'sales_order.quote_id = quote_address.quote_id' .
+                    ' AND sales_order_address.address_type = quote_address.address_type',
                 []
             )
             ->where(


### PR DESCRIPTION
### Summary

When upgrading from Magento < 2.2.4 to Magento >= 2.2.4, it's possible to get memory allocation errors and/or SQL server stall outs due to the fillQuoteAddressIdInSalesOrderAddress() method in Magento/Sales/Setup/UpgradeData.php. The method works well on sample data and small databases, but is non-performant on large database where there are close to 1M+ records in sales_order_address.

### Description

The original Magento/Sales/Setup/UpgradeData.php script's fillQuoteAddressIdInSalesOrderAddress() method loads the order and quote objects for each sales_order_address database row that has a NULL quote_address_id. That approach works well on small databases, but consumes too much system memory on large databases, leading to SQL server crashes and/or out of memory errors when running the ./bin/magento setup:upgrade command during the upgrade from < Magento 2.2.4. This refactor performs the update operation in SQL rather than in the Magento application in order to limit memory usage.

### Manual testing scenarios

1. Install Magento < 2.2.4
2. Migrate data from an existing Magento 1 site resulting in ~500,000+ sales_order_address records
3. Upgrade to Magento >= 2.2.4 and run ./bin/magento setup:upgrade