### PR TITLE
Declare module namespace before template path in all other modules

### DIFF
--- a/app/code/Magento/AdvancedSearch/Block/SearchData.php
+++ b/app/code/Magento/AdvancedSearch/Block/SearchData.php
@@ -30,7 +30,7 @@ abstract class SearchData extends Template implements SearchDataInterface
     /**
      * @var string
      */
-    protected $_template = 'search_data.phtml';
+    protected $_template = 'Magento_AdvancedSearch::search_data.phtml';
 
     /**
      * @param Template\Context $context

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Attribute.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Attribute/Set/Main/Tree/Attribute.php
@@ -14,5 +14,5 @@ class Attribute extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/attribute/set/main/tree/attribute.phtml';
+    protected $_template = 'Magento_Catalog::catalog/product/attribute/set/main/tree/attribute.phtml';
 }

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -18,7 +18,7 @@ class Js extends \Magento\Backend\Block\Template
      * @var string
      */
   
-    protected $_template = 'attribute/edit/js.phtml';
+    protected $_template = 'Magento_Eav::attribute/edit/js.phtml';
 
     /**
      * @var \Magento\Eav\Model\Adminhtml\System\Config\Source\Inputtype

--- a/app/code/Magento/OfflinePayments/Block/Form/Banktransfer.php
+++ b/app/code/Magento/OfflinePayments/Block/Form/Banktransfer.php
@@ -15,5 +15,5 @@ class Banktransfer extends \Magento\OfflinePayments\Block\Form\AbstractInstructi
      *
      * @var string
      */
-    protected $_template = 'form/banktransfer.phtml';
+    protected $_template = 'Magento_OfflinePayments::form/banktransfer.phtml';
 }

--- a/app/code/Magento/OfflinePayments/Block/Form/Cashondelivery.php
+++ b/app/code/Magento/OfflinePayments/Block/Form/Cashondelivery.php
@@ -15,5 +15,5 @@ class Cashondelivery extends \Magento\OfflinePayments\Block\Form\AbstractInstruc
      *
      * @var string
      */
-    protected $_template = 'form/cashondelivery.phtml';
+    protected $_template = 'Magento_OfflinePayments::form/cashondelivery.phtml';
 }

--- a/app/code/Magento/Payment/Block/Info/Instructions.php
+++ b/app/code/Magento/Payment/Block/Info/Instructions.php
@@ -23,7 +23,7 @@ class Instructions extends \Magento\Payment\Block\Info
     /**
      * @var string
      */
-    protected $_template = 'info/instructions.phtml';
+    protected $_template = 'Magento_Payment::info/instructions.phtml';
 
     /**
      * Get instructions text from order payment

--- a/app/code/Magento/ProductAlert/Block/Email/Price.php
+++ b/app/code/Magento/ProductAlert/Block/Email/Price.php
@@ -15,7 +15,7 @@ class Price extends \Magento\ProductAlert\Block\Email\AbstractEmail
     /**
      * @var string
      */
-    protected $_template = 'email/price.phtml';
+    protected $_template = 'Magento_ProductAlert::email/price.phtml';
 
     /**
      * Retrieve unsubscribe url for product

--- a/app/code/Magento/ProductAlert/Block/Email/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Email/Stock.php
@@ -15,7 +15,7 @@ class Stock extends \Magento\ProductAlert\Block\Email\AbstractEmail
     /**
      * @var string
      */
