### PR TITLE
[Forwardport] M2.2.4 missing meta title tag and doesn't show

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/View.php
+++ b/app/code/Magento/Catalog/Helper/Product/View.php
@@ -112,12 +112,9 @@ class View extends \Magento\Framework\App\Helper\AbstractHelper
         $pageLayout = $resultPage->getLayout();
         $pageConfig = $resultPage->getConfig();
 
-        $title = $product->getMetaTitle();
-        if ($title) {
-            $pageConfig->getTitle()->set($title);
-        } else {
-            $pageConfig->getTitle()->set($product->getName());
-        }
+        $metaTitle = $product->getMetaTitle();
+        $pageConfig->setMetaTitle($metaTitle);
+        $pageConfig->getTitle()->set($metaTitle ?: $product->getName());
 
         $keyword = $product->getMetaKeyword();
         $currentCategory = $this->_coreRegistry->registry('current_category');

--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -341,6 +341,14 @@ class Config
     }
 
     /**
+     * @param string $title
+     */
+    public function setMetaTitle($title)
+    {
+        $this->setMetadata('title', $title);
+    }
+
+    /**
      * @param string $keywords
      * @return void
      */

--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -7,7 +7,7 @@
 namespace Magento\Framework\View\Page;
 
 use Magento\Framework\App;
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\App\Area;
 use Magento\Framework\View;
 
 /**
@@ -42,6 +42,7 @@ class Config
     const META_TITLE = 'title';
     const META_KEYWORDS = 'keywords';
     const META_ROBOTS = 'robots';
+    const META_X_UI_COMPATIBLE = 'x_ua_compatible';
 
     /**
      * Constant body attribute class
@@ -254,7 +255,7 @@ class Config
      */
     public function setContentType($contentType)
     {
-        $this->setMetadata('content_type', $contentType);
+        $this->setMetadata(self::META_CONTENT_TYPE, $contentType);
     }
 
     /**
@@ -265,10 +266,10 @@ class Config
     public function getContentType()
     {
         $this->build();
-        if (strtolower($this->metadata['content_type']) === 'auto') {
-            $this->metadata['content_type'] = $this->getMediaType() . '; charset=' . $this->getCharset();
+        if (strtolower($this->metadata[self::META_CONTENT_TYPE]) === 'auto') {
+            $this->metadata[self::META_CONTENT_TYPE] = $this->getMediaType() . '; charset=' . $this->getCharset();
         }
-        return $this->metadata['content_type'];
+        return $this->metadata[self::META_CONTENT_TYPE];
     }
 
     /**
@@ -277,7 +278,7 @@ class Config
      */
     public function setMediaType($mediaType)
     {
-        $this->setMetadata('media_type', $mediaType);
+        $this->setMetadata(self::META_MEDIA_TYPE, $mediaType);
     }
 
     /**
@@ -288,13 +289,13 @@ class Config
     public function getMediaType()
     {
         $this->build();
-        if (empty($this->metadata['media_type'])) {
-            $this->metadata['media_type'] = $this->scopeConfig->getValue(
+        if (empty($this->metadata[self::META_MEDIA_TYPE])) {
+            $this->metadata[self::META_MEDIA_TYPE] = $this->scopeConfig->getValue(
                 'design/head/default_media_type',
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return $this->metadata['media_type'];
+        return $this->metadata[self::META_MEDIA_TYPE];
     }
 
     /**
@@ -303,7 +304,7 @@ class Config
      */
     public function setCharset($charset)
     {
-        $this->setMetadata('charset', $charset);
+        $this->setMetadata(self::META_CHARSET, $charset);
     }
 
     /**
@@ -314,13 +315,13 @@ class Config
     public function getCharset()
     {
         $this->build();
-        if (empty($this->metadata['charset'])) {
-            $this->metadata['charset'] = $this->scopeConfig->getValue(
+        if (empty($this->metadata[self::META_CHARSET])) {
+            $this->metadata[self::META_CHARSET] = $this->scopeConfig->getValue(
                 'design/head/default_charset',
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return $this->metadata['charset'];
+        return $this->metadata[self::META_CHARSET];
     }
 
     /**
@@ -329,7 +330,7 @@ class Config
      */
     public function setDescription($description)
     {
-        $this->setMetadata('description', $description);
+        $this->setMetadata(self::META_DESCRIPTION, $description);
     }
 
     /**
@@ -340,41 +341,13 @@ class Config
     public function getDescription()
     {
         $this->build();
-        if (empty($this->metadata['description'])) {
-            $this->metadata['description'] = $this->scopeConfig->getValue(
+        if (empty($this->metadata[self::META_DESCRIPTION])) {
+            $this->metadata[self::META_DESCRIPTION] = $this->scopeConfig->getValue(
                 'design/head/default_description',
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return $this->metadata['description'];
-    }
-
-    /**
-     * Get rendered metadata
-     * @param string $fieldName
-     * @return string
-     * @throws LocalizedException
-     */
-    public function getRenderedMetaTagValue(string $fieldName)
-    {
-        switch ($fieldName) {
-            case self::META_DESCRIPTION:
-                return $this->getDescription();
-            case self::META_CONTENT_TYPE:
-                return $this->getContentType();
-            case self::META_MEDIA_TYPE:
-                return $this->getMediaType();
-            case self::META_CHARSET:
-                return $this->getCharset();
-            case self::META_KEYWORDS:
-                return $this->getKeywords();
-            case self::META_ROBOTS:
-                return $this->getRobots();
-            case self::META_TITLE:
-                return $this->getMetaTitle();
-            default:
-                throw new LocalizedException(__('No rendered meta function for %1', $fieldName));
-        }
+        return $this->metadata[self::META_DESCRIPTION];
     }
 
     /**
@@ -382,7 +355,7 @@ class Config
      */
     public function setMetaTitle($title)
     {
-        $this->setMetadata('title', $title);
+        $this->setMetadata(self::META_TITLE, $title);
     }
 
     /**
@@ -393,11 +366,11 @@ class Config
     public function getMetaTitle()
     {
         $this->build();
-        if (empty($this->metadata['title'])) {
+        if (empty($this->metadata[self::META_TITLE])) {
             return '';
         }
 
-        return $this->metadata['title'];
+        return $this->metadata[self::META_TITLE];
     }
 
     /**
@@ -406,7 +379,7 @@ class Config
      */
     public function setKeywords($keywords)
     {
-        $this->setMetadata('keywords', $keywords);
+        $this->setMetadata(self::META_KEYWORDS, $keywords);
     }
 
     /**
@@ -417,13 +390,13 @@ class Config
     public function getKeywords()
     {
         $this->build();
-        if (empty($this->metadata['keywords'])) {
-            $this->metadata['keywords'] = $this->scopeConfig->getValue(
+        if (empty($this->metadata[self::META_KEYWORDS])) {
+            $this->metadata[self::META_KEYWORDS] = $this->scopeConfig->getValue(
                 'design/head/default_keywords',
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return $this->metadata['keywords'];
+        return $this->metadata[self::META_KEYWORDS];
     }
 
     /**
@@ -432,27 +405,28 @@ class Config
      */
     public function setRobots($robots)
     {
-        $this->setMetadata('robots', $robots);
+        $this->setMetadata(self::META_ROBOTS, $robots);
     }
 
     /**
      * Retrieve URL to robots file
      *
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getRobots()
     {
-        if ($this->getAreaResolver()->getAreaCode() !== 'frontend') {
+        if ($this->getAreaResolver()->getAreaCode() !== Area::AREA_FRONTEND) {
             return 'NOINDEX,NOFOLLOW';
         }
         $this->build();
-        if (empty($this->metadata['robots'])) {
-            $this->metadata['robots'] = $this->scopeConfig->getValue(
+        if (empty($this->metadata[self::META_ROBOTS])) {
+            $this->metadata[self::META_ROBOTS] = $this->scopeConfig->getValue(
                 'design/search_engine_robots/default_robots',
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return $this->metadata['robots'];
+        return $this->metadata[self::META_ROBOTS];
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -7,6 +7,7 @@
 namespace Magento\Framework\View\Page;
 
 use Magento\Framework\App;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\View;
 
 /**
@@ -33,6 +34,14 @@ class Config
     const ELEMENT_TYPE_HTML = 'html';
     const ELEMENT_TYPE_HEAD = 'head';
     /**#@-*/
