### PR TITLE
[Up port] Replacing deprecated methods in Magento_Backend module.

### DIFF
--- a/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
+++ b/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
@@ -160,7 +160,7 @@ class Authentication
             } else {
                 $this->_actionFlag->set('', \Magento\Framework\App\ActionInterface::FLAG_NO_DISPATCH, true);
                 $this->_response->setRedirect($this->_url->getCurrentUrl());
-                $this->messageManager->addError(__('Invalid Form Key. Please refresh the page.'));
+                $this->messageManager->addErrorMessage(__('Invalid Form Key. Please refresh the page.'));
                 $isRedirectNeeded = true;
             }
         }
@@ -205,7 +205,7 @@ class Authentication
             $this->_auth->login($username, $password);
         } catch (AuthenticationException $e) {
             if (!$request->getParam('messageSent')) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $request->setParam('messageSent', true);
                 $outputValue = false;
             }

--- a/app/code/Magento/Backend/Controller/Adminhtml/Auth/Logout.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Auth/Logout.php
@@ -16,7 +16,7 @@ class Logout extends \Magento\Backend\Controller\Adminhtml\Auth
     public function execute()
     {
         $this->_auth->logout();
-        $this->messageManager->addSuccess(__('You have logged out.'));
+        $this->messageManager->addSuccessMessage(__('You have logged out.'));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanImages.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanImages.php
@@ -28,11 +28,11 @@ class CleanImages extends \Magento\Backend\Controller\Adminhtml\Cache
         try {
             $this->_objectManager->create(\Magento\Catalog\Model\Product\Image::class)->clearCache();
             $this->_eventManager->dispatch('clean_catalog_images_cache_after');
-            $this->messageManager->addSuccess(__('The image cache was cleaned.'));
+            $this->messageManager->addSuccessMessage(__('The image cache was cleaned.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while clearing the image cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the image cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
@@ -32,7 +32,8 @@ class CleanMedia extends \Magento\Backend\Controller\Adminhtml\Cache
         } catch (LocalizedException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
+            $this->messageManager
+                ->addExceptionMessage($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanMedia.php
@@ -28,11 +28,11 @@ class CleanMedia extends \Magento\Backend\Controller\Adminhtml\Cache
         try {
             $this->_objectManager->get(\Magento\Framework\View\Asset\MergeService::class)->cleanMergedJsCss();
             $this->_eventManager->dispatch('clean_media_cache_after');
-            $this->messageManager->addSuccess(__('The JavaScript/CSS cache has been cleaned.'));
+            $this->messageManager->addSuccessMessage(__('The JavaScript/CSS cache has been cleaned.'));
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while clearing the JavaScript/CSS cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanStaticFiles.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/CleanStaticFiles.php
@@ -26,7 +26,7 @@ class CleanStaticFiles extends \Magento\Backend\Controller\Adminhtml\Cache
     {
         $this->_objectManager->get(\Magento\Framework\App\State\CleanupFiles::class)->clearMaterializedViewFiles();
         $this->_eventManager->dispatch('clean_static_files_cache_after');
-        $this->messageManager->addSuccess(__('The static files cache has been cleaned.'));
+        $this->messageManager->addSuccessMessage(__('The static files cache has been cleaned.'));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushAll.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushAll.php
@@ -27,7 +27,7 @@ class FlushAll extends \Magento\Backend\Controller\Adminhtml\Cache
         foreach ($this->_cacheFrontendPool as $cacheFrontend) {
             $cacheFrontend->getBackend()->clean();
         }
-        $this->messageManager->addSuccess(__("You flushed the cache storage."));
+        $this->messageManager->addSuccessMessage(__("You flushed the cache storage."));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();
         return $resultRedirect->setPath('adminhtml/*');

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushSystem.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/FlushSystem.php
@@ -27,7 +27,7 @@ class FlushSystem extends \Magento\Backend\Controller\Adminhtml\Cache
             $cacheFrontend->clean();
         }
         $this->_eventManager->dispatch('adminhtml_cache_flush_system');
-        $this->messageManager->addSuccess(__("The Magento cache storage has been flushed."));
+        $this->messageManager->addSuccessMessage(__("The Magento cache storage has been flushed."));
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultRedirectFactory->create();
         return $resultRedirect->setPath('adminhtml/*');

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassDisable.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassDisable.php
@@ -67,12 +67,12 @@ class MassDisable extends \Magento\Backend\Controller\Adminhtml\Cache
             }
             if ($updatedTypes > 0) {
                 $this->_cacheState->persist();
-                $this->messageManager->addSuccess(__("%1 cache type(s) disabled.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) disabled.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while disabling cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while disabling cache.'));
         }
     }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassEnable.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassEnable.php
@@ -66,12 +66,12 @@ class MassEnable extends \Magento\Backend\Controller\Adminhtml\Cache
             }
             if ($updatedTypes > 0) {
                 $this->_cacheState->persist();
-                $this->messageManager->addSuccess(__("%1 cache type(s) enabled.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) enabled.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while enabling cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while enabling cache.'));
         }
     }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassRefresh.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache/MassRefresh.php
@@ -37,12 +37,12 @@ class MassRefresh extends \Magento\Backend\Controller\Adminhtml\Cache
                 $updatedTypes++;
             }
             if ($updatedTypes > 0) {
-                $this->messageManager->addSuccess(__("%1 cache type(s) refreshed.", $updatedTypes));
+                $this->messageManager->addSuccessMessage(__("%1 cache type(s) refreshed.", $updatedTypes));
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('An error occurred while refreshing cache.'));
+            $this->messageManager->addExceptionMessage($e, __('An error occurred while refreshing cache.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
@@ -34,9 +34,9 @@ class RefreshStatistics extends \Magento\Reports\Controller\Adminhtml\Report\Sta
             foreach ($collectionsNames as $collectionName) {
                 $this->_objectManager->create($collectionName)->aggregate();
             }
-            $this->messageManager->addSuccess(__('We updated lifetime statistic.'));
+            $this->messageManager->addSuccessMessage(__('We updated lifetime statistic.'));
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t refresh lifetime statistics.'));
+            $this->messageManager->addErrorMessage(__('We can\'t refresh lifetime statistics.'));
             $this->logger->critical($e);
         }
 

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Account/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Account/Save.php
@@ -76,12 +76,12 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Account
             $errors = $user->validate();
             if ($errors !== true && !empty($errors)) {
                 foreach ($errors as $error) {
-                    $this->messageManager->addError($error);
+                    $this->messageManager->addErrorMessage($error);
                 }
             } else {
                 $user->save();
                 $user->sendNotificationEmailsIfRequired();
-                $this->messageManager->addSuccess(__('You saved the account.'));
+                $this->messageManager->addSuccessMessage(__('You saved the account.'));
             }
         } catch (UserLockedException $e) {
             $this->_auth->logout();
@@ -91,12 +91,12 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Account
         } catch (ValidatorException $e) {
             $this->messageManager->addMessages($e->getMessages());
             if ($e->getMessage()) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             }
         } catch (LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('An error occurred while saving account.'));
+            $this->messageManager->addErrorMessage(__('An error occurred while saving account.'));
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Delete.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Delete.php
@@ -19,11 +19,11 @@ class Delete extends \Magento\Backend\Controller\Adminhtml\System\Design
 
             try {
                 $design->delete();
-                $this->messageManager->addSuccess(__('You deleted the design change.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the design change.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addException($e, __("You can't delete the design change."));
+                $this->messageManager->addExceptionMessage($e, __("You can't delete the design change."));
             }
         }
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design/Save.php
@@ -50,9 +50,9 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Design
             try {
                 $design->save();
                 $this->_eventManager->dispatch('theme_save_after');
-                $this->messageManager->addSuccess(__('You saved the design change.'));
+                $this->messageManager->addSuccessMessage(__('You saved the design change.'));
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setDesignData($data);
                 return $resultRedirect->setPath('adminhtml/*/', ['id' => $design->getId()]);
             }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
@@ -103,12 +103,12 @@ abstract class Store extends Action
                 ->setType('db')
                 ->setPath($filesystem->getDirectoryRead(DirectoryList::VAR_DIR)->getAbsolutePath('backups'));
             $backupDb->createBackup($backup);
-            $this->messageManager->addSuccess(__('The database was backed up.'));
+            $this->messageManager->addSuccessMessage(__('The database was backed up.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             return false;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('We can\'t create a backup right now. Please try again later.')
             );
@@ -125,7 +125,7 @@ abstract class Store extends Action
      */
     protected function _addDeletionNotice($typeTitle)
     {
-        $this->messageManager->addNotice(
+        $this->messageManager->addNoticeMessage(
             __(
                 'Deleting a %1 will not delete the information associated with the %1 (e.g. categories, products, etc.)'
                 . ', but the %1 will not be able to be restored. It is suggested that you create a database backup '

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroup.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroup.php
@@ -15,13 +15,13 @@ class DeleteGroup extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Group::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroupPost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteGroupPost.php
@@ -21,11 +21,11 @@ class DeleteGroupPost extends \Magento\Backend\Controller\Adminhtml\System\Store
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Group::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $model->getId()]);
         }
 
@@ -35,12 +35,12 @@ class DeleteGroupPost extends \Magento\Backend\Controller\Adminhtml\System\Store
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the store.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the store.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the store. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store. Please try again later.'));
         }
         return $redirectResult->setPath('adminhtml/*/editGroup', ['group_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStore.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStore.php
@@ -15,13 +15,13 @@ class DeleteStore extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Store::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store view cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store view cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
@@ -42,7 +42,8 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store view. Please try again later.'));
+            $this->messageManager
+                ->addExceptionMessage($e, __('Unable to delete the store view. Please try again later.'));
         }
         return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteStorePost.php
@@ -22,11 +22,11 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Store::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This store view cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This store view cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $model->getId()]);
         }
 
@@ -37,12 +37,12 @@ class DeleteStorePost extends \Magento\Backend\Controller\Adminhtml\System\Store
         try {
             $model->delete();
 
-            $this->messageManager->addSuccess(__('You deleted the store view.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the store view.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the store view. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the store view. Please try again later.'));
         }
         return $redirectResult->setPath('adminhtml/*/editStore', ['store_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsite.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsite.php
@@ -15,13 +15,13 @@ class DeleteWebsite extends \Magento\Backend\Controller\Adminhtml\System\Store
     {
         $itemId = $this->getRequest()->getParam('item_id', null);
         if (!($model = $this->_objectManager->create(\Magento\Store\Model\Website::class)->load($itemId))) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This website cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This website cannot be deleted.'));
             /** @var \Magento\Backend\Model\View\Result\Redirect $redirectResult */
             $redirectResult = $this->resultRedirectFactory->create();
             return $redirectResult->setPath('adminhtml/*/editWebsite', ['website_id' => $itemId]);

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsitePost.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/DeleteWebsitePost.php
@@ -23,11 +23,11 @@ class DeleteWebsitePost extends \Magento\Backend\Controller\Adminhtml\System\Sto
         $redirectResult = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
 
         if (!$model) {
-            $this->messageManager->addError(__('Something went wrong. Please try again.'));
+            $this->messageManager->addErrorMessage(__('Something went wrong. Please try again.'));
             return $redirectResult->setPath('adminhtml/*/');
         }
         if (!$model->isCanDelete()) {
-            $this->messageManager->addError(__('This website cannot be deleted.'));
+            $this->messageManager->addErrorMessage(__('This website cannot be deleted.'));
             return $redirectResult->setPath('adminhtml/*/editWebsite', ['website_id' => $model->getId()]);
         }
 
@@ -37,12 +37,12 @@ class DeleteWebsitePost extends \Magento\Backend\Controller\Adminhtml\System\Sto
 
         try {
             $model->delete();
-            $this->messageManager->addSuccess(__('You deleted the website.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the website.'));
             return $redirectResult->setPath('adminhtml/*/');
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Unable to delete the website. Please try again later.'));
+            $this->messageManager->addExceptionMessage($e, __('Unable to delete the website. Please try again later.'));
         }
         return $redirectResult->setPath('*/*/editWebsite', ['website_id' => $itemId]);
     }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/EditStore.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/EditStore.php
@@ -57,7 +57,7 @@ class EditStore extends \Magento\Backend\Controller\Adminhtml\System\Store
         if ($model->getId() || $this->_coreRegistry->registry('store_action') == 'add') {
             $this->_coreRegistry->register('store_data', $model);
             if ($this->_coreRegistry->registry('store_action') == 'edit' && $codeBase && !$model->isReadOnly()) {
-                $this->messageManager->addNotice($codeBase);
+                $this->messageManager->addNoticeMessage($codeBase);
             }
             $resultPage = $this->createPage();
             if ($this->_coreRegistry->registry('store_action') == 'add') {
@@ -71,7 +71,7 @@ class EditStore extends \Magento\Backend\Controller\Adminhtml\System\Store
             ));
             return $resultPage;
         } else {
-            $this->messageManager->addError($notExists);
+            $this->messageManager->addErrorMessage($notExists);
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
             return $resultRedirect->setPath('adminhtml/*/');

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store/Save.php
@@ -32,7 +32,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
         }
 
         $websiteModel->save();
-        $this->messageManager->addSuccess(__('You saved the website.'));
+        $this->messageManager->addSuccessMessage(__('You saved the website.'));
 
         return $postData;
     }
@@ -68,7 +68,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
             );
         }
         $storeModel->save();
-        $this->messageManager->addSuccess(__('You saved the store view.'));
+        $this->messageManager->addSuccessMessage(__('You saved the store view.'));
 
         return $postData;
     }
