### PR TITLE
[Backport 2.2] MSI-1411: Add new rule to copy paste detector blacklist

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/common.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcpd/blacklist/common.txt
@@ -199,3 +199,4 @@ Magento/Framework/MessageQueue/Topology/Config/ExchangeConfigItem
 IntegrationConfig.php
 *Test.php
 setup/performance-toolkit/aggregate-report
+Test/_files


### PR DESCRIPTION
Original PR: #16508
### Description
In the MSI modules all fixtures for tests are in <Module_Name>/Test/_data which is different from Magento current implementations.
In order to avoid falling copy paste detector tests on the fixtures has been added a new rule to the blacklist.

