### PR TITLE
Removed unused interface reference

### DIFF
--- a/app/code/Magento/Customer/Model/Visitor.php
+++ b/app/code/Magento/Customer/Model/Visitor.php
@@ -6,8 +6,6 @@
 
 namespace Magento\Customer\Model;
 
-use Magento\Framework\Indexer\StateInterface;
-
 /**
  * Class Visitor
  * @package Magento\Customer\Model


### PR DESCRIPTION
Removed unused interface reference

### Description
The interface `Magento\Framework\Indexer\StateInterface` is not being used in this class, so its reference declaration is not necessary

### Fixed Issues (if relevant)
Improvement

### Manual testing scenarios
N/A

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)