### PR TITLE
[Forwardport] [TASK] Solve issue #14966 - Disabling product does not remove it from

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
@@ -61,6 +61,7 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
      * @param int|null $id
      * @return \Magento\Catalog\Model\Indexer\Product\Flat\Action\Row
      * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Zend_Db_Statement_Exception
      */
     public function execute($id = null)
     {
@@ -109,11 +110,10 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
                     }
                     $this->flatItemWriter->write($store->getId(), $ids[0], $this->_valueFieldSuffix);
                 }
-            } else {
+            }
+            if ($status['value'] == \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_DISABLED) {
                 $this->flatItemEraser->deleteProductsFromStore($id, $store->getId());
             }
-
-
         }
         return $this;
     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
@@ -79,7 +79,7 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
 
             /* @var $status \Magento\Eav\Model\Entity\Attribute */
             $status = $this->_productIndexerHelper->getAttribute('status');
-            $statusTable = $status->getBackendTable();
+            $statusTable = $status->getBackend()->getTable();
             $statusConditions = [
                 'store_id IN(0,' . (int)$store->getId() . ')',
                 'attribute_id = ' . (int)$status->getId(),

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
@@ -7,6 +7,8 @@ namespace Magento\Catalog\Model\Indexer\Product\Flat\Action;
 
 use Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder;
 use Magento\Catalog\Model\Indexer\Product\Flat\TableBuilder;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Catalog\Api\Data\ProductInterface;
 
 /**
  * Class Row reindex action
@@ -22,6 +24,10 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
      * @var Eraser
      */
     protected $flatItemEraser;
+    /**
+     * @var MetadataPool
+     */
+    private $metadataPool;
 
     /**
      * @param \Magento\Framework\App\ResourceConnection $resource
@@ -32,6 +38,7 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
      * @param FlatTableBuilder $flatTableBuilder
      * @param Indexer $flatItemWriter
      * @param Eraser $flatItemEraser
+     * @param MetadataPool $metadataPool
      */
     public function __construct(
         \Magento\Framework\App\ResourceConnection $resource,
@@ -41,7 +48,8 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
         TableBuilder $tableBuilder,
         FlatTableBuilder $flatTableBuilder,
         Indexer $flatItemWriter,
-        Eraser $flatItemEraser
+        Eraser $flatItemEraser,
+        MetadataPool $metadataPool
     ) {
         parent::__construct(
             $resource,
@@ -53,6 +61,7 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
         );
         $this->flatItemWriter = $flatItemWriter;
         $this->flatItemEraser = $flatItemEraser;
+        $this->metadataPool = $metadataPool;
     }
 
     /**
@@ -75,18 +84,45 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
             if ($tableExists) {
                 $this->flatItemEraser->removeDeletedProducts($ids, $store->getId());
             }
-            if (isset($ids[0])) {
-                if (!$tableExists) {
-                    $this->_flatTableBuilder->build(
-                        $store->getId(),
-                        [$ids[0]],
-                        $this->_valueFieldSuffix,
-                        $this->_tableDropSuffix,
-                        false
-                    );
+
+            /* @var $status \Magento\Eav\Model\Entity\Attribute */
+            $status = $this->_productIndexerHelper->getAttribute('status');
+            $statusTable = $status->getBackendTable();
+            $statusConditions = [
+                'store_id IN(0,' . (int)$store->getId() . ')',
+                'attribute_id = ' . (int)$status->getId(),
+                'entity_id = ' . (int)$id
+            ];
+            $select = $this->_connection->select();
+            $select->from(
+                $statusTable,
+                ['value']
+            )->where(
+                implode(' AND ', $statusConditions)
+            )->order(
+                'store_id DESC'
+            );
+            $result = $this->_connection->query($select);
+            $status = $result->fetch(1);
+
+            if ($status['value'] == \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED) {
+                if (isset($ids[0])) {
+                    if (!$tableExists) {
+                        $this->_flatTableBuilder->build(
+                            $store->getId(),
+                            [$ids[0]],
+                            $this->_valueFieldSuffix,
+                            $this->_tableDropSuffix,
+                            false
+                        );
+                    }
+                    $this->flatItemWriter->write($store->getId(), $ids[0], $this->_valueFieldSuffix);
                 }
-                $this->flatItemWriter->write($store->getId(), $ids[0], $this->_valueFieldSuffix);
+            } else {
+                $this->flatItemEraser->deleteProductsFromStore($id, $store->getId());
             }
+
+
         }
         return $this;
     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Row.php
@@ -7,8 +7,6 @@ namespace Magento\Catalog\Model\Indexer\Product\Flat\Action;
 
 use Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder;
 use Magento\Catalog\Model\Indexer\Product\Flat\TableBuilder;
