### PR TITLE
[Forwardport] Fix misprint ('_requesetd' > '_requested')

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js
@@ -66,7 +66,7 @@ define([
 
     Element = _.extend({
         defaults: {
-            _requesetd: {},
+            _requested: {},
             containers: [],
             exports: {},
             imports: {},
@@ -249,7 +249,7 @@ define([
          * @returns {Function} Async module wrapper.
          */
         requestModule: function (name) {
-            var requested = this._requesetd;
+            var requested = this._requested;
 
             if (!requested[name]) {
                 requested[name] = registry.async(name);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16971
### Description
Fix misprint: rename `_requesetd` to `_requested'`.

### Fixed Issues (if relevant)
No
### Manual testing scenarios
No

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
