### PR TITLE
[Forwardport] Remove direct use of object manager

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
@@ -6,8 +6,32 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml\Subscriber;
 
-class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
+use Magento\Newsletter\Controller\Adminhtml\Subscriber;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Framework\App\ObjectManager;
+
+class MassDelete extends Subscriber
 {
+    /**
+     * @var SubscriberFactory
+     */
+    private $subscriberFactory;
+    
+    /**
+     * @param Context $context
+     * @param FileFactory $fileFactory
+     */
+    public function __construct(
+        Context $context,
+        FileFactory $fileFactory,
+        SubscriberFactory $subscriberFactory = null
+    ) {
+        $this->subscriberFactory = $subscriberFactory ?: ObjectManager::getInstance()->get(SubscriberFactory::class);
+        parent::__construct($context, $fileFactory);
+    }
+    
     /**
      * Delete one or more subscribers action
      *
@@ -21,9 +45,7 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
-                    $subscriber = $this->_objectManager->create(
-                        \Magento\Newsletter\Model\Subscriber::class
-                    )->load(
+                    $subscriber = $this->subscriberFactory->create()->load(
                         $subscriberId
                     );
                     $subscriber->delete();

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -22,6 +22,7 @@ class MassUnsubscribe extends Subscriber
     /**
      * @param Context $context
      * @param FileFactory $fileFactory
+     * @param SubscriberFactory $subscriberFactory
      */
     public function __construct(
         Context $context,

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -6,8 +6,32 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml\Subscriber;
 
-class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
+use Magento\Newsletter\Controller\Adminhtml\Subscriber;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Framework\App\ObjectManager;
+
+class MassUnsubscribe extends Subscriber
 {
+    /**
+     * @var SubscriberFactory
+     */
+    private $subscriberFactory;
+    
+    /**
+     * @param Context $context
+     * @param FileFactory $fileFactory
+     */
+    public function __construct(
+        Context $context,
+        FileFactory $fileFactory,
+        SubscriberFactory $subscriberFactory = null
+    ) {
+        $this->subscriberFactory = $subscriberFactory ?: ObjectManager::getInstance()->get(SubscriberFactory::class);
+        parent::__construct($context, $fileFactory);
+    }
+    
     /**
      * Unsubscribe one or more subscribers action
      *
@@ -21,9 +45,7 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
-                    $subscriber = $this->_objectManager->create(
-                        \Magento\Newsletter\Model\Subscriber::class
-                    )->load(
+                    $subscriber = $this->subscriberFactory->create()->load(
                         $subscriberId
                     );
                     $subscriber->unsubscribe();


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16851
### Description
Remove the direct use of object manager and loaded the dependency via constructor dependency injection.

### Manual testing scenarios
1. Unsubscribe the newsletter subscribers using the unsubscription mass action in admin. 
2. Deleted the newsletter subscribers using the delete mass action in admin.
