### PR TITLE
Be able to add error before going to checkout

### DIFF
--- a/app/code/Magento/Checkout/Controller/Index/Index.php
+++ b/app/code/Magento/Checkout/Controller/Index/Index.php
@@ -23,6 +23,7 @@ class Index extends \Magento\Checkout\Controller\Onepage
         }
 
         $quote = $this->getOnepage()->getQuote();
+        $this->_eventManager->dispatch('validate_quote', ['quote' => $quote]);
         if (!$quote->hasItems() || $quote->getHasError() || !$quote->validateMinimumAmount()) {
             return $this->resultRedirectFactory->create()->setPath('checkout/cart');
         }


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

This event allow us to make custom check before going to checkout, and add some error messages : 

```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
    <event name="validate_quote">
        <observer name="namespace_module_check_quote" instance="Namespace\Module\Observer\CheckQuote"/>
    </event>
</config>

```

```php
<?php

namespace Namespace\Module\Observer;

use Magento\Framework\Event\Observer;
use Magento\Framework\Event\ObserverInterface;
use Magento\Framework\Message\ManagerInterface;

class CheckQuote implements ObserverInterface
{
    /**
     * @var MessageManager
     */
    protected $messageManager;

    /**
     * @param ManagerInterface $messageManager
     */
    public function __construct(ManagerInterface $messageManager)
    {
        $this->messageManager = $messageManager;
    }

    /**
     *
     * @param Observer $observer
     * @see validate_quote
     */
    public function execute(Observer $observer)
    {
        /** @var \Magento\Quote\Model\Quote $quote */
        $quote = $observer->getEvent()->getQuote();
        $quoteHasError = true; // Create the rule you want
        // Add message if quote has error (The user is not able to go to checkout)
        if ($quoteHasError) {
            $this->messageManager->addErrorMessage(
                __('Your custom error message.')
            );
            $quote->setHasError(true);
        }
    }
}
```
