### PR TITLE
Configurable Product with Only Size Options (No Color Options) Shows …

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageBuilder.php
@@ -122,7 +122,7 @@ class ImageBuilder
     public function create()
     {
         /** @var \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface $simpleOption */
-        $simpleOption = $this->product->getCustomOption('simple_product');
+        $simpleOption = $this->product->getOptionById('simple_product');
 
         if ($simpleOption !== null) {
             $optionProduct = $simpleOption->getProduct();

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageBuilderTest.php
@@ -306,7 +306,7 @@ class ImageBuilderTest extends \PHPUnit\Framework\TestCase
         $simpleOptionMock = $this->createMock(\Magento\Wishlist\Model\Item\Option::class);
         $simpleProductMock = $this->createMock(\Magento\Catalog\Model\Product::class);
 
-        $productMock->expects($this->once())->method('getCustomOption')
+        $productMock->expects($this->once())->method('getOptionById')
             ->with('simple_product')->willReturn($simpleOptionMock);
 
         $simpleOptionMock->expects($this->once())->method('getProduct')->willReturn($simpleProductMock);


### PR DESCRIPTION
### Description
Function getCustomOption() not working well for configurable product.
So I replace getCustomOption to getOptionById. than its work fine.

### Fixed Issues
1. magento/magento2#16843: Magento 2.2.5: Configurable Product with Only Size Options (No Color Options) Shows No Image in Cart.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set in admin: Stores > Configuration > Sales > Checkout > Shopping Cart: "Configurable Product Image: Parent Product Thumbnail"
2. Create a configurable product with multiple size options, but no color options.
3. Assign an image(s) only to the configurable product (not to child/simple products)
4. Visit the product page in the store front and add it to cart.

### Result
Product image should show on cart page (coming from configurable product)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
