### PR TITLE
Declare module namespace before template path name

### DIFF
--- a/app/code/Magento/Cookie/view/frontend/web/js/notices.js
+++ b/app/code/Magento/Cookie/view/frontend/web/js/notices.js
@@ -25,7 +25,7 @@ define([
                 });
 
                 if ($.mage.cookies.get(this.options.cookieName)) {
-                    window.location.reload();
+                    this.element.hide();
                 } else {
                     window.location.href = this.options.noCookiesUrl;
                 }

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template/Edit.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template/Edit.php
@@ -212,7 +212,7 @@ class Edit extends Widget
     }
 
     /**
-     * Return return template name for JS
+     * Return template name for JS
      *
      * @return string
      */

--- a/app/code/Magento/OfflinePayments/Block/Form/Banktransfer.php
+++ b/app/code/Magento/OfflinePayments/Block/Form/Banktransfer.php
@@ -15,5 +15,5 @@ class Banktransfer extends \Magento\OfflinePayments\Block\Form\AbstractInstructi
      *
      * @var string
      */
-    protected $_template = 'form/banktransfer.phtml';
+    protected $_template = 'Magento_OfflinePayments::form/banktransfer.phtml';
 }

--- a/app/code/Magento/OfflinePayments/Block/Form/Cashondelivery.php
+++ b/app/code/Magento/OfflinePayments/Block/Form/Cashondelivery.php
@@ -15,5 +15,5 @@ class Cashondelivery extends \Magento\OfflinePayments\Block\Form\AbstractInstruc
      *
      * @var string
      */
-    protected $_template = 'form/cashondelivery.phtml';
+    protected $_template = 'Magento_OfflinePayments::form/cashondelivery.phtml';
 }

--- a/app/code/Magento/Payment/Block/Info/Instructions.php
+++ b/app/code/Magento/Payment/Block/Info/Instructions.php
@@ -20,7 +20,7 @@ class Instructions extends \Magento\Payment\Block\Info
     /**
      * @var string
      */
-    protected $_template = 'info/instructions.phtml';
+    protected $_template = 'Magento_Payment::info/instructions.phtml';
 
     /**
      * Get instructions text from order payment

--- a/app/code/Magento/ProductAlert/Block/Email/Price.php
+++ b/app/code/Magento/ProductAlert/Block/Email/Price.php
@@ -15,7 +15,7 @@ class Price extends \Magento\ProductAlert\Block\Email\AbstractEmail
     /**
      * @var string
      */
-    protected $_template = 'email/price.phtml';
+    protected $_template = 'Magento_ProductAlert::email/price.phtml';
 
     /**
      * Retrieve unsubscribe url for product

--- a/app/code/Magento/ProductAlert/Block/Email/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Email/Stock.php
@@ -16,7 +16,7 @@ class Stock extends \Magento\ProductAlert\Block\Email\AbstractEmail
     /**
      * @var string
      */
-    protected $_template = 'email/stock.phtml';
+    protected $_template = 'Magento_ProductAlert::email/stock.phtml';
 
     /**
      * Retrieve unsubscribe url for product

--- a/app/code/Magento/Rss/Block/Feeds.php
+++ b/app/code/Magento/Rss/Block/Feeds.php
@@ -14,7 +14,7 @@ class Feeds extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'feeds.phtml';
+    protected $_template = 'Magento_Rss::feeds.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\RssManagerInterface

--- a/app/code/Magento/Sales/Block/Order/History.php
+++ b/app/code/Magento/Sales/Block/Order/History.php
@@ -16,7 +16,7 @@ class History extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/history.phtml';
+    protected $_template = 'Magento_Sales::order/history.phtml';
 
     /**
      * @var \Magento\Sales\Model\ResourceModel\Order\CollectionFactory

--- a/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging/Grid.php
+++ b/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging/Grid.php
@@ -10,7 +10,7 @@ class Grid extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'order/packaging/grid.phtml';
+    protected $_template = 'Magento_Shipping::order/packaging/grid.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Shipping/Block/Order/Shipment.php
+++ b/app/code/Magento/Shipping/Block/Order/Shipment.php
@@ -15,7 +15,7 @@ class Shipment extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/shipment.phtml';
+    protected $_template = 'Magento_Shipping::order/shipment.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/UrlRewrite/Block/Catalog/Category/Tree.php
+++ b/app/code/Magento/UrlRewrite/Block/Catalog/Category/Tree.php
@@ -26,7 +26,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     /**
      * @var string
      */
