### PR TITLE
[Backport] Add generated code to the psr-0 autoloader section so when optimizing…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -227,7 +227,8 @@
         },
         "psr-0": {
             "": [
-                "app/code/"
+                "app/code/",
+                "generated/code/"
             ]
         },
         "files": [


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16435
… the autoloader on a production environment the autoloader will find more classes in its classmap. This should result in fewer file_exists calls and might increase the performance a tiny bit.

As @orlangur requested, this is a backport of #15438 for Magento 2.2

### Description
Hi!

This PR was triggered by some discussions over here: https://github.com/davidalger/capistrano-magento2/issues/102

When you read the Magento [documentation](https://devdocs.magento.com/guides/v2.2/performance-best-practices/deployment-flow.html) around performance best practices for deploying to a production environment, you'll see something like this:

> Run the following command to preprocess and compile DI:
> `bin/magento setup:di:compile`
> After compilation completes, we recommend running the following command:
> `composer dump-autoload -o`
> This command allows Composer to rebuild the mapping to project files so that they load faster.

Since the docs mention you should dump the autoloader after certain php classes got autogenerated, you would assume that the autoloader classmap file (`vendor/composer/autoload_classmap.php`) should have a mapping of those generated classes.

But that isn't the case right now.

This PR fixes this.

This should - in theory - increase the autoloading performance ever so slightly on production environments, since the autoloader wouldn't have to go searching for files on the filesystem but would already find them in the classmap and wouldn't have to perform `file_exists` calls for those generated classes.

Watch out:
1) I haven't tested this out on a real project yet. This was only done after some debugging and tinkering and reading the `vendor/composer/ClassLoader.php` file and some research on the world wide web.
2) I'm not exactly sure if this should go into the `"psr-4"`or the `"psr-0"` or the `"classmap"` section of the `"autoload"` section in the `composer.json` file. It was already suggested to put it in the `classmap` section over here: https://github.com/magento/magento2/pull/9102 but I'm not sure after reading the [composer documentation](https://getcomposer.org/doc/04-schema.md#autoload)? It seems to work in all 3 sections while testing, but I've decided to put it in the already being used `"psr-0"` section for now.
3) If this gets approved, this change will also have to go into the meta package `magento/project-community-edition` of which the sources I can't seem to find on github (unless the `composer.json` file which comes with it is somehow build using the `composer.json` file of this project?)
4) If this gets approved, it wouldn't be a bad idea to put this in the release notes of whatever version this gets released in, since the `composer.json` file of already existing projects doesn't get updated automatically after upgrading to a newer version of Magento.
5) If this gets backported all the way down to Magento 2.1, the path should become `var/generation/`

### Fixed Issues (if relevant)
None that I could find

### Manual testing scenarios
1. Install Magento using composer
2. Run `bin/magento setup:di:compile`
3. Run `composer dump-autoload -o`
4. Take a look at the file `vendor/composer/autoload_classmap.php` and see if you can find a mapping to a file inside `generated/code`, you won't find any
5. Change your `composer.json` as in this PR
6. Run `composer dump-autoload -o`
7. Take a look at the file `vendor/composer/autoload_classmap.php` and see if you can find a mapping to a file inside `generated/code`, you will find some references

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
