### PR TITLE
Fix blocked a frame with origin

### DIFF
--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -53,7 +53,22 @@ define([
                 }
             }
 
-            $(element).contents().each(function (index, el) {
+            // rewrite jQuery contents()
+             var contents = function (element) {
+                return $.map(element, function (elem) {
+                    try {
+                        return $.nodeName(elem, "iframe") ?
+                               elem.contentDocument || (elem.contentWindow ? elem.contentWindow.document : []) :
+                               $.merge([], elem.childNodes);
+                    } catch (e) {
+                        return [];
+                    }
+                });
+            };
+
+            var elementContents = contents($(element));
+
+            $.each(elementContents, function (index, el) {
                 switch (el.nodeType) {
                     case 1: // ELEMENT_NODE
                         lookup(el);

--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -6,6 +6,7 @@
 define([
     'jquery',
     'domReady',
+    'consoleLogger',
     'jquery/ui',
     'mage/cookies'
 ], function ($, domReady) {
@@ -61,6 +62,7 @@ define([
                                elem.contentDocument || (elem.contentWindow ? elem.contentWindow.document : []) :
                                $.merge([], elem.childNodes);
                     } catch (e) {
+                        consoleLogger.error(e);
                         return [];
                     }
                 });

--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -9,7 +9,7 @@ define([
     'consoleLogger',
     'jquery/ui',
     'mage/cookies'
-], function ($, domReady) {
+], function ($, domReady, consoleLogger) {
     'use strict';
 
     /**


### PR DESCRIPTION
### Preconditions
1. Magento 2.2.3 or 2.2.4 or 2.2.5
2. Add  the following script to the product page: 
`<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>`

### Steps to reproduce
1. Flush cache
2. Open dev-console in your browser
3. Reload page many times

### Expected result
Console without errors

### Actual result
1. Sometime we'll have this error:
![console](https://user-images.githubusercontent.com/34220204/42828390-280d8f80-89f1-11e8-93d9-25559082edfc.png)

### Tech notes
Time to time created iframe on following line: https://github.com/magento/magento2/blob/2.2-develop/lib/web/jquery.js#L3123

Our change add try-catch to this method, and when error appears - we just returning an empty array.