### PR TITLE
[Forwardport] Customer group extension attributes not carried over on save

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
@@ -155,12 +155,11 @@ class GroupRepository implements \Magento\Customer\Api\GroupRepositoryInterface
             ->setId($groupModel->getId())
             ->setCode($groupModel->getCode())
             ->setTaxClassId($groupModel->getTaxClassId())
-            ->setTaxClassName($groupModel->getTaxClassName());
-        
+            ->setTaxClassName($groupModel->getTaxClassName());      
         if ($group->getExtensionAttributes()) {
             $groupDataObject->setExtensionAttributes($group->getExtensionAttributes());
         }
-        
+                
         return $groupDataObject;
     }
 

--- a/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
@@ -156,6 +156,11 @@ class GroupRepository implements \Magento\Customer\Api\GroupRepositoryInterface
             ->setCode($groupModel->getCode())
             ->setTaxClassId($groupModel->getTaxClassId())
             ->setTaxClassName($groupModel->getTaxClassName());
+        
+        if ($group->getExtensionAttributes()) {
+            $groupDataObject->setExtensionAttributes($group->getExtensionAttributes());
+        }
+        
         return $groupDataObject;
     }
 

--- a/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
@@ -155,11 +155,12 @@ class GroupRepository implements \Magento\Customer\Api\GroupRepositoryInterface
             ->setId($groupModel->getId())
             ->setCode($groupModel->getCode())
             ->setTaxClassId($groupModel->getTaxClassId())
-            ->setTaxClassName($groupModel->getTaxClassName());      
+            ->setTaxClassName($groupModel->getTaxClassName());
+
         if ($group->getExtensionAttributes()) {
             $groupDataObject->setExtensionAttributes($group->getExtensionAttributes());
         }
-                
+
         return $groupDataObject;
     }
 

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
@@ -173,7 +173,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $groupId = 0;
 
         $taxClass = $this->getMockForAbstractClass(\Magento\Tax\Api\Data\TaxClassInterface::class, [], '', false);
-        $groupExtensionAttributes = $this->getMockForAbstractClass(\Magento\Customer\Api\Data\GroupExtensionInterface::class);
+        $extensionAttributes = $this->getMockForAbstractClass(\Magento\Customer\Api\Data\GroupExtensionInterface::class);
 
         $this->group->expects($this->atLeastOnce())
             ->method('getCode')
@@ -186,7 +186,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturn(17);
         $this->group->expects($this->atLeastOnce())
             ->method('getExtensionAttributes')
-            ->willReturn($groupExtensionAttributes);
+            ->willReturn($extensionAttributes);
 
         $this->groupModel->expects($this->atLeastOnce())
             ->method('getId')
@@ -220,7 +220,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->factoryCreatedGroup->expects($this->once())
             ->method('setExtensionAttributes')
