### PR TITLE
[Forwardport] Replacing Usage of Deprecated Methods for Message Manager

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
@@ -44,12 +44,12 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Category
                 $this->_eventManager->dispatch('catalog_controller_category_delete', ['category' => $category]);
                 $this->_auth->getAuthStorage()->setDeletedPath($category->getPath());
                 $this->categoryRepository->delete($category);
-                $this->messageManager->addSuccess(__('You deleted the category.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the category.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while trying to delete the category.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while trying to delete the category.'));
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
@@ -54,7 +54,7 @@ abstract class Attribute extends Action
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
         }
 
         return !$error;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -192,7 +192,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_eventManager->dispatch('catalog_product_to_website_change', ['products' => $productIds]);
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) were updated.', count($this->attributeHelper->getProductIds()))
             );
 
@@ -205,9 +205,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_productPriceIndexerProcessor->reindexList($this->attributeHelper->getProductIds());
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
@@ -68,7 +68,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attr
             $response->setError(true);
             $response->setMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
@@ -21,23 +21,23 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             // entity type check
             $model->load($id);
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('We can\'t delete the attribute.'));
+                $this->messageManager->addErrorMessage(__('We can\'t delete the attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             try {
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the product attribute.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the product attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath(
                     'catalog/*/edit',
                     ['attribute_id' => $this->getRequest()->getParam('attribute_id')]
                 );
             }
         }
-        $this->messageManager->addError(__('We can\'t find an attribute to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find an attribute to delete.'));
         return $resultRedirect->setPath('catalog/*/');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
@@ -25,14 +25,14 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $model->load($id);
 
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This attribute no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This attribute no longer exists.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             // entity type check
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('This attribute cannot be edited.'));
+                $this->messageManager->addErrorMessage(__('This attribute cannot be edited.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -92,9 +92,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $attributeSet->setEntityTypeId($this->_entityTypeId)->load($setName, 'attribute_set_name');
             if ($attributeSet->getId()) {
                 $setName = $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($setName);
-                $this->messageManager->addError(
-                    __('A "%1" attribute set name already exists. Create a new name and try again.', $setName)
-                );
+                $this->messageManager->addErrorMessage(__('An attribute set named \'%1\' already exists.', $setName));
 
                 $layout = $this->layoutFactory->create();
                 $layout->initMessages();

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
@@ -43,11 +43,11 @@ class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
         $product = $this->productBuilder->build($this->getRequest());
         try {
             $newProduct = $this->productCopier->copy($product);
-            $this->messageManager->addSuccess(__('You duplicated the product.'));
+            $this->messageManager->addSuccessMessage(__('You duplicated the product.'));
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true, 'id' => $newProduct->getId()]);
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
@@ -52,12 +52,12 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product
         if (($productId && !$product->getEntityId())) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('This product doesn\'t exist.'));
+            $this->messageManager->addErrorMessage(__('This product doesn\'t exist.'));
             return $resultRedirect->setPath('catalog/*/');
         } elseif ($productId === 0) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('Invalid product id. Should be numeric value greater than 0'));
+            $this->messageManager->addErrorMessage(__('Invalid product id. Should be numeric value greater than 0'));
             return $resultRedirect->setPath('catalog/*/');
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
@@ -29,12 +29,12 @@ class Save extends \Magento\Backend\App\Action
         );
 
         if ($model->itemExists()) {
-            $this->messageManager->addError(__('A group with the same name already exists.'));
+            $this->messageManager->addErrorMessage(__('A group with the same name already exists.'));
         } else {
             try {
                 $model->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving this group.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving this group.'));
             }
         }
     }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -64,9 +64,12 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product
             $this->productRepository->delete($product);
             $productDeleted++;
         }
-        $this->messageManager->addSuccess(
-            __('A total of %1 record(s) have been deleted.', $productDeleted)
-        );
+
+        if ($productDeleted) {
+            $this->messageManager->addSuccessMessage(
+                __('A total of %1 record(s) have been deleted.', $productDeleted)
+            );
+        }
 
         return $this->resultFactory->create(ResultFactory::TYPE_REDIRECT)->setPath('catalog/*/index');
     }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
