### PR TITLE
Add delete action for default addresses

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/address/book.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/book.phtml
@@ -25,6 +25,9 @@
                     <a class="action edit" href="<?= $block->escapeUrl($block->getAddressEditUrl($_pAddsses)) ?>">
                         <span><?= $block->escapeHtml(__('Change Billing Address')) ?></span>
                     </a>
+                    <a class="action delete" href="#" role="delete-address" data-address="<?= $block->escapeHtmlAttr($_pAddsses) ?>">
+                        <span><?= $block->escapeHtml(__('Delete Address')) ?></span>
+                    </a>
                 </div>
             </div>
         <?php else: ?>
@@ -49,6 +52,9 @@
                 <div class="box-actions">
                     <a class="action edit" href="<?= $block->escapeUrl($block->getAddressEditUrl($_pAddsses)) ?>">
                         <span><?= $block->escapeHtml(__('Change Shipping Address')) ?></span>
+                    </a>
+                    <a class="action delete" href="#" role="delete-address" data-address="<?= $block->escapeHtmlAttr($_pAddsses) ?>">
+                        <span><?= $block->escapeHtml(__('Delete Address')) ?></span>
                     </a>
                 </div>
             </div>
@@ -98,7 +104,7 @@
     {
         ".page-main": {
             "address": {
-                "deleteAddress": "li.item a[role='delete-address']",
+                "deleteAddress": "a[role='delete-address']",
                 "deleteUrlPrefix": "<?= $block->escapeJs($block->escapeUrl($block->getDeleteUrl())) ?>id/",
                 "addAddress": "button[role='add-address']",
                 "addAddressLocation": "<?= $block->escapeJs($block->escapeUrl($block->getAddAddressUrl())) ?>"


### PR DESCRIPTION
Add delete button to the default  address on customer book page.

### Description
Delete a default address is possible in Magento, controller action allows it and the system can handle it.
However the customer can't delete a default address as there's no action button.  
The only way for a customer to delete his default address is to create a new, set it as default, then he can delete the first one.

### Manual testing scenarios

1. Go to the addresses section in customer account page
2. Click "Delete address" on a default address
