### PR TITLE
[Backport] Declare module namespace before template path in Magento_Theme,  Magento_Newsletter and Magento_Tax

### DIFF
--- a/app/code/Magento/Newsletter/Block/Adminhtml/Problem.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Problem.php
@@ -17,7 +17,7 @@ class Problem extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'problem/list.phtml';
+    protected $_template = 'Magento_Newsletter::problem/list.phtml';
 
     /**
      * @var \Magento\Newsletter\Model\ResourceModel\Problem\Collection

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Edit.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Edit.php
@@ -16,7 +16,7 @@ class Edit extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'queue/edit.phtml';
+    protected $_template = 'Magento_Newsletter::queue/edit.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Subscriber.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Subscriber.php
@@ -25,7 +25,7 @@ class Subscriber extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'subscriber/list.phtml';
+    protected $_template = 'Magento_Newsletter::subscriber/list.phtml';
 
     /**
      * @var \Magento\Newsletter\Model\ResourceModel\Queue\CollectionFactory

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template.php
@@ -16,7 +16,7 @@ class Template extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'template/list.phtml';
+    protected $_template = 'Magento_Newsletter::template/list.phtml';
 
     /**
      * @return $this

--- a/app/code/Magento/Reports/Block/Adminhtml/Product/Viewed.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Product/Viewed.php
@@ -15,7 +15,7 @@ class Viewed extends \Magento\Backend\Block\Widget\Grid\Container
     /**
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * @return void

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers.php
@@ -17,7 +17,7 @@ class Bestsellers extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Coupons.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Coupons.php
@@ -17,7 +17,7 @@ class Coupons extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Invoiced.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Invoiced.php
@@ -17,7 +17,7 @@ class Invoiced extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Refunded.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Refunded.php
@@ -17,7 +17,7 @@ class Refunded extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Sales.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Sales.php
@@ -17,7 +17,7 @@ class Sales extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Shipping.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Shipping.php
@@ -17,7 +17,7 @@ class Shipping extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Tax.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Tax.php
@@ -17,7 +17,7 @@ class Tax extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Wishlist.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Wishlist.php
@@ -18,7 +18,7 @@ class Wishlist extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'report/wishlist.phtml';
+    protected $_template = 'Magento_Reports::report/wishlist.phtml';
 
     /**
      * Reports wishlist collection factory

--- a/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
@@ -17,7 +17,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     /**
      * @var string
      */
-    protected $_template = 'rating/form.phtml';
+    protected $_template = 'Magento_Review::rating/form.phtml';
 
     /**
      * Session

--- a/app/code/Magento/Review/Block/Adminhtml/Rss/Grid/Link.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rss/Grid/Link.php
@@ -14,7 +14,7 @@ class Link extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rss/grid/link.phtml';
+    protected $_template = 'Magento_Review::rss/grid/link.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\UrlBuilderInterface

--- a/app/code/Magento/Review/Block/Customer/Recent.php
+++ b/app/code/Magento/Review/Block/Customer/Recent.php
@@ -17,7 +17,7 @@ class Recent extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'customer/list.phtml';
+    protected $_template = 'Magento_Review::customer/list.phtml';
 
     /**
      * Product reviews collection

--- a/app/code/Magento/Review/Block/Customer/View.php
+++ b/app/code/Magento/Review/Block/Customer/View.php
@@ -21,7 +21,7 @@ class View extends \Magento\Catalog\Block\Product\AbstractProduct
      *
      * @var string
      */
-    protected $_template = 'customer/view.phtml';
+    protected $_template = 'Magento_Review::customer/view.phtml';
 
     /**
      * Catalog product model

--- a/app/code/Magento/Review/Block/Rating/Entity/Detailed.php
+++ b/app/code/Magento/Review/Block/Rating/Entity/Detailed.php
@@ -15,7 +15,7 @@ class Detailed extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'detailed.phtml';
+    protected $_template = 'Magento_Review::detailed.phtml';
 
     /**
      * @var \Magento\Review\Model\RatingFactory

--- a/app/code/Magento/Review/Block/View.php
+++ b/app/code/Magento/Review/Block/View.php
@@ -17,7 +17,7 @@ class View extends \Magento\Catalog\Block\Product\AbstractProduct
      *
      * @var string
      */
-    protected $_template = 'view.phtml';
+    protected $_template = 'Magento_Review::view.phtml';
 
     /**
      * Rating option model

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
@@ -31,7 +31,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     /**
      * @var string
      */
-    protected $_template = 'rate/form.phtml';
+    protected $_template = 'Magento_Tax::rate/form.phtml';
 
     /**
      * Tax data

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Title.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Title.php
@@ -23,7 +23,7 @@ class Title extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rate/title.phtml';
+    protected $_template = 'Magento_Tax::rate/title.phtml';
 
     /**
      * @var \Magento\Store\Model\StoreFactory

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Add.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Add.php
@@ -18,7 +18,7 @@ class Add extends \Magento\Backend\Block\Template implements \Magento\Backend\Bl
     /**
      * @var string
      */
