### PR TITLE
[Backport] Set proper text-aligh for the <th> element of the Subtotal column in the Creditmemo email

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_email.less
+++ b/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_email.less
@@ -203,7 +203,8 @@
         text-align: center;
     }
 
-    .item-price {
+    .item-price,
+    .item-subtotal {
         text-align: right;
     }
 

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_email.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_email.less
@@ -207,7 +207,8 @@
         text-align: center;
     }
 
-    .item-price {
+    .item-price,
+    .item-subtotal {
         text-align: right;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://github.com/magento/magento2/pull/17153

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. We definitely do not need this 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an Invoice
2. Create a Credit Memo
3. Check the email that was sent to the Customer

**Expected result:**
![screenshot_20180725_025329](https://user-images.githubusercontent.com/11827230/43232603-7fceb796-907a-11e8-9eba-34b20a8dbf58.png)

**Actual result:**
![screenshot_20180725_025205](https://user-images.githubusercontent.com/11827230/43232606-864eb972-907a-11e8-91c8-d21d6ca773e9.png)
The Luma and the Blank theme are affected
 
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