-    protected $_template = 'email/stock.phtml';
+    protected $_template = 'Magento_ProductAlert::email/stock.phtml';
 
     /**
      * Retrieve unsubscribe url for product

--- a/app/code/Magento/Rss/Block/Feeds.php
+++ b/app/code/Magento/Rss/Block/Feeds.php
@@ -16,7 +16,7 @@ class Feeds extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'feeds.phtml';
+    protected $_template = 'Magento_Rss::feeds.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\RssManagerInterface

--- a/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging/Grid.php
+++ b/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging/Grid.php
@@ -10,7 +10,7 @@ class Grid extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'order/packaging/grid.phtml';
+    protected $_template = 'Magento_Shipping::order/packaging/grid.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Shipping/Block/Order/Shipment.php
+++ b/app/code/Magento/Shipping/Block/Order/Shipment.php
@@ -18,7 +18,7 @@ class Shipment extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/shipment.phtml';
+    protected $_template = 'Magento_Shipping::order/shipment.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Signifyd/Block/Fingerprint.php
+++ b/app/code/Magento/Signifyd/Block/Fingerprint.php
@@ -42,7 +42,7 @@ class Fingerprint extends Template
      * @var string
      * @since 100.2.0
      */
-    protected $_template = 'fingerprint.phtml';
+    protected $_template = 'Magento_Signifyd::fingerprint.phtml';
 
     /**
      * @param Context $context

--- a/app/code/Magento/UrlRewrite/Block/Catalog/Category/Tree.php
+++ b/app/code/Magento/UrlRewrite/Block/Catalog/Category/Tree.php
@@ -27,7 +27,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     /**
      * @var string
      */
-    protected $_template = 'categories.phtml';
+    protected $_template = 'Magento_UrlRewrite::categories.phtml';
 
     /**
      * Adminhtml data

--- a/app/code/Magento/UrlRewrite/Block/Selector.php
+++ b/app/code/Magento/UrlRewrite/Block/Selector.php
@@ -18,7 +18,7 @@ class Selector extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'selector.phtml';
+    protected $_template = 'Magento_UrlRewrite::selector.phtml';
 
     /**
      * Set block template and get available modes

--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -19,7 +19,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form implements \Magento\Backen
     /**
      * @var string
      */
-    protected $_template = 'role/edit.phtml';
+    protected $_template = 'Magento_User::role/edit.phtml';
 
     /**
      * Root ACL Resource

--- a/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
@@ -32,7 +32,7 @@ class Tax extends \Magento\Backend\Block\Widget implements
     /**
      * @var string
      */
-    protected $_template = 'renderer/tax.phtml';
+    protected $_template = 'Magento_Weee::renderer/tax.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -27,7 +27,7 @@ class Layout extends Template implements RendererInterface
     /**
      * @var string
      */
-    protected $_template = 'instance/edit/layout.phtml';
+    protected $_template = 'Magento_Widget::instance/edit/layout.phtml';
 
     /**
      * @var \Magento\Catalog\Model\Product\Type

--- a/app/code/Magento/Wishlist/Block/Rss/EmailLink.php
+++ b/app/code/Magento/Wishlist/Block/Rss/EmailLink.php
@@ -21,7 +21,7 @@ class EmailLink extends Link
     /**
      * @var string
      */
-    protected $_template = 'rss/email.phtml';
+    protected $_template = 'Magento_Wishlist::rss/email.phtml';
 
     /**
      * @return array

--- a/app/code/Magento/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/Magento/Wishlist/Block/Share/Email/Items.php
@@ -20,7 +20,7 @@ class Items extends \Magento\Wishlist\Block\AbstractBlock
     /**
      * @var string
      */
-    protected $_template = 'email/items.phtml';
+    protected $_template = 'Magento_Wishlist::email/items.phtml';
 
     /**
      * Retrieve Product View URL


### PR DESCRIPTION
Relates PR
https://github.com/magento/magento2/pull/16515
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When we override any core block to any custom module, It throws an error because it tries to find template file in the custom module if we do not declare module namespace before template path.
I tried to extend Block Magento\Sales\Block\Order\Creditmemo from my custom module.

`1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'form/newsletter.phtml' in module: 'Vendor_Module'`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Declare module namespace before template path name.
For example: `protected $_template = 'Magento_Customer::form/newsletter.phtml';`

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Override any block file which content static template file path

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
