### PR TITLE
[Backport] chore: remove extraneous cursor property

### DIFF
--- a/lib/web/css/source/lib/_buttons.less
+++ b/lib/web/css/source/lib/_buttons.less
@@ -266,8 +266,7 @@
     &.disabled,
     &[disabled],
     fieldset[disabled] & {
-        cursor: not-allowed;
-        pointer-events: none; // Disabling of clicks
+        pointer-events: none; // Disabling of all pointer events
         .lib-css(opacity, @button__disabled__opacity);
     }
 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15305
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
`cursor` is not usable with `pointer-events: none`. Also this would add the `not-allowed` cursor which does not make much sense imho.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. create a button with the disabled property
2. hover and click it
3. there is no `not-allowed` cursor

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