-use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Catalog\Api\Data\ProductInterface;
 
 /**
  * Class Row reindex action
@@ -24,10 +22,6 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
      * @var Eraser
      */
     protected $flatItemEraser;
-    /**
-     * @var MetadataPool
-     */
-    private $metadataPool;
 
     /**
      * @param \Magento\Framework\App\ResourceConnection $resource
@@ -38,7 +32,6 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
      * @param FlatTableBuilder $flatTableBuilder
      * @param Indexer $flatItemWriter
      * @param Eraser $flatItemEraser
-     * @param MetadataPool $metadataPool
      */
     public function __construct(
         \Magento\Framework\App\ResourceConnection $resource,
@@ -48,8 +41,7 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
         TableBuilder $tableBuilder,
         FlatTableBuilder $flatTableBuilder,
         Indexer $flatItemWriter,
-        Eraser $flatItemEraser,
-        MetadataPool $metadataPool
+        Eraser $flatItemEraser
     ) {
         parent::__construct(
             $resource,
@@ -61,7 +53,6 @@ class Row extends \Magento\Catalog\Model\Indexer\Product\Flat\AbstractAction
         );
         $this->flatItemWriter = $flatItemWriter;
         $this->flatItemEraser = $flatItemEraser;
-        $this->metadataPool = $metadataPool;
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */ 
+ */
 class RowTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -75,7 +75,9 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $this->storeManager->expects($this->any())->method('getStores')->will($this->returnValue([$this->store]));
         $this->flatItemEraser = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\Action\Eraser::class);
         $this->flatItemWriter = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\Action\Indexer::class);
-        $this->flatTableBuilder = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::class);
+        $this->flatTableBuilder = $this->createMock(
+            \Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::class
+        );
         $this->productIndexerHelper = $this->createMock(\Magento\Catalog\Helper\Product\Flat\Indexer::class);
         $statusAttributeMock = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
             ->disableOriginalConstructor()
@@ -101,18 +103,23 @@ class RowTest extends \PHPUnit\Framework\TestCase
         )->willReturnSelf();
         $selectMock->expects($this->any())->method('where')->willReturnSelf();
         $pdoMock = $this->createMock(\Zend_Db_Statement_Pdo::class);
-        $this->connection->expects($this->any())->method('query')->with($selectMock)->will($this->returnValue($pdoMock));
+        $this->connection->expects($this->any())
+            ->method('query')
+            ->with($selectMock)
+            ->will($this->returnValue($pdoMock));
         $pdoMock->expects($this->any())->method('fetch')->will($this->returnValue(['value' => 1]));
 
         $this->model = $objectManager->getObject(
-            \Magento\Catalog\Model\Indexer\Product\Flat\Action\Row::class, [
-            'resource' => $this->resource,
-            'storeManager' => $this->storeManager,
-            'productHelper' => $this->productIndexerHelper,
-            'flatItemEraser' => $this->flatItemEraser,
-            'flatItemWriter' => $this->flatItemWriter,
-            'flatTableBuilder' => $this->flatTableBuilder,
-        ]);
+            \Magento\Catalog\Model\Indexer\Product\Flat\Action\Row::class,
+            [
+                'resource' => $this->resource,
+                'storeManager' => $this->storeManager,
+                'productHelper' => $this->productIndexerHelper,
+                'flatItemEraser' => $this->flatItemEraser,
+                'flatItemWriter' => $this->flatItemWriter,
+                'flatTableBuilder' => $this->flatTableBuilder
+            ]
+        );
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -59,6 +59,8 @@ class RowTest extends \PHPUnit\Framework\TestCase
     {
         $objectManager = new ObjectManager($this);
 
+        $attributeTable = 'catalog_product_entity_int';
+        $statusId = 22;
         $this->connection = $this->createMock(\Magento\Framework\DB\Adapter\AdapterInterface::class);
         $this->resource = $this->createMock(\Magento\Framework\App\ResourceConnection::class);
         $this->resource->expects($this->any())->method('getConnection')
@@ -68,9 +70,9 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $this->store = $this->createMock(\Magento\Store\Model\Store::class);
         $this->store->expects($this->any())->method('getId')->will($this->returnValue('store_id_1'));
         $this->storeManager->expects($this->any())->method('getStores')->will($this->returnValue([$this->store]));
-        $this->productIndexerHelper = $this->createMock(\Magento\Catalog\Helper\Product\Flat\Indexer::class);
         $this->flatItemEraser = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\Action\Eraser::class);
         $this->flatItemWriter = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\Action\Indexer::class);
+<<<<<<< HEAD
         $this->flatTableBuilder = $this->createMock(
             \Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::class
         );
@@ -86,6 +88,46 @@ class RowTest extends \PHPUnit\Framework\TestCase
                 'flatTableBuilder' => $this->flatTableBuilder
             ]
         );
