### PR TITLE
[Forwardport] hide cookie notice instead of reloading site

### DIFF
--- a/app/code/Magento/Cookie/view/frontend/web/js/notices.js
+++ b/app/code/Magento/Cookie/view/frontend/web/js/notices.js
@@ -29,7 +29,7 @@ define([
                 });
 
                 if ($.mage.cookies.get(this.options.cookieName)) {
-                    window.location.reload();
+                    this.element.hide();
                 } else {
                     window.location.href = this.options.noCookiesUrl;
                 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16890
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Instead of reloading the whole site when a use accepts the cookie notice, it should be accpetable to close the cookie notice only.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set Cookie Restricton Mode to 'Yes'
2. Open the Homepage and click on 'Allow Cookies'
3. The Cookie Notice will be closed immediately

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
