### PR TITLE
[Backport] Fix docBlock for hasInvoices(), hasShipments(), hasCreditmemos()

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1766,7 +1766,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Check order invoices availability
      *
-     * @return bool
+     * @return int
      */
     public function hasInvoices()
     {
@@ -1776,7 +1776,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Check order shipments availability
      *
-     * @return bool
+     * @return int
      */
     public function hasShipments()
     {
@@ -1786,7 +1786,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Check order creditmemos availability
      *
-     * @return bool
+     * @return int
      */
     public function hasCreditmemos()
     {

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1766,31 +1766,31 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Check order invoices availability
      *
-     * @return int
+     * @return bool
      */
     public function hasInvoices()
     {
-        return $this->getInvoiceCollection()->count();
+        return boolval($this->getInvoiceCollection()->count());
     }
 
     /**
      * Check order shipments availability
      *
-     * @return int
+     * @return bool
      */
     public function hasShipments()
     {
-        return $this->getShipmentsCollection()->count();
+        return boolval($this->getShipmentsCollection()->count());
     }
 
     /**
      * Check order creditmemos availability
      *
-     * @return int
+     * @return bool
      */
     public function hasCreditmemos()
     {
-        return $this->getCreditmemosCollection()->count();
+        return boolval($this->getCreditmemosCollection()->count());
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16554
### Description
Small improvements of docBlock for app/code/Magento/Sales/Model/Order.php docBlock description.
hasInvoices(), hasShipments(), hasCreditmemos() returns **int** and not **bool**

### Manual testing scenarios
No testing scenarios, just docBlock changed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
