### PR TITLE
[Forwardport] Wrong namespace defined in compare.phtml

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addto/compare.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addto/compare.phtml
@@ -6,7 +6,7 @@
 
 // @codingStandardsIgnoreFile
 
-/** @var $block \Magento\Catalog\Block\Catalog\Product\View\Addto\Compare */
+/** @var $block \Magento\Catalog\Block\Product\View\Addto\Compare */
 ?>
 
 <a href="#" data-post='<?= /* @escapeNotVerified */ $block->getPostDataParams() ?>'


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16978
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Wrong namespace defined in compare.phtml

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
