### PR TITLE
[Backport] 7691: address with saveInAddressBook 0 are still being added to the a…

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -463,6 +463,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                     'email' => $quote->getCustomerEmail()
                 ]
             );
+            $shippingAddress->setData('quote_address_id', $quote->getShippingAddress()->getId());
             $addresses[] = $shippingAddress;
             $order->setShippingAddress($shippingAddress);
             $order->setShippingMethod($quote->getShippingAddress()->getShippingMethod());
@@ -474,6 +475,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                 'email' => $quote->getCustomerEmail()
             ]
         );
+        $billingAddress->setData('quote_address_id', $quote->getBillingAddress()->getId());
         $addresses[] = $billingAddress;
         $order->setBillingAddress($billingAddress);
         $order->setAddresses($addresses);

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
@@ -139,11 +139,6 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
     private $quoteIdMaskFactory;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    private $quoteFactoryMock;
-
-    /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp()

--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -6,10 +6,23 @@
 
 namespace Magento\Sales\Setup;
 
-use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Eav\Model\Config;
+use Magento\Framework\App\State;
+use Magento\Framework\DB\AggregatedFieldDataConverter;
+use Magento\Framework\DB\DataConverter\SerializedToJson;
+use Magento\Framework\DB\FieldToConvert;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\ResourceModel\Order\Address\CollectionFactory as AddressCollectionFactory;
 
+/**
+ * Data upgrade script
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class UpgradeData implements UpgradeDataInterface
 {
     /**
@@ -25,15 +38,55 @@ class UpgradeData implements UpgradeDataInterface
     protected $eavConfig;
 
     /**
+     * @var AggregatedFieldDataConverter
+     */
+    private $aggregatedFieldConverter;
+
+    /**
+     * @var AddressCollectionFactory
+     */
+    private $addressCollectionFactory;
+
+    /**
+     * @var OrderFactory
+     */
+    private $orderFactory;
+
+    /**
+     * @var QuoteFactory
+     */
+    private $quoteFactory;
+
+    /**
+     * @var State
+     */
+    private $state;
+
+    /**
      * @param SalesSetupFactory $salesSetupFactory
-     * @param \Magento\Eav\Model\Config $eavConfig
+     * @param Config $eavConfig
+     * @param AggregatedFieldDataConverter $aggregatedFieldConverter
+     * @param AddressCollectionFactory $addressCollFactory
+     * @param OrderFactory $orderFactory
+     * @param QuoteFactory $quoteFactory
+     * @param State $state
      */
     public function __construct(
         SalesSetupFactory $salesSetupFactory,
-        \Magento\Eav\Model\Config $eavConfig
+        Config $eavConfig,
+        AggregatedFieldDataConverter $aggregatedFieldConverter,
+        AddressCollectionFactory $addressCollFactory,
+        OrderFactory $orderFactory,
+        QuoteFactory $quoteFactory,
+        State $state
     ) {
         $this->salesSetupFactory = $salesSetupFactory;
         $this->eavConfig = $eavConfig;
+        $this->aggregatedFieldConverter = $aggregatedFieldConverter;
+        $this->addressCollectionFactory = $addressCollFactory;
+        $this->orderFactory = $orderFactory;
+        $this->quoteFactory = $quoteFactory;
+        $this->state = $state;
     }
 
     /**
@@ -46,50 +99,49 @@ class UpgradeData implements UpgradeDataInterface
 
         /** @var SalesSetup $salesSetup */
         $salesSetup = $this->salesSetupFactory->create(['setup' => $setup]);
-
         if (version_compare($context->getVersion(), '2.0.1', '<')) {
-            $salesSetup->updateEntityType(
-                \Magento\Sales\Model\Order::ENTITY,
-                'entity_model',
-                'Magento\Sales\Model\ResourceModel\Order'
-            );
-            $salesSetup->updateEntityType(
-                \Magento\Sales\Model\Order::ENTITY,
-                'increment_model',
-                'Magento\Eav\Model\Entity\Increment\NumericValue'
-            );
-            $salesSetup->updateEntityType(
-                'invoice',
-                'entity_model',
-                'Magento\Sales\Model\ResourceModel\Order'
-            );
-            $salesSetup->updateEntityType(
-                'invoice',
-                'increment_model',
-                'Magento\Eav\Model\Entity\Increment\NumericValue'
-            );
-            $salesSetup->updateEntityType(
-                'creditmemo',
-                'entity_model',
-                'Magento\Sales\Model\ResourceModel\Order\Creditmemo'
-            );
-            $salesSetup->updateEntityType(
-                'creditmemo',
-                'increment_model',
-                'Magento\Eav\Model\Entity\Increment\NumericValue'
-            );
-            $salesSetup->updateEntityType(
-                'shipment',
-                'entity_model',
-                'Magento\Sales\Model\ResourceModel\Order\Shipment'
-            );
-            $salesSetup->updateEntityType(
-                'shipment',
-                'increment_model',
-                'Magento\Eav\Model\Entity\Increment\NumericValue'
+            $salesSetup->updateEntityTypes();
+        }
+        if (version_compare($context->getVersion(), '2.0.6', '<')) {
+            $this->convertSerializedDataToJson($context->getVersion(), $salesSetup);
+        }
+        if (version_compare($context->getVersion(), '2.0.8', '<')) {
+            $this->state->emulateAreaCode(
+                \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE,
+                [$this, 'fillQuoteAddressIdInSalesOrderAddress'],
+                [$setup]
             );
         }
         $this->eavConfig->clear();
-        $setup->endSetup();
+    }
+
+    /**
+     * Fill quote_address_id in table sales_order_address if it is empty.
+     */
+    public function fillQuoteAddressIdInSalesOrderAddress()
+    {
+        $addressCollection = $this->addressCollectionFactory->create();
+        /** @var \Magento\Sales\Model\Order\Address $orderAddress */
+        foreach ($addressCollection as $orderAddress) {
+            if (!$orderAddress->getData('quote_address_id')) {
+                $orderId = $orderAddress->getParentId();
+                $addressType = $orderAddress->getAddressType();
+
+                /** @var \Magento\Sales\Model\Order $order */
+                $order = $this->orderFactory->create()->load($orderId);
+                $quoteId = $order->getQuoteId();
+                $quote = $this->quoteFactory->create()->load($quoteId);
+
+                if ($addressType == \Magento\Sales\Model\Order\Address::TYPE_SHIPPING) {
+                    $quoteAddressId = $quote->getShippingAddress()->getId();
+                    $orderAddress->setData('quote_address_id', $quoteAddressId);
+                } elseif ($addressType == \Magento\Sales\Model\Order\Address::TYPE_BILLING) {
+                    $quoteAddressId = $quote->getBillingAddress()->getId();
+                    $orderAddress->setData('quote_address_id', $quoteAddressId);
+                }
+
+                $orderAddress->save();
+            }
+        }
     }
 }

