### PR TITLE
Fix title position on my account page

### DIFF
--- a/app/code/Magento/Customer/etc/module.xml
+++ b/app/code/Magento/Customer/etc/module.xml
@@ -8,6 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Magento_Customer" setup_version="2.0.13">
         <sequence>
+            <module name="Magento_Theme"/>
             <module name="Magento_Eav"/>
             <module name="Magento_Directory"/>
         </sequence>


### PR DESCRIPTION
### Description
Fix for https://github.com/magento/magento2/issues/16786

### Fixed Issues (if relevant)
1. magento/magento2#16786: Page title on the my account page moved to bottom

### Manual testing scenarios
1. see https://github.com/magento/magento2/issues/16786

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
