### PR TITLE
Magento_Catalog: gallery - fotorama__caption show/hide

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -61,6 +61,7 @@
                     <?php endif; ?>
                     <?php if (($block->getVar("gallery/caption"))): ?>
                         "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
+                        "captions": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
                     <?php endif; ?>
                     "width": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'width') ?>",
                     "thumbwidth": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_small', 'width') ?>",

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -61,7 +61,9 @@
                     <?php endif; ?>
                     <?php if (($block->getVar("gallery/caption"))): ?>
                         "showCaption": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
-                        "captions": <?= /* @escapeNotVerified */ $block->getVar("gallery/caption") ?>,
+                    <?php endif; ?>
+                    <?php if ((!$block->getVar("gallery/captions"))): ?>
+                    "captions": false,
                     <?php endif; ?>
                     "width": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'width') ?>",
                     "thumbwidth": "<?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_small', 'width') ?>",

--- a/app/design/frontend/Magento/blank/etc/view.xml
+++ b/app/design/frontend/Magento/blank/etc/view.xml
@@ -196,6 +196,7 @@
             <var name="keyboard">true</var> <!-- Turn on/off keyboard arrows navigation (true/false) -->
             <var name="arrows">true</var> <!-- Turn on/off arrows on the sides preview (true/false) -->
             <var name="caption">false</var> <!-- Display alt text as image title (true/false) -->
+            <var name="captions">false</var> <!-- Display alt text as caption below images (true/false) -->
             <var name="allowfullscreen">true</var> <!-- Turn on/off fullscreen (true/false) -->
             <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->
             <var name="navarrows">true</var> <!-- Turn on/off on the thumbs navigation sides arrows(true/false) -->

--- a/app/design/frontend/Magento/luma/etc/view.xml
+++ b/app/design/frontend/Magento/luma/etc/view.xml
@@ -200,6 +200,7 @@
             <var name="keyboard">true</var> <!-- Turn on/off keyboard arrows navigation (true/false) -->
             <var name="arrows">true</var> <!-- Turn on/off arrows on the sides preview (true/false) -->
             <var name="caption">false</var> <!-- Display alt text as image title (true/false) -->
+            <var name="captions">false</var> <!-- Display alt text as caption below images (true/false) -->
             <var name="allowfullscreen">true</var> <!-- Turn on/off fullscreen (true/false) -->
             <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->
             <var name="navarrows">true</var> <!-- Turn on/off on the thumbs navigation sides arrows(true/false) -->


### PR DESCRIPTION
### Issue
The fotorama version in 2.2.5 in includes a parameter for `captions` in addition to `showCaption`, which defaults to true and shows the caption below the gallery image, there is no way to control this in the traditional sense, besides hiding with CSS or adding a plugin using the `setOptions()` function.

### Testing
With the blank/luma default view.xml vars:
```
...
    <vars module="Magento_Catalog">
        <var name="gallery">
            <var name="captions">false</var> <!-- Show caption below images -->
        </var>
    </vars>
...
```
The `fotorama__caption` element should be hidden on screen.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