-    protected $_template = 'toolbar/rate/add.phtml';
+    protected $_template = 'Magento_Tax::toolbar/rate/add.phtml';
 
     /**
      * @var \Magento\Backend\Block\Widget\Button\ButtonList

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Save.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Save.php
@@ -16,7 +16,7 @@ class Save extends \Magento\Backend\Block\Template implements \Magento\Backend\B
     /**
      * @var string
      */
-    protected $_template = 'toolbar/rate/save.phtml';
+    protected $_template = 'Magento_Tax::toolbar/rate/save.phtml';
 
     /**
      * @var \Magento\Backend\Block\Widget\Button\ButtonList

--- a/app/code/Magento/Tax/Block/Checkout/Grandtotal.php
+++ b/app/code/Magento/Tax/Block/Checkout/Grandtotal.php
@@ -15,7 +15,7 @@ class Grandtotal extends \Magento\Checkout\Block\Total\DefaultTotal
      *
      * @var string
      */
-    protected $_template = 'checkout/grandtotal.phtml';
+    protected $_template = 'Magento_Tax::checkout/grandtotal.phtml';
 
     /**
      * @var \Magento\Tax\Model\Config

--- a/app/code/Magento/Tax/Block/Checkout/Shipping.php
+++ b/app/code/Magento/Tax/Block/Checkout/Shipping.php
@@ -15,7 +15,7 @@ class Shipping extends \Magento\Checkout\Block\Total\DefaultTotal
      *
      * @var string
      */
-    protected $_template = 'checkout/shipping.phtml';
+    protected $_template = 'Magento_Tax::checkout/shipping.phtml';
 
     /**
      * @var \Magento\Tax\Model\Config

--- a/app/code/Magento/Tax/Block/Checkout/Subtotal.php
+++ b/app/code/Magento/Tax/Block/Checkout/Subtotal.php
@@ -15,7 +15,7 @@ class Subtotal extends \Magento\Checkout\Block\Total\DefaultTotal
      *
      * @var string
      */
-    protected $_template = 'checkout/subtotal.phtml';
+    protected $_template = 'Magento_Tax::checkout/subtotal.phtml';
 
     /**
      * @var \Magento\Tax\Model\Config

--- a/app/code/Magento/Tax/Block/Checkout/Tax.php
+++ b/app/code/Magento/Tax/Block/Checkout/Tax.php
@@ -14,5 +14,5 @@ class Tax extends \Magento\Checkout\Block\Total\DefaultTotal
     /**
      * @var string
      */
-    protected $_template = 'checkout/tax.phtml';
+    protected $_template = 'Magento_Tax::checkout/tax.phtml';
 }

--- a/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExport.php
+++ b/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExport.php
@@ -10,7 +10,7 @@ class ImportExport extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'importExport.phtml';
+    protected $_template = 'Magento_TaxImportExport::importExport.phtml';
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context

--- a/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExportHeader.php
+++ b/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExportHeader.php
@@ -16,5 +16,5 @@ class ImportExportHeader extends \Magento\Backend\Block\Widget
      *
      * @var string
      */
-    protected $_template = 'importExportHeader.phtml';
+    protected $_template = 'Magento_TaxImportExport::importExportHeader.phtml';
 }

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
@@ -17,7 +17,7 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
      *
      * @var string
      */
-    protected $_template = 'browser/content/uploader.phtml';
+    protected $_template = 'Magento_Theme::browser/content/uploader.phtml';
 
     /**
      * @var \Magento\Theme\Helper\Storage

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -15,7 +15,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'html/breadcrumbs.phtml';
+    protected $_template = 'Magento_Theme::html/breadcrumbs.phtml';
 
     /**
      * List of available breadcrumb properties

--- a/app/code/Magento/Theme/Block/Html/Header.php
+++ b/app/code/Magento/Theme/Block/Html/Header.php
@@ -16,7 +16,7 @@ class Header extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'html/header.phtml';
+    protected $_template = 'Magento_Theme::html/header.phtml';
 
     /**
      * Retrieve welcome text

--- a/app/code/Magento/Theme/Block/Html/Header/Logo.php
+++ b/app/code/Magento/Theme/Block/Html/Header/Logo.php
@@ -16,7 +16,7 @@ class Logo extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'html/header/logo.phtml';
+    protected $_template = 'Magento_Theme::html/header/logo.phtml';
 
     /**
      * @var \Magento\MediaStorage\Helper\File\Storage\Database


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16699
Relates PR
https://github.com/magento/magento2/pull/16515

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When we override any core block to any custom module, It throws an error because it tries to find template file in the custom module if we do not declare module namespace before template path.
I tried to extend Block Magento\Sales\Block\Order\Creditmemo from my custom module.

`1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'form/newsletter.phtml' in module: 'Vendor_Module'`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Declare module namespace before template path name.
For example: `protected $_template = 'Magento_Customer::form/newsletter.phtml';`

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Override any block file which content static template file path

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
