### PR TITLE
[#2291]:+ fixed inconsistent plugin placement

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Move.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Move.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\CatalogUrlRewrite\Model\Category\Plugin\Category;
+namespace Magento\CatalogUrlRewrite\Plugin\Model\Category;
 
 use Magento\Catalog\Model\Category;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator;

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Remove.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Remove.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\CatalogUrlRewrite\Model\Category\Plugin\Category;
+namespace Magento\CatalogUrlRewrite\Plugin\Model\Category;
 
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Storage.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Storage.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\CatalogUrlRewrite\Model\Category\Plugin;
+namespace Magento\CatalogUrlRewrite\Plugin\Model\Category;
 
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\UrlRewrite\Model\StorageInterface;

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Store/Group.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Store/Group.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\CatalogUrlRewrite\Model\Category\Plugin\Store;
+namespace Magento\CatalogUrlRewrite\Plugin\Model\Category\Store;
 
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Store/View.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/Store/View.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\CatalogUrlRewrite\Model\Category\Plugin\Store;
+namespace Magento\CatalogUrlRewrite\Plugin\Model\Category\Store;
 
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\CategoryFactory;

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/UpdateUrlPath.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Model/Category/UpdateUrlPath.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\CatalogUrlRewrite\Model\Category\Plugin\Category;
+namespace Magento\CatalogUrlRewrite\Plugin\Model\Category;
 
 use Magento\Framework\Model\AbstractModel;
 use Magento\Catalog\Model\Category;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/MoveTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/MoveTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\CatalogUrlRewrite\Test\Unit\Model\Category\Plugin\Category;
 
-use Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Move as CategoryMovePlugin;
+use Magento\CatalogUrlRewrite\Plugin\Model\Category\Move as CategoryMovePlugin;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\Category\ChildrenCategoriesProvider;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/RemoveTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/RemoveTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\CatalogUrlRewrite\Test\Unit\Model\Category\Plugin\Category;
 
-use Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Remove as CategoryRemovePlugin;
+use Magento\CatalogUrlRewrite\Plugin\Model\Category\Remove as CategoryRemovePlugin;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\CatalogUrlRewrite\Model\Category\ChildrenCategoriesProvider;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/UpdateUrlPathTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/UpdateUrlPathTest.php
@@ -97,7 +97,7 @@ class UpdateUrlPathTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
 
         $this->updateUrlPathPlugin = $this->objectManager->getObject(
-            \Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\UpdateUrlPath::class,
+            \Magento\CatalogUrlRewrite\Plugin\Model\Category\UpdateUrlPath::class,
             [
                 'categoryUrlPathGenerator' => $this->categoryUrlPathGenerator,
                 'categoryUrlRewriteGenerator' => $this->categoryUrlRewriteGenerator,

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/StorageTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/StorageTest.php
@@ -7,7 +7,7 @@ namespace Magento\CatalogUrlRewrite\Test\Unit\Model\Category\Plugin;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\UrlRewrite\Model\StorageInterface;
-use Magento\CatalogUrlRewrite\Model\Category\Plugin\Storage as CategoryStoragePlugin;
+use Magento\CatalogUrlRewrite\Plugin\Model\Category\Storage as CategoryStoragePlugin;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\CatalogUrlRewrite\Model\Category\Product;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/GroupTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/GroupTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\CatalogUrlRewrite\Test\Unit\Model\Category\Plugin\Store;
 
-use Magento\CatalogUrlRewrite\Model\Category\Plugin\Store\Group as GroupPlugin;
+use Magento\CatalogUrlRewrite\Plugin\Model\Category\Store\Group as GroupPlugin;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Store\Model\StoreManagerInterface;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/ViewTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/ViewTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\CatalogUrlRewrite\Test\Unit\Model\Category\Plugin\Store;
 
-use Magento\CatalogUrlRewrite\Model\Category\Plugin\Store\View as StoreViewPlugin;
+use Magento\CatalogUrlRewrite\Plugin\Model\Category\Store\View as StoreViewPlugin;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Store\Model\ResourceModel\Store;

--- a/app/code/Magento/CatalogUrlRewrite/etc/adminhtml/di.xml
+++ b/app/code/Magento/CatalogUrlRewrite/etc/adminhtml/di.xml
@@ -7,14 +7,10 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Store\Model\ResourceModel\Store">
-        <plugin name="store_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Store\View"/>
+        <plugin name="store_plugin" type="Magento\CatalogUrlRewrite\Plugin\Model\Category\Store\View"/>
     </type>
     <type name="Magento\Store\Model\ResourceModel\Group">
-        <plugin name="group_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Store\Group"/>
-    </type>
-    <type name="Magento\Catalog\Model\ResourceModel\Category">
-        <plugin name="category_move_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Move"/>
-        <plugin name="category_delete_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Remove"/>
+        <plugin name="group_plugin" type="Magento\CatalogUrlRewrite\Plugin\Model\Category\Store\Group"/>
     </type>
     <type name="Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Attributes">
         <plugin name="product_form_url_key_plugin" type="Magento\CatalogUrlRewrite\Plugin\Catalog\Block\Adminhtml\Product\Edit\Tab\Attributes"/>

--- a/app/code/Magento/CatalogUrlRewrite/etc/di.xml
+++ b/app/code/Magento/CatalogUrlRewrite/etc/di.xml
@@ -17,12 +17,12 @@
         </arguments>
     </type>
     <type name="Magento\Catalog\Model\ResourceModel\Category">
-        <plugin name="category_move_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Move"/>
-        <plugin name="category_delete_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Remove"/>
-        <plugin name="update_url_path_for_different_stores" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\UpdateUrlPath"/>
+        <plugin name="category_move_plugin" type="Magento\CatalogUrlRewrite\Plugin\Model\Category\Move"/>
+        <plugin name="category_delete_plugin" type="Magento\CatalogUrlRewrite\Plugin\Model\Category\Remove"/>
+        <plugin name="update_url_path_for_different_stores" type="Magento\CatalogUrlRewrite\Plugin\Model\Category\UpdateUrlPath"/>
     </type>
     <type name="Magento\UrlRewrite\Model\StorageInterface">
-        <plugin name="storage_plugin" type="Magento\CatalogUrlRewrite\Model\Category\Plugin\Storage"/>
+        <plugin name="storage_plugin" type="Magento\CatalogUrlRewrite\Plugin\Model\Category\Storage"/>
     </type>
     <type name="Magento\CatalogUrlRewrite\Model\Map\UrlRewriteFinder">
         <arguments>


### PR DESCRIPTION
Fixed folder structure for plugins to be placed in a root Plugin folder. Also removed duplicate plugins in adminhtml di which were already present in etc/di

### Description
To be consistent in the location where plugins are kept I updated the module CatalogUrlRewrite where a some model plugins where not in the Plugins root folder. 

### Fixed Issues (if relevant)
1. magento/magento2#2291: Inconsistent location for plugins

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
