### PR TITLE
[Backport]  Newsletter Label is broking on chinese Language like 订阅

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -67,6 +67,7 @@
             border-bottom-left-radius: 0;
             border-top-left-radius: 0;
             margin-left: -1px;
+            white-space: nowrap;
         }
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13029
<!--- Provide a general summary of the Pull Request in the Title above -->
When Set the newsletter subscribe button's title with at least two Chinese characters (either by changing it with your browser's Developer Tool or by switching the CMS language to Chinese), for instance "订阅". getting Wrap on Newsletter box.
### Description
<!--- Provide a description of the changes proposed in the pull request -->


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#12320, if relevant  -->
1. magento/magento2#12320: Newsletter subscribe button title wrapped

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add  two characters of the Chinese word "订阅" in translate for Newsletter "Subscribe"
Actual Result:
![screenshot from 2018-01-07 10-56-07](https://user-images.githubusercontent.com/18435810/34647027-df5c115c-f39c-11e7-952a-42c70b594aad.png)


Expected Result:
![screenshot from 2018-01-07 10-57-42](https://user-images.githubusercontent.com/18435810/34647019-cc5d99c2-f39c-11e7-9e37-6a5ff125347f.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
