### PR TITLE
Show billing form if shipping address can not usable as billing address

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
@@ -102,6 +102,10 @@ function (
                     this.saveInAddressBook(1);
                 }
                 this.isAddressDetailsVisible(true);
+
+                if (!this.canUseShippingAddress()) {
+                    this.isAddressDetailsVisible(false);
+                }
             }, this);
 
             return this;


### PR DESCRIPTION
### Description

In several cases I need to force the customer to fill out the billing address form and shipping address can not be the same as the billing address.


### Fixed Issues (if relevant)
1. magento/magento2#16380: Force to show billing address form

### Manual testing scenarios
1. As a guest, buy something, go and set shipping address
2. Press next
3. Billing form should be shown

