### PR TITLE
[Forwardport] Improve attribute checking

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -285,7 +285,11 @@ abstract class AbstractType
             }
         }
         foreach ($absentKeys as $attributeSetName => $attributeIds) {
-            $unknownAttributeIds = array_diff($attributeIds, array_keys(self::$commonAttributesCache), self::$invisibleAttributesCache);
+            $unknownAttributeIds = array_diff(
+                $attributeIds,
+                array_keys(self::$commonAttributesCache),
+                self::$invisibleAttributesCache
+            );
             if ($unknownAttributeIds) {
                 $this->attachAttributesById($attributeSetName, $attributeIds);
             }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -290,7 +290,7 @@ abstract class AbstractType
                 array_keys(self::$commonAttributesCache),
                 self::$invAttributesCache
             );
-            if ($unknownAttributeIds) {
+            if ($unknownAttributeIds || $this->_forcedAttributesCodes) {
                 $this->attachAttributesById($attributeSetName, $attributeIds);
             }
         }
@@ -317,8 +317,11 @@ abstract class AbstractType
     protected function attachAttributesById($attributeSetName, $attributeIds)
     {
         foreach ($this->_prodAttrColFac->create()->addFieldToFilter(
-            'main_table.attribute_id',
-            ['in' => $attributeIds]
+            ['main_table.attribute_id', 'main_table.attribute_code'],
+            [
+                ['in' => $attributeIds],
+                ['in' => $this->_forcedAttributesCodes]
+            ]
         ) as $attribute) {
             $attributeCode = $attribute->getAttributeCode();
             $attributeId = $attribute->getId();

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -33,7 +33,7 @@ abstract class AbstractType
      *
      * @var array
      */
-    public static $invisibleAttributesCache = [];
+    public static $invAttributesCache = [];
 
     /**
      * Attribute Code to Id cache
@@ -288,7 +288,7 @@ abstract class AbstractType
             $unknownAttributeIds = array_diff(
                 $attributeIds,
                 array_keys(self::$commonAttributesCache),
-                self::$invisibleAttributesCache
+                self::$invAttributesCache
             );
             if ($unknownAttributeIds) {
                 $this->attachAttributesById($attributeSetName, $attributeIds);
@@ -352,7 +352,7 @@ abstract class AbstractType
                     $attribute
                 );
             } else {
-                self::$invisibleAttributesCache[] = $attributeId;
+                self::$invAttributesCache[] = $attributeId;
             }
         }
     }

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Type/AbstractTypeTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Type/AbstractTypeTest.php
@@ -134,8 +134,28 @@ class AbstractTypeTest extends \PHPUnit\Framework\TestCase
             ->expects($this->any())
             ->method('addFieldToFilter')
             ->with(
-                'main_table.attribute_id',
-                ['in' => ['attribute_id', 'boolean_attribute']]
+                ['main_table.attribute_id', 'main_table.attribute_code'],
+                [
+                    [
+                        'in' =>
+                            [
+                                'attribute_id',
+                                'boolean_attribute',
+                            ],
+                    ],
+                    [
+                        'in' =>
+                            [
+                                'related_tgtr_position_behavior',
+                                'related_tgtr_position_limit',
+                                'upsell_tgtr_position_behavior',
+                                'upsell_tgtr_position_limit',
+                                'thumbnail_label',
+                                'small_image_label',
+                                'image_label',
+                            ],
+                    ],
+                ]
             )
             ->willReturn([$attribute1, $attribute2]);
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11554
On a store with a large number of attribute sets, a lot of repeated checking is done for the same attributes.

### Description
Instead of repeating the checks every time, keep track of the attributes that have already been checked and should be skipped (invisible). This we way we don't have to do the same check for the next attribute set.

### Fixed Issues (if relevant)

### Manual testing scenarios
1. Create a store with a large number of attribute sets, and add some invisible attributes in those sets
2. Upload a csv file with products to import, and click the Check Data button

With this change the checking phase will be much faster than without the change, without any functional change.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
