### PR TITLE
[Backport 2.3] Add spelling correction: formatedPrice to formattedPrice

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
@@ -105,9 +105,11 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Retrieve formatted price
+     *
      * @return string
      */
-    public function getFormatedPrice()
+    public function getFormattedPrice()
     {
         if ($option = $this->getOption()) {
             return $this->_formatPrice(
@@ -118,6 +120,17 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
             );
         }
         return '';
+    }
+
+    /**
+     * @return string
+     *
+     * @deprecated
+     * @see getFormattedPrice()
+     */
+    public function getFormatedPrice()
+    {
+        return $this->getFormattedPrice();
     }
 
     /**

--- a/app/code/Magento/Catalog/Block/Product/View/Price.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Price.php
@@ -9,6 +9,8 @@
  */
 namespace Magento\Catalog\Block\Product\View;
 
+use Magento\Catalog\Model\Product;
+
 class Price extends \Magento\Framework\View\Element\Template
 {
     /**
@@ -37,7 +39,8 @@ class Price extends \Magento\Framework\View\Element\Template
      */
     public function getPrice()
     {
+        /** @var Product $product */
         $product = $this->_coreRegistry->registry('product');
-        return $product->getFormatedPrice();
+        return $product->getFormattedPrice();
     }
 }

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -1149,11 +1149,24 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     /**
      * Get formatted by currency product price
      *
-     * @return  array || double
+     * @return  array|double
+     */
+    public function getFormattedPrice()
+    {
+        return $this->getPriceModel()->getFormattedPrice($this);
+    }
+
+    /**
+     * Get formatted by currency product price
+     *
+     * @return  array|double
+     *
+     * @deprecated
+     * @see getFormattedPrice()
      */
     public function getFormatedPrice()
     {
-        return $this->getPriceModel()->getFormatedPrice($this);
+        return $this->getFormattedPrice();
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Type/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Price.php
@@ -474,14 +474,15 @@ class Price
      *
      * @param   float $qty
      * @param   Product $product
+     *
      * @return  array|float
      */
-    public function getFormatedTierPrice($qty, $product)
+    public function getFormattedTierPrice($qty, $product)
     {
         $price = $product->getTierPrice($qty);
         if (is_array($price)) {
             foreach (array_keys($price) as $index) {
-                $price[$index]['formated_price'] = $this->priceCurrency->convertAndFormat(
+                $price[$index]['formatted_price'] = $this->priceCurrency->convertAndFormat(
                     $price[$index]['website_price']
                 );
             }
@@ -493,14 +494,44 @@ class Price
     }
 
     /**
+     * Get formatted by currency tier price
+     *
+     * @param   float $qty
+     * @param   Product $product
+     *
+     * @return  array|float
+     *
+     * @deprecated
+     * @see getFormattedTierPrice()
+     */
+    public function getFormatedTierPrice($qty, $product)
+    {
+        return $this->getFormattedTierPrice($qty, $product);
+    }
+
+    /**
+     * Get formatted by currency product price
+     *
+     * @param   Product $product
+     * @return  array|float
+     */
+    public function getFormattedPrice($product)
+    {
+        return $this->priceCurrency->format($product->getFinalPrice());
+    }
+
+    /**
      * Get formatted by currency product price
      *
      * @param   Product $product
      * @return  array || float
+     *
+     * @deprecated
+     * @see getFormattedPrice()
      */
     public function getFormatedPrice($product)
     {
-        return $this->priceCurrency->format($product->getFinalPrice());
+        return $this->getFormattedPrice($product);
     }
 
     /**

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
@@ -13,7 +13,7 @@
 <div class="admin__field field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
   <label class="label admin__field-label">
       <?= $block->escapeHtml($_option->getTitle()) ?>
-      <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+      <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
   </label>
   <div class="admin__field-control control">
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_fileInfo = $block->getFileInfo(); ?>
 <?php $_fileExists = $_fileInfo->hasData() ? true : false; ?>
@@ -64,7 +65,7 @@ require(['prototype'], function(){
 <div class="admin__field <?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="admin__field-label label">
         <?= $block->escapeHtml($_option->getTitle()) ?>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
     <div class="admin__field-control control">
         <?php if ($_fileExists): ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
@@ -12,7 +12,7 @@
 <div class="field admin__field<?php if ($_option->getIsRequire()) echo ' required _required' ?>">
     <label class="admin__field-label label">
         <?= $block->escapeHtml($_option->getTitle()) ?>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
     <div class="control admin__field-control">
         <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_FIELD): ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_optionId = $_option->getId() ?>
 <?php $class = ($_option->getIsRequire()) ? ' required' : ''; ?>
@@ -15,7 +16,7 @@
     <fieldset class="fieldset fieldset-product-options-inner<?= /* @escapeNotVerified */ $class ?>">
         <legend class="legend">
             <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
-            <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+            <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
         </legend>
         <div class="control">
             <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DATE_TIME

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_fileInfo = $block->getFileInfo(); ?>
 <?php $_fileExists = $_fileInfo->hasData(); ?>
@@ -19,7 +20,7 @@
 <div class="field file<?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="<?= /* @noEscape */ $_fileName ?>" id="<?= /* @noEscape */ $_fileName ?>-label">
         <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
     <?php if ($_fileExists): ?>
     <div class="control">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
@@ -7,6 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
+<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Text */ ?>
 <?php
 $_option = $block->getOption();
 $class = ($_option->getIsRequire()) ? ' required' : '';
@@ -17,7 +18,7 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
 } ?><?= /* @escapeNotVerified */ $class ?>">
     <label class="label" for="options_<?= /* @escapeNotVerified */ $_option->getId() ?>_text">
         <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
-        <?= /* @escapeNotVerified */ $block->getFormatedPrice() ?>
+        <?= /* @escapeNotVerified */ $block->getFormattedPrice() ?>
     </label>
 
     <div class="control">


### PR DESCRIPTION
Original PR: #16607 

Improve code quality with better spelling.

Added new public methods with correct name while added the `@deprecated`
annotation to the miss-spelled method name. These new old methods return
the new methods.