### PR TITLE
[Backport] 1190: CreateOrderBackendPartOneTest rework to support MSI reservation mechanism.

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Actions.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Actions.php
@@ -138,6 +138,16 @@ class Actions extends Block
     protected $confirmModal = '.confirm._show[data-role=modal]';
 
     /**
+     * Is shipment can be created.
+     *
+     * @return bool
+     */
+    public function canShip()
+    {
+        return $this->_rootElement->find($this->ship)->isVisible();
+    }
+
+    /**
      * Ship order.
      *
      * @return void

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateOrderBackendPartOneTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateOrderBackendPartOneTest.xml
@@ -19,10 +19,10 @@
                 <item name="grandTotal" xsi:type="string">425.00</item>
             </data>
             <data name="payment/method" xsi:type="string">cashondelivery</data>
-            <data name="status" xsi:type="string">Pending</data>
-            <data name="orderButtonsAvailable" xsi:type="string">Back, Reorder, Cancel, Send Email, Hold, Invoice, Ship, Edit</data>
+            <data name="status" xsi:type="string">Processing</data>
+            <data name="orderButtonsAvailable" xsi:type="string">Back, Reorder, Cancel, Send Email, Invoice, Edit</data>
             <data name="configData" xsi:type="string">cashondelivery</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderInOrdersGrid" />
@@ -42,7 +42,6 @@
             <data name="status" xsi:type="string">Pending</data>
             <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Hold, Invoice, Edit</data>
             <data name="configData" xsi:type="string">checkmo_specificcountry_gb</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderInOrdersGrid" />
@@ -59,10 +58,10 @@
                 <item name="grandTotal" xsi:type="string">565.00</item>
             </data>
             <data name="payment/method" xsi:type="string">banktransfer</data>
-            <data name="status" xsi:type="string">Pending</data>
-            <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Hold, Reorder, Invoice, Edit</data>
+            <data name="status" xsi:type="string">Processing</data>
+            <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Reorder, Invoice, Edit</data>
             <data name="configData" xsi:type="string">banktransfer</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderInOrdersGrid" />
@@ -84,7 +83,6 @@
             <data name="status" xsi:type="string">Pending</data>
             <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Hold, Invoice, Edit</data>
             <data name="configData" xsi:type="string">freeshipping_specificcountry_gb, banktransfer</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderInOrdersGrid" />
@@ -103,10 +101,10 @@
             </data>
             <data name="payment/method" xsi:type="string">purchaseorder</data>
             <data name="payment/po_number" xsi:type="string">123456</data>
-            <data name="status" xsi:type="string">Pending</data>
-            <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Hold, Invoice, Reorder, Edit</data>
+            <data name="status" xsi:type="string">Processing</data>
+            <data name="orderButtonsAvailable" xsi:type="string">Back, Cancel, Send Email, Invoice, Reorder, Edit</data>
             <data name="configData" xsi:type="string">purchaseorder</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderButtonsAvailable" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderInOrdersGrid" />
@@ -127,7 +125,7 @@
                 <item name="grandTotal" xsi:type="string">21.91</item>
             </data>
             <data name="payment/method" xsi:type="string">checkmo</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
         </variation>
         <variation name="CreateOrderBackendTestVariation7" summary="Create Order for New Customer in Admin with Offline Payment Method" ticketId="MAGETWO-12520">
@@ -145,7 +143,7 @@
                 <item name="grandTotal" xsi:type="string">21.91</item>
             </data>
             <data name="payment/method" xsi:type="string">checkmo</data>
-            <constraint name="Magento\Sales\Test\Constraint\AssertOrderSuccessCreateMessage" />
+            <constraint name="Magento\Shipping\Test\Constraint\AssertShipmentSuccessCreateMessage" />
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderGrandTotal" />
             <constraint name="Magento\Customer\Test\Constraint\AssertCustomerForm" />
         </variation>

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateShipmentStep.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateShipmentStep.php
@@ -99,13 +99,21 @@ class CreateShipmentStep implements TestStepInterface
     {
         $this->orderIndex->open();
         $this->orderIndex->getSalesOrderGrid()->searchAndOpen(['id' => $this->order->getId()]);
-        $this->salesOrderView->getPageActions()->ship();
-        if (!empty($this->data)) {
-            $this->orderShipmentNew->getFormBlock()->fillData($this->data, $this->order->getEntityId()['products']);
+        $shipmentIds = [];
+        /**
+         * As this step is used in general scenarios and not all test cases has shippable items(ex: virtual product)
+         * we need to check, if it possible to create shipment for given order.
+         */
+        if ($this->salesOrderView->getPageActions()->canShip()) {
+            $this->salesOrderView->getPageActions()->ship();
+            if (!empty($this->data)) {
+                $this->orderShipmentNew->getFormBlock()->fillData($this->data, $this->order->getEntityId()['products']);
+            }
+            $this->orderShipmentNew->getFormBlock()->submit();
+            $shipmentIds = $this->getShipmentIds();
         }
-        $this->orderShipmentNew->getFormBlock()->submit();
 
-        return ['shipmentIds' => $this->getShipmentIds()];
+        return ['shipmentIds' => $shipmentIds];
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/etc/testcase.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/etc/testcase.xml
@@ -54,7 +54,8 @@
         <step name="fillShippingAddress" module="Magento_Sales" next="selectShippingMethodForOrder" />
         <step name="selectShippingMethodForOrder" module="Magento_Sales" next="selectPaymentMethodForOrder" />
         <step name="selectPaymentMethodForOrder" module="Magento_Sales" next="submitOrder" />
-        <step name="submitOrder" module="Magento_Sales" />
+        <step name="submitOrder" module="Magento_Sales" next="createShipment" />
+        <step name="createShipment" module="Magento_Sales"/>
     </scenario>
     <scenario name="VoidAuthorizationTest" firstStep="setupConfiguration">
         <step name="setupConfiguration" module="Magento_Config" next="createProducts" />


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16153
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Add shipment step to CreateOrderBackendPartOneTest in order to support MSI reservation mechanism.

Standard magento behaviour - product quantity decreased immediately after place order, but with MSI quantity decreasing only after shipment created, as MSI introduces additional property for product as 'salable quantity'. And after order placement, 'salable quantity' decreasing, not quantity itself(more about reservation mechanism [here).](https://github.com/magento-engcom/msi/wiki/Reservations) Quantity decreasing only after shipment creation. So, in order to pass CreateOrderBackendPartOneTest with MSI, additional step with shipment creation should be added into test before assertions.
### Fixed Issues (if relevant)
1. magento-engcom/msi#1190: Fix Functional Test Magento\Sales\Test\TestCase\CreateOrderBackendPartOneTest::test with data set "CreateOrderBackendTestVariation1_0"

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. None

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
