### PR TITLE
Fix catalog product attribute update webapi

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -106,7 +106,7 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
      */
     public function save(\Magento\Catalog\Api\Data\ProductAttributeInterface $attribute)
     {
-        if ($attribute->getAttributeId()) {
+        if ($attribute->getAttributeCode()) {
             $existingModel = $this->get($attribute->getAttributeCode());
 
             if (!$existingModel->getAttributeId()) {

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
@@ -190,9 +190,8 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
     {
         $attributeMock = $this->createMock(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class);
         $existingModelMock = $this->createMock(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class);
-        $attributeMock->expects($this->once())->method('getAttributeId')->willReturn('12');
         $attributeCode = 'test attribute code';
-        $attributeMock->expects($this->once())->method('getAttributeCode')->willReturn($attributeCode);
+        $attributeMock->expects($this->exactly(2))->method('getAttributeCode')->willReturn($attributeCode);
         $this->eavAttributeRepositoryMock->expects($this->once())
             ->method('get')
             ->with(
@@ -216,7 +215,6 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
             \Magento\Catalog\Model\ResourceModel\Eav\Attribute::class,
             ['getFrontendLabels', 'getDefaultFrontendLabel', '__wakeup', 'getAttributeId', 'setAttributeId']
         );
-        $attributeMock->expects($this->once())->method('getAttributeId')->willReturn(null);
         $attributeMock->expects($this->once())->method('setAttributeId')->with(null)->willReturnSelf();
         $attributeMock->expects($this->once())->method('getFrontendLabels')->willReturn(null);
         $attributeMock->expects($this->once())->method('getDefaultFrontendLabel')->willReturn(null);
@@ -234,7 +232,6 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
             \Magento\Catalog\Model\ResourceModel\Eav\Attribute::class,
             ['getFrontendLabels', 'getDefaultFrontendLabel', 'getAttributeId', '__wakeup', 'setAttributeId']
         );
-        $attributeMock->expects($this->once())->method('getAttributeId')->willReturn(null);
         $attributeMock->expects($this->once())->method('setAttributeId')->with(null)->willReturnSelf();
         $labelMock = $this->createMock(\Magento\Eav\Model\Entity\Attribute\FrontendLabel::class);
         $attributeMock->expects($this->any())->method('getFrontendLabels')->willReturn([$labelMock]);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
If an existing attribute should be saved via webapi,
an exception "%1 already exists" is thrown.

The webapi endpoint "/rest/all/V1/products/attributes/{attributeCode}"
provides already an attribute code.

The save method checks if a "attributeId" is provided.
The use case of the "attributeCode" URL path paramter is to omit the
"attributeId" which is usally not known on API client side.

The fix replaces the "getAttributeId" method with "getAttributeCode".
That always works, because the "getAttributeCode" is used to load the
object by code in the next lines in the repository save method.

### Fixed Issues (if relevant)
Existing issue unkown.

### Manual testing scenarios

Try to update an existing catalog product EAV attribute via webapi.
In my case I tried to update the "color" attribute.

```bash
curl -X PUT \
  https://{base-url}/rest/all/V1/products/attributes/color \
  -H 'Authorization: Bearer {api-token}' \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -d '{
    "attribute": {
        "entity_type_id": "4",
        "is_wysiwyg_enabled": false,
        "is_html_allowed_on_front": false,
        "used_for_sort_by": false,
        "is_filterable": true,
        "is_filterable_in_search": false,
        "is_used_in_grid": true,
        "is_visible_in_grid": false,
        "is_filterable_in_grid": true,
        "position": 0,
        "apply_to": [
            "simple",
            "virtual",
            "configurable"
        ],
        "is_searchable": "1",
        "is_visible_in_advanced_search": "1",
        "is_comparable": "1",
        "is_used_for_promo_rules": "0",
        "is_visible_on_front": "0",
        "used_in_product_listing": "0",
        "is_visible": true,
        "scope": "global",
        "frontend_input": "select",
        "is_required": false,
        "options": [
            {
                "label": " ",
                "value": ""
            },
            {
                "label": "rot",
                "value": "15"
            },
            {
                "label": "grün",
                "value": "16"
            },
            {
                "label": "blau",
                "value": "17"
            }
        ],
        "is_user_defined": true,
        "default_frontend_label": "Color",
        "frontend_labels": null,
        "backend_type": "int",
        "backend_model": "Magento\\Eav\\Model\\Entity\\Attribute\\Backend\\DefaultBackend",
        "source_model": "Magento\\Eav\\Model\\Entity\\Attribute\\Source\\Table",
        "default_value": "",
        "is_unique": "0",
        "validation_rules": []
    }
}'
```

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