+=======
+        $this->flatTableBuilder = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::class);
+        $this->productIndexerHelper = $this->createMock(\Magento\Catalog\Helper\Product\Flat\Indexer::class);
+        $statusAttributeMock = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->productIndexerHelper->expects($this->any())->method('getAttribute')
+            ->with('status')
+            ->willReturn($statusAttributeMock);
+        $backendMock = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $backendMock->expects($this->any())->method('getTable')->willReturn($attributeTable);
+        $statusAttributeMock->expects($this->any())->method('getBackend')->willReturn(
+            $backendMock
+        );
+        $statusAttributeMock->expects($this->any())->method('getId')->willReturn($statusId);
+        $selectMock = $this->getMockBuilder(\Magento\Framework\DB\Select::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->connection->expects($this->any())->method('select')->willReturn($selectMock);
+        $selectMock->expects($this->any())->method('from')->with(
+            $attributeTable,
+            ['value']
+        )->willReturnSelf();
+        $selectMock->expects($this->any())->method('where')->willReturnSelf();
+        $pdoMock = $this->createMock(\Zend_Db_Statement_Pdo::class);
+        $this->connection->expects($this->any())->method('query')->with($selectMock)->will($this->returnValue($pdoMock));
+        $pdoMock->expects($this->any())->method('fetch')->will($this->returnValue(['value' => 1]));
+
+        $this->model = $objectManager->getObject(
+            \Magento\Catalog\Model\Indexer\Product\Flat\Action\Row::class, [
+            'resource' => $this->resource,
+            'storeManager' => $this->storeManager,
+            'productHelper' => $this->productIndexerHelper,
+            'flatItemEraser' => $this->flatItemEraser,
+            'flatItemWriter' => $this->flatItemWriter,
+            'flatTableBuilder' => $this->flatTableBuilder,
+        ]);
+>>>>>>> 38bd9d381bc... [TASK] Updated the Unit Test according to issue-14966
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -75,23 +75,6 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $this->storeManager->expects($this->any())->method('getStores')->will($this->returnValue([$this->store]));
         $this->flatItemEraser = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\Action\Eraser::class);
         $this->flatItemWriter = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\Action\Indexer::class);
-<<<<<<< HEAD
-        $this->flatTableBuilder = $this->createMock(
-            \Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::class
-        );
-
-        $this->model = $objectManager->getObject(
-            \Magento\Catalog\Model\Indexer\Product\Flat\Action\Row::class,
-            [
-                'resource' => $this->resource,
-                'storeManager' => $this->storeManager,
-                'productHelper' => $this->productIndexerHelper,
-                'flatItemEraser' => $this->flatItemEraser,
-                'flatItemWriter' => $this->flatItemWriter,
-                'flatTableBuilder' => $this->flatTableBuilder
-            ]
-        );
-=======
         $this->flatTableBuilder = $this->createMock(\Magento\Catalog\Model\Indexer\Product\Flat\FlatTableBuilder::class);
         $this->productIndexerHelper = $this->createMock(\Magento\Catalog\Helper\Product\Flat\Indexer::class);
         $statusAttributeMock = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
@@ -130,7 +113,6 @@ class RowTest extends \PHPUnit\Framework\TestCase
             'flatItemWriter' => $this->flatItemWriter,
             'flatTableBuilder' => $this->flatTableBuilder,
         ]);
->>>>>>> 38bd9d381bc... [TASK] Updated the Unit Test according to issue-14966
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -8,6 +8,9 @@ namespace Magento\Catalog\Test\Unit\Model\Indexer\Product\Flat\Action;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */ 
 class RowTest extends \PHPUnit\Framework\TestCase
 {
     /**


### PR DESCRIPTION
… the flat index

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
When you disable a product it should be removed from the flat table

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14966: Disabling product does not remove it from the flat index


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install Magento 2.2.3 together with the sample data set.
2. Make sure cron is run every minute (`bin/magento cron:run`).
3. Make sure the config setting `Use Flat Catalog Product` is set to `Yes`.
4. Make sure the flat index is up-to-date: `bin/magento index:reindex catalog_product_flat`.
5. Choose an enabled product in the Magento admin backend. Say its ID is `X`.
6. Make sure that there exists an entry in table `catalog_product_flat_1` with `entity_id = X`. If not, you've done something wrong.
7. Now, in the Magento admin backend, disable the product.
8. Wait a few minutes.
9. Check whether the table `catalog_product_flat_1` still contains an entry with `entity_id = X`.

### Expected result
1. The table `catalog_product_flat_1` should contain no entry with `entity_id = X`.

### Actual result
1. The table `catalog_product_flat_1` contains an entry with `entity_id = X`.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/15019