### PR TITLE
Fix "Huge input lookup" error for app config json largest then 10 Mb (libxml restriction)

### DIFF
--- a/lib/internal/Magento/Framework/View/TemplateEngine/Xhtml/Template.php
+++ b/lib/internal/Magento/Framework/View/TemplateEngine/Xhtml/Template.php
@@ -34,7 +34,7 @@ class Template
     ) {
         $this->logger = $logger;
         $document = new \DOMDocument(static::XML_VERSION, static::XML_ENCODING);
-        $document->loadXML($content);
+        $document->loadXML($content, LIBXML_PARSEHUGE);
         $this->templateNode = $document->documentElement;
     }
 


### PR DESCRIPTION
### Description
When xhtml template system add text with app-config json and this config is more then 10Mb then error happened `Warning: DOMDocumentFragment::appendXML(): Entity: line 1: parser error : internal error: Huge input lookup in /home/thevinyl/public_html/vendor/magento/framework/View/TemplateEngine/Xhtml/Template.php on line 60`.

Usually its happens when filtered admin grid returns too many rows.

### Fixed Issues (if relevant)
1. magento/magento2#8084: Grid pulls all data and doesnt have proper client/server pagination
 
### Manual testing scenarios
1. Open any grid with too many rows

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
