### PR TITLE
Delete the record when time used is 0

### DIFF
--- a/app/code/Magento/SalesRule/Model/ResourceModel/Coupon/Usage.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Coupon/Usage.php
@@ -44,13 +44,20 @@ class Usage extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         );
 
         $timesUsed = $connection->fetchOne($select, [':coupon_id' => $couponId, ':customer_id' => $customerId]);
-
         if ($timesUsed !== false) {
+            $updatedValue    = $increment ? 1 : -1;
+            $updatedTimeUsed = $timesUsed + $updatedValue;
             $this->getConnection()->update(
                 $this->getMainTable(),
-                ['times_used' => $timesUsed + ($increment ? 1 : -1)],
+                ['times_used' => $updatedTimeUsed],
                 ['coupon_id = ?' => $couponId, 'customer_id = ?' => $customerId]
             );
+            if ($updatedTimeUsed == 0) {
+                $connection->delete(
+                    $this->getMainTable(),
+                    ['coupon_id = ?' => $couponId, 'customer_id = ?' => $customerId]
+                );
+            }
         } elseif ($increment) {
             $this->getConnection()->insert(
                 $this->getMainTable(),
@@ -74,11 +81,11 @@ class Usage extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $select = $connection->select()->from(
                 $this->getMainTable()
             )->where(
-                'customer_id =:customet_id'
+                'customer_id =:customer_id'
             )->where(
                 'coupon_id = :coupon_id'
             );
-            $data = $connection->fetchRow($select, [':coupon_id' => $couponId, ':customet_id' => $customerId]);
+            $data = $connection->fetchRow($select, [':coupon_id' => $couponId, ':customer_id' => $customerId]);
             if ($data) {
                 $object->setData($data);
             }

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Customer.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Customer.php
@@ -48,4 +48,22 @@ class Customer extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $rule->setData($data);
         return $this;
     }
+
+    /**
+     * Delete the time Usage from salesrule_customer table when times_used is 0
+     * @param $ruleId
+     * @param $customerId
+     * @param $updatedTimeUsed
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function deleteCustomerTimeUsage($ruleId, $customerId, $updatedTimeUsed)
+    {
+        $connection = $this->getConnection();
+            if ($updatedTimeUsed == 0) {
+                $connection->delete(
+                    $this->getMainTable(),
+                    ['rule_id = ?' => $ruleId, 'customer_id = ?' => $customerId]
+                );
+            }
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
If Order Got Cancel and time used is reset to 0 then delete the record from salesrule_coupon_usage and salesrule_customer table:

### Fixed Issues (if relevant)
**magento/magento2#12817: Coupon code with canceled order.** 
This PR has fixed the issue which is related to coupon and no coupon time used but it has missed one scenario as mention.
If time used is 0 then we need to delete the record from the respective tables(salesrule_coupon_usage or salesrule_customer). 

Example : 
Customer has used a coupon code and place an order in this case times_used in salesrule_coupon_usage is set to 1 as mention below  :
  
![coupon_code_applied](https://user-images.githubusercontent.com/34090452/42417491-27a93c1e-82a9-11e8-8b27-5a22d49c1b51.png)


The order got cancel then times_used is reset to 0 but this record is persist in the table 
![order_cancel](https://user-images.githubusercontent.com/34090452/42417499-6040a88c-82a9-11e8-874a-d9cbb602516e.png)


**Fixes:**
I have added a code
**For Coupon Code:** 
 If times_used is equal to 0 delete the record from salesrule_coupon_usage 
```
          if ($updatedTimeUsed == 0) {
                $connection->delete(
                    $this->getMainTable(),
                    ['coupon_id = ?' => $couponId, 'customer_id = ?' => $customerId]
                );
            }
```

**For No Coupon**
RuleID,customerId and time used are saved in salesrule_customer.when the times_used is reset to 0 we are deleting the record.To achieve this,i have created a Function deleteCustomerTimeUsage().
### Manual testing scenarios

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