@@ -98,7 +98,7 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
             );
         }
         $groupModel->save();
-        $this->messageManager->addSuccess(__('You saved the store.'));
+        $this->messageManager->addSuccessMessage(__('You saved the store.'));
 
         return $postData;
     }
@@ -134,10 +134,10 @@ class Save extends \Magento\Backend\Controller\Adminhtml\System\Store
                 $redirectResult->setPath('adminhtml/*/');
                 return $redirectResult;
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 $this->_getSession()->setPostData($postData);
             } catch (\Exception $e) {
-                $this->messageManager->addException(
+                $this->messageManager->addExceptionMessage(
                     $e,
                     __('Something went wrong while saving. Please review the error log.')
                 );

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
@@ -38,7 +38,7 @@ class CleanMediaTest extends \PHPUnit\Framework\TestCase
         $messageManagerParams = $helper->getConstructArguments(\Magento\Framework\Message\Manager::class);
         $messageManagerParams['exceptionMessageFactory'] = $exceptionMessageFactory;
         $messageManager = $this->getMockBuilder(\Magento\Framework\Message\Manager::class)
-            ->setMethods(['addSuccess'])
+            ->setMethods(['addSuccessMessage'])
             ->setConstructorArgs($messageManagerParams)
             ->getMock();
 
@@ -86,7 +86,7 @@ class CleanMediaTest extends \PHPUnit\Framework\TestCase
         $mergeService->expects($this->once())->method('cleanMergedJsCss');
 
         $messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The JavaScript/CSS cache has been cleaned.');
 
         $valueMap = [

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
@@ -76,7 +76,7 @@ class CleanStaticFilesTest extends \PHPUnit\Framework\TestCase
             ->with('clean_static_files_cache_after');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('The static files cache has been cleaned.');
 
         $resultRedirect = $this->getMockBuilder(\Magento\Backend\Model\View\Result\Redirect::class)

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
@@ -156,7 +156,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['someCache']);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('These cache type(s) don\'t exist: someCache')
             ->willReturnSelf();
 
@@ -176,7 +176,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'An error occurred while disabling cache.')
             ->willReturnSelf();
 
@@ -216,7 +216,7 @@ class MassDisableTest extends \PHPUnit\Framework\TestCase
             ->method('persist');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 cache type(s) disabled.')
             ->willReturnSelf();
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
@@ -156,7 +156,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['someCache']);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addError')
+            ->method('addErrorMessage')
             ->with('These cache type(s) don\'t exist: someCache')
             ->willReturnSelf();
 
