### PR TITLE
[Backport] Fix type hints and add undefined property in Webapi [2.3-develop]

### DIFF
--- a/app/code/Magento/Webapi/Controller/Soap.php
+++ b/app/code/Magento/Webapi/Controller/Soap.php
@@ -52,6 +52,11 @@ class Soap implements \Magento\Framework\App\FrontControllerInterface
     protected $_errorProcessor;
 
     /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $_appState;
+
+    /**
      * @var \Magento\Framework\Locale\ResolverInterface
      */
     protected $_localeResolver;

--- a/app/code/Magento/Webapi/Controller/Soap/Request/Handler.php
+++ b/app/code/Magento/Webapi/Controller/Soap/Request/Handler.php
@@ -113,7 +113,7 @@ class Handler
      *
      * @param string $operation
      * @param array $arguments
-     * @return \stdClass|null
+     * @return array
      * @throws WebapiException
      * @throws \LogicException
      * @throws AuthorizationException

--- a/app/code/Magento/Webapi/Model/Plugin/GuestAuthorization.php
+++ b/app/code/Magento/Webapi/Model/Plugin/GuestAuthorization.php
@@ -19,7 +19,7 @@ class GuestAuthorization
      * Check if resource for which access is needed has anonymous permissions defined in webapi config.
      *
      * @param \Magento\Framework\Authorization $subject
-     * @param callable $proceed
+     * @param \Closure $proceed
      * @param string $resource
      * @param string $privilege
      * @return bool true If resource permission is anonymous,

--- a/app/code/Magento/Webapi/Model/Soap/Server.php
+++ b/app/code/Magento/Webapi/Model/Soap/Server.php
@@ -31,7 +31,7 @@ class Server
     const REQUEST_PARAM_LIST_WSDL = 'wsdl_list';
 
     /**
-     * @var \Magento\Framework\App\AreaLIst
+     * @var \Magento\Framework\App\AreaList
      */
     protected $_areaList;
 

--- a/app/code/Magento/Webapi/Test/Unit/Model/Soap/FaultTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Soap/FaultTest.php
@@ -125,7 +125,7 @@ XML;
     public function testToXmlDeveloperModeOn()
     {
         $this->_appStateMock->expects($this->any())->method('getMode')->will($this->returnValue('developer'));
-        $actualXml = $this->_soapFault->toXml(true);
+        $actualXml = $this->_soapFault->toXml();
         $this->assertContains('<m:Trace>', $actualXml, 'Exception trace is not found in XML.');
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16135
### Description

- Fix type hints in `Webapi/Controller/Soap/Request/Handler.php` and  `Webapi/Model/Plugin/GuestAuthorization.php`

- Fix incorrect case in property annotation in `Soap\Server.php` on line [34](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Webapi/Model/Soap/Server.php#L34)

- add undefined property `_appState` in `Controller\Soap.php` on line [104](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Webapi/Controller/Soap.php#L104)

- Fix method `Magento\Webapi\Model\Soap\Fault::toXml()` invoked with 1 parameter, 0 required in `Soap\FaultTest.php` on line [128](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Webapi/Test/Unit/Model/Soap/FaultTest.php#L128)


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
