### PR TITLE
[Forwardport] Fixed Issue #11354 Merged CSS file name generation

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/Merged.php
+++ b/lib/internal/Magento/Framework/View/Asset/Merged.php
@@ -41,6 +41,11 @@ class Merged implements \Iterator
     protected $contentType;
 
     /**
+     * @var StorageInterface
+     */
+    private $versionStorage;
+
+    /**
      * @var bool
      */
     protected $isInitialized = false;
@@ -56,11 +61,13 @@ class Merged implements \Iterator
         \Psr\Log\LoggerInterface $logger,
         MergeStrategyInterface $mergeStrategy,
         \Magento\Framework\View\Asset\Repository $assetRepo,
+        \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage,
         array $assets
     ) {
         $this->logger = $logger;
         $this->mergeStrategy = $mergeStrategy;
         $this->assetRepo = $assetRepo;
+        $this->versionStorage = $versionStorage;
 
         if (!$assets) {
             throw new \InvalidArgumentException('At least one asset has to be passed for merging.');
@@ -116,6 +123,12 @@ class Merged implements \Iterator
             $paths[] = $asset->getPath();
         }
         $paths = array_unique($paths);
+
+        $version=$this->versionStorage->load();
+        if ($version) {
+            $paths[]=$version;
+        }
+
         $filePath = md5(implode('|', $paths)) . '.' . $this->contentType;
         return $this->assetRepo->createArbitrary($filePath, self::getRelativeDir());
     }

--- a/lib/internal/Magento/Framework/View/Asset/Merged.php
+++ b/lib/internal/Magento/Framework/View/Asset/Merged.php
@@ -50,10 +50,14 @@ class Merged implements \Iterator
      */
     protected $isInitialized = false;
 
+
     /**
+     * Merged constructor.
+     *
      * @param \Psr\Log\LoggerInterface $logger
      * @param MergeStrategyInterface $mergeStrategy
      * @param \Magento\Framework\View\Asset\Repository $assetRepo
+     * @param \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage
      * @param MergeableInterface[] $assets
      * @throws \InvalidArgumentException
      */

--- a/lib/internal/Magento/Framework/View/Asset/Merged.php
+++ b/lib/internal/Magento/Framework/View/Asset/Merged.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\View\Asset;
 
+use Magento\Framework\App\ObjectManager;
+
 /**
  * \Iterator that aggregates one or more assets and provides a single public file with equivalent behavior
  */
@@ -56,21 +58,23 @@ class Merged implements \Iterator
      * @param \Psr\Log\LoggerInterface $logger
      * @param MergeStrategyInterface $mergeStrategy
      * @param \Magento\Framework\View\Asset\Repository $assetRepo
-     * @param \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage
      * @param MergeableInterface[] $assets
