### PR TITLE
[Backport] Fix meta title property

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config.php
+++ b/lib/internal/Magento/Framework/View/Page/Config.php
@@ -117,6 +117,7 @@ class Config
         'description' => null,
         'keywords' => null,
         'robots' => null,
+        'title' => null,
     ];
 
     /**

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -136,6 +136,12 @@ class Renderer implements RendererInterface
     protected function processMetadataContent($name, $content)
     {
         $method = 'get' . $this->string->upperCaseWords($name, '_', '');
+        if($name === 'title') {
+            if (!$content) {
+                $content = $this->escaper->escapeHtml($this->pageConfig->$method()->get());
+            }
+            return $content;
+        }
         if (method_exists($this->pageConfig, $method)) {
             $content = $this->pageConfig->$method();
         }

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -136,7 +136,7 @@ class Renderer implements RendererInterface
     protected function processMetadataContent($name, $content)
     {
         $method = 'get' . $this->string->upperCaseWords($name, '_', '');
-        if($name === 'title') {
+        if ($name === 'title') {
             if (!$content) {
                 $content = $this->escaper->escapeHtml($this->pageConfig->$method()->get());
             }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\Locale\Resolver;
 use Magento\Framework\View\Page\Config;
 
 /**
- * @covers Magento\Framework\View\Page\Config
+ * @covers \Magento\Framework\View\Page\Config
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -137,6 +137,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'description' => null,
             'keywords' => null,
             'robots' => null,
+            'title' => null,
             'name' => 'test_value',
             'html_encoded' => '&lt;title&gt;&lt;span class=&quot;test&quot;&gt;Test&lt;/span&gt;&lt;/title&gt;',
         ];


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11368
### Description
If, inside a controller you try to set metadata title with:

    $resultPage->getConfig()->setMetadata('title', 'some meta title');

you will get an error on frontend:

Recoverable Error: Object of class Magento\Framework\View\Page\Title could not be converted to string...

becouse `processMetadataContent` will return an istance of `Magento\Framework\View\Page\Title` instead of a string.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#2956: Unable to render page when 'meta title' page config param is set

### Manual testing scenarios

#### Scenario 1

1. Create a controller
2. Inside the `execute` function add: 
```
$resultPage = $this->resultPageFactory->create();
$resultPage->getConfig()->getTitle->set('my title');
$resultPage->getConfig()->setMetadata('title', 'metatitle');
return $resultPage;
```
3. As result you will have in your page:

```
<title>my title</title>
<meta name="title" content="metatitle"/>
```

#### Scenario 2

1. Create a controller
2. Inside the `execute` function add: 
```
$resultPage = $this->resultPageFactory->create();
$resultPage->getConfig()->getTitle->set('my title');
return $resultPage;
```
3. As result you will have in your page:

```
<title>my title</title>
<meta name="title" content="my title"/>
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
