### PR TITLE
[Backport] Broken Responsive Layout on Top page

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -421,6 +421,17 @@
 }
 
 //
+//  Mobile
+//  _____________________________________________
+
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
+    .cms-page-view .page-main {
+        padding-top: 41px;
+        position: relative;
+    }
+}
+
+//
 //  Desktop
 //  _____________________________________________
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16983
I checked as other pages were behaving to fit the page:
/privacy-policy-cookie-restriction-mode

I got references here:
/customer/account/

1 - Reference:
![account-page-main](https://user-images.githubusercontent.com/14968349/43028305-81d3fce6-8c55-11e8-905f-345b1eebcd79.png)

2 - The issue - Without code right:
![without-paddingtop-and-position](https://user-images.githubusercontent.com/14968349/43028306-81f4b224-8c55-11e8-9d40-a7b32bf7bbe2.png)

3 - With the code right:
![with-paddingtop-and-position](https://user-images.githubusercontent.com/14968349/43028307-82181ea8-8c55-11e8-98c4-eef6fb121f9d.png)

Thanks,
Rodrigo Biassi