+     * @param \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage
      * @throws \InvalidArgumentException
      */
     public function __construct(
         \Psr\Log\LoggerInterface $logger,
         MergeStrategyInterface $mergeStrategy,
         \Magento\Framework\View\Asset\Repository $assetRepo,
-        \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage,
-        array $assets
+        array $assets,
+        \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage = null
     ) {
         $this->logger = $logger;
         $this->mergeStrategy = $mergeStrategy;
         $this->assetRepo = $assetRepo;
-        $this->versionStorage = $versionStorage;
+        $this->versionStorage = $versionStorage ?: ObjectManager::getInstance()->get(
+            \Magento\Framework\App\View\Deployment\Version\StorageInterface::class
+        );
 
         if (!$assets) {
             throw new \InvalidArgumentException('At least one asset has to be passed for merging.');
@@ -127,9 +131,9 @@ class Merged implements \Iterator
         }
         $paths = array_unique($paths);
 
-        $version=$this->versionStorage->load();
+        $version = $this->versionStorage->load();
         if ($version) {
-            $paths[]=$version;
+            $paths[] = $version;
         }
 
         $filePath = md5(implode('|', $paths)) . '.' . $this->contentType;

--- a/lib/internal/Magento/Framework/View/Asset/Merged.php
+++ b/lib/internal/Magento/Framework/View/Asset/Merged.php
@@ -41,7 +41,7 @@ class Merged implements \Iterator
     protected $contentType;
 
     /**
-     * @var StorageInterface
+     * @var \Magento\Framework\App\View\Deployment\Version\StorageInterface
      */
     private $versionStorage;
 

--- a/lib/internal/Magento/Framework/View/Asset/Merged.php
+++ b/lib/internal/Magento/Framework/View/Asset/Merged.php
@@ -50,7 +50,6 @@ class Merged implements \Iterator
      */
     protected $isInitialized = false;
 
-
     /**
      * Merged constructor.
      *

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
@@ -101,8 +101,8 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
-            'versionStorage' => $this->versionStorage,
             'assets' => [$this->assetJsOne, $assetUrl],
+            'versionStorage' => $this->versionStorage,
         ]);
     }
 
@@ -121,8 +121,8 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
-            'versionStorage' => $this->versionStorage,
             'assets' => [$this->assetJsOne, $assetCss],
+            'versionStorage' => $this->versionStorage,
         ]);
     }
 
@@ -137,8 +137,8 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
-            'versionStorage' => $this->versionStorage,
             'assets' => $assets,
+            'versionStorage' => $this->versionStorage,
         ]);
 
         $mergedAsset = $this->createMock(\Magento\Framework\View\Asset\File::class);
@@ -172,8 +172,8 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
-            'versionStorage' => $this->versionStorage,
             'assets' => [$this->assetJsOne, $this->assetJsTwo, $assetBroken],
+            'versionStorage' => $this->versionStorage,
         ]);
 
         $this->logger->expects($this->once())->method('critical')->with($this->identicalTo($mergeError));

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
@@ -82,7 +82,8 @@ class MergedTest extends \PHPUnit\Framework\TestCase
     public function testConstructorNothingToMerge()
     {
         new \Magento\Framework\View\Asset\Merged(
-            $this->logger, $this->mergeStrategy,
+            $this->logger,
+            $this->mergeStrategy,
             $this->assetRepo,
             [],
             $this->versionStorage

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
@@ -81,7 +81,12 @@ class MergedTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstructorNothingToMerge()
     {
-        new \Magento\Framework\View\Asset\Merged($this->logger, $this->mergeStrategy, $this->assetRepo, $this->versionStorage, []);
+        new \Magento\Framework\View\Asset\Merged(
+            $this->logger, $this->mergeStrategy,
+            $this->assetRepo,
+            $this->versionStorage,
+            []
+        );
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
@@ -84,8 +84,8 @@ class MergedTest extends \PHPUnit\Framework\TestCase
         new \Magento\Framework\View\Asset\Merged(
             $this->logger, $this->mergeStrategy,
             $this->assetRepo,
-            $this->versionStorage,
-            []
+            [],
+            $this->versionStorage
         );
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergedTest.php
@@ -12,6 +12,7 @@ use Psr\Log\LoggerInterface;
 use Magento\Framework\View\Asset\Repository as AssetRepository;
 use Magento\Framework\View\Asset\MergeableInterface;
 use Magento\Framework\View\Asset\MergeStrategyInterface;
+use Magento\Framework\App\View\Deployment\Version\StorageInterface;
 
 /**
  * Class MergedTest
@@ -43,6 +44,11 @@ class MergedTest extends \PHPUnit\Framework\TestCase
      */
     private $assetRepo;
 
+    /**
+     * @var StorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $versionStorage;
+
     protected function setUp()
     {
         $this->assetJsOne = $this->getMockForAbstractClass(MergeableInterface::class);
@@ -66,6 +72,7 @@ class MergedTest extends \PHPUnit\Framework\TestCase
         $this->assetRepo = $this->getMockBuilder(AssetRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->versionStorage = $this->createMock(StorageInterface::class);
     }
 
     /**
@@ -74,7 +81,7 @@ class MergedTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstructorNothingToMerge()
     {
-        new \Magento\Framework\View\Asset\Merged($this->logger, $this->mergeStrategy, $this->assetRepo, []);
+        new \Magento\Framework\View\Asset\Merged($this->logger, $this->mergeStrategy, $this->assetRepo, $this->versionStorage, []);
     }
 
     /**
@@ -89,6 +96,7 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
+            'versionStorage' => $this->versionStorage,
             'assets' => [$this->assetJsOne, $assetUrl],
         ]);
     }
@@ -108,6 +116,7 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
+            'versionStorage' => $this->versionStorage,
             'assets' => [$this->assetJsOne, $assetCss],
         ]);
     }
@@ -123,6 +132,7 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
+            'versionStorage' => $this->versionStorage,
             'assets' => $assets,
         ]);
 
@@ -157,6 +167,7 @@ class MergedTest extends \PHPUnit\Framework\TestCase
             'logger' => $this->logger,
             'mergeStrategy' => $this->mergeStrategy,
             'assetRepo' => $this->assetRepo,
+            'versionStorage' => $this->versionStorage,
             'assets' => [$this->assetJsOne, $this->assetJsTwo, $assetBroken],
         ]);
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15144
Fixed  Issue #11354 Merged CSS file name generation

### Description
When "Sign Static Files" option enabled at the Stores->Configuration->Advanced->Developer->Static Files Settings minified and merged CSS file md5 hash will be based on deployed version number.

This allows CSS code to be updated after each deploy at browser automatically. Previously you have to do CTRL+F5 after deploy to see CSS changes. 

### Fixed Issues (if relevant)
1. magento/magento2#11354 : Merged CSS file name generation

### Manual testing scenarios
1. Stores->Configuration->Advanced->Developer set CSS Settings Merge and Minify CSS Files to YES
2. Stores->Configuration->Advanced->Developer set JavaScript Settings Merge and Minify JavaScript Files to YES
3.  Stores->Configuration->Advanced->Developer->Static Files Settings set Sign Static Files tp YES
4. Delete static content & deploy the static content again
5. Remember the CSS filename 
6.  Delete static content & deploy the static content again
7. Compare to CSS file name to the file name ftop step 5.  They should be different because the version of deployed files changed. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