+
+    const META_DESCRIPTION = 'description';
+    const META_CONTENT_TYPE = 'content_type';
+    const META_MEDIA_TYPE = 'media_type';
+    const META_CHARSET = 'charset';
+    const META_TITLE = 'title';
+    const META_KEYWORDS = 'keywords';
+    const META_ROBOTS = 'robots';
 
     /**
      * Constant body attribute class
@@ -341,11 +350,54 @@ class Config
     }
 
     /**
+     * Get rendered metadata
+     * @param string $fieldName
+     * @return string
+     * @throws LocalizedException
+     */
+    public function getRenderedMetaTagValue(string $fieldName)
+    {
+        switch ($fieldName) {
+            case self::META_DESCRIPTION:
+                return $this->getDescription();
+            case self::META_CONTENT_TYPE:
+                return $this->getContentType();
+            case self::META_MEDIA_TYPE:
+                return $this->getMediaType();
+            case self::META_CHARSET:
+                return $this->getCharset();
+            case self::META_KEYWORDS:
+                return $this->getKeywords();
+            case self::META_ROBOTS:
+                return $this->getRobots();
+            case self::META_TITLE:
+                return $this->getMetaTitle();
+            default:
+                throw new LocalizedException(__('No rendered meta function for %1', $fieldName));
+        }
+    }
+
+    /**
      * @param string $title
      */
     public function setMetaTitle($title)
     {
         $this->setMetadata('title', $title);
+    }
+
+    /**
+     * Retrieve meta title
+     *
+     * @return string
+     */
+    public function getMetaTitle()
+    {
+        $this->build();
+        if (empty($this->metadata['title'])) {
+            return '';
+        }
+
+        return $this->metadata['title'];
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -142,7 +142,8 @@ class Renderer implements RendererInterface
             }
             return $content;
         }
