### PR TITLE
Fix web API parameters parser

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -219,10 +219,6 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
 
         // Secondary method: fallback to setter methods
         foreach ($data as $propertyName => $value) {
-            if (isset($constructorArgs[$propertyName])) {
-                continue;
-            }
-
             // Converts snake_case to uppercase CamelCase to help form getter/setter method names
             // This use case is for REST only. SOAP request data is already camel cased
             $camelCaseProperty = SimpleDataObjectConverter::snakeCaseToUpperCamelCase($propertyName);

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessor/SimpleConstructor.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessor/SimpleConstructor.php
@@ -18,17 +18,32 @@ class SimpleConstructor
      * @var string
      */
     private $name;
+    /**
+     * @var \Magento\Framework\Webapi\Test\Unit\ServiceInputProcessor\Simple[]
+     */
+    private $customers;
 
     /**
      * @param int $entityId
      * @param string $name
+     * @param \Magento\Framework\Webapi\Test\Unit\ServiceInputProcessor\Simple[] $customers
      */
     public function __construct(
         int $entityId,
-        string $name
+        string $name,
+        array $customers = null
     ) {
         $this->entityId = $entityId;
         $this->name = $name;
+        $this->customers = $customers;
+    }
+
+    /**
+     * @param int $entityId
+     */
+    public function setEntityId(int $entityId)
+    {
+        $this->entityId = $entityId;
     }
 
     /**
@@ -40,10 +55,34 @@ class SimpleConstructor
     }
 
     /**
+     * @param string $name
+     */
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
      * @return string|null
      */
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return \Magento\Framework\Webapi\Test\Unit\ServiceInputProcessor\Simple[]
+     */
+    public function getCustomers(): array
+    {
+        return $this->customers;
+    }
+
+    /**
+     * @param \Magento\Framework\Webapi\Test\Unit\ServiceInputProcessor\Simple[] $customers
+     */
+    public function setCustomers(array $customers)
+    {
+        $this->customers = $customers;
     }
 }

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
@@ -219,6 +219,47 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Test', $arg->getName());
     }
 
+    public function testSimpleConstructorPropertiesWithObjectsArray()
+    {
+        $data = ['simpleConstructor' => [
+            'entityId' => 15,
+            'name' => 'Test',
+            'customers' => [
+                ['entity_id' => 1, 'name' => 'test 1'],
+                ['entity_id' => 2, 'name' => 'test 2'],
+            ]
+        ]];
+        $result = $this->serviceInputProcessor->process(
+            \Magento\Framework\Webapi\Test\Unit\ServiceInputProcessor\TestService::class,
+            'simpleConstructor',
+            $data
+        );
+        $this->assertNotNull($result);
+        /** @var SimpleConstructor $arg */
+        $arg = $result[0];
+
+        $this->assertTrue($arg instanceof SimpleConstructor);
+        $this->assertEquals(15, $arg->getEntityId());
+        $this->assertEquals('Test', $arg->getName());
+        $customersCount = count($data['simpleConstructor']['customers']);
+        $customers = $arg->getCustomers();
+        $this->assertEquals($customersCount, count($customers));
+
+        for ($i = 0; $i < $customersCount - 1; $i++) {
+            $this->assertTrue(isset($customers[$i]));
+            $customer = $customers[$i];
+            $this->assertTrue($customer instanceof Simple);
+            $this->assertEquals(
+                $data['simpleConstructor']['customers'][$i]['entity_id'],
+                $customer->getEntityId()
+            );
+            $this->assertEquals(
+                $data['simpleConstructor']['customers'][$i]['name'],
+                $customer->getName()
+            );
+        }
+    }
+
     public function testSimpleArrayProperties()
     {
         $data = ['ids' => [1, 2, 3, 4]];


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

Problem: If some API service expects as parameter an object with property, which is array of objects, it will receive array of arrays(not array of objects)

### Fixed Issues (if relevant)
none

### Preconditions
1. Add module to app/code/Magento from module.tar.gz
[module.tar.gz](https://github.com/magento/magento2/files/2201856/module.tar.gz)
2. run command bin/magento setup:upgrade

### Steps to reproduce
1. run web API command http://example.com/rest/V1/test with body 
{"test":{"entityId":1,"customers":[{"customer_id":1, "name":"test1"},{"customer_id":2, "name":"test2"}]}}

### Expected result 
["test1","test2"]

### Actual result
Error {"messages":{"error":[{"code":500,"message":"Server internal error. See details... 
Report error message: Uncaught Error: Call to a member function getName() on array

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
