### PR TITLE
[Backport] Improve attribute checking

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -29,7 +29,7 @@ abstract class AbstractType
      *
      * @var array
      */
-    public static $invisibleAttributesCache = [];
+    public static $invAttributesCache = [];
 
     /**
      * Attribute Code to Id cache
@@ -278,7 +278,7 @@ abstract class AbstractType
             $unknownAttributeIds = array_diff(
                 $attributeIds,
                 array_keys(self::$commonAttributesCache),
-                self::$invisibleAttributesCache
+                self::$invAttributesCache
             );
             if ($unknownAttributeIds) {
                 $this->attachAttributesById($attributeSetName, $attributeIds);
@@ -342,7 +342,7 @@ abstract class AbstractType
                     $attribute
                 );
             } else {
-                self::$invisibleAttributesCache[] = $attributeId;
+                self::$invAttributesCache[] = $attributeId;
             }
         }
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -280,7 +280,7 @@ abstract class AbstractType
                 array_keys(self::$commonAttributesCache),
                 self::$invAttributesCache
             );
-            if ($unknownAttributeIds) {
+            if ($unknownAttributeIds || $this->_forcedAttributesCodes) {
                 $this->attachAttributesById($attributeSetName, $attributeIds);
             }
         }
@@ -307,8 +307,11 @@ abstract class AbstractType
     protected function attachAttributesById($attributeSetName, $attributeIds)
     {
         foreach ($this->_prodAttrColFac->create()->addFieldToFilter(
-            'main_table.attribute_id',
-            ['in' => $attributeIds]
+            ['main_table.attribute_id', 'main_table.attribute_code'],
+            [
+                ['in' => $attributeIds],
+                ['in' => $this->_forcedAttributesCodes]
+            ]
         ) as $attribute) {
             $attributeCode = $attribute->getAttributeCode();
             $attributeId = $attribute->getId();

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -25,6 +25,13 @@ abstract class AbstractType
     public static $commonAttributesCache = [];
 
     /**
+     * Maintain a list of invisible attributes
+     *
+     * @var array
+     */
+    public static $invisibleAttributesCache = [];
+
+    /**
      * Attribute Code to Id cache
      *
      * @var array
@@ -268,7 +275,10 @@ abstract class AbstractType
             }
         }
         foreach ($absentKeys as $attributeSetName => $attributeIds) {
-            $this->attachAttributesById($attributeSetName, $attributeIds);
+            $unknownAttributeIds = array_diff($attributeIds, array_keys(self::$commonAttributesCache), self::$invisibleAttributesCache);
+            if ($unknownAttributeIds) {
+                $this->attachAttributesById($attributeSetName, $attributeIds);
+            }
         }
         foreach ($entityAttributes as $attributeRow) {
             if (isset(self::$commonAttributesCache[$attributeRow['attribute_id']])) {
@@ -300,30 +310,35 @@ abstract class AbstractType
             $attributeId = $attribute->getId();
 
             if ($attribute->getIsVisible() || in_array($attributeCode, $this->_forcedAttributesCodes)) {
-                self::$commonAttributesCache[$attributeId] = [
-                    'id' => $attributeId,
-                    'code' => $attributeCode,
-                    'is_global' => $attribute->getIsGlobal(),
-                    'is_required' => $attribute->getIsRequired(),
-                    'is_unique' => $attribute->getIsUnique(),
-                    'frontend_label' => $attribute->getFrontendLabel(),
-                    'is_static' => $attribute->isStatic(),
-                    'apply_to' => $attribute->getApplyTo(),
-                    'type' => \Magento\ImportExport\Model\Import::getAttributeType($attribute),
-                    'default_value' => strlen(
-                        $attribute->getDefaultValue()
-                    ) ? $attribute->getDefaultValue() : null,
-                    'options' => $this->_entityModel->getAttributeOptions(
-                        $attribute,
-                        $this->_indexValueAttributes
-                    ),
-                ];
+                if (!isset(self::$commonAttributesCache[$attributeId])) {
+                    self::$commonAttributesCache[$attributeId] = [
+                        'id' => $attributeId,
+                        'code' => $attributeCode,
+                        'is_global' => $attribute->getIsGlobal(),
+                        'is_required' => $attribute->getIsRequired(),
+                        'is_unique' => $attribute->getIsUnique(),
+                        'frontend_label' => $attribute->getFrontendLabel(),
+                        'is_static' => $attribute->isStatic(),
+                        'apply_to' => $attribute->getApplyTo(),
+                        'type' => \Magento\ImportExport\Model\Import::getAttributeType($attribute),
+                        'default_value' => strlen(
+                            $attribute->getDefaultValue()
+                        ) ? $attribute->getDefaultValue() : null,
+                        'options' => $this->_entityModel->getAttributeOptions(
+                            $attribute,
+                            $this->_indexValueAttributes
+                        ),
+                    ];
+                }
+
                 self::$attributeCodeToId[$attributeCode] = $attributeId;
                 $this->_addAttributeParams(
                     $attributeSetName,
                     self::$commonAttributesCache[$attributeId],
                     $attribute
                 );
+            } else {
+                self::$invisibleAttributesCache[] = $attributeId;
             }
         }
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -275,7 +275,11 @@ abstract class AbstractType
             }
         }
         foreach ($absentKeys as $attributeSetName => $attributeIds) {
-            $unknownAttributeIds = array_diff($attributeIds, array_keys(self::$commonAttributesCache), self::$invisibleAttributesCache);
+            $unknownAttributeIds = array_diff(
+                $attributeIds,
+                array_keys(self::$commonAttributesCache),
+                self::$invisibleAttributesCache
+            );
             if ($unknownAttributeIds) {
                 $this->attachAttributesById($attributeSetName, $attributeIds);
             }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11554
On a store with a large number of attribute sets, a lot of repeated checking is done for the same attributes.

### Description
Instead of repeating the checks every time, keep track of the attributes that have already been checked and should be skipped (invisible). This we way we don't have to do the same check for the next attribute set.

### Fixed Issues (if relevant)

### Manual testing scenarios
1. Create a store with a large number of attribute sets, and add some invisible attributes in those sets
2. Upload a csv file with products to import, and click the Check Data button

With this change the checking phase will be much faster than without the change, without any functional change.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
