### PR TITLE
[Forwardport] FIXED - appended payment code to ID field to make it unique

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html
@@ -16,8 +16,8 @@
             <!--/ko-->
             <!-- ko if: (isCustomerLoggedIn && customerHasAddresses) -->
             <div class="choice field">
-                <input type="checkbox" class="checkbox" id="billing-save-in-address-book" data-bind="checked: saveInAddressBook" />
-                <label class="label" for="billing-save-in-address-book">
+                <input type="checkbox" class="checkbox"  data-bind="checked: saveInAddressBook, attr: {id: 'billing-save-in-address-book-' + getCode($parent)}" />
+                <label class="label" data-bind="attr: {for: 'billing-save-in-address-book-' + getCode($parent)}" >
                     <span data-bind="i18n: 'Save in address book'"></span>
                 </label>
             </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15344
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13692: In payment step of checkout I cannot unselect #billing-save-in-address-book checkbox in non-first payment method

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Log in to your client account.
2. Add product to cart.
3. Go to checkout and click next button to be able to choose payment methods.
4. Open payment method other than the first one.
5. Uncheck My billing and shipping address are the same checkbox
6. Choose New address on the billing address dropdown
7. Fill address
8. Click on label Save in address book


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
