### PR TITLE
Check for new session messages after cart totals have been processed.

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/cart/totals-processor/default.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/cart/totals-processor/default.js
@@ -61,6 +61,8 @@ define([
         }).always(function () {
             // Stop loader for totals block
             totalsService.isLoading(false);
+            // Check for new session messages
+            customerData.reload('messages');
         });
     };
 

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
@@ -72,6 +72,7 @@ define([
             'Magento_Customer/js/customer-data': {
                 get: function () {
                 },
+                reload: jasmine.createSpy(),
                 set: jasmine.createSpy()
             }
         },
@@ -124,6 +125,7 @@ define([
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(0)[0]).toBe(true);
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(1)[0]).toBe(false);
             expect(mocks['mage/storage'].post).toHaveBeenCalled();
+            expect(mocks['Magento_Customer/js/customer-data'].reload).toHaveBeenCalledWith('messages');
             expect(mocks['Magento_Checkout/js/model/cart/cache'].get).not.toHaveBeenCalled();
             expect(mocks['Magento_Checkout/js/model/cart/cache'].set).toHaveBeenCalledWith('cart-data', data);
         });
@@ -143,6 +145,7 @@ define([
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(0)[0]).toBe(true);
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(1)[0]).toBe(false);
             expect(mocks['mage/storage'].post).toHaveBeenCalled();
+            expect(mocks['Magento_Customer/js/customer-data'].reload).toHaveBeenCalledWith('messages');
             expect(mocks['Magento_Checkout/js/model/cart/cache'].get).not.toHaveBeenCalled();
             expect(mocks['Magento_Checkout/js/model/error-processor'].process).toHaveBeenCalledWith('Error Message');
         });


### PR DESCRIPTION
Useful for third party modules that may perform operations during totals calculation (e.g. third party tax services)

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This change asks customerData to reload its messages after the cart's default totals processor has completed (success or failure).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

Resolves BUNDLE-1495

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