@@ -176,7 +176,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->willThrowException($exception);
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addException')
+            ->method('addExceptionMessage')
             ->with($exception, 'An error occurred while enabling cache.')
             ->willReturnSelf();
 
@@ -216,7 +216,7 @@ class MassEnableTest extends \PHPUnit\Framework\TestCase
             ->method('persist');
 
         $this->messageManagerMock->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with('1 cache type(s) enabled.')
             ->willReturnSelf();
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/RefreshStatisticsTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/RefreshStatisticsTest.php
@@ -107,7 +107,7 @@ class RefreshStatisticsTest extends \PHPUnit\Framework\TestCase
         $this->resultRedirectFactory->expects($this->any())->method('create')->willReturn($this->resultRedirect);
 
         $this->messageManager->expects($this->once())
-            ->method('addSuccess')
+            ->method('addSuccessMessage')
             ->with(__('We updated lifetime statistic.'));
 
         $this->objectManager->expects($this->any())

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
@@ -71,7 +71,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $this->_messagesMock = $this->getMockBuilder(\Magento\Framework\Message\Manager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccess'])
+            ->setMethods(['addSuccessMessage'])
             ->getMockForAbstractClass();
 
         $this->_authSessionMock = $this->getMockBuilder(\Magento\Backend\Model\Auth\Session::class)
@@ -221,7 +221,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
         $this->_requestMock->setParams($requestParams);
 
-        $this->_messagesMock->expects($this->once())->method('addSuccess')->with($this->equalTo($testedMessage));
+        $this->_messagesMock->expects($this->once())->method('addSuccessMessage')->with($this->equalTo($testedMessage));
 
         $this->_controller->execute();
     }


### PR DESCRIPTION
Replacing deprecated methods to Magento_Backend.

### Description
Replaced methods:

- `addSuccess()` by `addSuccessMessage()`;
- `addError()` by `addErrorMessage()`;
- `addException()` by `addExceptionMessage()`;
- `addNotice()` by `addNoticeMessage()`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR
https://github.com/magento/magento2/pull/17039