### PR TITLE
[Backport] Prevent running SQL query on every item in the database when the quote is empty

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
@@ -272,6 +272,10 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
      */
     private function removeItemsWithAbsentProducts()
     {
+        if (count($this->_productIds) === 0) {
+            return;
+        }
+
         $productCollection = $this->_productCollectionFactory->create()->addIdFilter($this->_productIds);
         $existingProductsIds = $productCollection->getAllIds();
         $absentProductsIds = array_diff($this->_productIds, $existingProductsIds);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16675

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
During custom development on Magento, we needed the ability to have a quote be created and loaded into the session with no items. We started noticing performance issues throughout ajax banner loads and checkout cart loads after this change. After further inspection, we noticed that a call to `\Magento\Quote\Model\ResourceModel\Quote\Item\Collection::removeItemsWithAbsentProducts` resulted in a query on the `catalog_product_entity` table that performed a table scan across all 1.3 million products in the database, simply because no filter was being applied. The requested change simply is a check if there are any product ids to filter before attempting to filter. While this may not affect any stand-alone magento installations, it has no negative effect and if any other developer seeks to implement the capability of loading empty quotes into the session, this will alleviate potential performance issues.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
