### PR TITLE
Adjust page-main container height for sticky footer; fixes #15118

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
@@ -52,6 +52,16 @@
         .lib-css(background-color, @page__background-color);
     }
 
+    .page-wrapper {
+        .lib-vendor-prefix-display(flex);
+        .lib-vendor-prefix-flex-direction(column);
+        min-height: 100vh; // Stretch content area for sticky footer
+    }
+
+    .page-main {
+        .lib-vendor-prefix-flex-grow(1);
+    }
+
     //
     //  Header
     //  ---------------------------------------------
@@ -279,17 +289,7 @@
 //  _____________________________________________
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
-
-    html,
-    body {
-        height: 100%; // Stretch screen area for sticky footer
-    }
-
     .page-wrapper {
-        .lib-vendor-prefix-display(flex);
-        .lib-vendor-prefix-flex-direction(column);
-        min-height: 100%; // Stretch content area for sticky footer
-
         > .breadcrumbs,
         > .top-container,
         > .widget {

--- a/app/design/frontend/Magento/blank/web/css/source/_layout.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_layout.less
@@ -95,10 +95,6 @@
     .page-main {
         width: 100%;
 
-        .lib-vendor-prefix-flex-grow(1);
-        .lib-vendor-prefix-flex-shrink(0);
-        .lib-vendor-prefix-flex-basis(auto);
-
         .ie9 & {
             width: auto;
         }

--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -74,6 +74,16 @@
         .lib-css(background-color, @page__background-color);
     }
 
+    .page-wrapper {
+        .lib-vendor-prefix-display(flex);
+        .lib-vendor-prefix-flex-direction(column);
+        min-height: 100vh; // Stretch content area for sticky footer
+    }
+
+    .page-main {
+        .lib-vendor-prefix-flex-grow(1);
+    }
+
     //
     //  Header
     //  ---------------------------------------------
@@ -313,14 +323,12 @@
     //
     //  Widgets
     //  ---------------------------------------------
-    //  @codingStandardsIgnoreStart caused by bug in CodeSniffer implementation
     .sidebar {
         .widget.block:not(:last-child),
         .widget:not(:last-child) {
             margin-bottom: @indent__xl;
         }
     }
-    //  @codingStandardsIgnoreEnd
 
     .widget {
         clear: both;
@@ -417,12 +425,6 @@
                 }
             }
         }
-    }
-    .page-footer,
-    .copyright {
-        bottom: 0;
-        position: absolute;
-        width: 100%;
     }
 }
 
@@ -616,10 +618,7 @@
     }
 
     .page-wrapper {
-        .lib-vendor-prefix-display(flex);
-        .lib-vendor-prefix-flex-direction(column);
         margin: 0;
-        min-height: 100%; // Stretch content area for sticky footer
         position: relative;
         transition: margin .3s ease-out 0s;
 


### PR DESCRIPTION
### Description
Adjusted page-main container height for sticky footer. Added fix for Blank and Luma themes

### Fixed Issues
#15118 Footers do not snap to bottom of screen on mobile devices