### PR TITLE
[Backport] Solved this issue : Drop down values are not showing in catalog produ…

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Option.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Option.php
@@ -44,8 +44,8 @@ class Option extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         );
         $valueExpr = $connection->getCheckSql(
             "{$optionTable2}.value_id IS NULL",
-            "{$optionTable1}.value",
-            "{$optionTable2}.value"
+            "{$optionTable1}.option_id",
+            "{$optionTable2}.option_id"
         );
 
         $collection->getSelect()->joinLeft(


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13861
Drop down values are not showing in catalog product grid magento2 #13006

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Now in catalog product grid **after applying filter and sorting** on drop-down/select attribute, values will be displayed. Testing done for **Manufacturer** product attribute.

### Fixed Issues
1. magento/magento2#13006: Drop down values are not showing in catalog product grid magento2

### Manual testing scenarios
1. Navigate to admin catalog product grid
2. Apply sorting on manufacturer/brand column
3. Apply filter on manufacturer/brand using filter
4. Now the manufacturer column will show values
5. If above is not working properly, please test once in private window

### Expected result
Manufacturer column showing values
![expected](https://user-images.githubusercontent.com/23444023/36724532-79a24592-1bd9-11e8-8a3c-3457a0a6c30c.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
