### PR TITLE
[Forwardport] 7399-clickableOverlay-less-fix - added pointer-events rule to .modal-…

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
@@ -63,6 +63,8 @@
     }
 
     .modal-popup {
+        pointer-events: none;
+
         .modal-title {
             .lib-css(border-bottom, @modal-title__border);
             .lib-css(font-weight, @font-weight__light);

--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -63,6 +63,8 @@
     }
 
     .modal-popup {
+        pointer-events: none;
+
         .modal-title {
             .lib-css(border-bottom, @modal-title__border);
             .lib-css(font-weight, @font-weight__light);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15172
…popup class to let user click deeper than modals and reach to overlay's div in modal-wrapper div

<!--- Provide a general summary of the Pull Request in the Title above -->
To reproduce issue please see: https://github.com/magento/magento2/issues/7399

### Description
Problem: modal's overlay div would not catch click event because is covered by modal's div above. That's why modal is would not fire close event when user is clicking outside modal.

My proposition of solution for that issue is add pointer-events: none css rule to modals in theme's less files.

### Fixed Issues (if relevant)
1. magento/magento2#7399: Modal UI: clickableOverlay option doesn't work

### Test scenario

1. Add a code to any .phtml template file:

```
<button id="btn-modal">
   Click to open modal
</button>
```
... add a js script code
```
require(['jquery', 'Magento_Ui/js/modal/modal'], function($, modal) {
  $('#btn-modal').click(function(e) {
      e.preventDefault();
      $('<p>Overlay content</p>').modal({ clickableOverlay: true }).modal('openModal');
  });
});
```

2. Open modal and click to overlay to close it


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
