### PR TITLE
[Backport] Fix function unnecessarily called multiple time

### DIFF
--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
@@ -13,10 +13,8 @@
  */
 ?>
 
-<?php $block->getCurrencySymbolsData();?>
-
-<form id="currency-symbols-form" action="<?php /* @escapeNotVerified */ echo $block->getFormActionUrl() ?>" method="post">
-    <input name="form_key" type="hidden" value="<?php /* @escapeNotVerified */ echo $block->getFormKey() ?>" />
+<form id="currency-symbols-form" action="<?= /* @escapeNotVerified */ $block->getFormActionUrl() ?>" method="post">
+    <input name="form_key" type="hidden" value="<?= /* @escapeNotVerified */ $block->getFormKey() ?>" />
     <fieldset class="admin__fieldset">
         <?php foreach ($block->getCurrencySymbolsData() as $code => $data): ?>
         <div class="admin__field _required">


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15346

Function is unnecessarily called multiple time.

### Description
getCurrencySymbolsData() is called multiple times in the same file. Remove the extra call of the same function.

### Fixed Issues (if relevant)
Issue Number - #15355

### Manual testing scenarios
1. Check the page. Stores > Currency > Currency Symbols

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
