### PR TITLE
Disable autocomplete for captcha inputs

### DIFF
--- a/app/code/Magento/Captcha/view/frontend/templates/default.phtml
+++ b/app/code/Magento/Captcha/view/frontend/templates/default.phtml
@@ -14,7 +14,7 @@ $captcha = $block->getCaptchaModel();
 <div class="field captcha required" role="<?= $block->escapeHtmlAttr($block->getFormId()) ?>">
     <label for="captcha_<?= $block->escapeHtmlAttr($block->getFormId()) ?>" class="label"><span><?= $block->escapeHtml(__('Please type the letters and numbers below')) ?></span></label>
     <div class="control captcha">
-        <input name="<?= $block->escapeHtmlAttr(\Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE) ?>[<?= $block->escapeHtmlAttr($block->getFormId()) ?>]" type="text" class="input-text required-entry" data-validate="{required:true}" id="captcha_<?= $block->escapeHtmlAttr($block->getFormId()) ?>" />
+        <input name="<?= $block->escapeHtmlAttr(\Magento\Captcha\Helper\Data::INPUT_NAME_FIELD_VALUE) ?>[<?= $block->escapeHtmlAttr($block->getFormId()) ?>]" type="text" class="input-text required-entry" data-validate="{required:true}" id="captcha_<?= $block->escapeHtmlAttr($block->getFormId()) ?>" autocomplete="off"/>
         <div class="nested">
             <div class="field captcha no-label"
                  data-captcha="<?= $block->escapeHtmlAttr($block->getFormId()) ?>"

--- a/app/code/Magento/Captcha/view/frontend/web/template/checkout/captcha.html
+++ b/app/code/Magento/Captcha/view/frontend/web/template/checkout/captcha.html
@@ -8,7 +8,7 @@
 <div class="field captcha required" data-bind="blockLoader: getIsLoading()">
     <label data-bind="attr: {for: 'captcha_' + formId}" class="label"><span data-bind="i18n: 'Please type the letters and numbers below'"></span></label>
     <div class="control captcha">
-        <input name="captcha_string" type="text" class="input-text required-entry" data-bind="value: captchaValue(), attr: {id: 'captcha_' + formId, 'data-scope': dataScope}" />
+        <input name="captcha_string" type="text" class="input-text required-entry" data-bind="value: captchaValue(), attr: {id: 'captcha_' + formId, 'data-scope': dataScope}" autocomplete="off"/>
         <input name="captcha_form_id" type="hidden" data-bind="value: formId,  attr: {'data-scope': dataScope}" />
         <div class="nested">
             <div class="field captcha no-label">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This PR removes captcha input autocomplete 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to login page 
2. Try to login with incorrect login/password until you get captha 
3. Click on captcha input field

### Before 
![screenshot_179](https://user-images.githubusercontent.com/21016905/43192151-7a23a5ba-9005-11e8-9097-e065d4770f57.png)

### After
![screenshot_180](https://user-images.githubusercontent.com/21016905/43192159-7d497f9e-9005-11e8-98ec-2733d0d27c5e.png)
