### PR TITLE
[Backport] Fixed ability to set field config from layout xml #11302

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -164,20 +164,19 @@ class AttributeMerger
 
         $element = [
             'component' => isset($additionalConfig['component']) ? $additionalConfig['component'] : $uiComponent,
-            'config' => [
-                // customScope is used to group elements within a single form (e.g. they can be validated separately)
-                'customScope' => $dataScopePrefix,
-                'customEntry' => isset($additionalConfig['config']['customEntry'])
-                    ? $additionalConfig['config']['customEntry']
-                    : null,
-                'template' => 'ui/form/field',
-                'elementTmpl' => isset($additionalConfig['config']['elementTmpl'])
-                    ? $additionalConfig['config']['elementTmpl']
-                    : $elementTemplate,
-                'tooltip' => isset($additionalConfig['config']['tooltip'])
-                    ? $additionalConfig['config']['tooltip']
-                    : null
-            ],
+            'config' => $this->mergeConfigurationNode(
+                'config',
+                $additionalConfig,
+                [
+                    'config' => [
+                        // customScope is used to group elements within a single
+                        // form (e.g. they can be validated separately)
+                        'customScope' => $dataScopePrefix,
+                        'template' => 'ui/form/field',
+                        'elementTmpl' => $elementTemplate,
+                    ],
+                ]
+            ),
             'dataScope' => $dataScopePrefix . '.' . $attributeCode,
             'label' => $attributeConfig['label'],
             'provider' => $providerName,


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11643

- This PR cherry-picked from [MAGETWO-81310](https://github.com/magento/magento2/commit/3f0a090093c972855551d90034c269eff1f1f097).
- Original [PR](https://github.com/magento/magento2/pull/11302).

### Description

Config array is hardcoded to read three settings only. The patch allows reading all settings from `config`.

Example:

```xml
<item name="postcode" xsi:type="array">
    <item name="config" xsi:type="array">
        <item name="label" xsi:type="string">Another Label</item>
        <item name="placeholder" xsi:type="string">Field Placeholder</item>
    </item>
</item>
```

### Manual testing scenarios

1. Open `Magento/Checkout/view/frontend/layout/checkout_index_index.xml` and find postcode settings
2. Change its settings as follows:

    ```xml
    <item name="postcode" xsi:type="array">
        <!-- post-code field has custom UI component -->
        <item name="component" xsi:type="string">Magento_Ui/js/form/element/post-code</item>
        <item name="validation" xsi:type="array">
            <item name="required-entry" xsi:type="string">true</item>
        </item>
        <item name="config" xsi:type="array">
            <item name="label" xsi:type="string">test label</item>
            <item name="placeholder" xsi:type="string">test placeholder</item>
        </item>
    </item>
    ```

3. Navigate to checkout and you'll see that settings are not working.
4. Apply the patch and settings will start working.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
