### PR TITLE
[Backport] Fix app/code/Magento/Backend/Block/Media/Uploader.php getConfigJson() method

### DIFF
--- a/app/code/Magento/Backend/Block/Media/Uploader.php
+++ b/app/code/Magento/Backend/Block/Media/Uploader.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Backend\Block\Media;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Serialize\Serializer\Json;
+
 /**
  * Adminhtml media library uploader
  * @api
@@ -28,16 +31,24 @@ class Uploader extends \Magento\Backend\Block\Widget
     protected $_fileSizeService;
 
     /**
+     * @var Json
+     */
+    private $jsonEncoder;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\File\Size $fileSize
      * @param array $data
+     * @param Json $jsonEncoder
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\File\Size $fileSize,
-        array $data = []
+        array $data = [],
+        Json $jsonEncoder = null
     ) {
         $this->_fileSizeService = $fileSize;
+        $this->jsonEncoder = $jsonEncoder ?: ObjectManager::getInstance()->get(Json::class);
         parent::__construct($context, $data);
     }
 
@@ -107,7 +118,7 @@ class Uploader extends \Magento\Backend\Block\Widget
      */
     public function getConfigJson()
     {
-        return $this->_coreData->jsonEncode($this->getConfig()->getData());
+        return $this->jsonEncoder->encode($this->getConfig()->getData());
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11665

This method is using an undefined class property _coreData, that method cannot work, only crash if called, since it will try to call jsonEncode() method from a null property (even if defined dynamically).

### Description
Adapted to use \Magento\Framework\Json\EncoderInterface instead of (probably) legacy code, the way it's done at \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links::getConfigJson.

### Fixed Issues (if relevant)
It may be related with some open issue, but after searching, I didn't find one that may be caused by this method.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
