### PR TITLE
[Forwardport] Fix for GitHub issue #14035.

### DIFF
--- a/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php
+++ b/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php
@@ -23,12 +23,11 @@ class ProductCategoryFilter implements CustomFilterInterface
     {
         $value = $filter->getValue();
         $conditionType = $filter->getConditionType() ?: 'in';
+        $filterValue = [$value];
         if (($conditionType === 'in' || $conditionType === 'nin') && is_string($value)) {
-            $value = explode(',', $value);
-        } else {
-            $value = [$value];
+            $filterValue = explode(',', $value);
         }
-        $categoryFilter = [$conditionType => $value];
+        $categoryFilter = [$conditionType => $filterValue];
 
         /** @var Collection $collection */
         $collection->addCategoriesFilter($categoryFilter);

--- a/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php
+++ b/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php
@@ -21,8 +21,14 @@ class ProductCategoryFilter implements CustomFilterInterface
      */
     public function apply(Filter $filter, AbstractDb $collection)
     {
-        $conditionType = $filter->getConditionType() ?: 'eq';
-        $categoryFilter = [$conditionType => [$filter->getValue()]];
+        $value = $filter->getValue();
+        $conditionType = $filter->getConditionType() ?: 'in';
+        if (($conditionType === 'in' || $conditionType === 'nin') && is_string($value)) {
+            $value = explode(',', $value);
+        } else {
+            $value = [$value];
+        }
+        $categoryFilter = [$conditionType => $value];
 
         /** @var Collection $collection */
         $collection->addCategoriesFilter($categoryFilter);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilterTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilterTest.php
@@ -40,7 +40,7 @@ class ProductCategoryFilterTest extends \PHPUnit\Framework\TestCase
 
         $collectionMock->expects($this->once())
             ->method('addCategoriesFilter')
-            ->with(['condition' => ['value']]);
+            ->with(['in' => ['value']]);
 
         $this->assertTrue($this->model->apply($filterMock, $collectionMock));
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilterTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilterTest.php
@@ -40,7 +40,7 @@ class ProductCategoryFilterTest extends \PHPUnit\Framework\TestCase
 
         $collectionMock->expects($this->once())
             ->method('addCategoriesFilter')
-            ->with(['in' => ['value']]);
+            ->with(['condition' => ['value']]);
 
         $this->assertTrue($this->model->apply($filterMock, $collectionMock));
     }
@@ -66,7 +66,7 @@ class ProductCategoryFilterTest extends \PHPUnit\Framework\TestCase
 
         $collectionMock->expects($this->once())
             ->method('addCategoriesFilter')
-            ->with(['eq' => ['value']]);
+            ->with(['in' => ['value']]);
 
         $this->assertTrue($this->model->apply($filterMock, $collectionMock));
     }


### PR DESCRIPTION
Original PR https://github.com/magento/magento2/pull/14048

### Fixed Issues (if relevant)
1. magento/magento2#14035: Magento REST API, wrong condition for product list category filter

### Manual testing scenarios
1. Access https://{magento_url}/rest/default/V1/products?store_id=1&searchCriteria[filter_groups][0][filters][0][field]=status&searchCriteria[filter_groups][0][filters][0][value]=1&searchCriteria[filter_groups][1][filters][0][field]=category_id&searchCriteria[filter_groups][1][filters][0][value]={csv_category_list}&searchCriteria[filter_groups][1][filters][0][condition_type]=in

Where {csv_category_list} is a comma separated list of category ids as per IN condition from http://devdocs.magento.com/guides/v2.2/rest/performing-searches.html

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
