### PR TITLE
[Forwardport] Removed double occurrence of  keywords in sentences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1977,7 +1977,7 @@ Tests:
     * [#686](https://github.com/magento/magento2/issues/686) -- Product save validation errors in the admin don't hide the overlay
     * [#702](https://github.com/magento/magento2/issues/702) -- Base table or view not found
     * [#652](https://github.com/magento/magento2/issues/652) -- Multishipping checkout not to change the Billing address js issue
-    * [#648](https://github.com/magento/magento2/issues/648) -- An equal (=) sign in the hash of the product page to to break the tabs functionality
+    * [#648](https://github.com/magento/magento2/issues/648) -- An equal (=) sign in the hash of the product page to break the tabs functionality
 * Service Contracts:
     * Refactored usage of new API of the Customer module
     * Implemented Service Contracts for the Sales module

--- a/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
@@ -31,7 +31,7 @@ define([
             this.options.cache.label = $(this.options.passwordStrengthMeterLabelSelector, this.element);
 
             // We need to look outside the module for backward compatibility, since someone can already use the module.
-            // @todo Narrow this selector in 2.3 so it doesn't accidentally finds the the email field from the
+            // @todo Narrow this selector in 2.3 so it doesn't accidentally finds the email field from the
             // newsletter email field or any other "email" field.
             this.options.cache.email = $(this.options.formSelector).find(this.options.emailSelector);
             this._bind();

--- a/app/code/Magento/Integration/view/adminhtml/web/js/integration.js
+++ b/app/code/Magento/Integration/view/adminhtml/web/js/integration.js
@@ -200,7 +200,7 @@ define([
                     if (IdentityLogin.win.closed ||
                         IdentityLogin.win.location.href == IdentityLogin.successCallbackUrl //eslint-disable-line eqeqeq
                     ) {
-                        //Stop the the polling
+                        //Stop the polling
                         clearInterval(IdentityLogin.checker);
                         $('body').trigger('processStart');
                         //Check for window closed

--- a/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/autosave/editor_plugin_src.js
+++ b/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/autosave/editor_plugin_src.js
@@ -20,7 +20,7 @@
  * 1. localStorage - A new feature of HTML 5, localStorage can store megabytes of data per domain
  * on the client computer. Data stored in the localStorage area has no expiration date, so we must
  * manage expiring the data ourselves.  localStorage is fully supported by IE8, and it is supposed
- * to be working in Firefox 3 and Safari 3.2, but in reality is is flaky in those browsers.  As
+ * to be working in Firefox 3 and Safari 3.2, but in reality is flaky in those browsers.  As
  * HTML 5 gets wider support, the AutoSave plugin will use it automatically. In Windows Vista/7,
  * localStorage is stored in the following folder:
  * C:\Users\[username]\AppData\Local\Microsoft\Internet Explorer\DOMStore\[tempFolder]
@@ -297,7 +297,7 @@
 		},
 
 		/**
-		 * This method will store the current contents in the the storage engine.
+		 * This method will store the current contents in the storage engine.
 		 *
 		 * @method storeDraft
 		 */

--- a/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/paste/editor_plugin_src.js
+++ b/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/paste/editor_plugin_src.js
@@ -207,7 +207,7 @@
 					sel.setRng(oldRng);
 					sel.setContent('');
 
-					// For some odd reason we need to detach the the mceInsertContent call from the paste event
+					// For some odd reason we need to detach the mceInsertContent call from the paste event
 					// It's like IE has a reference to the parent element that you paste in and the selection gets messed up
 					// when it tries to restore the selection
 					setTimeout(function() {

--- a/dev/tests/integration/testsuite/Magento/CatalogRule/Model/Indexer/ProductRuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogRule/Model/Indexer/ProductRuleTest.php
@@ -67,7 +67,7 @@ class ProductRuleTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             7.5,
             $this->resourceRule->getRulePrice(new \DateTime(), 1, 1, $product->getId()),
-            "Catalog price rule doesn't apply to to product with visibility value \"Not Visibility Individually\""
+            "Catalog price rule doesn't apply to product with visibility value \"Not Visibility Individually\""
         );
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/CustomerMetadataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/CustomerMetadataTest.php
@@ -262,7 +262,7 @@ class CustomerMetadataTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals(
                 $attributeMetadata,
                 $attributeMetadata1,
-                'Attribute metadata from the the same service became different after getAttributeCode was called'
+                'Attribute metadata from the same service became different after getAttributeCode was called'
             );
             // Verify the consistency of attribute metadata from two services
             // after getAttributeCode was called

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/TaxCalculationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/TaxCalculationTest.php
@@ -2192,7 +2192,7 @@ class TaxCalculationTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Create the base results for the the multi rules test
+     * Create the base results for the multi rules test
      *
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/internal/Magento/Framework/Api/Uploader.php
+++ b/lib/internal/Magento/Framework/Api/Uploader.php
@@ -19,7 +19,7 @@ class Uploader extends \Magento\Framework\File\Uploader
     }
 
     /**
-     * Explicitly set the the file attributes instead of setting it via constructor
+     * Explicitly set the file attributes instead of setting it via constructor
      *
      * @param array $fileAttributes
      * @return void

--- a/lib/web/MutationObserver.js
+++ b/lib/web/MutationObserver.js
@@ -324,7 +324,7 @@
     if (lastRecord === newRecord)
       return lastRecord;
 
-    // Check if the the record we are adding represents the same record. If
+    // Check if the record we are adding represents the same record. If
     // so, we keep the one with the oldValue in it.
     if (recordWithOldValue && recordRepresentsCurrentMutation(lastRecord))
       return recordWithOldValue;

--- a/lib/web/mage/requirejs/static.js
+++ b/lib/web/mage/requirejs/static.js
@@ -13,7 +13,7 @@ define('buildTools', [
         isEnabled: storage.getItem(storeName) === null,
 
         /**
-         * Removes base url from the the provided string
+         * Removes base url from the provided string
          *
          * @param {String} url - Url to be processed.
          * @param {Object} config - RequiereJs config object.

--- a/lib/web/modernizr/modernizr.js
+++ b/lib/web/modernizr/modernizr.js
@@ -1013,7 +1013,7 @@ window.Modernizr = (function( window, document, undefined ) {
         /** Name of the expando, to work with multiple documents or to re-shiv one document */
         var expando = '_html5shiv';
 
-        /** The id for the the documents expando */
+        /** The id for the documents expando */
         var expanID = 0;
 
         /** Cached data for each document */

--- a/setup/pub/angular/angular.js
+++ b/setup/pub/angular/angular.js
@@ -7770,7 +7770,7 @@
                  *      caching.
                  *    - **timeout** – `{number|Promise}` – timeout in milliseconds, or {@link ng.$q promise}
                  *      that should abort the request when resolved.
-                 *    - **withCredentials** - `{boolean}` - whether to to set the `withCredentials` flag on the
+                 *    - **withCredentials** - `{boolean}` - whether to set the `withCredentials` flag on the
                  *      XHR object. See [requests with credentials]https://developer.mozilla.org/en/http_access_control#section_5
                  *      for more information.
                  *    - **responseType** - `{string}` - see


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16182

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Removed double occurrence of keywords "to, the" from sentences.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
