### PR TITLE
[Backport] Admin tabs order not working properly

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -251,14 +251,15 @@ class Tabs extends \Magento\Backend\Block\Widget
     
     
     /**
+     * Reorder the tabs.
+     *
      * @return array
      */
     private function reorderTabs()
     {
         $orderByIdentity = [];
         $orderByPosition = [];
-        
-        $position  = 100;
+        $position        = 100;
     
         /**
          * Set the initial positions for each tab.
@@ -274,9 +275,21 @@ class Tabs extends \Magento\Backend\Block\Widget
             
             $position += 100;
         }
-        
+
+        return $this->applyTabsCorrectOrder($orderByPosition, $orderByIdentity);
+    }
+
+
+    /**
+     * @param array $orderByPosition
+     * @param array $orderByIdentity
+     *
+     * @return array
+     */
+    private function applyTabsCorrectOrder(array $orderByPosition, array $orderByIdentity)
+    {
         $positionFactor = 1;
-        
+
         /**
          * Rearrange the positions by using the after tag for each tab.
          *
@@ -288,26 +301,39 @@ class Tabs extends \Magento\Backend\Block\Widget
                 $positionFactor = 1;
                 continue;
             }
-            
+
             $grandPosition = $orderByIdentity[$tab->getAfter()]->getPosition();
             $newPosition   = $grandPosition + $positionFactor;
-            
+
             unset($orderByPosition[$position]);
             $orderByPosition[$newPosition] = $tab;
             $tab->setPosition($newPosition);
-    
+
             $positionFactor++;
         }
-        
+
+        return $this->finalTabsSortOrder($orderByPosition);
+    }
+
+
+    /**
+     * Apply the last sort order to tabs.
+     *
+     * @param array $orderByPosition
+     *
+     * @return array
+     */
+    private function finalTabsSortOrder(array $orderByPosition)
+    {
         ksort($orderByPosition);
-    
+
         $ordered = [];
-        
+
         /** @var TabInterface $tab */
         foreach ($orderByPosition as $tab) {
             $ordered[$tab->getId()] = $tab;
         }
-        
+
         return $ordered;
     }
     

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -114,7 +114,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         if (empty($tabId)) {
             throw new \Exception(__('Please correct the tab configuration and try again. Tab Id should be not empty'));
         }
-        
+
         if (is_array($tab)) {
             $this->_tabs[$tabId] = new \Magento\Framework\DataObject($tab);
         } elseif ($tab instanceof \Magento\Framework\DataObject) {

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -114,6 +114,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         if (empty($tabId)) {
             throw new \Exception(__('Please correct the tab configuration and try again. Tab Id should be not empty'));
         }
+        
         if (is_array($tab)) {
             $this->_tabs[$tabId] = new \Magento\Framework\DataObject($tab);
         } elseif ($tab instanceof \Magento\Framework\DataObject) {
@@ -123,6 +124,7 @@ class Tabs extends \Magento\Backend\Block\Widget
             }
         } elseif (is_string($tab)) {
             $this->_addTabByName($tab, $tabId);
+            
             if (!$this->_tabs[$tabId] instanceof TabInterface) {
                 unset($this->_tabs[$tabId]);
                 return $this;
@@ -130,6 +132,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         } else {
             throw new \Exception(__('Please correct the tab configuration and try again.'));
         }
+        
         if ($this->_tabs[$tabId]->getUrl() === null) {
             $this->_tabs[$tabId]->setUrl('#');
         }
@@ -140,10 +143,7 @@ class Tabs extends \Magento\Backend\Block\Widget
 
         $this->_tabs[$tabId]->setId($tabId);
         $this->_tabs[$tabId]->setTabId($tabId);
-
-        if ($this->_activeTab === null) {
-            $this->_activeTab = $tabId;
-        }
+        
         if (true === $this->_tabs[$tabId]->getActive()) {
             $this->setActiveTab($tabId);
         }
@@ -232,32 +232,79 @@ class Tabs extends \Magento\Backend\Block\Widget
      */
     protected function _beforeToHtml()
     {
+        $this->_tabs = $this->reorderTabs();
+        
+        if ($this->_activeTab === null) {
+            foreach ($this->_tabs as $tab) {
+                $this->_activeTab = $tab->getId();
+                break;
+            }
+        }
+        
         if ($activeTab = $this->getRequest()->getParam('active_tab')) {
             $this->setActiveTab($activeTab);
         } elseif ($activeTabId = $this->_authSession->getActiveTabId()) {
             $this->_setActiveTab($activeTabId);
         }
-
-        $_new = [];
-        foreach ($this->_tabs as $key => $tab) {
-            foreach ($this->_tabs as $k => $t) {
-                if ($t->getAfter() == $key) {
-                    $_new[$key] = $tab;
-                    $_new[$k] = $t;
-                } else {
-                    if (!$tab->getAfter() || !in_array($tab->getAfter(), array_keys($this->_tabs))) {
-                        $_new[$key] = $tab;
-                    }
-                }
-            }
-        }
-
-        $this->_tabs = $_new;
-        unset($_new);
-
+        
         $this->assign('tabs', $this->_tabs);
         return parent::_beforeToHtml();
     }
+    
+    
+    /**
+     * @return array
+     */
+    protected function reorderTabs()
+    {
+        $orderByIdentity = [];
+        $orderByPosition = [];
+        
+        $position  = 100;
+    
+        /**
+         * @var string                                         $key
+         * @var \Magento\Backend\Block\Widget\Tab\TabInterface $tab
+         */
+        foreach ($this->_tabs as $key => $tab) {
+            $tab->setPosition($position);
+    
+            $orderByIdentity[$key]      = $tab;
+            $orderByPosition[$position] = $tab;
+            
+            $position += 100;
+        }
+        
+        $positionFactor = 1;
+        
+        foreach ($orderByPosition as $position => $tab) {
+            if (!$tab->getAfter() || !in_array($tab->getAfter(), array_keys($orderByIdentity))) {
+                $positionFactor = 1;
+                continue;
+            }
+            
+            $grandPosition = $orderByIdentity[$tab->getAfter()]->getPosition();
+            $newPosition   = $grandPosition + $positionFactor;
+            
+            unset($orderByPosition[$position]);
+            $orderByPosition[$newPosition] = $tab;
+            $tab->setPosition($newPosition);
+    
+            $positionFactor++;
+        }
+        
+        ksort($orderByPosition);
+    
+        $ordered = [];
+        
+        /** @var  $tab */
+        foreach ($orderByPosition as $tab) {
+            $ordered[$tab->getId()] = $tab;
+        }
+        
+        return $ordered;
+    }
+    
 
     /**
      * @return string

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -249,7 +249,6 @@ class Tabs extends \Magento\Backend\Block\Widget
         return parent::_beforeToHtml();
     }
     
-    
     /**
      * Reorder the tabs.
      *
@@ -337,7 +336,6 @@ class Tabs extends \Magento\Backend\Block\Widget
         return $ordered;
     }
     
-
     /**
      * @return string
      */

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -234,18 +234,15 @@ class Tabs extends \Magento\Backend\Block\Widget
     {
         $this->_tabs = $this->reorderTabs();
         
-        if ($this->_activeTab === null) {
-            /** @var TabInterface $tab */
-            foreach ($this->_tabs as $tab) {
-                $this->_activeTab = $tab->getId();
-                break;
-            }
-        }
-        
         if ($activeTab = $this->getRequest()->getParam('active_tab')) {
             $this->setActiveTab($activeTab);
         } elseif ($activeTabId = $this->_authSession->getActiveTabId()) {
             $this->_setActiveTab($activeTabId);
+        }
+
+        if ($this->_activeTab === null && !empty($this->_tabs)) {
+            /** @var TabInterface $tab */
+            $this->_activeTab = (reset($this->_tabs))->getId();
         }
         
         $this->assign('tabs', $this->_tabs);
@@ -256,7 +253,7 @@ class Tabs extends \Magento\Backend\Block\Widget
     /**
      * @return array
      */
-    protected function reorderTabs()
+    private function reorderTabs()
     {
         $orderByIdentity = [];
         $orderByPosition = [];

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -235,7 +235,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         $this->_tabs = $this->reorderTabs();
         
         if ($this->_activeTab === null) {
-            /** @var  $tab */
+            /** @var TabInterface $tab */
             foreach ($this->_tabs as $tab) {
                 $this->_activeTab = $tab->getId();
                 break;
@@ -306,7 +306,7 @@ class Tabs extends \Magento\Backend\Block\Widget
     
         $ordered = [];
         
-        /** @var  $tab */
+        /** @var TabInterface $tab */
         foreach ($orderByPosition as $tab) {
             $ordered[$tab->getId()] = $tab;
         }

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -278,7 +278,6 @@ class Tabs extends \Magento\Backend\Block\Widget
         return $this->applyTabsCorrectOrder($orderByPosition, $orderByIdentity);
     }
 
-
     /**
      * @param array $orderByPosition
      * @param array $orderByIdentity
@@ -313,7 +312,6 @@ class Tabs extends \Magento\Backend\Block\Widget
 
         return $this->finalTabsSortOrder($orderByPosition);
     }
-
 
     /**
      * Apply the last sort order to tabs.

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -235,6 +235,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         $this->_tabs = $this->reorderTabs();
         
         if ($this->_activeTab === null) {
+            /** @var  $tab */
             foreach ($this->_tabs as $tab) {
                 $this->_activeTab = $tab->getId();
                 break;
@@ -263,8 +264,10 @@ class Tabs extends \Magento\Backend\Block\Widget
         $position  = 100;
     
         /**
-         * @var string                                         $key
-         * @var \Magento\Backend\Block\Widget\Tab\TabInterface $tab
+         * Set the initial positions for each tab.
+         *
+         * @var string       $key
+         * @var TabInterface $tab
          */
         foreach ($this->_tabs as $key => $tab) {
             $tab->setPosition($position);
@@ -277,6 +280,12 @@ class Tabs extends \Magento\Backend\Block\Widget
         
         $positionFactor = 1;
         
+        /**
+         * Rearrange the positions by using the after tag for each tab.
+         *
+         * @var integer      $position
+         * @var TabInterface $tab
+         */
         foreach ($orderByPosition as $position => $tab) {
             if (!$tab->getAfter() || !in_array($tab->getAfter(), array_keys($orderByIdentity))) {
                 $positionFactor = 1;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16412
- Created a method to reorder the tabs which is less complex and works better.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

When you add 2 or more tabs to admin area, like order view page, by using the method addTabAfter and the second new tab is placed after the first new tab the sort order does not work as expected.

More details in the issue.

### Fixed Issues

1. magento/magento2#16174: Issue title

### Manual testing scenarios

Described in the issue.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/16175