### PR TITLE
[Backport] Issues 13769. Fix wrong info about sent email in order sender.

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender.php
@@ -78,6 +78,8 @@ abstract class Sender
             $sender->sendCopyTo();
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
+
+            return false;
         }
 
         return true;

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
@@ -59,10 +59,11 @@ class OrderSenderTest extends AbstractSenderTest
      * @param int $configValue
      * @param bool|null $forceSyncMode
      * @param bool|null $emailSendingResult
-     * @dataProvider sendDataProvider
+     * @param $senderSendException
      * @return void
+     * @dataProvider sendDataProvider
      */
-    public function testSend($configValue, $forceSyncMode, $emailSendingResult)
+    public function testSend($configValue, $forceSyncMode, $emailSendingResult, $senderSendException)
     {
         $address = 'address_test';
         $configPath = 'sales_email/general/async_sending';
@@ -122,19 +123,23 @@ class OrderSenderTest extends AbstractSenderTest
 
                 $this->senderMock->expects($this->once())->method('send');
 
-                $this->senderMock->expects($this->once())->method('sendCopyTo');
+                if ($senderSendException) {
+                    $this->checkSenderSendExceptionCase();
+                } else {
+                    $this->senderMock->expects($this->once())->method('sendCopyTo');
 
-                $this->orderMock->expects($this->once())
-                    ->method('setEmailSent')
-                    ->with(true);
+                    $this->orderMock->expects($this->once())
+                        ->method('setEmailSent')
+                        ->with(true);
 
-                $this->orderResourceMock->expects($this->once())
-                    ->method('saveAttribute')
-                    ->with($this->orderMock, ['send_email', 'email_sent']);
+                    $this->orderResourceMock->expects($this->once())
+                        ->method('saveAttribute')
+                        ->with($this->orderMock, ['send_email', 'email_sent']);
 
-                $this->assertTrue(
-                    $this->sender->send($this->orderMock)
-                );
+                    $this->assertTrue(
+                        $this->sender->send($this->orderMock)
+                    );
+                }
             } else {
                 $this->orderResourceMock->expects($this->once())
                     ->method('saveAttribute')
@@ -156,18 +161,41 @@ class OrderSenderTest extends AbstractSenderTest
     }
 
     /**
+     * Methods check case when method "send" in "senderMock" throw exception.
+     *
+     * @return void
+     */
+    protected function checkSenderSendExceptionCase()
+    {
+        $this->senderMock->expects($this->once())
+            ->method('send')
+            ->willThrowException(new \Exception('exception'));
+
+        $this->orderResourceMock->expects($this->once())
+            ->method('saveAttribute')
+            ->with($this->orderMock, 'send_email');
+
+        $this->assertFalse(
+            $this->sender->send($this->orderMock)
+        );
+    }
+
+    /**
      * @return array
      */
     public function sendDataProvider()
     {
         return [
-            [0, 0, true],
-            [0, 0, true],
-            [0, 0, false],
-            [0, 0, false],
-            [0, 1, true],
-            [0, 1, true],
-            [1, null, null, null]
+            [0, 0, true, false],
+            [0, 0, true, false],
+            [0, 0, true, true],
+            [0, 0, false, false],
+            [0, 0, false, false],
+            [0, 0, false, true],
+            [0, 1, true, false],
+            [0, 1, true, false],
+            [0, 1, true, false],
+            [1, null, null, false]
         ];
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13878
### Description
Fixes wrong info about sent email in Order Sender. Order sender when send method got exception then checkAndSend should return false.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13769: Order Email Sender

### Manual testing scenarios
1. If we want check issue we should have wrong config sendmail in server.
2. We should place order.
3. We had wrong configuration in sendmail, so email not sent.
4. In database in sales_order we should have email_send and send_email as false.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
