### PR TITLE
Issue 8131 - Use Redirect Factory to Allow Error Message Display on Advanced Search

### DIFF
--- a/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
+++ b/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
@@ -6,7 +6,6 @@
  */
 namespace Magento\CatalogSearch\Controller\Advanced;
 
-use Magento\Catalog\Model\Layer\Resolver;
 use Magento\CatalogSearch\Model\Advanced as ModelAdvanced;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\UrlFactory;
@@ -45,7 +44,7 @@ class Result extends \Magento\Framework\App\Action\Action
     }
 
     /**
-     * @return void
+     * @return \Magento\Framework\Controller\Result\Redirect
      */
     public function execute()
     {
@@ -58,7 +57,9 @@ class Result extends \Magento\Framework\App\Action\Action
             $defaultUrl = $this->_urlFactory->create()
                 ->addQueryParams($this->getRequest()->getQueryValue())
                 ->getUrl('*/*/');
-            $this->getResponse()->setRedirect($this->_redirect->error($defaultUrl));
+            $resultRedirect = $this->resultRedirectFactory->create();
+            $resultRedirect->setUrl($this->_redirect->error($defaultUrl));
+            return $resultRedirect;
         }
     }
 }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Controller/Advanced/ResultTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Controller/Advanced/ResultTest.php
@@ -136,6 +136,6 @@ class ResultTest extends \PHPUnit\Framework\TestCase
             'urlFactory' => $urlFactoryMock
             ]
         );
-        $instance->execute();
+        $this->assertEquals($redirectResultMock, $instance->execute());
     }
 }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Controller/Advanced/ResultTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Controller/Advanced/ResultTest.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\CatalogSearch\Test\Unit\Controller\Advanced;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testResultActionFiltersSetBeforeLoadLayout()
@@ -46,6 +49,92 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $instance = $objectManager->getObject(
             \Magento\CatalogSearch\Controller\Advanced\Result::class,
             ['context' => $context, 'catalogSearchAdvanced' => $catalogSearchAdvanced]
+        );
+        $instance->execute();
+    }
+
+    public function testUrlSetOnException()
+    {
+        $redirectResultMock = $this->createMock(\Magento\Framework\Controller\Result\Redirect::class);
+        $redirectResultMock->expects($this->once())
+            ->method('setUrl');
+
+        $resultRedirectFactoryMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\RedirectFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $resultRedirectFactoryMock->expects($this->any())
+            ->method('create')
+            ->willReturn($redirectResultMock);
+
+        $catalogSearchAdvanced = $this->createPartialMock(
+            \Magento\CatalogSearch\Model\Advanced::class,
+            ['addFilters']
+        );
+
+        $catalogSearchAdvanced->expects($this->once())->method('addFilters')->will(
+            $this->throwException(new \Magento\Framework\Exception\LocalizedException(
+                new \Magento\Framework\Phrase("Test Exception")
+            ))
+        );
+
+        $responseMock = $this->createMock(\Magento\Framework\Webapi\Response::class);
+        $requestMock = $this->createPartialMock(
+            \Magento\Framework\App\Request\Http::class,
+            ['getQueryValue']
+        );
+        $requestMock->expects($this->any())->method('getQueryValue')->willReturn(['key' => 'value']);
+
+        $redirectMock = $this->createMock(\Magento\Framework\App\Response\RedirectInterface::class);
+        $redirectMock->expects($this->any())->method('error')->with('urlstring');
+
+        $messageManagerMock = $this->createMock(\Magento\Framework\Message\Manager::class);
+
+        $eventManagerMock = $this->createMock(\Magento\Framework\Event\ManagerInterface::class);
+
+        $contextMock = $this->createMock(\Magento\Framework\App\Action\Context::class);
+        $contextMock->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($requestMock);
+        $contextMock->expects($this->any())
+            ->method('getResponse')
+            ->willReturn($responseMock);
+        $contextMock->expects($this->any())
+            ->method('getRedirect')
+            ->willReturn($redirectMock);
+        $contextMock->expects($this->any())
+            ->method('getMessageManager')
+            ->willReturn($messageManagerMock);
+        $contextMock->expects($this->any())
+            ->method('getEventManager')
+            ->willReturn($eventManagerMock);
+        $contextMock->expects($this->any())
+            ->method('getResultRedirectFactory')
+            ->willReturn($resultRedirectFactoryMock);
+
+        $urlMock = $this->createMock(\Magento\Framework\Url::class);
+        $urlMock->expects($this->once())
+            ->method('addQueryParams')
+            ->willReturnSelf();
+        $urlMock->expects($this->once())
+            ->method('getUrl')
+            ->willReturn("urlstring");
+
+        $urlFactoryMock = $this->createMock(\Magento\Framework\UrlFactory::class);
+        $urlFactoryMock->expects($this->once())
+            ->method('create')
+            ->will($this->returnValue($urlMock));
+
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        /** @var \Magento\CatalogSearch\Controller\Advanced\Result $instance */
+        $instance = $objectManager->getObject(
+            \Magento\CatalogSearch\Controller\Advanced\Result::class,
+            ['context' => $contextMock,
+            'catalogSearchAdvanced' => $catalogSearchAdvanced,
+            'urlFactory' => $urlFactoryMock
+            ]
         );
         $instance->execute();
     }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Controller/Advanced/ResultTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Controller/Advanced/ResultTest.php
@@ -59,12 +59,12 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $redirectResultMock->expects($this->once())
             ->method('setUrl');
 
-        $resultRedirectFactoryMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\RedirectFactory::class)
+        $redirectFactoryMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\RedirectFactory::class)
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $resultRedirectFactoryMock->expects($this->any())
+        $redirectFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($redirectResultMock);
 
@@ -111,7 +111,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
             ->willReturn($eventManagerMock);
         $contextMock->expects($this->any())
             ->method('getResultRedirectFactory')
-            ->willReturn($resultRedirectFactoryMock);
+            ->willReturn($redirectFactoryMock);
 
         $urlMock = $this->createMock(\Magento\Framework\Url::class);
         $urlMock->expects($this->once())


### PR DESCRIPTION
Change controller to use result redirect factory which fixes error message display on advanced search form.

https://github.com/magento/magento2/issues/8131

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
The way the redirect was initiated from the result controller needed to be changed to use a result redirect so that the error message would be written to the cookie.  Without this, the Index controller wouldn't be called when Page Cache was enabled, and the error message would never reach the page.

### Fixed Issues (if relevant)
1. magento/magento2#8131: Magento 2.1.3 - There is a bug in advanced search form regarding validation messages

### Manual testing scenarios
1. Navigate to Advanced Search
2. Without filling out any form input field, click "Search"
3. You should see the error message requiring you to fill in at least one form.

This should work when page cache is enabled and disabled.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
