### PR TITLE
[Forwardport] typo in private method name getUniq[ue]ImageIndex

### DIFF
--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -202,7 +202,7 @@ class ImageResize
             ]);
             $images = $config->getMediaEntities('Magento_Catalog', ImageHelper::MEDIA_TYPE_CONFIG_NODE);
             foreach ($images as $imageId => $imageData) {
-                $uniqIndex = $this->getUniqImageIndex($imageData);
+                $uniqIndex = $this->getUniqueImageIndex($imageData);
                 $imageData['id'] = $imageId;
                 $viewImages[$uniqIndex] = $imageData;
             }
@@ -211,11 +211,11 @@ class ImageResize
     }
 
     /**
-     * Get uniq image index
+     * Get unique image index
      * @param array $imageData
      * @return string
      */
-    private function getUniqImageIndex(array $imageData): string
+    private function getUniqueImageIndex(array $imageData): string
     {
         ksort($imageData);
         unset($imageData['type']);


### PR DESCRIPTION
Original PR https://github.com/magento/magento2/pull/15282

### Description
Private method name `\Magento\Catalog\Console\Command\ImagesResizeCommand::getUniqImageIndex` contained typo/misspelling.

Renamed it to getUniqueImageIndex and updated its phpdoc.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
