### PR TITLE
[Backport] Add @api annotation to Filter Group & Sort Order

### DIFF
--- a/lib/internal/Magento/Framework/Api/Search/FilterGroup.php
+++ b/lib/internal/Magento/Framework/Api/Search/FilterGroup.php
@@ -10,6 +10,9 @@ use Magento\Framework\Api\AbstractSimpleObject;
 
 /**
  * Groups two or more filters together using a logical OR
+ *
+ * @api
+ * @since 100.0.2
  */
 class FilterGroup extends AbstractSimpleObject
 {

--- a/lib/internal/Magento/Framework/Api/Search/FilterGroupBuilder.php
+++ b/lib/internal/Magento/Framework/Api/Search/FilterGroupBuilder.php
@@ -12,6 +12,9 @@ use Magento\Framework\Api\ObjectFactory;
 
 /**
  * Builder for FilterGroup Data.
+ *
+ * @api
+ * @since 100.0.2
  */
 class FilterGroupBuilder extends AbstractSimpleObjectBuilder
 {

--- a/lib/internal/Magento/Framework/Api/SortOrder.php
+++ b/lib/internal/Magento/Framework/Api/SortOrder.php
@@ -11,6 +11,9 @@ use Magento\Framework\Phrase;
 
 /**
  * Data object for sort order.
+ *
+ * @api
+ * @since 100.0.2
  */
 class SortOrder extends AbstractSimpleObject
 {

--- a/lib/internal/Magento/Framework/Api/SortOrderBuilder.php
+++ b/lib/internal/Magento/Framework/Api/SortOrderBuilder.php
@@ -10,6 +10,9 @@ namespace Magento\Framework\Api;
 /**
  * Builder for sort order data object.
  * @method SortOrder create()
+ *
+ * @api
+ * @since 100.0.2
  */
 class SortOrderBuilder extends AbstractSimpleObjectBuilder
 {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16252
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

### Description

This PR adds the FilterGroup and SortOrder classes to the public API for the magento/framework component.  They are the only pieces of SearchCriteriaInterface that are not identified with an `@api` annotation.  This causes usages of them for searching repositories in modules to depend on the patch level of the framework.  Once merged, modules may use them while depending on the major version of the framework.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
