### PR TITLE
[Forwardport] Fixed type hints and docs for Downloadable Samples block

### DIFF
--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
@@ -41,7 +41,7 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
      * @param SampleInterface $sample
      * @return string
      */
-    public function getSampleUrl(SampleInterface $sample)
+    public function getSampleUrl($sample)
     {
         return $this->getUrl('downloadable/download/sample', ['sample_id' => $sample->getId()]);
     }

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
@@ -6,7 +6,8 @@
 
 namespace Magento\Downloadable\Block\Catalog\Product;
 
-use Magento\Downloadable\Model\ResourceModel\Sample;
+use Magento\Downloadable\Model\ResourceModel\Sample\Collection as SampleCollection;
+use Magento\Downloadable\Api\Data\SampleInterface;
 
 /**
  * Downloadable Product Samples part block
@@ -29,7 +30,7 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
     /**
      * Get downloadable product samples
      *
-     * @return array
+     * @return SampleCollection
      */
     public function getSamples()
     {
@@ -37,10 +38,10 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
     }
 
     /**
-     * @param Sample $sample
+     * @param SampleInterface $sample
      * @return string
      */
-    public function getSampleUrl($sample)
+    public function getSampleUrl(SampleInterface $sample)
     {
         return $this->getUrl('downloadable/download/sample', ['sample_id' => $sample->getId()]);
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16408
### Summary

Fixes type hints and PHPDocs in Magento\Downloadable\Block\Catalog\Product\Samples.

### Description

In the block class unprecise type hints and PHPDocs are provided. Instead of Magento\Downloadable\Model\ResourceModel\Sample the method getSampleUrl gets an object of type Magento\Downloadable\Model\Sample which actually should be considered as Magento\Downloadable\Api\Data\SampleInterface. Also getSamples doesn't return an array, it returns a Collection.

### Fixed Issues

This pull request is not fixing a bug, it just to improve type hints in IDE.