### PR TITLE
Replace strval() function by using direct type casting to (string)

### DIFF
--- a/app/code/Magento/Authorizenet/Model/Directpost/Request.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost/Request.php
@@ -112,50 +112,50 @@ class Request extends AuthorizenetRequest
             sprintf('%.2F', $order->getBaseShippingAmount())
         );
 
-        //need to use strval() because NULL values IE6-8 decodes as "null" in JSON in JavaScript,
+        //need to use (string) because NULL values IE6-8 decodes as "null" in JSON in JavaScript,
         //but we need "" for null values.
         $billing = $order->getBillingAddress();
         if (!empty($billing)) {
-            $this->setXFirstName(strval($billing->getFirstname()))
-                ->setXLastName(strval($billing->getLastname()))
-                ->setXCompany(strval($billing->getCompany()))
-                ->setXAddress(strval($billing->getStreetLine(1)))
-                ->setXCity(strval($billing->getCity()))
-                ->setXState(strval($billing->getRegion()))
-                ->setXZip(strval($billing->getPostcode()))
-                ->setXCountry(strval($billing->getCountryId()))
-                ->setXPhone(strval($billing->getTelephone()))
-                ->setXFax(strval($billing->getFax()))
-                ->setXCustId(strval($billing->getCustomerId()))
-                ->setXCustomerIp(strval($order->getRemoteIp()))
-                ->setXCustomerTaxId(strval($billing->getTaxId()))
-                ->setXEmail(strval($order->getCustomerEmail()))
-                ->setXEmailCustomer(strval($paymentMethod->getConfigData('email_customer')))
-                ->setXMerchantEmail(strval($paymentMethod->getConfigData('merchant_email')));
+            $this->setXFirstName((string)$billing->getFirstname())
+                ->setXLastName((string)$billing->getLastname())
+                ->setXCompany((string)$billing->getCompany())
+                ->setXAddress((string)$billing->getStreetLine(1))
+                ->setXCity((string)$billing->getCity())
+                ->setXState((string)$billing->getRegion())
+                ->setXZip((string)$billing->getPostcode())
+                ->setXCountry((string)$billing->getCountryId())
+                ->setXPhone((string)$billing->getTelephone())
+                ->setXFax((string)$billing->getFax())
+                ->setXCustId((string)$billing->getCustomerId())
+                ->setXCustomerIp((string)$order->getRemoteIp())
+                ->setXCustomerTaxId((string)$billing->getTaxId())
+                ->setXEmail((string)$order->getCustomerEmail())
+                ->setXEmailCustomer((string)$paymentMethod->getConfigData('email_customer'))
+                ->setXMerchantEmail((string)$paymentMethod->getConfigData('merchant_email'));
         }
 
         $shipping = $order->getShippingAddress();
         if (!empty($shipping)) {
             $this->setXShipToFirstName(
-                strval($shipping->getFirstname())
+                (string)$shipping->getFirstname()
             )->setXShipToLastName(
-                strval($shipping->getLastname())
+                (string)$shipping->getLastname()
             )->setXShipToCompany(
-                strval($shipping->getCompany())
+                (string)$shipping->getCompany()
             )->setXShipToAddress(
-                strval($shipping->getStreetLine(1))
+                (string)$shipping->getStreetLine(1)
             )->setXShipToCity(
-                strval($shipping->getCity())
+                (string)$shipping->getCity()
             )->setXShipToState(
-                strval($shipping->getRegion())
+                (string)$shipping->getRegion()
             )->setXShipToZip(
-                strval($shipping->getPostcode())
+                (string)$shipping->getPostcode()
             )->setXShipToCountry(
-                strval($shipping->getCountryId())
+                (string)$shipping->getCountryId()
             );
         }
 
-        $this->setXPoNum(strval($payment->getPoNumber()));
+        $this->setXPoNum((string)$payment->getPoNumber());
 
         return $this;
     }

--- a/app/code/Magento/Config/Model/Config/Backend/Currency/AbstractCurrency.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Currency/AbstractCurrency.php
@@ -71,7 +71,7 @@ abstract class AbstractCurrency extends \Magento\Framework\App\Config\Value
                 $this->getScopeId()
             );
         }
