### PR TITLE
[Forwardport] #17163: Add meta NOINDEX,NOFOLLOW to admin scope to avoid accidental crawling

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/layout/default.xml
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/layout/default.xml
@@ -7,6 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
+        <meta name="robots" content="NOINDEX,NOFOLLOW"/>
         <css src="jquery/jstree/themes/default/style.css"/>
         <css src="css/styles-old.css"/>
         <css src="css/styles.css"/>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17163
### Description
On occasion the admin url may be leaked to the frontend. This can (and has) result in the admin URL being available in search engines. This provides easy targets for brute force/password guessing hacks.

This fix will add a meta tag which instructs Google and other friendly bots not to add the admin URL to search results.

### Manual testing scenarios
Visit the admin panel and view the source code. The head section should contain 
```
<meta name="robots" content="NOINDEX,NOFOLLOW"/>
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
