### PR TITLE
[backport] fix #16764 Rating Star issue on Product detail Page.

### DIFF
--- a/lib/web/css/source/lib/_rating.less
+++ b/lib/web/css/source/lib/_rating.less
@@ -38,7 +38,7 @@
     input[type="radio"] {
         .lib-visually-hidden();
 
-        &:focus,
+        &:hover,
         &:checked {
             + label {
                 &:before {


### PR DESCRIPTION

### Description
Backport of PR #16766

Changed focus to hover, because field validation focuses first incorrect field
### Fixed Issues (if relevant)

1. magento/magento2#16764: Rating Star issue on Product detail Page.

### Manual testing scenarios
1.Go to product page
2.submit review without any input
Expected result:
rating stars show message "Please select one of each of the ratings above"
Actual result:
Shows message "Please select one of each of the ratings above" and first star is in focus (shows as filled star)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
