### PR TITLE
Fixed inactive admin user token

### DIFF
--- a/app/code/Magento/Integration/Model/AdminTokenService.php
+++ b/app/code/Magento/Integration/Model/AdminTokenService.php
@@ -107,7 +107,7 @@ class AdminTokenService implements \Magento\Integration\Api\AdminTokenServiceInt
     {
         $tokenCollection = $this->tokenModelCollectionFactory->create()->addFilterByAdminId($adminId);
         if ($tokenCollection->getSize() == 0) {
-            throw new LocalizedException(__('This user has no tokens.'));
+            return true;
         }
         try {
             foreach ($tokenCollection as $token) {

--- a/app/code/Magento/Integration/Test/Unit/Model/AdminTokenServiceTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/AdminTokenServiceTest.php
@@ -100,10 +100,6 @@ class AdminTokenServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->_tokenService->revokeAdminAccessToken($adminId));
     }
 
-    /**
-     * @expectedException \Magento\Framework\Exception\LocalizedException
-     * @expectedExceptionMessage This user has no tokens.
-     */
     public function testRevokeAdminAccessTokenWithoutAdminId()
     {
         $this->_tokenModelCollectionMock->expects($this->once())

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/User/InvalidateTokenTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/User/InvalidateTokenTest.php
@@ -91,10 +91,6 @@ class InvalidateTokenTest extends \Magento\TestFramework\TestCase\AbstractBacken
         // invalidate token
         $this->getRequest()->setParam('user_id', $adminUserId);
         $this->dispatch('backend/admin/user/invalidateToken');
-        $this->assertSessionMessages(
-            $this->equalTo(['This user has no tokens.']),
-            MessageInterface::TYPE_ERROR
-        );
     }
 
     public function testInvalidateToken_NoUser()
@@ -112,9 +108,5 @@ class InvalidateTokenTest extends \Magento\TestFramework\TestCase\AbstractBacken
         // invalidate token
         $this->getRequest()->setParam('user_id', $adminUserId);
         $this->dispatch('backend/admin/user/invalidateToken');
-        $this->assertSessionMessages(
-            $this->equalTo(['This user has no tokens.']),
-            MessageInterface::TYPE_ERROR
-        );
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed inactive admin user token error.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16513: Can not save an inactive Admin User that has no access tokens generated

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log in to Admin Panel
2. Navigate to "System" -> "Permissions" -> "All Users"
3. Click on the inactive Admin User
4. Click "Save User"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
