### PR TITLE
Categories > Left menu > Item title space fix

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
@@ -209,7 +209,7 @@
                 .column.main & {
                 }
             }
-
+            display: block;
             margin-bottom: @indent__s;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

Aligning the distribution of the Title and Items on the left bar, it already has a property to add this `margin-bottom`, but it's not taking effect, so I added the fix on that PR.

**Before:**
<img width="255" alt="screen shot 2018-07-20 at 23 53 51" src="https://user-images.githubusercontent.com/610598/43031640-09db02f8-8c7c-11e8-8f84-b99e0f45dd52.png">

**After:**
<img width="267" alt="screen shot 2018-07-20 at 23 54 05" src="https://user-images.githubusercontent.com/610598/43031642-1012e622-8c7c-11e8-89fd-321d23ef6a42.png">

### Manual testing scenarios

Go to Women category page and check the left bar.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