@@ -36,10 +36,10 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         $resultRedirect = $this->resultRedirectFactory->create();
         try {
             $this->attributeSetRepository->deleteById($setId);
-            $this->messageManager->addSuccess(__('The attribute set has been removed.'));
+            $this->messageManager->addSuccessMessage(__('The attribute set has been removed.'));
             $resultRedirect->setPath('catalog/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete this set right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete this set right now.'));
             $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -100,15 +100,15 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
                 $model->initFromSkeleton($this->getRequest()->getParam('skeleton_set'));
             }
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the attribute set.'));
+            $this->messageManager->addSuccessMessage(__('You saved the attribute set.'));
         } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong while saving the attribute set.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the attribute set.'));
             $hasError = true;
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
@@ -137,7 +137,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product
             $response->setError(true);
             $response->setMessages([$e->getMessage()]);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $layout = $this->layoutFactory->create();
             $layout->initMessages();
             $response->setError(true);

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
@@ -30,12 +30,12 @@ class Clear extends \Magento\Catalog\Controller\Product\Compare
 
         try {
             $items->clear();
-            $this->messageManager->addSuccess(__('You cleared the comparison list.'));
+            $this->messageManager->addSuccessMessage(__('You cleared the comparison list.'));
             $this->_objectManager->get(\Magento\Catalog\Helper\Product\Compare::class)->calculate();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong  clearing the comparison list.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong  clearing the comparison list.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
@@ -44,7 +44,7 @@ class Remove extends \Magento\Catalog\Controller\Product\Compare
                     $item->delete();
                     $productName = $this->_objectManager->get(\Magento\Framework\Escaper::class)
                         ->escapeHtml($product->getName());
-                    $this->messageManager->addSuccess(
+                    $this->messageManager->addSuccessMessage(
                         __('You removed product %1 from the comparison list.', $productName)
                     );
                     $this->_eventManager->dispatch(

--- a/app/code/Magento/Catalog/Controller/Product/View.php
+++ b/app/code/Magento/Catalog/Controller/Product/View.php
@@ -78,13 +78,16 @@ class View extends \Magento\Catalog\Controller\Product
 
         if ($this->getRequest()->isPost() && $this->getRequest()->getParam(self::PARAM_NAME_URL_ENCODED)) {
             $product = $this->_initProduct();
+            
             if (!$product) {
                 return $this->noProductRedirect();
             }
+            
             if ($specifyOptions) {
                 $notice = $product->getTypeInstance()->getSpecifyOptionMessage();
-                $this->messageManager->addNotice($notice);
+                $this->messageManager->addNoticeMessage($notice);
             }
+            
             if ($this->getRequest()->isAjax()) {
                 $this->getResponse()->representJson(
                     $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)->jsonEncode([

--- a/app/code/Magento/User/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth.php
@@ -22,12 +22,12 @@ abstract class Auth extends AbstractAction
     /**
      * User model factory
      *
-     * @var \Magento\User\Model\UserFactory
+     * @var UserFactory
      */
     protected $_userFactory;
     
     /**
-     * @var \Magento\Backend\Helper\Data
+     * @var Data
      */
     protected $_backendDataHelper;
 

--- a/app/code/Magento/User/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth.php
@@ -7,6 +7,7 @@
 namespace Magento\User\Controller\Adminhtml;
 
 use Magento\Framework\Encryption\Helper\Security;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * \Magento\User Auth controller
@@ -19,19 +20,28 @@ abstract class Auth extends \Magento\Backend\App\AbstractAction
      * @var \Magento\User\Model\UserFactory
      */
     protected $_userFactory;
+    
+    /**
+     * @var \Magento\Backend\Helper\Data
+     */
+    protected $_backendHelper;
 
     /**
      * Construct
      *
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\User\Model\UserFactory $userFactory
+     * @param \Magento\Backend\Helper\Data $backendHelper
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\User\Model\UserFactory $userFactory
+        \Magento\User\Model\UserFactory $userFactory,
+        \Magento\Backend\Helper\Data $backendHelper = null
     ) {
         parent::__construct($context);
         $this->_userFactory = $userFactory;
+        $this->_backendHelper = $backendHelper ?:
+                ObjectManager::getInstance()->get(\Magento\Backend\Helper\Data::class);
     }
 
     /**

--- a/app/code/Magento/User/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth.php
@@ -7,11 +7,9 @@
 namespace Magento\User\Controller\Adminhtml;
 
 use Magento\Framework\Encryption\Helper\Security;
-use Magento\Framework\App\ObjectManager;
 use Magento\Backend\App\AbstractAction;
 use Magento\Backend\App\Action\Context;
 use Magento\User\Model\UserFactory;
-use Magento\Backend\Helper\Data;
 use Magento\Framework\Exception\LocalizedException;
 
 /**
@@ -25,27 +23,19 @@ abstract class Auth extends AbstractAction
      * @var UserFactory
      */
     protected $_userFactory;
-    
-    /**
-     * @var Data
-     */
-    protected $_backendDataHelper;
 
     /**
      * Construct
      *
      * @param Context $context
      * @param UserFactory $userFactory
-     * @param Data $backendDataHelper
      */
     public function __construct(
         Context $context,
-        UserFactory $userFactory,
-        Data $backendDataHelper = null
+        UserFactory $userFactory
     ) {
         parent::__construct($context);
         $this->_userFactory = $userFactory;
-        $this->_backendDataHelper = $backendDataHelper ?: ObjectManager::getInstance()->get(Data::class);
     }
 
     /**

--- a/app/code/Magento/User/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth.php
@@ -8,11 +8,16 @@ namespace Magento\User\Controller\Adminhtml;
 
 use Magento\Framework\Encryption\Helper\Security;
 use Magento\Framework\App\ObjectManager;
+use Magento\Backend\App\AbstractAction;
+use Magento\Backend\App\Action\Context;
+use Magento\User\Model\UserFactory;
+use Magento\Backend\Helper\Data;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * \Magento\User Auth controller
  */
-abstract class Auth extends \Magento\Backend\App\AbstractAction
+abstract class Auth extends AbstractAction
 {
     /**
      * User model factory
@@ -24,24 +29,23 @@ abstract class Auth extends \Magento\Backend\App\AbstractAction
     /**
      * @var \Magento\Backend\Helper\Data
      */
-    protected $_backendHelper;
+    protected $_backendDataHelper;
 
     /**
      * Construct
      *
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\User\Model\UserFactory $userFactory
-     * @param \Magento\Backend\Helper\Data $backendHelper
+     * @param Context $context
+     * @param UserFactory $userFactory
+     * @param Data $backendDataHelper
      */
     public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\User\Model\UserFactory $userFactory,
-        \Magento\Backend\Helper\Data $backendHelper = null
+        Context $context,
+        UserFactory $userFactory,
+        Data $backendDataHelper = null
     ) {
         parent::__construct($context);
         $this->_userFactory = $userFactory;
-        $this->_backendHelper = $backendHelper ?:
-                ObjectManager::getInstance()->get(\Magento\Backend\Helper\Data::class);
+        $this->_backendDataHelper = $backendDataHelper ?: ObjectManager::getInstance()->get(Data::class);
     }
 
     /**
@@ -50,7 +54,7 @@ abstract class Auth extends \Magento\Backend\App\AbstractAction
      * @param int $userId
      * @param string $resetPasswordToken
      * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     protected function _validateResetPasswordLinkToken($userId, $resetPasswordToken)
     {
@@ -60,22 +64,20 @@ abstract class Auth extends \Magento\Backend\App\AbstractAction
             $resetPasswordToken
         ) || empty($resetPasswordToken) || empty($userId) || $userId < 0
         ) {
-            throw new \Magento\Framework\Exception\LocalizedException(
-                __('The password reset token is incorrect. Verify the token and try again.')
-            );
+            throw new LocalizedException(__('Please correct the password reset token.'));
         }
 
         /** @var $user \Magento\User\Model\User */
         $user = $this->_userFactory->create()->load($userId);
         if (!$user->getId()) {
-            throw new \Magento\Framework\Exception\LocalizedException(
+            throw new LocalizedException(
                 __('Please specify the correct account and try again.')
             );
         }
 
         $userToken = $user->getRpToken();
         if (!Security::compareStrings($userToken, $resetPasswordToken) || $user->isResetPasswordLinkTokenExpired()) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('Your password reset link has expired.'));
+            throw new LocalizedException(__('Your password reset link has expired.'));
         }
     }
 

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
@@ -15,6 +15,7 @@ use Magento\Framework\Validator\EmailAddress;
 use Magento\Security\Model\PasswordResetRequestEvent;
 use Magento\Framework\Exception\SecurityViolationException;
 use Magento\User\Controller\Adminhtml\Auth;
+use Magento\Backend\Helper\Data;
 
 class Forgotpassword extends Auth
 {
@@ -22,13 +23,18 @@ class Forgotpassword extends Auth
      * @var SecurityManager
      */
     protected $securityManager;
-    
+
     /**
      * User model factory
      *
      * @var CollectionFactory
      */
     private $userCollectionFactory;
+
+    /**
+     * @var Data
+     */
+    private $backendDataHelper;
 
     /**
      * @param Context $context
@@ -40,12 +46,15 @@ class Forgotpassword extends Auth
         Context $context,
         UserFactory $userFactory,
         SecurityManager $securityManager,
-        CollectionFactory $userCollectionFactory = null
+        CollectionFactory $userCollectionFactory = null,
+        Data $backendDataHelper = null
     ) {
         parent::__construct($context, $userFactory);
         $this->securityManager = $securityManager;
         $this->userCollectionFactory = $userCollectionFactory ?:
                 ObjectManager::getInstance()->get(CollectionFactory::class);
+        $this->backendDataHelper = $backendDataHelper ?:
+                ObjectManager::getInstance()->get(Data::class);
     }
 
     /**
@@ -84,7 +93,7 @@ class Forgotpassword extends Auth
                             /** @var \Magento\User\Model\User $user */
                             $user = $this->_userFactory->create()->load($item->getId());
                             if ($user->getId()) {
-                                $newPassResetToken = $this->_backendDataHelper->generateResetPasswordLinkToken();
+                                $newPassResetToken = $this->backendDataHelper->generateResetPasswordLinkToken();
                                 $user->changeResetPasswordLinkToken($newPassResetToken);
                                 $user->save();
                                 $user->sendPasswordResetConfirmationEmail();
@@ -103,7 +112,7 @@ class Forgotpassword extends Auth
                 $this->messageManager->addSuccess(__('We\'ll email you a link to reset your password.'));
                 // @codingStandardsIgnoreEnd
                 $this->getResponse()->setRedirect(
-                    $this->_backendDataHelper->getHomePageUrl()
+                    $this->backendDataHelper->getHomePageUrl()
                 );
                 return;
             } else {

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/Forgotpassword.php
@@ -10,7 +10,6 @@ use Magento\Security\Model\SecurityManager;
 use Magento\Framework\App\ObjectManager;
 use Magento\Backend\App\Action\Context;
 use Magento\User\Model\UserFactory;
-use Magento\Security\Model\SecurityManager;
 use Magento\User\Model\ResourceModel\User\CollectionFactory;
 use Magento\Framework\Validator\EmailAddress;
 use Magento\Security\Model\PasswordResetRequestEvent;

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -7,6 +7,7 @@
 namespace Magento\User\Controller\Adminhtml\Auth;
 
 use Magento\User\Controller\Adminhtml\Auth;
+use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\ObjectManager;
 use Magento\Backend\Helper\Data;
 use Magento\User\Model\UserFactory;

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -7,9 +7,27 @@
 namespace Magento\User\Controller\Adminhtml\Auth;
 
 use Magento\User\Controller\Adminhtml\Auth;
+use Magento\Framework\App\ObjectManager;
+use Magento\Backend\Helper\Data;
 
 class ResetPasswordPost extends Auth
 {
+    /**
+     * @var Data
+     */
+    private $backendDataHelper;
+
+    /**
+     * @param Context $context
+     * @param Data $backendDataHelper
+     */
+    public function __construct(
+        Context $context,
+        Data $backendDataHelper = null
+    ) {
+        parent::__construct($context, $userFactory);
+        $this->backendDataHelper = $backendDataHelper ?: ObjectManager::getInstance()->get(Data::class);
+    }
     /**
      * Reset forgotten password
      *
@@ -29,7 +47,7 @@ class ResetPasswordPost extends Auth
         } catch (\Exception $exception) {
             $this->messageManager->addError(__('Your password reset link has expired.'));
             $this->getResponse()->setRedirect(
-                $this->_backendDataHelper->getHomePageUrl()
+                $this->backendDataHelper->getHomePageUrl()
             );
             return;
         }
@@ -55,7 +73,7 @@ class ResetPasswordPost extends Auth
                 $user->save();
                 $this->messageManager->addSuccess(__('You updated your password.'));
                 $this->getResponse()->setRedirect(
-                    $this->_backendDataHelper->getHomePageUrl()
+                    $this->backendDataHelper->getHomePageUrl()
                 );
             }
         } catch (\Magento\Framework\Validator\Exception $exception) {

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -27,7 +27,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
         } catch (\Exception $exception) {
             $this->messageManager->addError(__('Your password reset link has expired.'));
             $this->getResponse()->setRedirect(
-                $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
+                $this->_backendHelper->getHomePageUrl()
             );
             return;
         }
@@ -53,7 +53,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
                 $user->save();
                 $this->messageManager->addSuccess(__('You updated your password.'));
                 $this->getResponse()->setRedirect(
-                    $this->_objectManager->get(\Magento\Backend\Helper\Data::class)->getHomePageUrl()
+                    $this->_backendHelper->getHomePageUrl()
                 );
             }
         } catch (\Magento\Framework\Validator\Exception $exception) {

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -9,6 +9,7 @@ namespace Magento\User\Controller\Adminhtml\Auth;
 use Magento\User\Controller\Adminhtml\Auth;
 use Magento\Framework\App\ObjectManager;
 use Magento\Backend\Helper\Data;
+use Magento\User\Model\UserFactory;
 
 class ResetPasswordPost extends Auth
 {
@@ -19,10 +20,12 @@ class ResetPasswordPost extends Auth
 
     /**
      * @param Context $context
+     * @param UserFactory $userFactory
      * @param Data $backendDataHelper
      */
     public function __construct(
         Context $context,
+        UserFactory $userFactory,
         Data $backendDataHelper = null
     ) {
         parent::__construct($context, $userFactory);

--- a/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth/ResetPasswordPost.php
@@ -6,7 +6,9 @@
  */
 namespace Magento\User\Controller\Adminhtml\Auth;
 
-class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
+use Magento\User\Controller\Adminhtml\Auth;
+
+class ResetPasswordPost extends Auth
 {
     /**
      * Reset forgotten password
@@ -27,7 +29,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
         } catch (\Exception $exception) {
             $this->messageManager->addError(__('Your password reset link has expired.'));
             $this->getResponse()->setRedirect(
-                $this->_backendHelper->getHomePageUrl()
+                $this->_backendDataHelper->getHomePageUrl()
             );
             return;
         }
@@ -53,7 +55,7 @@ class ResetPasswordPost extends \Magento\User\Controller\Adminhtml\Auth
                 $user->save();
                 $this->messageManager->addSuccess(__('You updated your password.'));
                 $this->getResponse()->setRedirect(
-                    $this->_backendHelper->getHomePageUrl()
+                    $this->_backendDataHelper->getHomePageUrl()
                 );
             }
         } catch (\Magento\Framework\Validator\Exception $exception) {


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16924
https://github.com/magento/magento2/pull/16560

Replacing usage of deprecated methods for message manager.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

Changes:

 - `addSuccess` -> `addSuccessMessage`;
 - `addError` -> `addErrorMessage`;
 - `addException` -> `addExceptionMessage`;
 - `addWarning` -> `addWarningMessage`;

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
