### PR TITLE
[Backport] Admin tabs order not working properly

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -252,7 +252,6 @@ class Tabs extends \Magento\Backend\Block\Widget
         return parent::_beforeToHtml();
     }
     
-    
     /**
      * Reorder the tabs.
      *
@@ -340,7 +339,6 @@ class Tabs extends \Magento\Backend\Block\Widget
         return $ordered;
     }
     
-
     /**
      * @return string
      */

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -117,7 +117,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         if (empty($tabId)) {
             throw new \Exception(__('Please correct the tab configuration and try again. Tab Id should be not empty'));
         }
-        
+
         if (is_array($tab)) {
             $this->_tabs[$tabId] = new \Magento\Framework\DataObject($tab);
         } elseif ($tab instanceof \Magento\Framework\DataObject) {

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -281,7 +281,6 @@ class Tabs extends \Magento\Backend\Block\Widget
         return $this->applyTabsCorrectOrder($orderByPosition, $orderByIdentity);
     }
 
-
     /**
      * @param array $orderByPosition
      * @param array $orderByIdentity
@@ -316,7 +315,6 @@ class Tabs extends \Magento\Backend\Block\Widget
 
         return $this->finalTabsSortOrder($orderByPosition);
     }
-
 
     /**
      * Apply the last sort order to tabs.

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -238,6 +238,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         $this->_tabs = $this->reorderTabs();
         
         if ($this->_activeTab === null) {
+            /** @var  $tab */
             foreach ($this->_tabs as $tab) {
                 $this->_activeTab = $tab->getId();
                 break;
@@ -266,8 +267,10 @@ class Tabs extends \Magento\Backend\Block\Widget
         $position  = 100;
     
         /**
-         * @var string                                         $key
-         * @var \Magento\Backend\Block\Widget\Tab\TabInterface $tab
+         * Set the initial positions for each tab.
+         *
+         * @var string       $key
+         * @var TabInterface $tab
          */
         foreach ($this->_tabs as $key => $tab) {
             $tab->setPosition($position);
@@ -280,6 +283,12 @@ class Tabs extends \Magento\Backend\Block\Widget
         
         $positionFactor = 1;
         
+        /**
+         * Rearrange the positions by using the after tag for each tab.
+         *
+         * @var integer      $position
+         * @var TabInterface $tab
+         */
         foreach ($orderByPosition as $position => $tab) {
             if (!$tab->getAfter() || !in_array($tab->getAfter(), array_keys($orderByIdentity))) {
                 $positionFactor = 1;

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -254,14 +254,15 @@ class Tabs extends \Magento\Backend\Block\Widget
     
     
     /**
+     * Reorder the tabs.
+     *
      * @return array
      */
     private function reorderTabs()
     {
         $orderByIdentity = [];
         $orderByPosition = [];
-        
-        $position  = 100;
+        $position        = 100;
     
         /**
          * Set the initial positions for each tab.
@@ -277,9 +278,21 @@ class Tabs extends \Magento\Backend\Block\Widget
             
             $position += 100;
         }
-        
+
+        return $this->applyTabsCorrectOrder($orderByPosition, $orderByIdentity);
+    }
+
+
+    /**
+     * @param array $orderByPosition
+     * @param array $orderByIdentity
+     *
+     * @return array
+     */
+    private function applyTabsCorrectOrder(array $orderByPosition, array $orderByIdentity)
+    {
         $positionFactor = 1;
-        
+
         /**
          * Rearrange the positions by using the after tag for each tab.
          *
@@ -291,26 +304,39 @@ class Tabs extends \Magento\Backend\Block\Widget
                 $positionFactor = 1;
                 continue;
             }
-            
+
             $grandPosition = $orderByIdentity[$tab->getAfter()]->getPosition();
             $newPosition   = $grandPosition + $positionFactor;
-            
+
             unset($orderByPosition[$position]);
             $orderByPosition[$newPosition] = $tab;
             $tab->setPosition($newPosition);
-    
+
             $positionFactor++;
         }
-        
+
+        return $this->finalTabsSortOrder($orderByPosition);
+    }
+
+
+    /**
+     * Apply the last sort order to tabs.
+     *
+     * @param array $orderByPosition
+     *
+     * @return array
+     */
+    private function finalTabsSortOrder(array $orderByPosition)
+    {
         ksort($orderByPosition);
-    
+
         $ordered = [];
-        
+
         /** @var TabInterface $tab */
         foreach ($orderByPosition as $tab) {
             $ordered[$tab->getId()] = $tab;
         }
-        
+
         return $ordered;
     }
     

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -238,7 +238,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         $this->_tabs = $this->reorderTabs();
         
         if ($this->_activeTab === null) {
-            /** @var  $tab */
+            /** @var TabInterface $tab */
             foreach ($this->_tabs as $tab) {
                 $this->_activeTab = $tab->getId();
                 break;
@@ -309,7 +309,7 @@ class Tabs extends \Magento\Backend\Block\Widget
     
         $ordered = [];
         
-        /** @var  $tab */
+        /** @var TabInterface $tab */
         foreach ($orderByPosition as $tab) {
             $ordered[$tab->getId()] = $tab;
         }

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -237,18 +237,15 @@ class Tabs extends \Magento\Backend\Block\Widget
     {
         $this->_tabs = $this->reorderTabs();
         
-        if ($this->_activeTab === null) {
-            /** @var TabInterface $tab */
-            foreach ($this->_tabs as $tab) {
-                $this->_activeTab = $tab->getId();
-                break;
-            }
-        }
-        
         if ($activeTab = $this->getRequest()->getParam('active_tab')) {
             $this->setActiveTab($activeTab);
         } elseif ($activeTabId = $this->_authSession->getActiveTabId()) {
             $this->_setActiveTab($activeTabId);
+        }
+
+        if ($this->_activeTab === null && !empty($this->_tabs)) {
+            /** @var TabInterface $tab */
+            $this->_activeTab = (reset($this->_tabs))->getId();
         }
         
         $this->assign('tabs', $this->_tabs);
@@ -259,7 +256,7 @@ class Tabs extends \Magento\Backend\Block\Widget
     /**
      * @return array
      */
-    protected function reorderTabs()
+    private function reorderTabs()
     {
         $orderByIdentity = [];
         $orderByPosition = [];


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16412
- Created a method to reorder the tabs which is less complex and works better.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

When you add 2 or more tabs to admin area, like order view page, by using the method addTabAfter and the second new tab is placed after the first new tab the sort order does not work as expected.

More details in the issue.

### Fixed Issues

1. magento/magento2#16174: Issue title

### Manual testing scenarios

Described in the issue.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
