### PR TITLE
Invalid return type for Price Currency Interface `format` method

### DIFF
--- a/app/code/Magento/Directory/Model/PriceCurrency.php
+++ b/app/code/Magento/Directory/Model/PriceCurrency.php
@@ -3,8 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-declare(strict_types=1);
-
 namespace Magento\Directory\Model;
 
 use Magento\Framework\App\ScopeInterface;
@@ -50,7 +48,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(float $amount, $scope = null, $currency = null): float
+    public function convert($amount, $scope = null, $currency = null)
     {
         $currentCurrency = $this->getCurrency($scope, $currency);
 
@@ -62,12 +60,8 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function convertAndRound(
-        float $amount,
-        $scope = null,
-        $currency = null,
-        int $precision = self::DEFAULT_PRECISION
-    ): float {
+    public function convertAndRound($amount, $scope = null, $currency = null, $precision = self::DEFAULT_PRECISION)
+    {
         $currentCurrency = $this->getCurrency($scope, $currency);
         $convertedValue = $this->getStore($scope)->getBaseCurrency()->convert($amount, $currentCurrency);
         return round($convertedValue, $precision);
@@ -77,12 +71,12 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * {@inheritdoc}
      */
     public function format(
-        float $amount,
-        bool $includeContainer = true,
-        int $precision = self::DEFAULT_PRECISION,
+        $amount,
+        $includeContainer = true,
+        $precision = self::DEFAULT_PRECISION,
         $scope = null,
         $currency = null
-    ): string {
+    ) {
         return $this->getCurrency($scope, $currency)
             ->formatPrecision($amount, $precision, [], $includeContainer);
     }
@@ -91,12 +85,12 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * {@inheritdoc}
      */
     public function convertAndFormat(
-        float $amount,
-        bool $includeContainer = true,
-        int $precision = self::DEFAULT_PRECISION,
+        $amount,
+        $includeContainer = true,
+        $precision = self::DEFAULT_PRECISION,
         $scope = null,
         $currency = null
-    ): string {
+    ) {
         $amount = $this->convert($amount, $scope, $currency);
 
         return $this->format($amount, $includeContainer, $precision, $scope, $currency);
@@ -105,7 +99,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function getCurrency($scope = null, $currency = null): \Magento\Framework\Model\AbstractModel
+    public function getCurrency($scope = null, $currency = null)
     {
         if ($currency instanceof Currency) {
             $currentCurrency = $currency;
@@ -128,7 +122,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * @param \Magento\Framework\Model\AbstractModel|string|null $currency
      * @return string
      */
-    public function getCurrencySymbol($scope = null, $currency = null): string
+    public function getCurrencySymbol($scope = null, $currency = null)
     {
         return $this->getCurrency($scope, $currency)->getCurrencySymbol();
     }
@@ -159,7 +153,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * @param float $price
      * @return float
      */
-    public function round(float $price): float
+    public function round($price)
     {
         return round($price, 2);
     }

--- a/app/code/Magento/Directory/Model/PriceCurrency.php
+++ b/app/code/Magento/Directory/Model/PriceCurrency.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Directory\Model;
 
 use Magento\Framework\App\ScopeInterface;
@@ -48,7 +50,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function convert($amount, $scope = null, $currency = null)
+    public function convert(float $amount, $scope = null, $currency = null): float
     {
         $currentCurrency = $this->getCurrency($scope, $currency);
 
@@ -60,8 +62,12 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function convertAndRound($amount, $scope = null, $currency = null, $precision = self::DEFAULT_PRECISION)
-    {
+    public function convertAndRound(
+        float $amount,
+        $scope = null,
+        $currency = null,
+        int $precision = self::DEFAULT_PRECISION
+    ): float {
         $currentCurrency = $this->getCurrency($scope, $currency);
         $convertedValue = $this->getStore($scope)->getBaseCurrency()->convert($amount, $currentCurrency);
         return round($convertedValue, $precision);
@@ -71,12 +77,12 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * {@inheritdoc}
      */
     public function format(
-        $amount,
-        $includeContainer = true,
-        $precision = self::DEFAULT_PRECISION,
+        float $amount,
+        bool $includeContainer = true,
+        int $precision = self::DEFAULT_PRECISION,
         $scope = null,
         $currency = null
-    ) {
+    ): string {
         return $this->getCurrency($scope, $currency)
             ->formatPrecision($amount, $precision, [], $includeContainer);
     }
@@ -85,12 +91,12 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * {@inheritdoc}
      */
     public function convertAndFormat(
-        $amount,
-        $includeContainer = true,
-        $precision = self::DEFAULT_PRECISION,
+        float $amount,
+        bool $includeContainer = true,
+        int $precision = self::DEFAULT_PRECISION,
         $scope = null,
         $currency = null
-    ) {
+    ): string {
         $amount = $this->convert($amount, $scope, $currency);
 
         return $this->format($amount, $includeContainer, $precision, $scope, $currency);
@@ -99,7 +105,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function getCurrency($scope = null, $currency = null)
+    public function getCurrency($scope = null, $currency = null): \Magento\Framework\Model\AbstractModel
     {
         if ($currency instanceof Currency) {
             $currentCurrency = $currency;
@@ -122,7 +128,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * @param \Magento\Framework\Model\AbstractModel|string|null $currency
      * @return string
      */
-    public function getCurrencySymbol($scope = null, $currency = null)
+    public function getCurrencySymbol($scope = null, $currency = null): string
     {
         return $this->getCurrency($scope, $currency)->getCurrencySymbol();
     }
@@ -153,7 +159,7 @@ class PriceCurrency implements \Magento\Framework\Pricing\PriceCurrencyInterface
      * @param float $price
      * @return float
      */
-    public function round($price)
+    public function round(float $price): float
     {
         return round($price, 2);
     }

--- a/lib/internal/Magento/Framework/Pricing/PriceCurrencyInterface.php
+++ b/lib/internal/Magento/Framework/Pricing/PriceCurrencyInterface.php
@@ -47,7 +47,7 @@ interface PriceCurrencyInterface
      * @param int $precision
      * @param null|string|bool|int|\Magento\Framework\App\ScopeInterface $scope
      * @param \Magento\Framework\Model\AbstractModel|string|null $currency
-     * @return float
+     * @return string
      */
     public function format(
         $amount,

--- a/lib/internal/Magento/Framework/Pricing/PriceCurrencyInterface.php
+++ b/lib/internal/Magento/Framework/Pricing/PriceCurrencyInterface.php
@@ -26,7 +26,7 @@ interface PriceCurrencyInterface
      * @param \Magento\Framework\Model\AbstractModel|string|null $currency
      * @return float
      */
-    public function convert($amount, $scope = null, $currency = null);
+    public function convert(float $amount, $scope = null, $currency = null): float;
 
     /**
      * Convert and round price value
@@ -37,7 +37,12 @@ interface PriceCurrencyInterface
      * @param int $precision
      * @return float
      */
-    public function convertAndRound($amount, $scope = null, $currency = null, $precision = self::DEFAULT_PRECISION);
+    public function convertAndRound(
+        float $amount,
+        $scope = null,
+        $currency = null,
+        int $precision = self::DEFAULT_PRECISION
+    ): float;
 
     /**
      * Format price value
@@ -50,12 +55,12 @@ interface PriceCurrencyInterface
      * @return string
      */
     public function format(
-        $amount,
-        $includeContainer = true,
-        $precision = self::DEFAULT_PRECISION,
+        float $amount,
+        bool $includeContainer = true,
+        int $precision = self::DEFAULT_PRECISION,
         $scope = null,
         $currency = null
-    );
+    ): string;
 
     /**
      * Convert and format price value
@@ -68,12 +73,12 @@ interface PriceCurrencyInterface
      * @return string
      */
     public function convertAndFormat(
-        $amount,
-        $includeContainer = true,
-        $precision = self::DEFAULT_PRECISION,
+        float $amount,
+        bool $includeContainer = true,
+        int $precision = self::DEFAULT_PRECISION,
         $scope = null,
         $currency = null
-    );
+    ): string;
 
     /**
      * Round price
@@ -81,7 +86,7 @@ interface PriceCurrencyInterface
      * @param float $price
      * @return float
      */
-    public function round($price);
+    public function round(float $price): float;
 
     /**
      * Get currency model
@@ -90,12 +95,12 @@ interface PriceCurrencyInterface
      * @param \Magento\Framework\Model\AbstractModel|string|null $currency
      * @return \Magento\Framework\Model\AbstractModel
      */
-    public function getCurrency($scope = null, $currency = null);
+    public function getCurrency($scope = null, $currency = null): \Magento\Framework\Model\AbstractModel;
 
     /**
      * @param null|string|bool|int|\Magento\Framework\App\ScopeInterface $scope
      * @param \Magento\Framework\Model\AbstractModel|string|null $currency
      * @return string
      */
-    public function getCurrencySymbol($scope = null, $currency = null);
+    public function getCurrencySymbol($scope = null, $currency = null): string;
 }


### PR DESCRIPTION
### Description
As long as `format()` method lets you return formatted price with container - the return type is not float but string.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
