### PR TITLE
[Forwardport] #16273: Fix bug in method getUrlInStore() of product model

### DIFF
--- a/app/code/Magento/Store/Test/Unit/Url/Plugin/RouteParamsResolverTest.php
+++ b/app/code/Magento/Store/Test/Unit/Url/Plugin/RouteParamsResolverTest.php
@@ -23,6 +23,11 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
     protected $queryParamsResolverMock;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Store\Model\Store
+     */
+    protected $storeMock;
+
+    /**
      * @var \Magento\Store\Url\Plugin\RouteParamsResolver
      */
     protected $model;
@@ -30,7 +35,19 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->scopeConfigMock = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+
+        $this->storeMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+            ->setMethods(['getCode'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->storeMock->expects($this->any())->method('getCode')->willReturn('custom_store');
+
         $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
+        $this->storeManagerMock
+            ->expects($this->once())
+            ->method('getStore')
+            ->willReturn($this->storeMock);
+
         $this->queryParamsResolverMock = $this->createMock(\Magento\Framework\Url\QueryParamsResolverInterface::class);
         $this->model = new \Magento\Store\Url\Plugin\RouteParamsResolver(
             $this->scopeConfigMock,
@@ -42,6 +59,8 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
     public function testBeforeSetRouteParamsScopeInParams()
     {
         $storeCode = 'custom_store';
+        $data = ['_scope' => $storeCode, '_scope_to_url' => true];
+
         $this->scopeConfigMock
             ->expects($this->once())
             ->method('getValue')
@@ -52,7 +71,41 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
             )
             ->will($this->returnValue(false));
         $this->storeManagerMock->expects($this->any())->method('hasSingleStore')->willReturn(false);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject $routeParamsResolverMock */
+        $routeParamsResolverMock = $this->getMockBuilder(\Magento\Framework\Url\RouteParamsResolver::class)
+            ->setMethods(['setScope', 'getScope'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $routeParamsResolverMock->expects($this->once())->method('setScope')->with($storeCode);
+        $routeParamsResolverMock->expects($this->once())->method('getScope')->willReturn($storeCode);
+
+        $this->queryParamsResolverMock->expects($this->never())->method('setQueryParam');
+
+
+        $this->model->beforeSetRouteParams(
+            $routeParamsResolverMock,
+            $data
+        );
+    }
+
+    public function testBeforeSetRouteParamsScopeUseStoreInUrl()
+    {
+        $storeCode = 'custom_store';
         $data = ['_scope' => $storeCode, '_scope_to_url' => true];
+
+        $this->scopeConfigMock
+            ->expects($this->once())
+            ->method('getValue')
+            ->with(
+                \Magento\Store\Model\Store::XML_PATH_STORE_IN_URL,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $storeCode
+            )
+            ->will($this->returnValue(true));
+
+        $this->storeManagerMock->expects($this->any())->method('hasSingleStore')->willReturn(false);
+
         /** @var \PHPUnit_Framework_MockObject_MockObject $routeParamsResolverMock */
         $routeParamsResolverMock = $this->getMockBuilder(\Magento\Framework\Url\RouteParamsResolver::class)
             ->setMethods(['setScope', 'getScope'])
@@ -69,39 +122,11 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testBeforeSetRouteParamsScopeUseStoreInUrl()
-    {
-        $storeCode = 'custom_store';
-        $this->scopeConfigMock
-            ->expects($this->once())
-            ->method('getValue')
-            ->with(
-                \Magento\Store\Model\Store::XML_PATH_STORE_IN_URL,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                $storeCode
-            )
-            ->will($this->returnValue(true));
-        $this->storeManagerMock->expects($this->any())->method('hasSingleStore')->willReturn(false);
-        $data = ['_scope' => $storeCode, '_scope_to_url' => true];
-        /** @var \PHPUnit_Framework_MockObject_MockObject $routeParamsResolverMock */
-        $routeParamsResolverMock = $this->getMockBuilder(\Magento\Framework\Url\RouteParamsResolver::class)
-            ->setMethods(['setScope', 'getScope'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $routeParamsResolverMock->expects($this->once())->method('setScope')->with($storeCode);
-        $routeParamsResolverMock->expects($this->once())->method('getScope')->willReturn($storeCode);
-
-        $this->queryParamsResolverMock->expects($this->never())->method('setQueryParam');
-
-        $this->model->beforeSetRouteParams(
-            $routeParamsResolverMock,
-            $data
-        );
-    }
-
     public function testBeforeSetRouteParamsSingleStore()
     {
         $storeCode = 'custom_store';
+        $data = ['_scope' => $storeCode, '_scope_to_url' => true];
+
         $this->scopeConfigMock
             ->expects($this->once())
             ->method('getValue')
@@ -112,7 +137,7 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
             )
             ->will($this->returnValue(false));
         $this->storeManagerMock->expects($this->any())->method('hasSingleStore')->willReturn(true);
-        $data = ['_scope' => $storeCode, '_scope_to_url' => true];
+
         /** @var \PHPUnit_Framework_MockObject_MockObject $routeParamsResolverMock */
         $routeParamsResolverMock = $this->getMockBuilder(\Magento\Framework\Url\RouteParamsResolver::class)
             ->setMethods(['setScope', 'getScope'])
@@ -132,6 +157,8 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
     public function testBeforeSetRouteParamsNoScopeInParams()
     {
         $storeCode = 'custom_store';
+        $data = ['_scope_to_url' => true];
+
         $this->scopeConfigMock
             ->expects($this->once())
             ->method('getValue')
@@ -140,17 +167,10 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
                 $storeCode
             )
-            ->will($this->returnValue(false));
-        $this->storeManagerMock->expects($this->any())->method('hasSingleStore')->willReturn(false);
-        /** @var \PHPUnit_Framework_MockObject_MockObject| $routeParamsResolverMock */
-        $storeMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
-            ->setMethods(['getCode'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $storeMock->expects($this->any())->method('getCode')->willReturn($storeCode);
-        $this->storeManagerMock->expects($this->any())->method('getStore')->willReturn($storeMock);
+            ->will($this->returnValue(true));
 
-        $data = ['_scope_to_url' => true];
+        $this->storeManagerMock->expects($this->any())->method('hasSingleStore')->willReturn(false);
+
         /** @var \PHPUnit_Framework_MockObject_MockObject $routeParamsResolverMock */
         $routeParamsResolverMock = $this->getMockBuilder(\Magento\Framework\Url\RouteParamsResolver::class)
             ->setMethods(['setScope', 'getScope'])

--- a/app/code/Magento/Store/Test/Unit/Url/Plugin/RouteParamsResolverTest.php
+++ b/app/code/Magento/Store/Test/Unit/Url/Plugin/RouteParamsResolverTest.php
@@ -82,7 +82,6 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
 
         $this->queryParamsResolverMock->expects($this->never())->method('setQueryParam');
 
-
         $this->model->beforeSetRouteParams(
             $routeParamsResolverMock,
             $data

--- a/app/code/Magento/Store/Url/Plugin/RouteParamsResolver.php
+++ b/app/code/Magento/Store/Url/Plugin/RouteParamsResolver.php
@@ -6,6 +6,7 @@
 namespace Magento\Store\Url\Plugin;
 
 use \Magento\Store\Model\Store;
+use \Magento\Store\Api\Data\StoreInterface;
 use \Magento\Store\Model\ScopeInterface as StoreScopeInterface;
 
 /**
@@ -65,9 +66,9 @@ class RouteParamsResolver
             unset($data['_scope']);
         }
         if (isset($data['_scope_to_url']) && (bool)$data['_scope_to_url'] === true) {
-            /** @var Store $currentScope */
+            /** @var StoreInterface $currentScope */
             $currentScope = $subject->getScope();
-            $storeCode = $currentScope && $currentScope instanceof Store ?
+            $storeCode = $currentScope && $currentScope instanceof StoreInterface ?
                 $currentScope->getCode() :
                 $this->storeManager->getStore()->getCode();
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16468
### Description
This PR reference changes how/what is returned when `product` model method `getUrlInStore()` is called `$product->getUrlInStore()`.
Problem is in how the current store is checked and what is returned based on it.

### Fixed Issues
1. magento/magento2#16273
2. Having set _Add store code to URLs_ in Admin Configuration to _NO_, store code is still shown in the product URL.

### Manual testing scenarios

__For issue 1__ - please see the issue description.
__For issue 2__:

1. Go to Admin -> Stores -> Configuration -> Catalog -> Web -> Url Options -> Add Store Code to Urls and set it to NO.
2. In some `.phtml` file, list.phtml for example, call method `getUrlInStore()` for a product.

#### Expected Result
Store code is not added into product url
```
https://www.domain.com/my-product.html
```

#### Actual Result
Store code is added into product url
```
https://www.domain.com/my-product.html?___store=default
```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
