### PR TITLE
Improved code and remove unnecessary space

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
@@ -63,7 +63,7 @@ class ConfiguredRegularPrice extends RegularPrice implements ConfiguredPriceInte
 
         return $this;
     }
-    
+
     /**
      * Price value of product with configured options.
      *
@@ -73,7 +73,7 @@ class ConfiguredRegularPrice extends RegularPrice implements ConfiguredPriceInte
     {
         $basePrice = parent::getValue();
 
-        return $this->item
+        return $this->item && $basePrice !== false
             ? $basePrice + $this->configuredOptions->getItemOptionsValue($basePrice, $this->item)
             : $basePrice;
     }


### PR DESCRIPTION
### Original Pull
https://github.com/magento/magento2/pull/15129

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
`parent::getValue()` can return false while `$this->configuredOptions->getItemOptionsValue` only accepts float. So if the parent method returns false then it fails with the following error:

```
NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Catalog\Pricing\Price\ConfiguredOptions::getItemOptionsValue() must be of the type float, boolean given, called in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredRegularPrice.php on line 74 and defined in /app/vendor/magento/module-catalog/Pricing/Price/ConfiguredOptions.php:24
```


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
