### PR TITLE
Fix for the checkout-breaking bug, related to the state/province field. Issue: 14052

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -648,7 +648,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
                     //If country actually has regions and requires you to
                     //select one then it must be selected.
                     $errors[] = __('%fieldName is a required field.', ['fieldName' => 'regionId']);
-                } elseif ($regionId && !in_array($regionId, $allowedRegions, true)) {
+                } elseif ($regionId && !in_array($regionId, $allowedRegions, true) && !empty($allowedRegions)) {
                     //If a region is selected then checking if it exists.
                     $errors[] = __(
                         'Invalid value of "%value" provided for the %fieldName field.',


### PR DESCRIPTION
### Description

The reason I made this update is because the variable $allowedRegions is always an empty array in cases when a country which doesn't have a selection of regions for choosing is selected by users.

This elseif is checking if the region_id is in_array, but the array is empty in these cases and will always trigger the error. Also, I believe that regions collection does not exist for countries for which users have to type the name of their region, so this elseif only has sense for countries with region collections, otherwise it is always triggering the error.

### Fixed Issues (if relevant)

1. magento/magento2#14052: M2.2.3 Checkout - Once integer is stored for State/Province field, it can not be changed to alphanumeric

### Manual testing scenarios

1. While on the checkout page, select the US as the shipping country and select a state.
2. Change the shipping country to the United Kingdom again.
3. It should be possible to complete the checkout proccess, while this is not possible without this change.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
