### PR TITLE
[Up Port 2.3] Replacing deprecated methods in Magento_Backup module.

### DIFF
--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/Create.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/Create.php
@@ -82,7 +82,7 @@ class Create extends \Magento\Backup\Controller\Adminhtml\Index
 
             $backupManager->create();
 
-            $this->messageManager->addSuccess($successMessage);
+            $this->messageManager->addSuccessMessage($successMessage);
 
             $response->setRedirectUrl($this->getUrl('*/*/index'));
         } catch (\Magento\Framework\Backup\Exception\NotEnoughFreeSpace $e) {

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index/MassDelete.php
@@ -49,13 +49,13 @@ class MassDelete extends \Magento\Backup\Controller\Adminhtml\Index
 
             $resultData->setIsSuccess(true);
             if ($allBackupsDeleted) {
-                $this->messageManager->addSuccess(__('You deleted the selected backup(s).'));
+                $this->messageManager->addSuccessMessage(__('You deleted the selected backup(s).'));
             } else {
                 throw new \Exception($deleteFailMessage);
             }
         } catch (\Exception $e) {
             $resultData->setIsSuccess(false);
-            $this->messageManager->addError($deleteFailMessage);
+            $this->messageManager->addErrorMessage($deleteFailMessage);
         }
 
         return $this->_redirect('backup/*/index');


### PR DESCRIPTION
Replacing deprecated methods to Magento_Backup module.

### Description
Replaced methods:

- `addSuccess()` by `addSuccessMessage()`;
- `addError()` by `addErrorMessage()`;
- `addException()` by `addExceptionMessage()`;
- `addNotice()` by `addNoticeMessage()`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR
https://github.com/magento/magento2/pull/17048