### PR TITLE
[Forwardport] Don't force enable "Use system value" checkboxes

### DIFF
--- a/lib/web/mage/adminhtml/form.js
+++ b/lib/web/mage/adminhtml/form.js
@@ -494,7 +494,8 @@ define([
                     inputs.each(function (item) {
                         // don't touch hidden inputs (and Use Default inputs too), bc they may have custom logic
                         if ((!item.type || item.type != 'hidden') && !($(item.id + '_inherit') && $(item.id + '_inherit').checked) && //eslint-disable-line
-                            !(currentConfig['can_edit_price'] != undefined && !currentConfig['can_edit_price']) //eslint-disable-line
+                            !(currentConfig['can_edit_price'] != undefined && !currentConfig['can_edit_price']) &&  //eslint-disable-line
+                            !item.id.endsWith('_inherit')
                         ) {
                             item.disabled = false;
                             jQuery(item).removeClass('ignore-validate');


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16000
### Description
"Use system value"

### Fixed Issues (if relevant)
No

### Manual testing scenarios
1. Create plugin for \Magento\Config\Block\System\Config\Form\Field with beforeRender() method with code:

```
$element->setDisabled(true);
$element->setIsDisableInheritance(true);
```

2. Open System config page with field disabled by plugin.
Expected: Field is disabled.
Current: Field is enabled.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
