### PR TITLE
[Backport] Stabilize Travis CI integration tests suite

### DIFF
--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -13,8 +13,8 @@ case $TEST_SUITE in
 
         test_set_list=$(find testsuite/* -maxdepth 1 -mindepth 1 -type d | sort)
         test_set_count=$(printf "$test_set_list" | wc -l)
-        test_set_size[1]=$(printf "%.0f" $(echo "$test_set_count*0.12" | bc))  #12%
-        test_set_size[2]=$(printf "%.0f" $(echo "$test_set_count*0.32" | bc))  #32%
+        test_set_size[1]=$(printf "%.0f" $(echo "$test_set_count*0.17" | bc))  #17%
+        test_set_size[2]=$(printf "%.0f" $(echo "$test_set_count*0.27" | bc))  #27%
         test_set_size[3]=$((test_set_count-test_set_size[1]-test_set_size[2])) #56%
         echo "Total = ${test_set_count}; Batch #1 = ${test_set_size[1]}; Batch #2 = ${test_set_size[2]}; Batch #3 = ${test_set_size[3]};";
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16909
### Description
Travis CI integration test suites for `2.3-develop` branch are frequently failing with timeout on integration batch 2. This is caused by incorrect distribution of the tests across suites, where suite 1 runs for just 11 minutes, and suite 2 runs for up to 50 minutes. 

This Pull Request changes this distribution to spread execution time more evenly between batches 1, 2 and 3.

Reference build result: https://travis-ci.org/ishakhsuvarov/magento2/builds/405247843

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
