### PR TITLE
[Backport] Fix negative basket total due to shipping tax residue

### DIFF
--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
@@ -142,12 +142,23 @@ class Tax extends CommonTaxCollector
         $total->setBaseTotalAmount('subtotal', 0);
         $total->setTotalAmount('tax', 0);
         $total->setBaseTotalAmount('tax', 0);
+        $total->setTotalAmount('shipping', 0);
+        $total->setBaseTotalAmount('shipping', 0);
         $total->setTotalAmount('discount_tax_compensation', 0);
         $total->setBaseTotalAmount('discount_tax_compensation', 0);
         $total->setTotalAmount('shipping_discount_tax_compensation', 0);
         $total->setBaseTotalAmount('shipping_discount_tax_compensation', 0);
         $total->setSubtotalInclTax(0);
         $total->setBaseSubtotalInclTax(0);
+        $total->setShippingInclTax(0);
+        $total->setBaseShippingInclTax(0);
+        $total->setShippingTaxAmount(0);
+        $total->setBaseShippingTaxAmount(0);
+        $total->setShippingAmountForDiscount(0);
+        $total->setBaseShippingAmountForDiscount(0);
+        $total->setBaseShippingAmountForDiscount(0);
+        $total->setTotalAmount('extra_tax', 0);
+        $total->setBaseTotalAmount('extra_tax', 0);
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13185
### Description
A negative basket total is produced when:

- tax was applied;
- shipping was calculated and saved; and
- basket is emptied

This PR fixes the issue by completing an earlier return on tax total collector that failed to unset taxed shipping total information.

![negative-price](https://user-images.githubusercontent.com/945819/35267742-2b4e6fcc-001f-11e8-9847-a79665c8bf87.png)

### Fixed Issues (if relevant)

No directly related issue found

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Set up tax to 20%

1. Set up tax settings like below

    ![tax-settings](https://user-images.githubusercontent.com/945819/35267734-234db940-001f-11e8-804c-19826540f650.png)


1. Sign in on front-end

1. Add a default shipping address that will result in 20% tax rate

1. Add a product to basket

1. Go to checkout page

1. Select default shipping address and select shipping method

1. Step to billing (At this point, shipping tax should be calculated and show up on the breakdown)

1. Go to basket page

1. Empty the basket by removing the only product from it

#### Expected result

Basket total should become 0

#### Actual result

Basket total become negative (e.g., -1)

```/customer/section/load/?sections=cart```

**DEMO**

http://recordit.co/vERAS5KL1x


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
