### PR TITLE
[Backport] Update Israeli ZIP code mask, 7 digits instead of 5 ,according to the…

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -196,7 +196,7 @@
     </zip>
     <zip countryCode="IL">
         <codes>
-            <code id="pattern_1" active="true" example="12345">^[0-9]{5}$</code>
+            <code id="pattern_1" active="true" example="6687865">^[0-9]{7}$</code>
         </codes>
     </zip>
     <zip countryCode="IT">


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16250
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The Israeli ZIP code format had changed 2 years ago.
Magento uses the 5 digits format. It's old and outdated. 
The new format is 7 digits. 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. add a product to cart
2. go to the checkout page 
3. select Israel on shipping addreds country field
4. enter the following zip code 6687865