### PR TITLE
[Backport] Fixed widget template rendering issue while rewriting widget block

### DIFF
--- a/app/code/Magento/CatalogWidget/etc/widget.xml
+++ b/app/code/Magento/CatalogWidget/etc/widget.xml
@@ -33,7 +33,7 @@
             <parameter name="template" xsi:type="select" required="true" visible="true">
                 <label translate="true">Template</label>
                 <options>
-                    <option name="default" value="product/widget/content/grid.phtml" selected="true">
+                    <option name="default" value="Magento_CatalogWidget::product/widget/content/grid.phtml" selected="true">
                         <label translate="true">Products Grid Template</label>
                     </option>
                 </options>

--- a/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
@@ -174,7 +174,7 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
             'show_pager' => '1',
             'products_per_page' => '5',
             'products_count' => '10',
-            'template' => 'product/widget/content/grid.phtml',
+            'template' => 'Magento_CatalogWidget::product/widget/content/grid.phtml',
             'conditions' => $conditions
         ];
 
@@ -187,7 +187,7 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
                 ['1', false, '1'],
                 ['5', false, '5'],
                 ['10', false, '10'],
-                ['product/widget/content/grid.phtml', false, 'product/widget/content/grid.phtml'],
+                ['Magento_CatalogWidget::product/widget/content/grid.phtml', false, 'Magento_CatalogWidget::product/widget/content/grid.phtml'],
                 ['encoded-conditions-string', false, 'encoded-conditions-string'],
             ]);
 
@@ -225,7 +225,7 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
             'show_pager' => '1',
             'products_per_page' => '5',
             'products_count' => '0',
-            'template' => 'product/widget/content/grid.phtml',
+            'template' => 'Magento_CatalogWidget::product/widget/content/grid.phtml',
             'conditions' => $conditions
         ];
 

--- a/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
@@ -187,7 +187,10 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
                 ['1', false, '1'],
                 ['5', false, '5'],
                 ['10', false, '10'],
-                ['Magento_CatalogWidget::product/widget/content/grid.phtml', false, 'Magento_CatalogWidget::product/widget/content/grid.phtml'],
+                ['Magento_CatalogWidget::product/widget/content/grid.phtml',
+                 false,
+                 'Magento_CatalogWidget::product/widget/content/grid.phtml'
+                ],
                 ['encoded-conditions-string', false, 'encoded-conditions-string'],
             ]);
 


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16530

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed template notation for **Magento_CatalogWidget** module.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Magento version **2.2.x**
1. magento/magento2#16529: Rewriting product listing widget block breaks its template rendering.2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.-->
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
