### PR TITLE
Avoid undefined index warning when using uppercase reserved word

### DIFF
--- a/dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php
@@ -64,7 +64,7 @@ class ReservedWordsSniff implements Sniff
                     'Cannot use "%s" in namespace as it is reserved since PHP %s',
                     $stackPtr,
                     'Namespace',
-                    [$namespacePart, $this->reservedWords[$namespacePart]]
+                    [$namespacePart, $this->reservedWords[strtolower($namespacePart)]]
                 );
             }
             $stackPtr++;


### PR DESCRIPTION
ReservedWordsSniff will trigger an undefined index error if a reserved word is used in uppercase.

### Manual testing scenarios
1. Create a class containing a reserved word, with at least 1 uppercase character (e.g. Bool)
2. execute phpcs codesniffer with dev/tests/static/framework/Magento/ruleset.xml ruleset

### Expected result
Code sniffer error "Cannot use "Bool" in namespace as it is reserved since PHP 7"

### Actual result
Code sniffer error "An error occurred during processing; checking has been aborted. The error message was: Undefined index: Bool"