-    protected $_template = 'categories.phtml';
+    protected $_template = 'Magento_UrlRewrite::categories.phtml';
 
     /**
      * Adminhtml data

--- a/app/code/Magento/UrlRewrite/Block/Selector.php
+++ b/app/code/Magento/UrlRewrite/Block/Selector.php
@@ -18,7 +18,7 @@ class Selector extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'selector.phtml';
+    protected $_template = 'Magento_UrlRewrite::selector.phtml';
 
     /**
      * Set block template and get available modes

--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -18,7 +18,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form implements \Magento\Backen
     /**
      * @var string
      */
-    protected $_template = 'role/edit.phtml';
+    protected $_template = 'Magento_User::role/edit.phtml';
 
     /**
      * Root ACL Resource

--- a/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
@@ -33,7 +33,7 @@ class Tax extends \Magento\Backend\Block\Widget implements \Magento\Framework\Da
     /**
      * @var string
      */
-    protected $_template = 'renderer/tax.phtml';
+    protected $_template = 'Magento_Weee::renderer/tax.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -25,7 +25,7 @@ class Layout extends \Magento\Backend\Block\Template implements \Magento\Framewo
     /**
      * @var string
      */
-    protected $_template = 'instance/edit/layout.phtml';
+    protected $_template = 'Magento_Widget::instance/edit/layout.phtml';
 
     /**
      * @var \Magento\Catalog\Model\Product\Type

--- a/app/code/Magento/Wishlist/Block/Rss/EmailLink.php
+++ b/app/code/Magento/Wishlist/Block/Rss/EmailLink.php
@@ -19,7 +19,7 @@ class EmailLink extends Link
     /**
      * @var string
      */
-    protected $_template = 'rss/email.phtml';
+    protected $_template = 'Magento_Wishlist::rss/email.phtml';
 
     /**
      * @return array

--- a/app/code/Magento/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/Magento/Wishlist/Block/Share/Email/Items.php
@@ -16,7 +16,7 @@ class Items extends \Magento\Wishlist\Block\AbstractBlock
     /**
      * @var string
      */
-    protected $_template = 'email/items.phtml';
+    protected $_template = 'Magento_Wishlist::email/items.phtml';
 
     /**
      * Retrieve Product View URL

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/group.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/group.xml
@@ -9,17 +9,17 @@
     <block class="Magento\Framework\View\Element\Text" name="block1">
         <block class="Magento\Framework\View\Element\Text" name="block2" group="group1">
             <arguments>
-                <argument xsi:type="string" name="text">blok2</argument>
+                <argument xsi:type="string" name="text">block2</argument>
             </arguments>
         </block>
         <block class="Magento\Framework\View\Element\Text" name="block3" group="group1" >
             <arguments>
-                <argument xsi:type="string" name="text">blok3</argument>
+                <argument xsi:type="string" name="text">block3</argument>
             </arguments>
         </block>
         <block class="Magento\Framework\View\Element\Text" name="block4">
             <arguments>
-                <argument xsi:type="string" name="text">blok4</argument>
+                <argument xsi:type="string" name="text">block4</argument>
             </arguments>
         </block>
         </block>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When we override block history(Magento\Sales\Block\Order\History) to my custom module.
It throws an error and finding order/history.phtml in my custom module.
I tried to extend Block Magento\Sales\Block\Order\History from my custom module.

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'order/history.phtml' in module: 'Vendor_Module' block's name: 'sales.order.history'
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16484: Declare module namespace before template path name(Magento_Sales::order/history.phtml).

### Manual testing scenarios
1. I override history block
`<preference for="Magento\Sales\Block\Order\History" type="Vendor\Module\Block\Order\History" />`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
