### PR TITLE
Resolve incorrect scope code selection when the requested scopeCode is null

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -55,7 +55,7 @@ class ScopeCodeResolver
             $resolverScopeCode = $resolverScopeCode->getCode();
         }
 
-        if ($scopeCode == null) {
+        if ($scopeCode === null) {
             $scopeCode = $resolverScopeCode;
         }
 

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\App\Config;
 
+use Magento\Framework\App\ScopeInterface;
 use Magento\Framework\App\ScopeResolverPool;
 
 /**
@@ -34,7 +35,7 @@ class ScopeCodeResolver
      * Resolve scope code
      *
      * @param string $scopeType
-     * @param string $scopeCode
+     * @param string|null $scopeCode
      * @return string
      */
     public function resolve($scopeType, $scopeCode)
@@ -42,20 +43,25 @@ class ScopeCodeResolver
         if (isset($this->resolvedScopeCodes[$scopeType][$scopeCode])) {
             return $this->resolvedScopeCodes[$scopeType][$scopeCode];
         }
-        if (($scopeCode === null || is_numeric($scopeCode))
-            && $scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT
-        ) {
+
+        if ($scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
             $scopeResolver = $this->scopeResolverPool->get($scopeType);
             $resolverScopeCode = $scopeResolver->getScope($scopeCode);
-        } else {
+        }
+        else {
             $resolverScopeCode = $scopeCode;
         }
 
-        if ($resolverScopeCode instanceof \Magento\Framework\App\ScopeInterface) {
+        if ($resolverScopeCode instanceof ScopeInterface) {
             $resolverScopeCode = $resolverScopeCode->getCode();
         }
 
+        if ($scopeCode == null) {
+            $scopeCode = $resolverScopeCode;
+        }
+
         $this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
+
         return $resolverScopeCode;
     }
 

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -47,8 +47,7 @@ class ScopeCodeResolver
         if ($scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
             $scopeResolver = $this->scopeResolverPool->get($scopeType);
             $resolverScopeCode = $scopeResolver->getScope($scopeCode);
-        }
-        else {
+        } else {
             $resolverScopeCode = $scopeCode;
         }
 


### PR DESCRIPTION
### Description
- resolves an issue whereby the incorrect scope could be returned when attempting to resolve a scope with a requested scopeCode of null
- simplify the scope resolver logic to a avoid multiple if conditional checks
- move scope interface class to an alias of the class
- update docblock on the expected values available for scopeCode

Resolves https://github.com/magento/magento2/issues/16939

### Fixed Issues (if relevant)
1. magento/magento2#16939: Incorrect configuration scope is occasionally returned when attempting to resolve a null scope id

### Manual testing scenarios
1. See magento/magento2#16939 for steps to repeat issue + confirm issue is not present when these changes are active

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
