### PR TITLE
Fixed typo in TaxRuleRepositoryTest class.

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Tax/Model/TaxRuleRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/TaxRuleRepositoryTest.php
@@ -108,7 +108,7 @@ class TaxRuleRepositoryTest extends \PHPUnit\Framework\TestCase
      * @expectedExceptionMessage No such entity with taxRuleId = 9999
      * @magentoDbIsolation enabled
      */
-    public function testSaveThrowsExceptionIdTargetTaxRulDoesNotExist()
+    public function testSaveThrowsExceptionIdTargetTaxRuleDoesNotExist()
     {
         $taxRuleDataObject = $this->taxRuleFactory->create();
         $taxRuleDataObject->setId(9999)

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/TaxRuleRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/TaxRuleRepositoryTest.php
@@ -108,7 +108,7 @@ class TaxRuleRepositoryTest extends \PHPUnit\Framework\TestCase
      * @expectedExceptionMessage No such entity with taxRuleId = 9999
      * @magentoDbIsolation enabled
      */
-    public function testSaveThrowsExceptionIdTargetTaxRuleDoesNotExist()
+    public function testSaveThrowsExceptionIdIfTargetTaxRuleDoesNotExist()
     {
         $taxRuleDataObject = $this->taxRuleFactory->create();
         $taxRuleDataObject->setId(9999)


### PR DESCRIPTION
### Description
This PR fixes a typo in the TaxRuleRepositoryTest class and changed the method name because the "If" was missing in the name of the method. 

Since it's a test we can rename the method without deprecating it.  