### PR TITLE
Move including "_extend.less" in css root files; fixes #11098, fixes #16989

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/styles-l.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-l.less
@@ -22,6 +22,7 @@
 
 //@magento_import 'source/_module.less'; // Theme modules
 //@magento_import 'source/_widgets.less'; // Theme widgets
+//@magento_import 'source/_extend.less'; // Extend for minor customisation
 
 //
 //  Media queries collector
@@ -37,9 +38,3 @@
 //  ---------------------------------------------
 
 @import 'source/_theme.less';
-
-//
-//  Extend for minor customisation
-//  ---------------------------------------------
-
-//@magento_import 'source/_extend.less';

--- a/app/design/frontend/Magento/blank/web/css/styles-m.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-m.less
@@ -23,6 +23,7 @@
 
 //@magento_import 'source/_module.less'; // Theme modules
 //@magento_import 'source/_widgets.less'; // Theme widgets
+//@magento_import 'source/_extend.less'; // Extend for minor customisation
 
 //
 //  Media queries collector
@@ -37,9 +38,3 @@
 //  ---------------------------------------------
 
 @import 'source/_theme.less';
-
-//
-//  Extend for minor customisation
-//  ---------------------------------------------
-
-//@magento_import 'source/_extend.less';


### PR DESCRIPTION
# This PR fixes two issues #16989 and #11098

## #16989

### Summary
Less variables defined in theme `<Module>/_extend.less` can't be overridden in `_theme.less`

### Steps to reproduce
1.  Create new theme
2.  Add `Magento_Theme/web/css/source/_extend.less`  with this content:
```
@test: red;

& when (@media-common = true) {
    body {
        background-color: @test;
    }
}
```
3. Try to override `@test` in `web/css/source/_theme.less`:
```@test: green;```

### Expected result
`body` has `green` background

### Actual result
`body` has `red` background

### Solution
In `web\css\styles-m.less` and `web\css\styles-l.less` move `@import 'source/_theme.less';` below  `//@magento_import 'source/_extend.less';`

## #11098

### Summary

Styles in `_extend.less` declared for mobile (`.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) { ... }`) are overridden by common styles (`& when (@media-common = true) { ... }`)

###  Illustration of the issue:

`_module.less`
![screenshot_167](https://user-images.githubusercontent.com/21016905/43040638-ab2ff0ca-8d51-11e8-9346-94b7384db0d0.png)

`_extend.less`
![screenshot_166](https://user-images.githubusercontent.com/21016905/43040639-ae6fe826-8d51-11e8-83be-58e9161b24a3.png)

On desktop styles have expected priority
![screenshot_163](https://user-images.githubusercontent.com/21016905/43040650-e02bef7c-8d51-11e8-989c-613912de4ede.png)

But on mobile common styles have higher priority than mobile-specific styles which is not expected result ![screenshot_164](https://user-images.githubusercontent.com/21016905/43040659-2ecb2148-8d52-11e8-8c6d-db2a892b885e.png)

After the fix applied mobile styles have expected order
![screenshot_165](https://user-images.githubusercontent.com/21016905/43040668-7504fefe-8d52-11e8-8a76-a85390dccae6.png)

_This PR is duplicate of #16991, I changed PR source branch_