### PR TITLE
[Backport] [Fix] forgot to add lowercase conversion on grouped product assignation

### DIFF
--- a/app/code/Magento/GroupedImportExport/Model/Import/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedImportExport/Model/Import/Product/Type/Grouped.php
@@ -99,7 +99,7 @@ class Grouped extends \Magento\CatalogImportExport\Model\Import\Product\Type\Abs
                     }
                     $scope = $this->_entityModel->getRowScope($rowData);
                     if (Product::SCOPE_DEFAULT == $scope) {
-                        $productData = $newSku[$rowData[Product::COL_SKU]];
+                        $productData = $newSku[strtolower($rowData[Product::COL_SKU])];
                     } else {
                         $colAttrSet = Product::COL_ATTR_SET;
                         $rowData[$colAttrSet] = $productData['attr_set_code'];

--- a/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
+++ b/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
@@ -217,26 +217,26 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 'skus' => [
                     'newSku' => [
                         'sku_assoc1' => ['entity_id' => 1],
-                        'productSku' => ['entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
+                        'productsku' => ['entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
                     ],
                     'oldSku' => ['sku_assoc2' => ['entity_id' => 2]]
                 ],
                 'bunch' => [
                     'associated_skus' => 'sku_assoc1=1, sku_assoc2=2',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'grouped'
                 ]
             ],
             [
                 'skus' => [
                     'newSku' => [
-                        'productSku' => ['entity_id' => 1, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
+                        'productsku' => ['entity_id' => 1, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
                     ],
                     'oldSku' => []
                 ],
                 'bunch' => [
                     'associated_skus' => '',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'grouped'
                 ]
             ],
@@ -244,7 +244,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 'skus' => ['newSku' => [],'oldSku' => []],
                 'bunch' => [
                     'associated_skus' => 'sku_assoc1=1, sku_assoc2=2',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'grouped'
                 ]
             ],
@@ -252,13 +252,13 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 'skus' => [
                     'newSku' => [
                         'sku_assoc1' => ['entity_id' => 1],
-                        'productSku' => ['entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
+                        'productsku' => ['entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
                     ],
                     'oldSku' => []
                 ],
                 'bunch' => [
                     'associated_skus' => 'sku_assoc1=1',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'simple'
                 ]
             ]
@@ -272,7 +272,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
     {
         $this->entityModel->expects($this->once())->method('getNewSku')->will($this->returnValue([
             'sku_assoc1' => ['entity_id' => 1],
-            'productSku' => ['entity_id' => 2, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
+            'productsku' => ['entity_id' => 2, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
         ]));
         $this->entityModel->expects($this->once())->method('getOldSku')->will($this->returnValue([
             'sku_assoc2' => ['entity_id' => 3]
@@ -282,7 +282,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
 
         $bunch = [[
             'associated_skus' => 'sku_assoc1=1, sku_assoc2=2',
-            'sku' => 'productSku',
+            'sku' => 'productsku',
             'product_type' => 'grouped'
         ]];
         $this->entityModel->expects($this->at(2))->method('getNextBunch')->will($this->returnValue($bunch));


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15312
Forgot to add lowercase conversion on grouped product assignation after changes done in MAGETWO-67240

- See changes done for MAGETWO-67240 here https://github.com/magento/magento2/commit/02596b720fab5bd01fbc8026a1392c4971f78fed#diff-b876c962d83b3bee42acba83af842309

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
