### PR TITLE
[Forwardport] #15588 Fixed incorrect image urls in multistore xml sitemap

### DIFF
--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -28,8 +28,8 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
             $context
         );
     }
-    
-   /**
+
+    /**
      * Generate sitemap
      *
      * @return void

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -45,7 +45,8 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         if ($sitemap->getId()) {
             try {
                 //We need to emulate to get the correct frontend URL for the product images
-                $this->appEmulation->startEnvironmentEmulation($sitemap->getStoreId(),
+                $this->appEmulation->startEnvironmentEmulation(
+                    $sitemap->getStoreId(),
                     \Magento\Framework\App\Area::AREA_FRONTEND,
                     true
                 );

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -43,6 +43,7 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         $sitemap->load($id);
         // if sitemap record exists
         if ($sitemap->getId()) {
+            
             try {
                 //We need to emulate to get the correct frontend URL for the product images
                 $this->appEmulation->startEnvironmentEmulation(
@@ -51,7 +52,6 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
                     true
                 );
                 $sitemap->generateXml();
-                $this->appEmulation->stopEnvironmentEmulation();
 
                 $this->messageManager->addSuccess(
                     __('The sitemap "%1" has been generated.', $sitemap->getSitemapFilename())
@@ -60,6 +60,8 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
                 $this->messageManager->addError($e->getMessage());
             } catch (\Exception $e) {
                 $this->messageManager->addException($e, __('We can\'t generate the sitemap right now.'));
+            } finally {
+                $this->appEmulation->stopEnvironmentEmulation();
             }
         } else {
             $this->messageManager->addError(__('We can\'t find a sitemap to generate.'));

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -8,6 +8,7 @@ namespace Magento\Sitemap\Controller\Adminhtml\Sitemap;
 
 use Magento\Backend\App\Action;
 use Magento\Store\Model\App\Emulation;
+use Magento\Framework\App\ObjectManager;
 
 class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
 {
@@ -17,16 +18,15 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
     /**
      * Generate constructor.
      * @param Action\Context $context
-     * @param \Magento\Store\Model\App\Emulation $appEmulation
+     * @param \Magento\Store\Model\App\Emulation|null $appEmulation
      */
     public function __construct(
         Action\Context $context,
-        Emulation $appEmulation
+        Emulation $appEmulation = null
     ) {
-        $this->appEmulation = $appEmulation;
-        parent::__construct(
-            $context
-        );
+        parent::__construct($context);
+        $this->appEmulation = $appEmulation ?: ObjectManager::getInstance()
+            ->get(\Magento\Store\Model\App\Emulation::class);
     }
 
     /**

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -6,8 +6,29 @@
  */
 namespace Magento\Sitemap\Controller\Adminhtml\Sitemap;
 
+use Magento\Backend\App\Action;
+use Magento\Store\Model\App\Emulation;
+
 class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
 {
+    /** @var \Magento\Store\Model\App\Emulation $appEmulation */
+    private $appEmulation;
+
+    /**
+     * Generate constructor.
+     * @param Action\Context $context
+     * @param \Magento\Store\Model\App\Emulation $appEmulation
+     */
+    public function __construct(
+        Action\Context $context,
+        Emulation $appEmulation
+    ) {
+        $this->appEmulation = $appEmulation;
+        parent::__construct(
+            $context
+        );
+    }
+    
     /**
      * Generate sitemap
      *
@@ -23,7 +44,13 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         // if sitemap record exists
         if ($sitemap->getId()) {
             try {
+                //We need to emulate to get the correct frontend URL for the product images
+                $this->appEmulation->startEnvironmentEmulation($sitemap->getStoreId(),
+                    \Magento\Framework\App\Area::AREA_FRONTEND,
+                    true
+                );
                 $sitemap->generateXml();
+                $this->appEmulation->stopEnvironmentEmulation();
 
                 $this->messageManager->addSuccess(
                     __('The sitemap "%1" has been generated.', $sitemap->getSitemapFilename())

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -29,7 +29,7 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         );
     }
     
-    /**
+   /**
      * Generate sitemap
      *
      * @return void

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -43,7 +43,6 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         $sitemap->load($id);
         // if sitemap record exists
         if ($sitemap->getId()) {
-            
             try {
                 //We need to emulate to get the correct frontend URL for the product images
                 $this->appEmulation->startEnvironmentEmulation(


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15689

### Description
Added the appEmulation to get the correct image Url for the generated sitemaps. This was needed because the catalog image helper context had incorrect Url data. 

### Fixed Issues (if relevant)
1. magento/magento2#15588: Images in XML sitemap are always linked to base store in multistore#15588

### Manual testing scenarios
1. In a multistore environment generate multiple sitemaps. Check if the <image:loc> has the correct base URL for set store. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
