### PR TITLE
Update nginx.config.sample to exclude php5-fpm

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -3,7 +3,6 @@
 #    # use tcp connection
 #    # server  127.0.0.1:9000;
 #    # or socket
-#    server   unix:/var/run/php5-fpm.sock;
 #    server   unix:/var/run/php/php7.0-fpm.sock;
 # }
 # server {


### PR DESCRIPTION
### Description
M2.2.x is not compatible with php5.x so there's no reason to include it as an option in the nginx.config.sample. Refer to: https://devdocs.magento.com/guides/v2.2/install-gde/system-requirements-tech.html

### Fixed Issues (if relevant)
This does not fix any issues. However, it does prevent someone from thinking that M2.2.x is compatible with php5.

### Manual testing scenarios
No tests needed.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
