### PR TITLE
Log when Magento is in maintenance mode

### DIFF
--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -108,13 +108,6 @@ class Bootstrap
     private $factory;
 
     /**
-     * Logger
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * Static method so that client code does not have to create Object Manager Factory every time Bootstrap is called
      *
      * @param string $rootDir
@@ -214,7 +207,6 @@ class Bootstrap
         $this->rootDir = $rootDir;
         $this->server = $initParams;
         $this->objectManager = $this->factory->create($this->server);
-        $this->logger = $this->objectManager->create(LoggerInterface::class);
     }
 
     /**
@@ -267,7 +259,7 @@ class Bootstrap
                 \Magento\Framework\Profiler::stop('magento');
             } catch (\Exception $e) {
                 \Magento\Framework\Profiler::stop('magento');
-                $this->logger->error($e->getMessage());
+                $this->objectManager->get(LoggerInterface::class)->error($e);
                 if (!$application->catchException($this, $e)) {
                     throw $e;
                 }

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -108,6 +108,13 @@ class Bootstrap
     private $factory;
 
     /**
+     * Logger
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Static method so that client code does not have to create Object Manager Factory every time Bootstrap is called
      *
      * @param string $rootDir
@@ -207,6 +214,7 @@ class Bootstrap
         $this->rootDir = $rootDir;
         $this->server = $initParams;
         $this->objectManager = $this->factory->create($this->server);
+        $this->logger = $this->objectManager->create(LoggerInterface::class);
     }
 
     /**
@@ -259,6 +267,7 @@ class Bootstrap
                 \Magento\Framework\Profiler::stop('magento');
             } catch (\Exception $e) {
                 \Magento\Framework\Profiler::stop('magento');
+                $this->logger->error($e->getMessage());
                 if (!$application->catchException($this, $e)) {
                     throw $e;
                 }

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -12,6 +12,7 @@ use Magento\Framework\Autoload\AutoloaderRegistry;
 use Magento\Framework\Autoload\Populator;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Filesystem\DriverPool;
+use Psr\Log\LoggerInterface;
 
 /**
  * A bootstrap of Magento application
@@ -423,7 +424,7 @@ class Bootstrap
                 if (!$this->objectManager) {
                     throw new \DomainException();
                 }
-                $this->objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
+                $this->objectManager->get(LoggerInterface::class)->critical($e);
             } catch (\Exception $e) {
                 $message .= "Could not write error message to log. Please use developer mode to see the message.\n";
             }

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -259,7 +259,7 @@ class Bootstrap
                 \Magento\Framework\Profiler::stop('magento');
             } catch (\Exception $e) {
                 \Magento\Framework\Profiler::stop('magento');
-                $this->objectManager->get(LoggerInterface::class)->error($e);
+                $this->objectManager->get(LoggerInterface::class)->error($e->getMessage());
                 if (!$application->catchException($this, $e)) {
                     throw $e;
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Logging when Magento is in maintenance mode. 

Not sure if I'm the only one that fell for this, but I've (embarrassingly) spent hours trying figuring out why Magento was throwing a 500 error; only to find that it was just in maintenance mode...

Logging this will save developers some time, and eliminate some of the guess work involved with troubleshooting obscure errors.

This is usually applicable when a deployment goes a little haywire.

    ==> var/log/system.log <==
    [2018-07-15 19:38:12] main.ERROR: Unable to proceed: the maintenance mode is enabled.

----

As a "side-affect" we'd also be logging errors coming from the [launch process](https://github.com/magento/magento2/blob/2.2-develop/lib/internal/Magento/Framework/App/Bootstrap.php#L252L258), which I don't think is that much of an issue.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable maintenance mode
2. Run `tail -f var/log/system.log`
3. Expect "Unable to proceed: the maintenance mode is enabled"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
