### PR TITLE
[Backport] Declare module namespace before template path in Magento_Sales and Magento_Paypal

### DIFF
--- a/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Form.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Form.php
@@ -13,5 +13,5 @@ class Form extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'billing/agreement/view/form.phtml';
+    protected $_template = 'Magento_Paypal::billing/agreement/view/form.phtml';
 }

--- a/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
@@ -15,7 +15,7 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
     /**
      * @var string
      */
-    protected $_template = 'billing/agreement/view/tab/info.phtml';
+    protected $_template = 'Magento_Paypal::billing/agreement/view/tab/info.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
@@ -16,5 +16,5 @@ class Advanced extends \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink
      *
      * @var string
      */
-    protected $_template = 'system/config/payflowlink/advanced.phtml';
+    protected $_template = 'Magento_Paypal::system/config/payflowlink/advanced.phtml';
 }

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
@@ -16,7 +16,7 @@ class Info extends \Magento\Config\Block\System\Config\Form\Field
      *
      * @var string
      */
-    protected $_template = 'system/config/payflowlink/info.phtml';
+    protected $_template = 'Magento_Paypal::system/config/payflowlink/info.phtml';
 
     /**
      * Render fieldset html

--- a/app/code/Magento/Paypal/Block/Hosted/Pro/Form.php
+++ b/app/code/Magento/Paypal/Block/Hosted/Pro/Form.php
@@ -15,5 +15,5 @@ class Form extends \Magento\Payment\Block\Form
     /**
      * @var string
      */
-    protected $_template = 'hss/info.phtml';
+    protected $_template = 'Magento_Paypal::hss/info.phtml';
 }

--- a/app/code/Magento/Paypal/Block/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Iframe.php
@@ -41,7 +41,7 @@ class Iframe extends \Magento\Payment\Block\Form
     /**
      * @var string
      */
-    protected $_template = 'hss/js.phtml';
+    protected $_template = 'Magento_Paypal::hss/js.phtml';
 
     /**
      * @var \Magento\Sales\Model\OrderFactory

--- a/app/code/Magento/Paypal/Block/Payflow/Advanced/Form.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Advanced/Form.php
@@ -15,7 +15,7 @@ class Form extends \Magento\Paypal\Block\Payflow\Link\Form
     /**
      * @var string
      */
-    protected $_template = 'payflowadvanced/info.phtml';
+    protected $_template = 'Magento_Paypal::payflowadvanced/info.phtml';
 
     /**
      * Get frame action URL

--- a/app/code/Magento/Paypal/Block/Payflow/Link/Form.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Link/Form.php
@@ -15,7 +15,7 @@ class Form extends \Magento\Payment\Block\Form
     /**
      * @var string
      */
-    protected $_template = 'payflowlink/info.phtml';
+    protected $_template = 'Magento_Paypal::payflowlink/info.phtml';
 
     /**
      * Get frame action URL

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Address/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Address/Form.php
@@ -19,7 +19,7 @@ class Form extends \Magento\Sales\Block\Adminhtml\Order\Create\Form\Address
      *
      * @var string
      */
-    protected $_template = 'order/address/form.phtml';
+    protected $_template = 'Magento_Sales::order/address/form.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Grandtotal.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Grandtotal.php
@@ -20,7 +20,7 @@ class Grandtotal extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defa
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/grandtotal.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/grandtotal.phtml';
 
     /**
      * Tax config

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Shipping.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Shipping.php
@@ -20,7 +20,7 @@ class Shipping extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defaul
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/shipping.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/shipping.phtml';
 
     /**
      * Tax config

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Subtotal.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Subtotal.php
@@ -20,7 +20,7 @@ class Subtotal extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defaul
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/subtotal.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/subtotal.phtml';
 
     /**
      * Tax config

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Tax.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Tax.php
@@ -18,5 +18,5 @@ class Tax extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\DefaultTota
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/tax.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/tax.phtml';
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Details.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Details.php
@@ -14,5 +14,5 @@ class Details extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/details.phtml';
+    protected $_template = 'Magento_Sales::order/details.phtml';
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Form.php
@@ -17,5 +17,5 @@ class Form extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'order/view/form.phtml';
+    protected $_template = 'Magento_Sales::order/view/form.phtml';
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/History.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/History.php
@@ -17,7 +17,7 @@ class History extends \Magento\Backend\Block\Template implements \Magento\Backen
      *
      * @var string
      */
-    protected $_template = 'order/view/tab/history.phtml';
+    protected $_template = 'Magento_Sales::order/view/tab/history.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Adminhtml/Rss/Order/Grid/Link.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Rss/Order/Grid/Link.php
@@ -14,7 +14,7 @@ class Link extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rss/order/grid/link.phtml';
+    protected $_template = 'Magento_Sales::rss/order/grid/link.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\UrlBuilderInterface

--- a/app/code/Magento/Sales/Block/Order/Info/Buttons.php
+++ b/app/code/Magento/Sales/Block/Order/Info/Buttons.php
@@ -16,7 +16,7 @@ class Buttons extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/info/buttons.phtml';
+    protected $_template = 'Magento_Sales::order/info/buttons.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Order/Info/Buttons/Rss.php
+++ b/app/code/Magento/Sales/Block/Order/Info/Buttons/Rss.php
@@ -13,7 +13,7 @@ class Rss extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/info/buttons/rss.phtml';
+    protected $_template = 'Magento_Sales::order/info/buttons/rss.phtml';
 
     /**
      * @var \Magento\Sales\Model\OrderFactory

--- a/app/code/Magento/Sales/Block/Order/Invoice.php
+++ b/app/code/Magento/Sales/Block/Order/Invoice.php
@@ -15,7 +15,7 @@ class Invoice extends \Magento\Sales\Block\Order\Invoice\Items
     /**
      * @var string
      */
-    protected $_template = 'order/invoice.phtml';
+    protected $_template = 'Magento_Sales::order/invoice.phtml';
 
     /**
      * @var \Magento\Framework\App\Http\Context

--- a/app/code/Magento/Sales/Block/Order/View.php
+++ b/app/code/Magento/Sales/Block/Order/View.php
@@ -15,7 +15,7 @@ class View extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/view.phtml';
+    protected $_template = 'Magento_Sales::order/view.phtml';
 
     /**
      * Core registry


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16698
Relates PR
https://github.com/magento/magento2/pull/16515

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When we override any core block to any custom module, It throws an error because it tries to find template file in the custom module if we do not declare module namespace before template path.
I tried to extend Block Magento\Sales\Block\Order\Creditmemo from my custom module.

`1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'form/newsletter.phtml' in module: 'Vendor_Module'`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Declare module namespace before template path name.
For example: `protected $_template = 'Magento_Customer::form/newsletter.phtml';`

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Override any block file which content static template file path

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
