### PR TITLE
[Forwardport] Fix false cache_lifetime usage in xml layouts

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
+++ b/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
@@ -1074,7 +1074,7 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
 
         $cacheLifetime = $this->getData('cache_lifetime');
         if (false === $cacheLifetime || null === $cacheLifetime) {
-            return $cacheLifetime;
+            return null;
         }
 
         return (int)$cacheLifetime;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16086
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fix cache_lifetime usage with false value
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix
`<argument name="cache_lifetime" xsi:type="boolean">false</argument>`
Usage eg in
Magento/Swatches/view/frontend/layout/checkout_cart_configure_type_configurable.xml

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Reproduced in 2.2 and 2.1 version
1. Add configurable product to cart
2. Move to cart
2. Edit Configurable product

**Expected result**
Configurable product options should be preselected

**Actual result:**
Configurable product options are not preselected

It happens because there is a check in
View/Element/AbstractBlock.php
`
protected function _loadCache() { 
if ($this->getCacheLifetime() === null || !$this->_cacheState->isEnabled(self::CACHE_GROUP)) { return false; }
`

### Contribution checklist
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
