### PR TITLE
[Fix #16655] Block totalbar not used in invoice create and credit memo create screens

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Totalbar.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Totalbar.php
@@ -8,6 +8,7 @@ namespace Magento\Sales\Block\Adminhtml\Order;
 /**
  * Adminhtml creditmemo bar
  *
+ * @deprecated
  * @api
  * @author      Magento Core Team <core@magentocommerce.com>
  * @since 100.0.2

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_new.xml
@@ -22,7 +22,6 @@
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Totalbar" name="order_totalbar" template="Magento_Sales::order/totalbar.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
                             <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Adjustments" name="adjustments" template="Magento_Sales::order/creditmemo/create/totals/adjustments.phtml"/>
                             <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -13,7 +13,6 @@
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
             <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-            <block class="Magento\Sales\Block\Adminhtml\Order\Totalbar" name="order_totalbar" template="Magento_Sales::order/totalbar.phtml"/>
             <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Totals" name="creditmemo_totals" template="Magento_Sales::order/totals.phtml">
                 <block class="Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Adjustments" name="adjustments" template="Magento_Sales::order/creditmemo/create/totals/adjustments.phtml"/>
                 <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -25,7 +25,6 @@
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-                        <block class="Magento\Sales\Block\Adminhtml\Order\Totalbar" name="order_totalbar" template="Magento_Sales::order/totalbar.phtml"/>
                         <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
                             <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
                         </block>

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -13,7 +13,6 @@
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Qty" name="column_qty" template="Magento_Sales::items/column/qty.phtml" group="column"/>
             <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
             <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
-            <block class="Magento\Sales\Block\Adminhtml\Order\Totalbar" name="order_totalbar" template="Magento_Sales::order/totalbar.phtml"/>
             <block class="Magento\Sales\Block\Adminhtml\Order\Invoice\Totals" name="invoice_totals" template="Magento_Sales::order/totals.phtml">
                 <block class="Magento\Sales\Block\Adminhtml\Order\Totals\Tax" name="tax" template="Magento_Sales::order/totals/tax.phtml"/>
             </block>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totalbar.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totalbar.phtml
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 
+// @deprecated
 // @codingStandardsIgnoreFile
 
 ?>


### PR DESCRIPTION
### Description
Upon investigation there is a totalbar block in the create invoice and credit memo screens which is not being used. This PR addresses that: 

- Removed the unused Totalbar block from the invoice create and credit memo create layouts.
- Deprecated Totalbar class
- Deprecated totalbar template file

### Fixed Issues
1. magento/magento2#16655: Block totalbar not used in invoice create and credit memo create screens
2. magento/magento2#16653: Not possible to create an invoice in Magento 2.3

### Related PR's
There is a PR related to this PR, which does not solve the issue correctly. 
1. magento/magento2#16563: $block->getTotals() is not countable

### Manual testing scenarios
1. Create a new order
2. Create an invoice, screen will look the same as before the changes.
3. Update invoice quantity, screen will look the same as before the changes.
4. Create a credit memo, screen will look the same as before the changes.
5. Update credit memo quantity, screen will look the same as before the changes.