-        return strval($value);
+        return (string)$value;
     }
 
     /**
@@ -88,7 +88,7 @@ abstract class AbstractCurrency extends \Magento\Framework\App\Config\Value
                 $this->getScopeId()
             );
         }
-        return strval($value);
+        return (string)$value;
     }
 
     /**

--- a/app/code/Magento/Paypal/Controller/Payflow/ReturnUrl.php
+++ b/app/code/Magento/Paypal/Controller/Payflow/ReturnUrl.php
@@ -50,7 +50,7 @@ class ReturnUrl extends Payflow
                     $redirectBlock->setData('goto_success_page', true);
                 } else {
                     if ($this->checkPaymentMethod($order)) {
-                        $gotoSection = $this->_cancelPayment(strval($this->getRequest()->getParam('RESPMSG')));
+                        $gotoSection = $this->_cancelPayment((string)$this->getRequest()->getParam('RESPMSG'));
                         $redirectBlock->setData('goto_section', $gotoSection);
                         $redirectBlock->setData('error_msg', __('Your payment has been declined. Please try again.'));
                     } else {

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -1609,7 +1609,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
          * Error message
          */
         if (is_string($cartCandidates) || $cartCandidates instanceof \Magento\Framework\Phrase) {
-            return strval($cartCandidates);
+            return (string)$cartCandidates;
         }
 
         /**

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
@@ -2523,5 +2523,6 @@ return [
     ['_isAttributeValueEmpty', 'Magento\Catalog\Model\ResourceModel\AbstractResource'],
     ['var_dump', ''],
     ['each', ''],
+    ['strval', ''],
     ['isOrderIncrementIdUsed', 'Magento\Quote\Model\ResourceModel\Quote', 'Magento\Sales\Model\OrderIncrementIdChecker::isIncrementIdUsed']
 ];

--- a/lib/internal/Magento/Framework/DB/Select/OrderRenderer.php
+++ b/lib/internal/Magento/Framework/DB/Select/OrderRenderer.php
@@ -40,12 +40,12 @@ class OrderRenderer implements RendererInterface
             $order = [];
             foreach ($select->getPart(Select::ORDER) as $term) {
                 if (is_array($term)) {
-                    if (is_numeric($term[0]) && strval(intval($term[0])) == $term[0]) {
+                    if (is_numeric($term[0]) && (string)(int)$term[0] == $term[0]) {
                         $order[] = (int)trim($term[0]) . ' ' . $term[1];
                     } else {
                         $order[] = $this->quote->quoteIdentifier($term[0]) . ' ' . $term[1];
                     }
-                } elseif (is_numeric($term) && strval(intval($term)) == $term) {
+                } elseif (is_numeric($term) && (string)(int)$term == $term) {
                     $order[] = (int)trim($term);
                 } else {
                     $order[] = $this->quote->quoteIdentifier($term);

--- a/lib/internal/Magento/Framework/Data/Form/Element/Checkboxes.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Checkboxes.php
@@ -121,13 +121,13 @@ class Checkboxes extends AbstractElement
             return;
         }
         if (!is_array($checked)) {
-            $checked = [strval($checked)];
+            $checked = [(string)$checked];
         } else {
             foreach ($checked as $k => $v) {
-                $checked[$k] = strval($v);
+                $checked[$k] = (string)$v;
             }
         }
-        if (in_array(strval($value), $checked)) {
+        if (in_array((string)$value, $checked)) {
             return 'checked';
         }
         return;
@@ -141,13 +141,13 @@ class Checkboxes extends AbstractElement
     {
         if ($disabled = $this->getData('disabled')) {
             if (!is_array($disabled)) {
-                $disabled = [strval($disabled)];
+                $disabled = [(string)$disabled];
             } else {
                 foreach ($disabled as $k => $v) {
-                    $disabled[$k] = strval($v);
+                    $disabled[$k] = (string)$v;
                 }
             }
-            if (in_array(strval($value), $disabled)) {
+            if (in_array((string)$value, $disabled)) {
                 return 'disabled';
             }
         }

--- a/lib/internal/Magento/Framework/Filter/Translit.php
+++ b/lib/internal/Magento/Framework/Filter/Translit.php
@@ -409,7 +409,7 @@ class Translit implements \Zend_Filter_Interface
         $convertConfig = $config->getValue('url/convert', 'default');
         if ($convertConfig) {
             foreach ($convertConfig as $configValue) {
-                $this->convertTable[strval($configValue['from'])] = strval($configValue['to']);
+                $this->convertTable[(string)$configValue['from']] = (string)$configValue['to'];
             }
         }
     }

--- a/lib/internal/Magento/Framework/Phrase/Renderer/Placeholder.php
+++ b/lib/internal/Magento/Framework/Phrase/Renderer/Placeholder.php
@@ -40,6 +40,6 @@ class Placeholder implements RendererInterface
      */
     private function keyToPlaceholder($key)
     {
-        return '%' . (is_int($key) ? strval($key + 1) : $key);
+        return '%' . (is_int($key) ? (string)($key + 1) : $key);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Direct type casting is **up to 6x faster** than using casting functions like` strval()`. So this pull request replaces the `strval()` functions by direct type casting to `(string)`.

**Similar PRs:** 

> #16422 Replace intval() function by using direct type casting to (int) where no default value is needed 
> #16848 Replace floatval() function by using direct type casting to (float)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] [All automated tests passed successfully (all builds on Travis CI are green)](https://travis-ci.org/mhauri/magento2/builds/404317117)
