### PR TITLE
[Forwardport] Credit memo email template file: fixing incorrect object type error

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
@@ -31,6 +31,6 @@
     </td>
     <td class="item-qty"><?= /* @escapeNotVerified */  $_item->getQty() * 1 ?></td>
     <td class="item-price">
-        <?= /* @escapeNotVerified */  $block->getItemPrice($_item) ?>
+        <?= /* @escapeNotVerified */  $block->getItemPrice($_item->getOrderItem()) ?>
     </td>
 </tr>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16438
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When creating a credit memo and checking the "Email" checkbox, you would get an error like:
```
Fatal error: Uncaught TypeError: Argument 1 passed to Magento\Sales\Block\Order\Email\Items\Order\DefaultOrder::getItemPrice() must be an instance of Magento\Sales\Model\Order\Item, instance of Magento\Sales\Model\Order\Creditmemo\Item given, called in /var/www/sites/magento/vendor/magento/module-sales/view/frontend/templates/email/items/creditmemo/default.phtml on line 34 and defined in /var/www/sites/magento/vendor/magento/module-sales/Block/Order/Email/Items/Order/DefaultOrder.php on line 99
```

Adding `->getOrderItem()` sends the correct type and the error is resolved. [Reference](https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml).

### Manual testing scenarios
1. Create an order
2. Invoice the order
3. Create a credit memo for the order, and check "Send email".
4. You should receive an email with the credit memo instead of an error.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
