### PR TITLE
Don't add empty method to the cart summary

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/methods.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/methods.phtml
@@ -14,7 +14,8 @@
 <?php $methods = $block->getMethods('methods') ?: $block->getMethods('top_methods') ?>
 <ul class="checkout methods items checkout-methods-items">
 <?php foreach ($methods as $method): ?>
-    <?php if ($methodHtml = $block->getMethodHtml($method)): ?>
+    <?php $methodHtml = $block->getMethodHtml($method); ?>
+    <?php if (trim($methodHtml) !== ''): ?>
     <li class="item"><?= /* @escapeNotVerified */ $methodHtml ?></li>
     <?php endif; ?>
 <?php endforeach; ?>


### PR DESCRIPTION
### Description
In some cases the method html is empty, this will result in an empty
list item, which in the end results in an extra margin of 20px because
of default styling.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
