### PR TITLE
[Backport] Display a more meaningful error message in case of misspelt module name unit test.

### DIFF
--- a/lib/internal/Magento/Framework/Module/Test/Unit/DirTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/DirTest.php
@@ -66,4 +66,17 @@ class DirTest extends \PHPUnit_Framework_TestCase
 
         $this->_model->getDir('Test_Module', 'unknown');
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Module 'Test Module' is not correctly registered.
+     */
+    public function testGetDirModuleIncorrectlyRegistered()
+    {
+        $this->moduleRegistryMock->expects($this->once())
+            ->method('getPath')
+            ->with($this->identicalTo(ComponentRegistrar::MODULE), $this->identicalTo('Test Module'))
+            ->willReturn(null);
+        $this->_model->getDir('Test Module');
+    }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13740
<!--- Provide a general summary of the Pull Request in the Title above -->
Unit test, which covers code changes made in https://github.com/magento/magento2/pull/12843
2.3-develop: https://github.com/magento/magento2/pull/13731
### Description
<!--- Provide a description of the changes proposed in the pull request -->
Test for /Magento/Framework/Module/Dir::getDir(). Case: wrong registered module.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
None.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
None.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
