### PR TITLE
[Forwardport]Delete all unused imports of lib/internal/Magento

### DIFF
--- a/lib/internal/Magento/Framework/Api/CombinedFilterGroup.php
+++ b/lib/internal/Magento/Framework/Api/CombinedFilterGroup.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Api;
 
-use Magento\Framework\Api\AbstractSimpleObject;
-use Magento\Framework\DB\Select;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Phrase;
 

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -10,9 +10,7 @@
 namespace Magento\Framework\App\Cache\Frontend;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\DriverInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/lib/internal/Magento/Framework/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Archive/Tar.php
@@ -12,7 +12,6 @@
 namespace Magento\Framework\Archive;
 
 use Magento\Framework\Archive\Helper\File;
-use Magento\Framework\Filesystem\DriverInterface;
 
 class Tar extends \Magento\Framework\Archive\AbstractArchive implements \Magento\Framework\Archive\ArchiveInterface
 {

--- a/lib/internal/Magento/Framework/Composer/Test/Unit/ComposerInformationTest.php
+++ b/lib/internal/Magento/Framework/Composer/Test/Unit/ComposerInformationTest.php
@@ -7,7 +7,6 @@ namespace Magento\Framework\Composer\Test\Unit;
 
 use Composer\Composer;
 use Composer\Package\Locker;
-use Magento\Framework\Composer\ComposerInformation;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 class ComposerInformationTest extends \PHPUnit\Framework\TestCase

--- a/lib/internal/Magento/Framework/Console/Test/Unit/QuestionPerformer/YesNoTest.php
+++ b/lib/internal/Magento/Framework/Console/Test/Unit/QuestionPerformer/YesNoTest.php
@@ -11,8 +11,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\QuestionFactory;
 use Symfony\Component\Console\Question\Question;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Phrase;
 
 class YesNoTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/DB/AbstractMapper.php
+++ b/lib/internal/Magento/Framework/DB/AbstractMapper.php
@@ -10,7 +10,6 @@ use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
 use Magento\Framework\Data\ObjectFactory;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Psr\Log\LoggerInterface as Logger;
-use Magento\Framework\DataObject;
 
 /**
  * Class AbstractMapper

--- a/lib/internal/Magento/Framework/DB/Select/GroupRenderer.php
+++ b/lib/internal/Magento/Framework/DB/Select/GroupRenderer.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\DB\Select;
 
 use Magento\Framework\DB\Select;
-use Magento\Framework\DB\Platform;
 use Magento\Framework\DB\Platform\Quote;
 
 /**

--- a/lib/internal/Magento/Framework/DB/SelectFactory.php
+++ b/lib/internal/Magento/Framework/DB/SelectFactory.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\DB;
 
-use Magento\Framework\DB\Select;
 use Magento\Framework\DB\Select\SelectRenderer;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 

--- a/lib/internal/Magento/Framework/DB/TemporaryTableService.php
+++ b/lib/internal/Magento/Framework/DB/TemporaryTableService.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\DB;
 
 use Magento\Framework\DB\Adapter\AdapterInterface;
-use Magento\Framework\DB\Select;
 
 /**
  * Class TemporaryTableService creates a temporary table in mysql from a Magento\Framework\DB\Select.

--- a/lib/internal/Magento/Framework/DB/Test/Unit/SelectTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/SelectTest.php
@@ -7,8 +7,6 @@ namespace Magento\Framework\DB\Test\Unit;
 
 use \Magento\Framework\DB\Select;
 
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-
 /**
  * Class SelectTest
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/lib/internal/Magento/Framework/Data/Form/Element/Date.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Date.php
@@ -12,7 +12,6 @@
 namespace Magento\Framework\Data\Form\Element;
 
 use Magento\Framework\Escaper;
-use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 class Date extends AbstractElement

--- a/lib/internal/Magento/Framework/Data/Form/FilterFactory.php
+++ b/lib/internal/Magento/Framework/Data/Form/FilterFactory.php
@@ -7,7 +7,6 @@ namespace Magento\Framework\Data\Form;
 
 use Magento\Framework\Data\Form\Filter\FilterInterface;
 use Magento\Framework\ObjectManagerInterface;
-use Magento\Framework\Phrase;
 
 class FilterFactory
 {

--- a/lib/internal/Magento/Framework/DataObject/Test/Unit/Copy/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/DataObject/Test/Unit/Copy/Config/SchemaLocatorTest.php
@@ -6,8 +6,6 @@
 
 namespace Magento\Framework\DataObject\Test\Unit\Copy\Config;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-
 class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
+++ b/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
@@ -7,7 +7,6 @@ namespace Magento\Framework\Encryption\Test\Unit;
 
 use Magento\Framework\Encryption\Encryptor;
 use Magento\Framework\Encryption\Crypt;
-use Magento\Framework\App\DeploymentConfig;
 
 class EncryptorTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/EntityManager/AbstractModelHydrator.php
+++ b/lib/internal/Magento/Framework/EntityManager/AbstractModelHydrator.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\EntityManager;
 
-use Magento\Framework\Model\AbstractModel;
-
 /**
  * Class AbstractModelHydrator
  */

--- a/lib/internal/Magento/Framework/EntityManager/Hydrator.php
+++ b/lib/internal/Magento/Framework/EntityManager/Hydrator.php
@@ -5,10 +5,8 @@
  */
 namespace Magento\Framework\EntityManager;
 
-use Magento\Framework\EntityManager\MapperPool;
 use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Framework\Api\DataObjectHelper;
-use Magento\Framework\EntityManager\TypeResolver;
 
 /**
  * Class Hydrator

--- a/lib/internal/Magento/Framework/EntityManager/Observer/BeforeEntityDelete.php
+++ b/lib/internal/Magento/Framework/EntityManager/Observer/BeforeEntityDelete.php
@@ -9,7 +9,6 @@ namespace Magento\Framework\EntityManager\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 /**
  * Class BeforeEntityDelete

--- a/lib/internal/Magento/Framework/EntityManager/Operation/ExtensionPool.php
+++ b/lib/internal/Magento/Framework/EntityManager/Operation/ExtensionPool.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\EntityManager\Operation;
 
 use Magento\Framework\ObjectManagerInterface;
-use Magento\Framework\EntityManager\Operation\ExtensionInterface;
 
 /**
  * Class ExtensionPool

--- a/lib/internal/Magento/Framework/EntityManager/OperationPool.php
+++ b/lib/internal/Magento/Framework/EntityManager/OperationPool.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\EntityManager;
 
 use Magento\Framework\ObjectManagerInterface as ObjectManager;
-use Magento\Framework\EntityManager\OperationInterface;
 use Magento\Framework\EntityManager\Operation\CheckIfExists;
 use Magento\Framework\EntityManager\Operation\Read;
 use Magento\Framework\EntityManager\Operation\Create;

--- a/lib/internal/Magento/Framework/Event/Test/Unit/ObserverTest.php
+++ b/lib/internal/Magento/Framework/Event/Test/Unit/ObserverTest.php
@@ -8,8 +8,6 @@ namespace Magento\Framework\Event\Test\Unit;
 
 use \Magento\Framework\Event\Observer;
 
-use Magento\Framework\Event;
-
 /**
  * Class ConfigTest
  *

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\File;
 
-use Magento\Framework\Filesystem\DriverInterface;
-
 /**
  * File upload class
  *

--- a/lib/internal/Magento/Framework/Filesystem/Io/Ftp.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/Ftp.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\Filesystem\Io;
 
-use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Exception\LocalizedException;
 

--- a/lib/internal/Magento/Framework/Filesystem/Io/IoInterface.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/IoInterface.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Filesystem\Io;
 
-use Magento\Framework\Filesystem\DriverInterface;
-
 /**
  * Input/output client interface
  */

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/File/ReadFactoryTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/File/ReadFactoryTest.php
@@ -7,8 +7,6 @@ namespace Magento\Framework\Filesystem\Test\Unit\File;
 
 use \Magento\Framework\Filesystem\File\ReadFactory;
 
-use Magento\Framework\Filesystem\DriverPool;
-
 /**
  * Class ReadFactoryTest
  */

--- a/lib/internal/Magento/Framework/Filter/DataObject/Grid.php
+++ b/lib/internal/Magento/Framework/Filter/DataObject/Grid.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Filter\DataObject;
 
-use Magento\Framework\DataObject;
-
 class Grid extends \Magento\Framework\Filter\DataObject
 {
     /**

--- a/lib/internal/Magento/Framework/Indexer/SaveHandler/IndexerHandler.php
+++ b/lib/internal/Magento/Framework/Indexer/SaveHandler/IndexerHandler.php
@@ -12,7 +12,6 @@ use Magento\Framework\Search\Request\IndexScopeResolverInterface;
 use Magento\Framework\Indexer\IndexStructureInterface;
 use Magento\Framework\Indexer\ScopeResolver\FlatScopeResolver;
 use Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver;
-use Magento\Framework\Indexer\SaveHandler\Batch;
 
 class IndexerHandler implements IndexerInterface
 {

--- a/lib/internal/Magento/Framework/Indexer/SaveHandlerFactory.php
+++ b/lib/internal/Magento/Framework/Indexer/SaveHandlerFactory.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\Indexer;
 
-use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Indexer\SaveHandler\IndexerInterface as SaveHandlerInterface;
 

--- a/lib/internal/Magento/Framework/Indexer/StructureFactory.php
+++ b/lib/internal/Magento/Framework/Indexer/StructureFactory.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Indexer;
 
-use Magento\Framework\Indexer\IndexStructureInterface;
-
 class StructureFactory
 {
     /**

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/IndexStructureTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/IndexStructureTest.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\Indexer\Test\Unit;
 
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Ddl\Table;
 use \Magento\Framework\TestFramework\Unit\Helper\ObjectManager;

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Locale\Test\Unit;
 
 use Magento\Framework\Locale\Currency;
-use Magento\Framework\Locale\CurrencyInterface;
 
 class CurrencyTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Message/Test/Unit/AbstractMessageTest.php
+++ b/lib/internal/Magento/Framework/Message/Test/Unit/AbstractMessageTest.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Message\Test\Unit;
 
-use Magento\Framework\Message\MessageInterface;
-
 /**
  * \Magento\Framework\Message\AbstractMessage test case
  */

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/DeleteEntityRow.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/DeleteEntityRow.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\Model\ResourceModel\Db;
 
 use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Framework\EntityManager\EntityMetadata;
 
 class DeleteEntityRow
 {

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Relation/ActionPool.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Relation/ActionPool.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Model\ResourceModel\Db\Relation;
 
 use Magento\Framework\ObjectManagerInterface as ObjectManager;
-use Magento\Framework\Model\ResourceModel\Db\ProcessEntityRelationInterface;
 
 /**
  * Class ActionPool

--- a/lib/internal/Magento/Framework/Model/Test/Unit/AbstractExtensibleModelTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/AbstractExtensibleModelTest.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Model\Test\Unit;
 
 use Magento\Framework\Api\AttributeValue;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Model\Test\Unit\ResourceModel\Db\Collection;
 
 use Magento\Framework\DB\Select;
-use Magento\Framework\DataObject as MagentoObject;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\ObjectManagerInterface;
 

--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -9,7 +9,6 @@ namespace Magento\Framework\Module;
 
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
-use Magento\Framework\Filesystem;
 
 class Dir
 {

--- a/lib/internal/Magento/Framework/Module/Test/Unit/Dir/ReaderTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/Dir/ReaderTest.php
@@ -11,7 +11,6 @@
 namespace Magento\Framework\Module\Test\Unit\Dir;
 
 use Magento\Framework\Config\FileIteratorFactory;
-use Magento\Framework\Filesystem;
 use Magento\Framework\Module\Dir;
 
 class ReaderTest extends \PHPUnit\Framework\TestCase

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ManagerTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ManagerTest.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Module\Test\Unit;
 
-use Magento\Framework\Module\Plugin\DbStatusValidator;
-
 class ManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/Mview/Config/Converter.php
+++ b/lib/internal/Magento/Framework/Mview/Config/Converter.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\Mview\Config;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Mview\View\SubscriptionInterface;
 
 class Converter implements \Magento\Framework\Config\ConverterInterface

--- a/lib/internal/Magento/Framework/Mview/Config/SchemaLocator.php
+++ b/lib/internal/Magento/Framework/Mview/Config/SchemaLocator.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Mview\Config;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-
 class SchemaLocator implements \Magento\Framework\Config\SchemaLocatorInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/Config/ReaderTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/Config/ReaderTest.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\Mview\Test\Unit\Config;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-
 class ReaderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\Mview\View;
 
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Phrase;
 
 class Changelog implements ChangelogInterface

--- a/lib/internal/Magento/Framework/ObjectManager/DefinitionFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/DefinitionFactory.php
@@ -6,10 +6,7 @@
 namespace Magento\Framework\ObjectManager;
 
 use Magento\Framework\Filesystem\DriverInterface;
-use Magento\Framework\Interception\Code\Generator as InterceptionGenerator;
 use Magento\Framework\ObjectManager\Definition\Runtime;
-use Magento\Framework\ObjectManager\Profiler\Code\Generator as ProfilerGenerator;
-use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\Code\Generator\Autoloader;
 
 /**

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/RepositoryTest.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\ObjectManager\Test\Unit\Code\Generator;
 
 use Magento\Framework\Api\Test\Unit\Code\Generator\EntityChildTestAbstract;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
  * Class RepositoryTest

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Helper/CompositeTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Helper/CompositeTest.php
@@ -9,7 +9,6 @@ namespace Magento\Framework\ObjectManager\Test\Unit\Helper;
 use \Magento\Framework\ObjectManager\Helper\Composite;
 
 use Magento\Framework\ObjectManager\Helper\Composite as CompositeHelper;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 class CompositeTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Reflection/CustomAttributesProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/CustomAttributesProcessor.php
@@ -6,11 +6,8 @@
 
 namespace Magento\Framework\Reflection;
 
-use Magento\Framework\Phrase;
 use Magento\Framework\Api\AttributeInterface;
 use Magento\Framework\Api\AttributeValue;
-use Magento\Framework\Api\SimpleDataObjectConverter;
-use Zend\Code\Reflection\MethodReflection;
 use Magento\Framework\Api\CustomAttributesDataInterface;
 use Magento\Framework\Api\AttributeTypeResolverInterface;
 

--- a/lib/internal/Magento/Framework/Reflection/ExtensionAttributesProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/ExtensionAttributesProcessor.php
@@ -11,7 +11,6 @@ use Magento\Framework\Api\ExtensionAttribute\Config\Converter;
 use Magento\Framework\AuthorizationInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Api\ExtensionAttributesInterface;
-use Magento\Framework\Reflection\MethodsMap;
 use Zend\Code\Reflection\MethodReflection;
 
 /**

--- a/lib/internal/Magento/Framework/Reflection/FieldNamer.php
+++ b/lib/internal/Magento/Framework/Reflection/FieldNamer.php
@@ -6,12 +6,7 @@
 
 namespace Magento\Framework\Reflection;
 
-use Magento\Framework\Phrase;
-use Magento\Framework\Api\AttributeValue;
-use Magento\Framework\Api\CustomAttributesDataInterface;
 use Magento\Framework\Api\SimpleDataObjectConverter;
-use Zend\Code\Reflection\ClassReflection;
-use Zend\Code\Reflection\MethodReflection;
 
 /**
  * Determines the name to use for fields in a data output array given method metadata.

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/NameFinderTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/NameFinderTest.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Reflection\Test\Unit;
 
 use Zend\Code\Reflection\ClassReflection;
-use Magento\Framework\Exception\SerializationException;
 
 /**
  * NameFinder Unit Test

--- a/lib/internal/Magento/Framework/Search/Adapter/Mysql/Aggregation/Builder/Term.php
+++ b/lib/internal/Magento/Framework/Search/Adapter/Mysql/Aggregation/Builder/Term.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\Search\Adapter\Mysql\Aggregation\Builder;
 
 use Magento\Framework\DB\Ddl\Table;
-use Magento\Framework\DB\Select;
 use Magento\Framework\Search\Adapter\Mysql\Aggregation\DataProviderInterface;
 use Magento\Framework\Search\Request\BucketInterface as RequestBucketInterface;
 

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/AdapterTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/AdapterTest.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\Search\Test\Unit\Adapter\Mysql;
 
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Search\Request\BucketInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 

--- a/lib/internal/Magento/Framework/Serialize/Test/Unit/Serializer/SerializeTest.php
+++ b/lib/internal/Magento/Framework/Serialize/Test/Unit/Serializer/SerializeTest.php
@@ -7,7 +7,6 @@ namespace Magento\Framework\Serialize\Test\Unit\Serializer;
 
 use Magento\Framework\Serialize\Serializer\Serialize;
 use Magento\Framework\Serialize\Signer;
-use Psr\Log\LoggerInterface;
 use Magento\Framework\Serialize\InvalidSignatureException;
 
 class SerializeTest extends \PHPUnit\Framework\TestCase

--- a/lib/internal/Magento/Framework/Session/SaveHandler/DbTable.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/DbTable.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\Session\SaveHandler;
 
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\SessionException;
 use Magento\Framework\Phrase;
 

--- a/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandler/Redis/LoggerTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandler/Redis/LoggerTest.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\Session\Test\Unit\SaveHandler\Redis;
 
 use Cm\RedisSession\Handler\LoggerInterface;
-use Magento\Framework\Session\SaveHandler\Redis\Logger;
 
 class LoggerTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/_files/setcookie_mock.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/_files/setcookie_mock.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Framework\Stdlib\Cookie;
 
-use \Magento\Framework\Stdlib\Cookie\PhpCookieManager;
 use \Magento\Framework\Stdlib\Test\Unit\Cookie\PhpCookieManagerTest;
 
 /**

--- a/lib/internal/Magento/Framework/System/Dirs.php
+++ b/lib/internal/Magento/Framework/System/Dirs.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Framework\System;
 
-use Magento\Framework\Filesystem\DriverInterface;
-
 class Dirs
 {
     /**

--- a/lib/internal/Magento/Framework/System/Ftp.php
+++ b/lib/internal/Magento/Framework/System/Ftp.php
@@ -6,8 +6,6 @@
 
 namespace Magento\Framework\System;
 
-use Magento\Framework\Filesystem\DriverInterface;
-
 /**
  * Class to work with remote FTP server
  */

--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\Asset\PreProcessor;
 
-use Magento\Framework\Filesystem;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\View\Asset\File\FallbackContext;
 use Magento\Framework\View\Asset\LockerProcessInterface;

--- a/lib/internal/Magento/Framework/View/Layout.php
+++ b/lib/internal/Magento/Framework/View/Layout.php
@@ -13,7 +13,6 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Layout\Element;
-use Magento\Framework\View\Layout\ScheduledStructure;
 use Psr\Log\LoggerInterface as Logger;
 
 /**

--- a/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
@@ -9,7 +9,6 @@ use Magento\Framework\Api\AbstractExtensibleObject;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Framework\Reflection\MethodsMap;
-use Magento\Framework\Webapi\ServicePayloadConverterInterface;
 
 /**
  * Data object converter

--- a/lib/internal/Magento/Framework/Xml/Security.php
+++ b/lib/internal/Magento/Framework/Xml/Security.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\Xml;
 
 use DOMDocument;
-use Magento\Framework\Phrase;
 
 /**
  * Class Security


### PR DESCRIPTION
### Description
Deleted Manually all imports not used inside lib/internal/Magento that not needed
Original PR: https://github.com/magento/magento2/pull/16946

PS. Some imports are already fixed so this PR contain fewer changes then the original one.