### PR TITLE
Resolved special character issue for sidebar

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/summary/item/details.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/summary/item/details.html
@@ -12,7 +12,7 @@
 
     <div class="product-item-inner">
         <div class="product-item-name-block">
-            <strong class="product-item-name" data-bind="text: $parent.name"></strong>
+            <strong class="product-item-name" data-bind="html: $parent.name"></strong>
             <div class="details-qty">
                 <span class="label"><!-- ko i18n: 'Qty' --><!-- /ko --></span>
                 <span class="value" data-bind="text: $parent.qty"></span>

--- a/app/code/Magento/Wishlist/view/frontend/templates/sidebar.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/sidebar.phtml
@@ -31,7 +31,7 @@ $wishlistHelper = $this->helper('Magento\Wishlist\Helper\Data');
                             <div class="product-item-details">
                                 <strong class="product-item-name">
                                     <a data-bind="attr: { href: product_url }" class="product-item-link">
-                                        <span data-bind="text: product_name"></span>
+                                        <span data-bind="html: product_name"></span>
                                     </a>
                                 </strong>
                                 <div data-bind="html: product_price"></div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Side bar for wishlist on catalog page or my account page, if product name contains special character like TM it will display `&trade;` instead of special character.

Also resolved same issue for order summary on checkout page.

### Manual testing scenarios

1. Verified My Account page wishlist sidebar with product in wishlist having special character.
2. Verified Catalog page wishlist sidebar with product in wishlist having special character.
3. Verified Catalog Search page wishlist sidebar with product in wishlist having special character.
4. Verified Wishlist page wishlist sidebar with product in wishlist having special character.
5. Verified Checkout page with products added in cart with product name having special character.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
