### PR TITLE
Allow import to skip errors

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Validate.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Validate.php
@@ -132,7 +132,7 @@ class Validate extends ImportResultController
     private function addMessageToSkipErrors(Result $resultBlock)
     {
         $import = $this->getImport();
-        if (!$import->getErrorAggregator()->hasFatalExceptions()) {
+        if (!$import->getErrorAggregator()->hasToBeTerminated()) {
             $resultBlock->addSuccess(
                 __('Please fix errors and re-upload file or simply press "Import" button to skip rows with errors'),
                 true

--- a/app/code/Magento/ImportExport/Model/Import.php
+++ b/app/code/Magento/ImportExport/Model/Import.php
@@ -409,6 +409,11 @@ class Import extends \Magento\ImportExport\Model\AbstractModel
 
         $this->addLogComment(__('Begin import of "%1" with "%2" behavior', $this->getEntity(), $this->getBehavior()));
 
+        $this->getErrorAggregator()->initValidationStrategy(
+            $this->getData(self::FIELD_NAME_VALIDATION_STRATEGY),
+            $this->getData(self::FIELD_NAME_ALLOWED_ERROR_COUNT)
+        );
+
         $result = $this->processImport();
 
         if ($result) {

--- a/app/code/Magento/ImportExport/Model/Import/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/AbstractEntity.php
@@ -517,7 +517,7 @@ abstract class AbstractEntity
         $errorRowNum,
         $colName = null,
         $errorMessage = null,
-        $errorLevel = ProcessingError::ERROR_LEVEL_CRITICAL,
+        $errorLevel = ProcessingError::ERROR_LEVEL_NOT_CRITICAL,
         $errorDescription = null
     ) {
         $errorCode = (string)$errorCode;

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -469,7 +469,7 @@ abstract class AbstractEntity
         $errorRowNum,
         $colName = null,
         $errorMessage = null,
-        $errorLevel = ProcessingError::ERROR_LEVEL_CRITICAL,
+        $errorLevel = ProcessingError::ERROR_LEVEL_NOT_CRITICAL,
         $errorDescription = null
     ) {
         $errorCode = (string)$errorCode;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This appears to be a bug that has been in the codebase 3+ years? Maybe it never worked. The "skip error entries" essentially does nothing when importing products or customers. With this PR they can be skipped as expected. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento-engcom/import-export-improvements/issues/75: Magento 2.2.2-dev - CSV Import, skip errors not working
2. https://github.com/magento/magento2/issues/12808: Magento 2.2.2-dev - CSV Import, skip errors not working

### Manual testing scenarios
1. Import csv with one or more validation errors
2. Interface will indicate an error was found but allow user to continue

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
