### PR TITLE
Fixed created_at and updated_at fields issue in ui_bookmark table #17120

### DIFF
--- a/app/code/Magento/Ui/Setup/InstallSchema.php
+++ b/app/code/Magento/Ui/Setup/InstallSchema.php
@@ -64,10 +64,34 @@ class InstallSchema implements InstallSchemaInterface
                 ['nullable' => false],
                 'Mark current bookmark per user and identifier'
             )
-            ->addColumn('title', Table::TYPE_TEXT, 255, ['nullable' => true], 'Bookmark title')
-            ->addColumn('config', Table::TYPE_TEXT, Table::MAX_TEXT_SIZE, ['nullable' => true], 'Bookmark config')
-            ->addColumn('created_at', Table::TYPE_DATETIME, null, ['nullable' => false], 'Bookmark created at')
-            ->addColumn('updated_at', Table::TYPE_DATETIME, null, ['nullable' => false], 'Bookmark updated at')
+            ->addColumn(
+                'title',
+                Table::TYPE_TEXT,
+                255,
+                ['nullable' => true],
+                'Bookmark title'
+            )
+            ->addColumn(
+                'config',
+                Table::TYPE_TEXT,
+                Table::MAX_TEXT_SIZE,
+                ['nullable' => true],
+                'Bookmark config'
+            )
+            ->addColumn(
+                'created_at',
+                Table::TYPE_TIMESTAMP,
+                null,
+                ['nullable' => false, 'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT],
+                'Bookmark created at'
+            )
+            ->addColumn(
+                'updated_at',
+                Table::TYPE_TIMESTAMP,
+                null,
+                ['nullable' => false, 'default' => Table::TIMESTAMP_INIT_UPDATE],
+                'Bookmark updated at'
+            )
             ->addIndex(
                 $setup->getIdxName(
                     'ui_bookmark',


### PR DESCRIPTION
Fixed created_at and updated_at fields issue in ui_bookmark table.

### Description
I've fixed Ui Bookmark field created_at and updated_at fields always show '0000-00-00 00:00:00' issue.

### Fixed Issues (if relevant)
1. magento/magento2#17120: Ui Bookmark field created_at and updated_at fields always shows '0000-00-00 00:00:00'

### Manual testing scenarios
1. Delete entry from `setup_module` table: <code>DELETE FROM `setup_module` WHERE `setup_module`.`module` = 'Magento_Ui'</code>
2. Drop the `ui_bookmark` table: <code>DROP TABLE ui_bookmark</code>
3. Run `php bin/magento setup:upgrade` command.
4. Visit any Ui listing grid (Products listing, CMS page listing, Customer listing etc...)
5. Now, check created_at and updated_at fields in `ui_bookmark` table.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)