### PR TITLE
[Forwardport] Fix newsletter subscription behaviour for registered customer. 

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -428,13 +428,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             || $this->getStatus() == self::STATUS_NOT_ACTIVE
         ) {
             if ($isConfirmNeed === true) {
-                // if user subscribes own login email - confirmation is not needed
-                $isOwnSubscribes = $isSubscribeOwnEmail;
-                if ($isOwnSubscribes == true) {
-                    $this->setStatus(self::STATUS_SUBSCRIBED);
-                } else {
-                    $this->setStatus(self::STATUS_NOT_ACTIVE);
-                }
+                $this->setStatus(self::STATUS_NOT_ACTIVE);
             } else {
                 $this->setStatus(self::STATUS_SUBSCRIBED);
             }
@@ -460,9 +454,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         try {
             /* Save model before sending out email */
             $this->save();
-            if ($isConfirmNeed === true
-                && $isOwnSubscribes === false
-            ) {
+            if ($isConfirmNeed === true) {
                 $this->sendConfirmationRequestEmail();
             } else {
                 $this->sendConfirmationSuccessEmail();

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -419,7 +419,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             self::XML_PATH_CONFIRMATION_FLAG,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) == 1 ? true : false;
-        $isOwnSubscribes = false;
 
         $isSubscribeOwnEmail = $this->_customerSession->isLoggedIn()
             && $this->_customerSession->getCustomerDataObject()->getEmail() == $email;

--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Newsletter\Test\Unit\Model;
 
+use Magento\Newsletter\Model\Subscriber;
+
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -116,7 +118,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $email = 'subscriber_email@magento.com';
         $this->resource->expects($this->any())->method('loadByEmail')->willReturn(
             [
-                'subscriber_status' => 3,
+                'subscriber_status' => Subscriber::STATUS_UNSUBSCRIBED,
                 'subscriber_email' => $email,
                 'name' => 'subscriber_name'
             ]
@@ -133,7 +135,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->sendEmailCheck();
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
 
-        $this->assertEquals(1, $this->subscriber->subscribe($email));
+        $this->assertEquals(Subscriber::STATUS_NOT_ACTIVE, $this->subscriber->subscribe($email));
     }
 
     public function testSubscribeNotLoggedIn()
@@ -141,7 +143,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $email = 'subscriber_email@magento.com';
         $this->resource->expects($this->any())->method('loadByEmail')->willReturn(
             [
-                'subscriber_status' => 3,
+                'subscriber_status' => Subscriber::STATUS_UNSUBSCRIBED,
                 'subscriber_email' => $email,
                 'name' => 'subscriber_name'
             ]
@@ -158,7 +160,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->sendEmailCheck();
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
 
-        $this->assertEquals(2, $this->subscriber->subscribe($email));
+        $this->assertEquals(Subscriber::STATUS_NOT_ACTIVE, $this->subscriber->subscribe($email));
     }
 
     public function testUpdateSubscription()
@@ -175,7 +177,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 [
                     'subscriber_id' => 1,
-                    'subscriber_status' => 1
+                    'subscriber_status' => Subscriber::STATUS_SUBSCRIBED
                 ]
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
@@ -210,7 +212,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 [
                     'subscriber_id' => 1,
-                    'subscriber_status' => 1
+                    'subscriber_status' => Subscriber::STATUS_SUBSCRIBED
                 ]
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
@@ -236,7 +238,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 [
                     'subscriber_id' => 1,
-                    'subscriber_status' => 3
+                    'subscriber_status' => Subscriber::STATUS_UNSUBSCRIBED
                 ]
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
@@ -262,7 +264,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 [
                     'subscriber_id' => 1,
-                    'subscriber_status' => 3
+                    'subscriber_status' => Subscriber::STATUS_UNSUBSCRIBED
                 ]
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
@@ -276,7 +278,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->scopeConfig->expects($this->atLeastOnce())->method('getValue')->with()->willReturn(true);
 
         $this->subscriber->subscribeCustomerById($customerId);
-        $this->assertEquals(\Magento\Newsletter\Model\Subscriber::STATUS_NOT_ACTIVE, $this->subscriber->getStatus());
+        $this->assertEquals(Subscriber::STATUS_NOT_ACTIVE, $this->subscriber->getStatus());
     }
 
     public function testSubscribeCustomerByIdAfterConfirmation()
@@ -293,7 +295,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 [
                     'subscriber_id' => 1,
-                    'subscriber_status' => 4
+                    'subscriber_status' => Subscriber::STATUS_UNCONFIRMED
                 ]
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
@@ -305,7 +307,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->scopeConfig->expects($this->atLeastOnce())->method('getValue')->with()->willReturn(true);
 
         $this->subscriber->updateSubscription($customerId);
-        $this->assertEquals(\Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED, $this->subscriber->getStatus());
+        $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $this->subscriber->getStatus());
     }
 
     public function testUnsubscribe()


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15479
This Pull Request fix newsletter subscription behaviour for registered customer. 

Registered customer can subscribe to newsletter from 2 places: 
1. From newsletter list in my account.
2. From newsletter block form. 

If set Magento Admin->Stores->Configuration->Customers->Newsletter->"Need to Confirm" to "yes" subscribe to newsletter from My Account require customer confirmation, but from newsletter block confirmation not required and registered customer will be subscribed to newsletter.

We expect that in both cases behaviour will be the same: customer must confirm subscribe to newsletter action. (It also compliance with new GDPR).

Backend background: 
issue with different behaviour is come because subscribe from My Account and subscribe from newsletter block use different methods with different logic.

Subscribe to newsletter from MyAccount use \Magento\Newsletter\Model\Subscriber::_updateCustomerSubscription($customerId, $subscribe)

Subscribe to newsletter from newsletter block use \Magento\Newsletter\Model\Subscriber::subscribe($email)
subscribe($email) have row which checking if email for subscribe the same as customer email
$isSubscribeOwnEmail = $this->_customerSession->isLoggedIn() && $this->_customerSession->getCustomerDataObject()->getEmail() == $email;
 and if NeedToConfirm is active:
 customer will be subscribed to newsletter without confirmation if $isSubscribeOwnEmail =true
or 
customer must confirm email when $isSubscribeOwnEmail =false
Instead of subscribe($email) method _updateCustomerSubscription($customerId, $subscribe) doesn't have this check $isSubscribeOwnEmail and in any case require confirmation if NeedToConfirm is active.

PR fix remove $isSubscribeOwnEmail var from subscribe($email) method and  behaviour will be the same in both cases for subscribe to newsletter action: from MyAccount and from newsletter block.