### PR TITLE
Resolved : Mobile device style groups incorrect order

### DIFF
--- a/lib/web/css/source/lib/_responsive.less
+++ b/lib/web/css/source/lib/_responsive.less
@@ -27,24 +27,24 @@
 
 & when (@media-target = 'mobile'), (@media-target = 'all') {
 
-    @media only screen and (max-width: (@screen__xxs - 1)) {
-        .media-width('max', @screen__xxs);
-    }
-
-    @media only screen and (max-width: (@screen__xs - 1)) {
-        .media-width('max', @screen__xs);
-    }
-
-    @media only screen and (max-width: (@screen__s - 1)) {
-        .media-width('max', @screen__s);
+    @media only screen and (max-width: @screen__m) {
+        .media-width('max', (@screen__m + 1));
     }
 
     @media only screen and (max-width: (@screen__m - 1)) {
         .media-width('max', @screen__m);
     }
 
-    @media only screen and (max-width: @screen__m) {
-        .media-width('max', (@screen__m + 1));
+    @media only screen and (max-width: (@screen__s - 1)) {
+        .media-width('max', @screen__s);
+    }
+
+    @media only screen and (max-width: (@screen__xs - 1)) {
+        .media-width('max', @screen__xs);
+    }
+
+    @media only screen and (max-width: (@screen__xxs - 1)) {
+        .media-width('max', @screen__xxs);
     }
 
     @media all and (min-width: @screen__s) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Style groups for mobile devices (max-width) are specified in the wrong order. 

In `lib/web/css/source/lib/_responsive.less` the style groups run breakpoint-size ascending: 319px, 479px, 639px, 767px, which leads to outputting max-width media queries breakpoint-size ascending - the last-defined breakpoint overrides smaller screen size breakpoints...
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Style groups for mobile devices (max-width) are specified in the wrong order.

1. magento/magento2https://github.com/magento/magento2/issues/14476: Mobile device style groups incorrect order in _responsive.less
2. ...

### Expected result

CSS should be output as follows:

```
@media only screen and (max-width: 479px) {
  .logo {
    max-width: 140px;
  }
}
@media only screen and (max-width: 639px) {
  .logo {
    max-width: 165px;
  }
}
```

### Actual result

CSS is output as follows:

```
@media only screen and (max-width: 639px) {
  .logo {
    max-width: 165px;
  }
}
@media only screen and (max-width: 479px) {
  .logo {
    max-width: 140px;
  }
}
```


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
