### PR TITLE
[Forwardport] Allow 3rd party modules to perform actions after totals calculation

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/cart/totals-processor/default.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/cart/totals-processor/default.js
@@ -38,7 +38,7 @@ define([
             payload.addressInformation['shipping_carrier_code'] = quote.shippingMethod()['carrier_code'];
         }
 
-        storage.post(
+        return storage.post(
             serviceUrl, JSON.stringify(payload), false
         ).done(function (result) {
             var data = {
@@ -96,7 +96,7 @@ define([
             ) {
                 quote.setTotals(cartCache.get('totals'));
             } else {
-                loadFromServer(address);
+                return loadFromServer(address);
             }
         }
     };

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
@@ -114,7 +114,7 @@ define([
 
         it('estimateTotals if data wasn\'t cached and request was successfully sent', function () {
             var deferral = new $.Deferred();
-            
+
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'isChanged').and.returnValue(true);
             spyOn(mocks['Magento_Customer/js/customer-data'], 'get').and.returnValue(
                 ko.observable({
@@ -139,7 +139,7 @@ define([
 
         it('estimateTotals if data wasn\'t cached and request returns error', function () {
             var deferral = new $.Deferred();
-            
+
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'isChanged').and.returnValue(true);
             spyOn(mocks['Magento_Customer/js/customer-data'], 'get').and.returnValue(
                 ko.observable({

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
@@ -113,13 +113,13 @@ define([
         });
 
         it('estimateTotals if data wasn\'t cached and request was successfully sent', function () {
+            var deferral = new $.Deferred();
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'isChanged').and.returnValue(true);
             spyOn(mocks['Magento_Customer/js/customer-data'], 'get').and.returnValue(
                 ko.observable({
                     'data_id': 1
                 })
             );
-            var deferral = new $.Deferred();
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'get');
             spyOn(mocks['mage/storage'], 'post').and.callFake(function () {
                 data.shippingMethodCode = mocks['Magento_Checkout/js/model/quote'].shippingMethod()['method_code'];
@@ -137,6 +137,7 @@ define([
         });
 
         it('estimateTotals if data wasn\'t cached and request returns error', function () {
+            var deferral = new $.Deferred();
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'isChanged').and.returnValue(true);
             spyOn(mocks['Magento_Customer/js/customer-data'], 'get').and.returnValue(
                 ko.observable({
@@ -144,7 +145,6 @@ define([
                 })
             );
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'get');
-            var deferral = new $.Deferred();
             spyOn(mocks['mage/storage'], 'post').and.callFake(function () {
                 return deferral.reject('Error Message');
             });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
@@ -114,6 +114,7 @@ define([
 
         it('estimateTotals if data wasn\'t cached and request was successfully sent', function () {
             var deferral = new $.Deferred();
+            
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'isChanged').and.returnValue(true);
             spyOn(mocks['Magento_Customer/js/customer-data'], 'get').and.returnValue(
                 ko.observable({
@@ -138,6 +139,7 @@ define([
 
         it('estimateTotals if data wasn\'t cached and request returns error', function () {
             var deferral = new $.Deferred();
+            
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'isChanged').and.returnValue(true);
             spyOn(mocks['Magento_Customer/js/customer-data'], 'get').and.returnValue(
                 ko.observable({

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/totals-processor/default.test.js
@@ -119,14 +119,15 @@ define([
                     'data_id': 1
                 })
             );
+            var deferral = new $.Deferred();
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'get');
             spyOn(mocks['mage/storage'], 'post').and.callFake(function () {
                 data.shippingMethodCode = mocks['Magento_Checkout/js/model/quote'].shippingMethod()['method_code'];
                 data.shippingCarrierCode = mocks['Magento_Checkout/js/model/quote'].shippingMethod()['carrier_code'];
 
-                return new $.Deferred().resolve(result);
+                return deferral.resolve(result);
             });
-            expect(defaultProcessor.estimateTotals(address)).toBeUndefined();
+            expect(defaultProcessor.estimateTotals(address)).toBe(deferral);
             expect(mocks['Magento_Checkout/js/model/quote'].setTotals).toHaveBeenCalledWith(totals);
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(0)[0]).toBe(true);
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(1)[0]).toBe(false);
@@ -143,10 +144,11 @@ define([
                 })
             );
             spyOn(mocks['Magento_Checkout/js/model/cart/cache'], 'get');
+            var deferral = new $.Deferred();
             spyOn(mocks['mage/storage'], 'post').and.callFake(function () {
-                return new $.Deferred().reject('Error Message');
+                return deferral.reject('Error Message');
             });
-            expect(defaultProcessor.estimateTotals(address)).toBeUndefined();
+            expect(defaultProcessor.estimateTotals(address)).toBe(deferral);
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(0)[0]).toBe(true);
             expect(mocks['Magento_Checkout/js/model/totals'].isLoading.calls.argsFor(1)[0]).toBe(false);
             expect(mocks['mage/storage'].post).toHaveBeenCalled();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This is a forwardport of https://github.com/magento/magento2/pull/17127

By returning the storage.post promise, third party modules can perform
additional actions by adding .done/.fail or .always tasks to the request
promise by creating a Javascript mixin for the totals processor.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
