### PR TITLE
Update regex in ControllerAclTest

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/ControllerAclTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/ControllerAclTest.php
@@ -232,7 +232,7 @@ class ControllerAclTest extends \PHPUnit\Framework\TestCase
      */
     private function getControllerPath($relativeFilePath)
     {
-        if (preg_match('~(Magento\/.*Controller\/Adminhtml\/.*)\.php~', $relativeFilePath, $matches)) {
+        if (preg_match('~(Magento\/[^\/]+\/Controller\/Adminhtml\/.*)\.php~', $relativeFilePath, $matches)) {
             if (count($matches) === 2 && count($partPath = $matches[1]) >= 1) {
                 $partPath = $matches[1];
                 return $partPath;


### PR DESCRIPTION
### Description
Change regex in `ControllerAclTest::getControllerPath()` to avoid classes which are under a namespace with a "Controller" part (like for example controller plugins) being interpreted as controllers causing the Act test to fail.

I need this change because, in the scope of MSI development, I have to define the following plugin for a controller:

```
    <type name="Magento\Catalog\Controller\Adminhtml\Product\Initialization\StockDataFilter">
        <plugin name="allow_negative_min_qty"
                type="Magento\InventoryCatalog\Plugin\Catalog\Controller\Adminhtml\Product\Initialization\StockDataFilter\AllowNegativeMinQtyPlugin"
                sortOrder="1"/>
```

The `Magento\InventoryCatalog\Plugin\Catalog\Controller\Adminhtml\Product\Initialization\StockDataFilter\AllowNegativeMinQtyPlugin` plugin class makes the test fail because it is considered a controller but doesn't extend `\Magento\Backend\App\AbstractAction`.

### Manual testing scenarios
- define a plugin on a controller declaring it under a namespace with a "Controller" part
- run the `ControllerAclTest` static test
- expect the test to fail