### PR TITLE
[Up Port 2.3] Replacing deprecated methods in Magento_CatalogRule module.

### DIFF
--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
@@ -25,14 +25,14 @@ class ApplyRules extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
             $ruleJob->applyAll();
 
             if ($ruleJob->hasSuccess()) {
-                $this->messageManager->addSuccess($ruleJob->getSuccess());
+                $this->messageManager->addSuccessMessage($ruleJob->getSuccess());
                 $this->_objectManager->create(\Magento\CatalogRule\Model\Flag::class)->loadSelf()->setState(0)->save();
             } elseif ($ruleJob->hasError()) {
-                $this->messageManager->addError($errorMessage . ' ' . $ruleJob->getError());
+                $this->messageManager->addErrorMessage($errorMessage . ' ' . $ruleJob->getError());
             }
         } catch (\Exception $e) {
             $this->_objectManager->create(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError($errorMessage);
+            $this->messageManager->addErrorMessage($errorMessage);
         }
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Delete.php
@@ -25,13 +25,13 @@ class Delete extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 $ruleRepository->deleteById($id);
 
                 $this->_objectManager->create(\Magento\CatalogRule\Model\Flag::class)->loadSelf()->setState(1)->save();
-                $this->messageManager->addSuccess(__('You deleted the rule.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the rule.'));
                 $this->_redirect('catalog_rule/*/');
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('We can\'t delete this rule right now. Please review the log and try again.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
@@ -39,7 +39,7 @@ class Delete extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 return;
             }
         }
-        $this->messageManager->addError(__('We can\'t find a rule to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find a rule to delete.'));
         $this->_redirect('catalog_rule/*/');
     }
 }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Edit.php
@@ -24,7 +24,7 @@ class Edit extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
             try {
                 $model = $ruleRepository->get($id);
             } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
-                $this->messageManager->addError(__('This rule no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
                 $this->_redirect('catalog_rule/*');
                 return;
             }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -68,7 +68,7 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 $validateResult = $model->validateData(new \Magento\Framework\DataObject($data));
                 if ($validateResult !== true) {
                     foreach ($validateResult as $errorMessage) {
-                        $this->messageManager->addError($errorMessage);
+                        $this->messageManager->addErrorMessage($errorMessage);
                     }
                     $this->_getSession()->setPageData($data);
                     $this->dataPersistor->set('catalog_rule', $data);
@@ -88,7 +88,7 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
 
                 $ruleRepository->save($model);
 
-                $this->messageManager->addSuccess(__('You saved the rule.'));
+                $this->messageManager->addSuccessMessage(__('You saved the rule.'));
                 $this->_objectManager->get(\Magento\Backend\Model\Session::class)->setPageData(false);
                 $this->dataPersistor->clear('catalog_rule');
 
@@ -111,9 +111,9 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
                 }
                 return;
             } catch (LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
-                $this->messageManager->addError(
+                $this->messageManager->addErrorMessage(
                     __('Something went wrong while saving the rule data. Please review the error log.')
                 );
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/CatalogRule/Observer/AddDirtyRulesNotice.php
+++ b/app/code/Magento/CatalogRule/Observer/AddDirtyRulesNotice.php
@@ -37,7 +37,7 @@ class AddDirtyRulesNotice implements ObserverInterface
         $dirtyRules = $observer->getData('dirty_rules');
         if (!empty($dirtyRules)) {
             if ($dirtyRules->getState()) {
-                $this->messageManager->addNotice($observer->getData('message'));
+                $this->messageManager->addNoticeMessage($observer->getData('message'));
             }
         }
     }

--- a/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
+++ b/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
@@ -103,7 +103,7 @@ class Attribute
 
         if ($disabledRulesCount) {
             $this->ruleProductProcessor->markIndexerAsInvalid();
-            $this->messageManager->addWarning(
+            $this->messageManager->addWarningMessage(
                 __(
                     'You disabled %1 Catalog Price Rules based on "%2" attribute.',
                     $disabledRulesCount,

--- a/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
@@ -49,7 +49,7 @@ class AddDirtyRulesNoticeTest extends \PHPUnit\Framework\TestCase
         $eventObserverMock->expects($this->at(0))->method('getData')->with('dirty_rules')->willReturn($flagMock);
         $flagMock->expects($this->once())->method('getState')->willReturn(1);
         $eventObserverMock->expects($this->at(1))->method('getData')->with('message')->willReturn($message);
-        $this->messageManagerMock->expects($this->once())->method('addNotice')->with($message);
+        $this->messageManagerMock->expects($this->once())->method('addNoticeMessage')->with($message);
         $this->observer->execute($eventObserverMock);
     }
 }


### PR DESCRIPTION
Replacing deprecated methods in Magento_CatalogRule module.

### Description
Replaced methods:

- `addSuccess()` by `addSuccessMessage()`;
- `addError()` by `addErrorMessage()`;
- `addException()` by `addExceptionMessage()`;
- `addNotice()` by `addNoticeMessage()`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR
https://github.com/magento/magento2/pull/17058