### PR TITLE
fix _utilities.less font-size issue

### DIFF
--- a/lib/web/css/source/lib/_utilities.less
+++ b/lib/web/css/source/lib/_utilities.less
@@ -260,9 +260,8 @@
     @_line-height: normal
 ) {
     .lib-font-size(@_font-size);
-    font-size: @_font-size;
+    .lib-line-height(@_line-height);
     letter-spacing: normal;
-    line-height: @_line-height;
 }
 
 //


### PR DESCRIPTION
### Description

Toolbar pager item has font-size atribute twice, should be defined only once. 

### Fixed Issues (if relevant)
none

### Manual testing scenarios
look product toolbar pager number css
should be: 

.pages .item {
font-size: 1.2rem;
...
}

is: 
.pages .item {
font-size: 1.2rem;
font-size: 12px;
...
}


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