--- a/app/code/Magento/Sales/Setup/UpgradeData.php
+++ b/app/code/Magento/Sales/Setup/UpgradeData.php
@@ -40,7 +40,7 @@ class UpgradeData implements UpgradeDataInterface
     /**
      * @var AggregatedFieldDataConverter
      */
-    private $aggregatedFieldConverter;
+    private $aggregatedField;
 
     /**
      * @var AddressCollectionFactory
@@ -65,7 +65,7 @@ class UpgradeData implements UpgradeDataInterface
     /**
      * @param SalesSetupFactory $salesSetupFactory
      * @param Config $eavConfig
-     * @param AggregatedFieldDataConverter $aggregatedFieldConverter
+     * @param AggregatedFieldDataConverter $aggregatedField
      * @param AddressCollectionFactory $addressCollFactory
      * @param OrderFactory $orderFactory
      * @param QuoteFactory $quoteFactory
@@ -74,7 +74,7 @@ class UpgradeData implements UpgradeDataInterface
     public function __construct(
         SalesSetupFactory $salesSetupFactory,
         Config $eavConfig,
-        AggregatedFieldDataConverter $aggregatedFieldConverter,
+        AggregatedFieldDataConverter $aggregatedField,
         AddressCollectionFactory $addressCollFactory,
         OrderFactory $orderFactory,
         QuoteFactory $quoteFactory,
@@ -82,7 +82,7 @@ class UpgradeData implements UpgradeDataInterface
     ) {
         $this->salesSetupFactory = $salesSetupFactory;
         $this->eavConfig = $eavConfig;
-        $this->aggregatedFieldConverter = $aggregatedFieldConverter;
+        $this->aggregatedField = $aggregatedField;
         $this->addressCollectionFactory = $addressCollFactory;
         $this->orderFactory = $orderFactory;
         $this->quoteFactory = $quoteFactory;

--- a/app/code/Magento/Sales/etc/module.xml
+++ b/app/code/Magento/Sales/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Sales" setup_version="2.0.3">
+    <module name="Magento_Sales" setup_version="2.0.8">
         <sequence>
             <module name="Magento_Rule"/>
             <module name="Magento_Catalog"/>

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -313,12 +313,12 @@ define([
                 data = this.serializeData(this.billingAddressContainer);
             } else {
                 data = this.serializeData(this.shippingAddressContainer);
-                areasToLoad.push('shipping_method');
             }
+            areasToLoad.push('shipping_method');
             data = data.toObject();
             data['shipping_as_billing'] = flag ? 1 : 0;
             data['reset_shipping'] = 1;
-            this.loadArea( areasToLoad, true, data);
+            this.loadArea(areasToLoad, true, data);
         },
 
         resetShippingMethod : function(data){

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/Shipping/Method.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/Shipping/Method.php
@@ -36,9 +36,14 @@ class Method extends Block
      */
     public function selectShippingMethod(array $shippingMethod)
     {
-        if ($this->_rootElement->find($this->shippingMethodsLink)->isVisible()) {
-            $this->_rootElement->find($this->shippingMethodsLink)->click();
-        }
+        $this->waitFormLoading();
+        $this->_rootElement->waitUntil(
+            function () {
+                return $this->_rootElement->find($this->shippingMethodsLink)->isVisible() ? true : null;
+            }
+        );
+
+        $this->_rootElement->find($this->shippingMethodsLink)->click();
         $selector = sprintf(
             $this->shippingMethod,
             $shippingMethod['shipping_service'],


### PR DESCRIPTION
### Original Pull request
#11903

If you place an order as a guest and set the save_in_address_book for an address on 0, that address will still be copied to the customer address book when registering as a new customer on the checkout success page.

### Fixed Issues (if relevant)
1. magento/magento2#7691: address with saveInAddressBook 0 are still being added to the address book for new customers.

### Manual testing scenarios
1. Place an order as a guest and set the save_in_address_book for your shipping address to 0 
2. Click the register link on the checkout success page
3. Addresses with save_in_address_book set to 0 should not be copied to the new customer address book.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
