### PR TITLE
[Backport] FIXED: FTP user and password strings urldecoded

### DIFF
--- a/lib/internal/Magento/Framework/System/Ftp.php
+++ b/lib/internal/Magento/Framework/System/Ftp.php
@@ -109,8 +109,9 @@ class Ftp
         }
         
         // Decode user & password strings from URL
-        if ( array_key_exists('user', $data) ) $data['user'] = urldecode($data['user']);
-        if ( array_key_exists('pass', $data) ) $data['pass'] = urldecode($data['pass']);
+        foreach (array_intersect(array_keys($data), ['user','pass']) as $key) {
+            $data[$key] = urldecode($data[$key]);
+        }
         
         return $data;
     }

--- a/lib/internal/Magento/Framework/System/Ftp.php
+++ b/lib/internal/Magento/Framework/System/Ftp.php
@@ -107,6 +107,11 @@ class Ftp
         if ($data['scheme'] != 'ftp') {
             throw new \Exception("Support for scheme unsupported: '{$data['scheme']}'");
         }
+        
+        // Decode user & password strings from URL
+        if ( array_key_exists('user', $data) ) $data['user'] = urldecode($data['user']);
+        if ( array_key_exists('pass', $data) ) $data['pass'] = urldecode($data['pass']);
+        
         return $data;
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16876
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
FTP connections can't use user or password strings with special characters, like @ or #.
$user = 'my@mail.com';
$pass = '#my@pass';
$host = 'ftphost.com';
$ftp->connect("ftp://{$user}:{$pass}@{$host}");

connect() calls parse_url() and this will break down bad the special chars...

Solution:
// ...
$user = urlencode($user);
$pass = urlencode($pass);
$ftp->connect( ... );

But connect() method calls ftp_login() without decode the $user and $pass vars


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. $ftp->connect("ftp://my%23mail.com:mypass@myhost.com"); // this works
2. $ftp->connect("ftp://no_special_chars:mypass@myhost.com"); // this works too

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
