### PR TITLE
[backport] removed _responsive.less import from gallery.less

### DIFF
--- a/lib/web/mage/gallery/gallery.less
+++ b/lib/web/mage/gallery/gallery.less
@@ -7,7 +7,6 @@
 @import '../../css/source/lib/_lib.less'; // Global lib
 @import '../../css/source/_theme.less'; // Theme overrides
 @import '../../css/source/_variables.less'; // Local theme variables
-@import '../../css/source/lib/_responsive.less';
 @import 'module/_mixins.less'; //Mixins in gallery
 @import 'module/_extends.less';
 @import 'module/_focus.less';


### PR DESCRIPTION
Backport of PR https://github.com/magento/magento2/pull/16579

### Description
As gallery.less is not part of default styles-l and styles-m files and gallery.less is not using any breakpoints there is no need to import _responsive.less

### Fixed Issues (if relevant)

none

### Manual testing scenarios


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
