### PR TITLE
[Backport] Fixed invalid knockoutjs data binding for Braintree PayPal

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/template/payment/paypal.html
+++ b/app/code/Magento/Braintree/view/frontend/web/template/payment/paypal.html
@@ -12,7 +12,7 @@
                data-bind="attr: {'id': getCode()}, value: getCode(), checked: isChecked, click: selectPaymentMethod, visible: isRadioButtonVisible()" />
         <label class="label" data-bind="attr: {'for': getCode()}">
             <!-- PayPal Logo -->
-            <img data-bind="attr: {src: getPaymentAcceptanceMarkSrc(), alt: $t('Acceptance Mark')}, title: $t('Acceptance Mark')}"
+            <img data-bind="attr: {src: getPaymentAcceptanceMarkSrc(), alt: $t('Acceptance Mark'), title: $t('Acceptance Mark')}"
                  class="payment-icon"/>
             <!-- PayPal Logo -->
             <span text="getTitle()"></span>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17067

### Description
These changes fix the broken knockoutjs data binding introduced in https://github.com/magento/magento2/pull/16769 for Braintree PayPal.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