-        if (method_exists($this->pageConfig, $method)) {
+        // We skip title, because PageConfig::getTitle() refers to the tag <title> and not to meta title.
+        if (!in_array($name, ['title']) && method_exists($this->pageConfig, $method)) {
             $content = $this->pageConfig->$method();
         }
         return $content;

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -3,8 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\View\Page\Config;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\View\Asset\GroupedCollection;
 use Magento\Framework\View\Page\Config;
 
@@ -131,22 +133,15 @@ class Renderer implements RendererInterface
     /**
      * @param string $name
      * @param string $content
-     * @return mixed
+     * @return string
      */
     protected function processMetadataContent($name, $content)
     {
-        $method = 'get' . $this->string->upperCaseWords($name, '_', '');
-        if ($name === 'title') {
-            if (!$content) {
-                $content = $this->escaper->escapeHtml($this->pageConfig->$method()->get());
-            }
-            return $content;
+        try {
+            return $this->pageConfig->getRenderedMetaTagValue((string) $name);
+        } catch (LocalizedException $e) {
+            return (string) $content;
         }
-        // We skip title, because PageConfig::getTitle() refers to the tag <title> and not to meta title.
-        if (!in_array($name, ['title']) && method_exists($this->pageConfig, $method)) {
-            $content = $this->pageConfig->$method();
-        }
-        return $content;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -23,7 +23,7 @@ class Renderer implements RendererInterface
     protected $assetTypeOrder = ['css', 'ico', 'js'];
 
     /**
-     * @var \Magento\Framework\View\Page\Config
+     * @var Config
      */
     protected $pageConfig;
 
@@ -53,7 +53,7 @@ class Renderer implements RendererInterface
     protected $urlBuilder;
 
     /**
-     * @param \Magento\Framework\View\Page\Config $pageConfig
+     * @param Config $pageConfig
      * @param \Magento\Framework\View\Asset\MergeService $assetMergeService
      * @param \Magento\Framework\UrlInterface $urlBuilder
      * @param \Magento\Framework\Escaper $escaper
@@ -137,10 +137,30 @@ class Renderer implements RendererInterface
      */
     protected function processMetadataContent($name, $content)
     {
-        try {
-            return $this->pageConfig->getRenderedMetaTagValue((string) $name);
-        } catch (LocalizedException $e) {
-            return (string) $content;
+        switch ($name) {
+            case Config::META_DESCRIPTION:
+                return $this->pageConfig->getDescription();
+
+            case Config::META_CONTENT_TYPE:
+                return $this->pageConfig->getContentType();
+
+            case Config::META_MEDIA_TYPE:
+                return $this->pageConfig->getMediaType();
+
+            case Config::META_CHARSET:
+                return $this->pageConfig->getCharset();
+
+            case Config::META_KEYWORDS:
+                return $this->pageConfig->getKeywords();
+
+            case Config::META_ROBOTS:
+                return $this->pageConfig->getRobots();
+
+            case Config::META_TITLE:
+                return $this->pageConfig->getMetaTitle();
+
+            default:
+                return $content;
         }
     }
 
@@ -155,19 +175,19 @@ class Renderer implements RendererInterface
         }
 
         switch ($name) {
-            case 'charset':
+            case Config::META_CHARSET:
                 $metadataTemplate = '<meta charset="%content"/>' . "\n";
                 break;
 
-            case 'content_type':
+            case Config::META_CONTENT_TYPE:
                 $metadataTemplate = '<meta http-equiv="Content-Type" content="%content"/>' . "\n";
                 break;
 
-            case 'x_ua_compatible':
+            case Config::META_X_UI_COMPATIBLE:
                 $metadataTemplate = '<meta http-equiv="X-UA-Compatible" content="%content"/>' . "\n";
                 break;
 
-            case 'media_type':
+            case Config::META_MEDIA_TYPE:
                 $metadataTemplate = false;
                 break;
 
@@ -354,7 +374,7 @@ class Renderer implements RendererInterface
                 );
                 $result .= sprintf($template, $asset->getUrl());
             }
-        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+        } catch (LocalizedException $e) {
             $this->logger->critical($e);
             $result .= sprintf($template, $this->urlBuilder->getUrl('', ['_direct' => 'core/index/notFound']));
         }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
@@ -157,14 +157,13 @@ class RendererTest extends \PHPUnit\Framework\TestCase
             . '<meta http-equiv="X-UA-Compatible" content="x_ua_compatible_value"/>' . "\n"
             . '<meta property="og:video:secure_url" content="secure_url"/>' . "\n";
 
-        $this->stringMock->expects($this->at(0))
-            ->method('upperCaseWords')
-            ->with('charset', '_', '')
-            ->willReturn('Charset');
-
         $this->pageConfigMock->expects($this->once())
             ->method('getCharset')
             ->willReturn($metadataValueCharset);
+
+        $this->pageConfigMock->expects($this->once())
+            ->method('getContentType')
+            ->willReturn('content_type_value');
 
         $this->pageConfigMock
             ->expects($this->once())


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15532

FIX for issue #15501 - M2.2.4 missing meta title tag and doesn't show product name if meta title is empty

### Description
The current Magento behaviour does not allow to specify a title meta tag and the "Meta Title" option in the product's page is binded to the page's title.

This PR adds the meta tile tag and allows to use title and meta title independently.

### Fixed Issues (if relevant)
1. magento/magento2#15501: M2.2.4 missing meta title tag and doesn't show product name if meta title is empty

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