-            ->with($groupExtensionAttributes)
+            ->with($extensionAttributes)
             ->willReturnSelf();
         $this->factoryCreatedGroup->expects($this->atLeastOnce())
             ->method('getCode')

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
@@ -37,6 +37,11 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Customer\Api\Data\GroupInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $group;
+    
+    /**
+     * @var \Magento\Customer\Api\Data\GroupInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $factoryCreatedGroup;
 
     /**
      * @var \Magento\Customer\Model\ResourceModel\Group|\PHPUnit_Framework_MockObject_MockObject
@@ -153,6 +158,12 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             'group',
             false
         );
+        $this->factoryCreatedGroup = $this->getMockForAbstractClass(
+            \Magento\Customer\Api\Data\GroupInterface::class,
+            [],
+            'group',
+            false
+        );
 
         $this->groupResourceModel = $this->createMock(\Magento\Customer\Model\ResourceModel\Group::class);
     }
@@ -162,16 +173,20 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $groupId = 0;
 
         $taxClass = $this->getMockForAbstractClass(\Magento\Tax\Api\Data\TaxClassInterface::class, [], '', false);
+        $groupExtensionAttributes = $this->getMockForAbstractClass(\Magento\Customer\Api\Data\GroupExtensionInterface::class);
 
-        $this->group->expects($this->once())
+        $this->group->expects($this->atLeastOnce())
             ->method('getCode')
             ->willReturn('Code');
         $this->group->expects($this->atLeastOnce())
             ->method('getId')
             ->willReturn($groupId);
-        $this->group->expects($this->once())
+        $this->group->expects($this->atLeastOnce())
             ->method('getTaxClassId')
             ->willReturn(17);
+        $this->group->expects($this->atLeastOnce())
+            ->method('getExtensionAttributes')
+            ->willReturn($groupExtensionAttributes);
 
         $this->groupModel->expects($this->atLeastOnce())
             ->method('getId')
@@ -185,22 +200,34 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->groupModel->expects($this->atLeastOnce())
             ->method('getTaxClassName')
             ->willReturn('Tax class name');
-        $this->group->expects($this->once())
+        
+        
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setId')
             ->with($groupId)
             ->willReturnSelf();
-        $this->group->expects($this->once())
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setCode')
             ->with('Code')
             ->willReturnSelf();
-        $this->group->expects($this->once())
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setTaxClassId')
             ->with(234)
             ->willReturnSelf();
-        $this->group->expects($this->once())
+        $this->factoryCreatedGroup->expects($this->once())
             ->method('setTaxClassName')
             ->with('Tax class name')
             ->willReturnSelf();
+        $this->factoryCreatedGroup->expects($this->once())
+            ->method('setExtensionAttributes')
+            ->with($groupExtensionAttributes)
+            ->willReturnSelf();
+        $this->factoryCreatedGroup->expects($this->atLeastOnce())
+            ->method('getCode')
+            ->willReturn('Code');
+        $this->factoryCreatedGroup->expects($this->atLeastOnce())
+            ->method('getTaxClassId')
+            ->willReturn(17);
 
         $this->taxClassRepository->expects($this->once())
             ->method('get')
@@ -229,9 +256,12 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
             ->with($groupId);
         $this->groupDataFactory->expects($this->once())
             ->method('create')
-            ->willReturn($this->group);
+            ->willReturn($this->factoryCreatedGroup);
 
-        $this->assertSame($this->group, $this->model->save($this->group));
+        $updatedGroup = $this->model->save($this->group);
+
+        $this->assertSame($this->group->getCode(), $updatedGroup->getCode());
+        $this->assertSame($this->group->getTaxClassId(), $updatedGroup->getTaxClassId());
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
@@ -202,8 +202,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->groupModel->expects($this->atLeastOnce())
             ->method('getTaxClassName')
             ->willReturn('Tax class name');
-        
-        
+
         $this->factoryCreatedGroup->expects($this->once())
             ->method('setId')
             ->with($groupId)

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/GroupRepositoryTest.php
@@ -37,7 +37,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Customer\Api\Data\GroupInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $group;
-    
+
     /**
      * @var \Magento\Customer\Api\Data\GroupInterface|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -173,7 +173,9 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $groupId = 0;
 
         $taxClass = $this->getMockForAbstractClass(\Magento\Tax\Api\Data\TaxClassInterface::class, [], '', false);
-        $extensionAttributes = $this->getMockForAbstractClass(\Magento\Customer\Api\Data\GroupExtensionInterface::class);
+        $extensionAttributes = $this->getMockForAbstractClass(
+            \Magento\Customer\Api\Data\GroupExtensionInterface::class
+        );
 
         $this->group->expects($this->atLeastOnce())
             ->method('getCode')


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16254
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When saving a customer group, extension attributes should be copied to the new data model that is returned. Unfortunately, this action was not completed and results in unexpected behavior.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Ensure that saving a customer group does not throw any errors.
2. Ensure that utilizing extension attributes for a customer group now carries over through the save process.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
