### PR TITLE
[Backport] FIX for issue#14869 - Wrong price at backend after update

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
@@ -53,9 +53,9 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
      * @param Option\CollectionFactory $itemOptionCollectionFactory
      * @param \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory
      * @param \Magento\Quote\Model\Quote\Config $quoteConfig
-     * @param \Magento\Store\Model\StoreManagerInterface|null $storeManager
      * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
      * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource
+     * @param \Magento\Store\Model\StoreManagerInterface|null $storeManager
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -67,9 +67,9 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
         \Magento\Quote\Model\ResourceModel\Quote\Item\Option\CollectionFactory $itemOptionCollectionFactory,
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollectionFactory,
         \Magento\Quote\Model\Quote\Config $quoteConfig,
-        \Magento\Store\Model\StoreManagerInterface $storeManager = null,
         \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null
     ) {
         parent::__construct(
             $entityFactory,


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14904

A previous commit 9d3be732a88884a66d667b443b3dc1655ddd0721 (cc @neeta-wagento) changed the default behaviour of
`\Magento\Quote\Model\ResourceModel\Quote\Item\Collection::getStoreId()` using the store coming from the current session
instead of using the one from quote. The previous commit was made to fix an error while using `getItems()` without setting a quote.
The implemetation is correctly working in the frontend because the quote storeId is and the session storeId are matchnig, but it breaks the admin implementation because they can be different.

The current fix restore the previous behaviour and adds a check if the quote is not specified.

### Fixed Issues (if relevant)
1. magento/magento2#14869: Wrong price at backend after update

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
