### PR TITLE
'Allowed Countries' - get countries for scope 'default'.

### DIFF
--- a/app/code/Magento/Directory/Model/AllowedCountries.php
+++ b/app/code/Magento/Directory/Model/AllowedCountries.php
@@ -55,7 +55,7 @@ class AllowedCountries
         $scope = ScopeInterface::SCOPE_WEBSITE,
         $scopeCode = null
     ) {
-        if (empty($scopeCode)) {
+        if ($scopeCode === null) {
             $scopeCode = $this->getDefaultScopeCode($scope);
         }
 

--- a/app/code/Magento/Directory/Test/Unit/Model/AllowedCountriesTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/AllowedCountriesTest.php
@@ -70,4 +70,20 @@ class AllowedCountriesTest extends \PHPUnit\Framework\TestCase
             $this->allowedCountriesReader->getAllowedCountries(ScopeInterface::SCOPE_WEBSITE, true)
         );
     }
+
+    public function testGetAllowedCountriesDefaultScope()
+    {
+        $this->storeManagerMock->expects($this->never())
+            ->method('getStore');
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('getValue')
+            ->with(AllowedCountries::ALLOWED_COUNTRIES_PATH, ScopeInterface::SCOPE_STORE, 0)
+            ->willReturn('AM');
+
+        $this->assertEquals(
+            ['AM' => 'AM'],
+            $this->allowedCountriesReader->getAllowedCountries(ScopeInterface::SCOPE_STORE, 0)
+        );
+    }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
- fix 'if' for scope with id 0;
- add test for this case;


### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#?: Not found relevant issue for the problem

### Manual testing scenarios
#### Pre-conditions
1. Installation with website - Website and tore - Store.
2. Configured different 'Allowed Countries' for 'Default' and Store scopes.
#### Steps To Reproduce
1. Require `Magento\Directory\Model\AllowedCountries` class
2. Get Allowed Countries for default scope 0:
`Magento\Directory\Model\ResourceModel\Country::getAllowedCountries('ScopeInterface::SCOPE_STORE, 0)`

#### Expected Result:
1. Returned Allowed Countries for Default config

#### Actual Result:
1. Will be returned Allowed Countries for default store - Store.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
