### PR TITLE
[Forwardport] Remove spaces around amount span.

### DIFF
--- a/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
@@ -19,9 +19,8 @@
         <?= ($block->getPriceDisplayLabel()) ? 'data-label="' . $block->getPriceDisplayLabel() . $block->getPriceDisplayInclExclTaxes() . '"' : '' ?>
         data-price-amount="<?= /* @escapeNotVerified */ $block->getDisplayValue() ?>"
         data-price-type="<?= /* @escapeNotVerified */ $block->getPriceType() ?>"
-        class="price-wrapper <?= /* @escapeNotVerified */ $block->getPriceWrapperCss() ?>">
-        <?= /* @escapeNotVerified */ $block->formatCurrency($block->getDisplayValue(), (bool)$block->getIncludeContainer()) ?>
-    </span>
+        class="price-wrapper <?= /* @escapeNotVerified */ $block->getPriceWrapperCss() ?>"
+    ><?= /* @escapeNotVerified */ $block->formatCurrency($block->getDisplayValue(), (bool)$block->getIncludeContainer()) ?></span>
     <?php if ($block->hasAdjustmentsHtml()): ?>
         <?= $block->getAdjustmentsHtml() ?>
     <?php endif; ?>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17027
### Description
There is unnecessary spaces exists around price. Therefor if add some text after span with price there is one crossed space shown after price. 

### Fixed Issues (if relevant)
No

### Manual testing scenarios
1.  Set  "Manufacturer's Suggested Retail Price" in "Advanced Pricing" on product edit page.
2. On frontend add (manually or by js-code) some text after span with crossed price.

Before:
![spacearoundpricebuggy](https://user-images.githubusercontent.com/603401/43079131-f3e86e16-8e94-11e8-8b3e-d88deacb814e.png)

After:
![spacearoundpricefixed](https://user-images.githubusercontent.com/603401/43079132-f40a0328-8e94-11e8-91eb-34068deefc3e.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
