### PR TITLE
[Backport 2.2]Filter test result collection with the cron job code defined in the c…

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Cron/Observer/ProcessCronQueueObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cron/Observer/ProcessCronQueueObserverTest.php
@@ -27,7 +27,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @magentoConfigFixture current_store crontab/default/jobs/catalog_product_alert/schedule/cron_expr 8 * * * *
+     * @magentoConfigFixture current_store crontab/default/jobs/catalog_product_alert/schedule/cron_expr * * * * *
      */
     public function testDispatchScheduled()
     {
@@ -35,6 +35,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit\Framework\TestCase
             \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
         );
         $collection->addFieldToFilter('status', \Magento\Cron\Model\Schedule::STATUS_PENDING);
+        $collection->addFieldToFilter('job_code', 'catalog_product_alert');
         $this->assertGreaterThan(0, $collection->count(), 'Cron has failed to schedule tasks for itself for future.');
     }
 


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/16253

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Filter test result collection with the cron job code defined in the config fixture. Set the schedule for every minute so that the job is scheduled regardless of the time when you run the test.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16243

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. run dev/tests/integration/testsuite/Magento/Cron/Observer/ProcessCronQueueObserverTest.php

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
