### PR TITLE
magento/magento2#14510: Creating custom customer attribute with default value 0 will cause not saving value for customer entity.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Boolean.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Boolean.php
@@ -25,7 +25,9 @@ class Boolean extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBacken
         $attributeCode = $this->getAttribute()->getName();
         if ($object->getData('use_config_' . $attributeCode)) {
             $object->setData($attributeCode, BooleanSource::VALUE_USE_CONFIG);
+            return $this;
         }
-        return $this;
+
+        return parent::beforeSave($object);
     }
 }

--- a/app/code/Magento/Downloadable/Setup/UpgradeData.php
+++ b/app/code/Magento/Downloadable/Setup/UpgradeData.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Downloadable\Setup;
+
+use Magento\Eav\Setup\EavSetup;
+use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class UpgradeData implements UpgradeDataInterface
+{
+    /**
+     * EAV setup factory
+     *
+     * @var EavSetupFactory
+     */
+    private $eavSetupFactory;
+
+    /**
+     * Init
+     *
+     * @param EavSetupFactory $eavSetupFactory
+     */
+    public function __construct(EavSetupFactory $eavSetupFactory)
+    {
+        $this->eavSetupFactory = $eavSetupFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        if (version_compare($context->getVersion(), '2.0.3', '<')) {
+            /** @var EavSetup $eavSetup */
+            $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+            // remove default value
+            $eavSetup->updateAttribute(
+                \Magento\Catalog\Model\Product::ENTITY,
+                'links_exist',
+                'default_value',
+                null
+            );
+        }
+
+        $setup->endSetup();
+    }
+}

--- a/app/code/Magento/Downloadable/Setup/UpgradeData.php
+++ b/app/code/Magento/Downloadable/Setup/UpgradeData.php
@@ -35,7 +35,7 @@ class UpgradeData implements UpgradeDataInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {

--- a/app/code/Magento/Downloadable/etc/module.xml
+++ b/app/code/Magento/Downloadable/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Downloadable" setup_version="2.0.2">
+    <module name="Magento_Downloadable" setup_version="2.0.3">
         <sequence>
             <module name="Magento_Catalog"/>
         </sequence>

--- a/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
@@ -383,7 +383,7 @@ abstract class AbstractAttribute extends \Magento\Framework\Model\AbstractExtens
     }
 
     /**
-     * @return string|int|bool|float
+     * @return string|null
      * @codeCoverageIgnore
      */
     public function getDefaultValue()

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/AbstractBackend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/AbstractBackend.php
@@ -203,12 +203,12 @@ abstract class AbstractBackend implements \Magento\Eav\Model\Entity\Attribute\Ba
     /**
      * Retrieve default value
      *
-     * @return mixed
+     * @return string
      */
     public function getDefaultValue()
     {
         if ($this->_defaultValue === null) {
-            if ($this->getAttribute()->getDefaultValue()) {
+            if ($this->getAttribute()->getDefaultValue() !== null) {
                 $this->_defaultValue = $this->getAttribute()->getDefaultValue();
             } else {
                 $this->_defaultValue = "";
@@ -280,7 +280,7 @@ abstract class AbstractBackend implements \Magento\Eav\Model\Entity\Attribute\Ba
     public function beforeSave($object)
     {
         $attrCode = $this->getAttribute()->getAttributeCode();
-        if (!$object->hasData($attrCode) && $this->getDefaultValue()) {
+        if (!$object->hasData($attrCode) && $this->getDefaultValue() !== '') {
             $object->setData($attrCode, $this->getDefaultValue());
         }
 


### PR DESCRIPTION
- fix default value check in case of type conversion;
- add boolean attribute default value assignment;

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14510: Creating custom customer attribute with default value 0 will cause not saving value for customer entity

### Manual testing scenarios
#### Steps to 
1. Create attribute with type "boolean" and default value via Data Install.


            $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
            $eavSetup->addAttribute(
                \Magento\Catalog\Model\Product::ENTITY,
                'custom_product',
                [
                    'type' => 'int',
                    'label' => 'Custom Product',
                    'input' => 'boolean',
                    'source' => \Magento\Eav\Model\Entity\Attribute\Source\Boolean::class,
                    'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_GLOBAL,
                    'backend' => \Magento\Catalog\Model\Product\Attribute\Backend\Boolean::class,
                    'visible' => true,
                    'required' => true,
                    'user_defined' => false,
                    'default' => '0',
                    'searchable' => false,
                    'filterable' => false,
                    'comparable' => false,
                    'visible_on_front' => false,
                    'used_in_product_listing' => true,
                    'unique' => false,
                ]
            );

            $entityTypeId = $eavSetup->getEntityTypeId(\Magento\Catalog\Model\Product::ENTITY);
            $attributeSetId = $eavSetup->getDefaultAttributeSetId($entityTypeId);
            $attributeGroupId = $eavSetup->getDefaultAttributeGroupId($entityTypeId, $attributeSetId);
            $this->attributeManagement->assign(
                \Magento\Catalog\Model\Product::ENTITY,
                $attributeSetId,
                $attributeGroupId,
                'custom_product',
                100
            );

2. Open Swagger. 
3. Create new product with REST API via CATALOGPRODUCTREPOSITORYV1. Attribute 'custom_product' should be missed.
`{
  "product": {
    "status": 2,
    "visibility": 4,
    "type_id": "simple",
    "sku": "testattr",
    "name": "TEST ATTR",
    "attribute_set_id": 4,
    "price": 0.5,
    "weight": 0.0,
    "extension_attributes": {
      "stock_item": {
        "qty": 0,
        "is_in_stock": true,
        "use_config_backorders": false,
        "backorders": 1,
        "use_config_manage_stock": false
      }
    },
    "custom_attributes": [
      {
        "attribute_code": "description",
        "value": ""
      },
      {
        "attribute_code": "short_description",
        "value": ""
      },
      {
        "attribute_code": "weight",
        "value": ""
      }
    ]
  }
}
`
4. Check a product attribute 'custom_product' value in DB.

#### Expected result
1. Default attribute value '0' was set for attribute 'custom_product'.
#### Actual result
1. No value was set for attribute ' custom_product' was set.
 
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
