### PR TITLE
[Backport] Trim issue on customer confirmation form

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
@@ -13,7 +13,7 @@
         <div class="field email required">
             <label for="email_address" class="label"><span><?php echo $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" id="email_address" class="input-text" value="<?php echo $this->helper(\Magento\Framework\EscapeHelper::class)->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}">
+                <input type="email" name="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}" data-mage-init='{"mage/trim-input":{}}'>
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16595
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Related to issue: #6058 

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Trim email address by remove leading or trailing space in confirmation form

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6058: IE11 user login email validation fails if field has leading or trailing space

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Open customer confirmation page in Firefox or IE browser.
2. Try to add space before entering an email address in the Email field.
3. Copy `" johndoe@domain.com "` and paste in the Email field. It will automatically remove leading or trailing space.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
