### PR TITLE
[Forwardport] [Fix] forgot to add lowercase conversion on grouped product assignation

### DIFF
--- a/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
+++ b/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
@@ -198,7 +198,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 ],
                 'bunch' => [
                     'associated_skus' => 'sku_assoc1=1, sku_assoc2=2',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'grouped'
                 ]
             ],
@@ -211,7 +211,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 ],
                 'bunch' => [
                     'associated_skus' => '',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'grouped'
                 ]
             ],
@@ -219,7 +219,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 'skus' => ['newSku' => [],'oldSku' => []],
                 'bunch' => [
                     'associated_skus' => 'sku_assoc1=1, sku_assoc2=2',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'grouped'
                 ]
             ],
@@ -227,13 +227,13 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
                 'skus' => [
                     'newSku' => [
                         'sku_assoc1' => ['entity_id' => 1],
-                        'productSku' => ['entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
+                        'productsku' => ['entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'grouped']
                     ],
                     'oldSku' => []
                 ],
                 'bunch' => [
                     'associated_skus' => 'sku_assoc1=1',
-                    'sku' => 'productSku',
+                    'sku' => 'productsku',
                     'product_type' => 'simple'
                 ]
             ]
@@ -257,7 +257,7 @@ class GroupedTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractI
 
         $bunch = [[
             'associated_skus' => 'sku_assoc1=1, sku_assoc2=2',
-            'sku' => 'productSku',
+            'sku' => 'productsku',
             'product_type' => 'grouped'
         ]];
         $this->entityModel->expects($this->at(2))->method('getNextBunch')->will($this->returnValue($bunch));


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15312
Forgot to add lowercase conversion on grouped product assignation after changes done in MAGETWO-67240

- See changes done for MAGETWO-67240 here https://github.com/magento/magento2/commit/02596b720fab5bd01fbc8026a1392c4971f78fed#diff-b876c962d83b3bee42acba83af842309

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
