### PR TITLE
[Forwardport] [BUGFIX] Added row_id to the flat action indexer so the value isn't s…

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Indexer.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Indexer.php
@@ -175,6 +175,7 @@ class Indexer
 
         if (!empty($updateData)) {
             $updateData += ['entity_id' => $productId];
+            $updateData += ['row_id' => $productId];
             $updateFields = [];
             foreach ($updateData as $key => $value) {
                 $updateFields[$key] = $key;

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -61,12 +61,13 @@ class RowTest extends \Magento\TestFramework\Indexer\TestCase
             $this->_processor->getIndexer()->isScheduled(),
             'Indexer is in scheduled mode when turned to update on save mode'
         );
-        $this->_processor->reindexAll();
 
         $this->_product->load(1);
         $this->_product->setName('Updated Product');
         $this->_product->save();
 
+        $this->_processor->reindexAll();
+        
         $category = $categoryFactory->create()->load(9);
         $layer = $listProduct->getLayer();
         $layer->setCurrentCategory($category);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15010

**reopen https://github.com/magento/magento2/pull/13446**

…et to 0 for new products when using index on save

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
If you use the `\Magento\Framework\Api\SearchCriteriaBuilder` and the flat product row_id is set to 0. The product isn't shown in the getList of the ProductRepository

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
**Issue was in the Commerce (EE) version but can be solved in the Open Source Codebase**
1. Enable Product Flat Catalog `Stores > Settings > Configuration > Catalog > Catalog > Storefront > Use Flat Catalog Product`
2. Run the index manually through the command line `php bin/magento indexer:reindex catalog_product_flat`
3. Set the Indexes to On Save `System > Tools > Index Management > Select all and select the action Update on Save`
4. Create a New Product with SKU `test`
5. Take a look in the database in the catalog_product_flat_1 tabel and search for the product with SKU `test`
6. The row_id will be set to **0**
7. Apply Changes
8. Save the Product
9. Take a look at the database in the catalog_product_flat_1 tabel and search for the product with SKU `test`
10. The row_id should now be equal to the entity_id

Besides looking in the database you could create a simpel collection by using the SearchCritieria and the ProductRepository

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
