### PR TITLE
[Forwardport] Fix for #14593 (second try #16431) 

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -92,9 +92,7 @@ define([
 
                         /** @inheritdoc */
                         always: function (e) {
-                            if (e && typeof e.stopImmediatePropagation === 'function') {
-                                e.stopImmediatePropagation();
-                            }
+                            e.stopImmediatePropagation();
                         }
                     }
                 });

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -92,7 +92,9 @@ define([
 
                         /** @inheritdoc */
                         always: function (e) {
-                            e.stopImmediatePropagation();
+                            if (e && typeof e.stopImmediatePropagation === 'function') {
+                                e.stopImmediatePropagation();
+                            }
                         }
                     }
                 });

--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -104,11 +104,12 @@ define([
                 /**
                  * Escape key press handler,
                  * close modal window
+                 * @param {Object} event - event
                  */
-                escapeKey: function () {
+                escapeKey: function (event) {
                     if (this.options.isOpen && this.modal.find(document.activeElement).length ||
                         this.options.isOpen && this.modal[0] === document.activeElement) {
-                        this.closeModal();
+                        this.closeModal(event);
                     }
                 }
             }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16477
### Description

#### Preconditions: 

Magento version 2.2.4 with luma theme

#### Step to reproduce:

 - Open chrome developer console
 - Add a product to the cart.
 - From the mini cart in the upper right click the trash icon.
 - A confirmation modal will open.
 - Press Esc button

#### Expected Result
- Close the confirm

#### Actual result
- js error

https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js#L96

~~~
Uncaught TypeError: Cannot read property 'stopImmediatePropagation' of undefined
~~~
![2018-06-21 15-50-01](https://user-images.githubusercontent.com/412612/41720145-cbfd9e28-756a-11e8-9c4a-1500171c3788.png)

### Fixed Issues 

1. magento/magento2#14593

### P.S.

First, pull request - https://github.com/magento/magento2/pull/16431

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
