### PR TITLE
[Forwardport] Correctly save Product Custom Option values

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Option.php
@@ -8,6 +8,7 @@ namespace Magento\Catalog\Model\Product;
 
 use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
 use Magento\Catalog\Api\Data\ProductCustomOptionValuesInterface;
+use Magento\Catalog\Api\Data\ProductCustomOptionValuesInterfaceFactory;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\Option\Value\Collection;
@@ -103,6 +104,11 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
     private $metadataPool;
 
     /**
+     * @var ProductCustomOptionValuesInterfaceFactory
+     */
+    private $customOptionValuesFactory;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -114,6 +120,7 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
+     * @param ProductCustomOptionValuesInterfaceFactory|null $customOptionValuesFactory
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -127,12 +134,16 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
         Option\Validator\Pool $validatorPool,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        ProductCustomOptionValuesInterfaceFactory $customOptionValuesFactory = null
     ) {
         $this->productOptionValue = $productOptionValue;
         $this->optionTypeFactory = $optionFactory;
         $this->validatorPool = $validatorPool;
         $this->string = $string;
+        $this->customOptionValuesFactory = $customOptionValuesFactory ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(ProductCustomOptionValuesInterfaceFactory::class);
+
         parent::__construct(
             $context,
             $registry,
@@ -390,20 +401,21 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
      */
     public function afterSave()
     {
-        $this->getValueInstance()->unsetValues();
         $values = $this->getValues() ?: $this->getData('values');
         if (is_array($values)) {
             foreach ($values as $value) {
-                if ($value instanceof \Magento\Catalog\Api\Data\ProductCustomOptionValuesInterface) {
+                if ($value instanceof ProductCustomOptionValuesInterface) {
                     $data = $value->getData();
                 } else {
                     $data = $value;
                 }
-                $this->getValueInstance()->addValue($data);
-            }
 
-            $this->getValueInstance()->setOption($this)->saveValues();
-        } elseif ($this->getGroupByType($this->getType()) == self::OPTION_GROUP_SELECT) {
+                $this->customOptionValuesFactory->create()
+                    ->addValue($data)
+                    ->setOption($this)
+                    ->saveValues();
+            }
+        } elseif ($this->getGroupByType($this->getType()) === self::OPTION_GROUP_SELECT) {
             throw new LocalizedException(__('Select type options required values rows.'));
         }
 
@@ -804,7 +816,7 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
     }
 
     /**
-     * @param \Magento\Catalog\Api\Data\ProductCustomOptionValuesInterface[] $values
+     * @param ProductCustomOptionValuesInterface[] $values
      * @return $this
      */
     public function setValues(array $values = null)

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -202,27 +202,29 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
     public function saveValues()
     {
         foreach ($this->getValues() as $value) {
-            $this->isDeleted(false);
-            $this->setData(
+            $optionValue = clone $this;
+            $optionValue->isDeleted(false);
+
+            $optionValue->setData(
                 $value
             )->setData(
                 'option_id',
-                $this->getOption()->getId()
+                $optionValue->getOption()->getId()
             )->setData(
                 'store_id',
-                $this->getOption()->getStoreId()
+                $optionValue->getOption()->getStoreId()
             );
 
-            if ($this->getData('is_delete') == '1') {
-                if ($this->getId()) {
-                    $this->deleteValues($this->getId());
-                    $this->delete();
+            if ($optionValue->getData('is_delete') == '1') {
+                if ($optionValue->getId()) {
+                    $optionValue->deleteValues($optionValue->getId());
+                    $optionValue->delete();
                 }
             } else {
-                $this->save();
+                $optionValue->save();
             }
         }
-        //eof foreach()
+
         return $this;
     }
 

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -76,6 +76,7 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
+     * @param CustomOptionPriceCalculator|null $customOptionPriceCalculator
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
@@ -89,6 +90,7 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
         $this->_valueCollectionFactory = $valueCollectionFactory;
         $this->customOptionPriceCalculator = $customOptionPriceCalculator
             ?? \Magento\Framework\App\ObjectManager::getInstance()->get(CustomOptionPriceCalculator::class);
+
         parent::__construct(
             $context,
             $registry,
@@ -201,27 +203,21 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
      */
     public function saveValues()
     {
+        $option = $this->getOption();
+
         foreach ($this->getValues() as $value) {
-            $optionValue = clone $this;
-            $optionValue->isDeleted(false);
+            $this->isDeleted(false);
+            $this->setData($value)
+                ->setData('option_id', $option->getId())
+                ->setData('store_id', $option->getStoreId());
 
-            $optionValue->setData(
-                $value
-            )->setData(
-                'option_id',
-                $optionValue->getOption()->getId()
-            )->setData(
-                'store_id',
-                $optionValue->getOption()->getStoreId()
-            );
-
-            if ($optionValue->getData('is_delete') == '1') {
-                if ($optionValue->getId()) {
-                    $optionValue->deleteValues($optionValue->getId());
-                    $optionValue->delete();
+            if ((bool) $this->getData('is_delete') === true) {
+                if ($this->getId()) {
+                    $this->deleteValues($this->getId());
+                    $this->delete();
                 }
             } else {
-                $optionValue->save();
+                $this->save();
             }
         }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13569
### Description
This occurred because the same value object is used for saving all values. After the save `updateStoredData()` is called and is used in `prepareDataForUpdate()`.
https://github.com/magento/magento2/blob/3561b6614eeafb70cbcbf0dc0254359b857af3d4/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php#L718-L733

### Fixed Issues (if relevant)
1. magento/magento2#5067: Custom option values do not save correctly

### Manual testing scenarios
1. Install module [ReachDigital_CustomOption.zip](https://github.com/magento/magento2/files/1707887/ReachDigital_CustomOption.zip)
2. An extra column as added to the Product Custom Options (http://cloud.h-o.nl/pP3N).
3. Uncheck all `Changes Appearance` checkboxes and save product.
4. Only the first checkbox is saved.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
