### PR TITLE
Fix "Required parameter 'theme_dir' was not passed" error when emulating an environment inside an emulated area

### DIFF
--- a/app/code/Magento/Store/Model/App/Emulation.php
+++ b/app/code/Magento/Store/Model/App/Emulation.php
@@ -11,6 +11,7 @@ namespace Magento\Store\Model\App;
 
 use Magento\Framework\App\Area;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Translate\Inline\ConfigInterface;
 
 /**
  * @api
@@ -25,10 +26,35 @@ class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\
      */
     private $appEmulation;
 
+    /**
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\View\DesignInterface $viewDesign
+     * @param \Magento\Framework\App\DesignInterface $design
+     * @param \Magento\Framework\TranslateInterface $translate
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param ConfigInterface $inlineConfig
+     * @param \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation
+     * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param array $data
+     * @param \Magento\Store\Model\App\EnvironmentEmulation $appEmulation
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
     public function __construct(
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\View\DesignInterface $viewDesign,
+        \Magento\Framework\App\DesignInterface $design,
+        \Magento\Framework\TranslateInterface $translate,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        ConfigInterface $inlineConfig,
+        \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation,
+        \Magento\Framework\Locale\ResolverInterface $localeResolver,
+        \Psr\Log\LoggerInterface $logger,
+        array $data = [],
         \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
     ) {
-        parent::__construct();
+        parent::__construct($data);
         $this->appEmulation = $appEmulation ?? ObjectManager::getInstance()
                 ->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
     }

--- a/app/code/Magento/Store/Model/App/Emulation.php
+++ b/app/code/Magento/Store/Model/App/Emulation.php
@@ -4,9 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-/**
- * Emulation model
- */
 namespace Magento\Store\Model\App;
 
 use Magento\Framework\App\Area;
@@ -14,15 +11,17 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Translate\Inline\ConfigInterface;
 
 /**
+ * Emulation model
+ *
  * @api
  * @since 100.0.2
- * @deprecated
- * @see \Magento\Store\Model\App\EnvironmentEmulation
+ * @deprecated because additional public functionality needed to be added. Used only for backward compatibility.
+ * @see \Magento\Store\Model\App\EmulationInterface
  */
-class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\Model\App\EmulationInterface
+class Emulation extends \Magento\Framework\DataObject
 {
     /**
-     * @var \Magento\Store\Model\App\EnvironmentEmulation
+     * @var \Magento\Store\Model\App\EmulationInterface
      */
     private $appEmulation;
 
@@ -37,7 +36,7 @@ class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\
      * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
      * @param \Psr\Log\LoggerInterface $logger
      * @param array $data
-     * @param \Magento\Store\Model\App\EnvironmentEmulation $appEmulation
+     * @param \Magento\Store\Model\App\EmulationInterface $appEmulation
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -52,15 +51,22 @@ class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\
         \Magento\Framework\Locale\ResolverInterface $localeResolver,
         \Psr\Log\LoggerInterface $logger,
         array $data = [],
-        \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
+        \Magento\Store\Model\App\EmulationInterface $appEmulation = null
     ) {
         parent::__construct($data);
         $this->appEmulation = $appEmulation ?? ObjectManager::getInstance()
-                ->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
+                ->get(\Magento\Store\Model\App\EmulationInterface::class);
     }
 
     /**
-     * {@inheritdoc}
+     * Start environment emulation of the specified store
+     *
+     * Function returns information about initial store environment and emulates environment of another store
+     *
+     * @param integer $storeId
+     * @param string $area
+     * @param bool $force A true value will ensure that environment is always emulated, regardless of current store
+     * @return void
      */
     public function startEnvironmentEmulation($storeId, $area = Area::AREA_FRONTEND, $force = false)
     {
@@ -68,7 +74,11 @@ class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\
     }
 
     /**
-     * {@inheritdoc}
+     * Stop environment emulation
+     *
+     * Function restores initial store environment
+     *
+     * @return $this
      */
     public function stopEnvironmentEmulation()
     {
@@ -78,7 +88,9 @@ class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\
     }
 
     /**
-     * {@inheritdoc}
+     * Stores current environment info
+     *
+     * @return void
      */
     public function storeCurrentEnvironmentInfo()
     {

--- a/app/code/Magento/Store/Model/App/Emulation.php
+++ b/app/code/Magento/Store/Model/App/Emulation.php
@@ -9,250 +9,53 @@
  */
 namespace Magento\Store\Model\App;
 
-use Magento\Framework\Translate\Inline\ConfigInterface;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * @api
  * @since 100.0.2
+ * @deprecated
+ * @see \Magento\Store\Model\App\EnvironmentEmulation
  */
-class Emulation extends \Magento\Framework\DataObject
+class Emulation extends \Magento\Framework\DataObject implements \Magento\Store\Model\App\EmulationInterface
 {
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var \Magento\Store\Model\App\EnvironmentEmulation
      */
-    protected $_storeManager;
+    private $appEmulation;
 
-    /**
-     * @var \Magento\Framework\TranslateInterface
-     */
-    protected $_translate;
-
-    /**
-     * Core store config
-     *
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
-     */
-    protected $_scopeConfig;
-
-    /**
-     * @var \Magento\Framework\Locale\ResolverInterface
-     */
-    protected $_localeResolver;
-
-    /**
-     * @var \Magento\Framework\App\DesignInterface
-     */
-    protected $_design;
-
-    /**
-     * @var ConfigInterface
-     */
-    protected $inlineConfig;
-
-    /**
-     * @var \Magento\Framework\Translate\Inline\StateInterface
-     */
-    protected $inlineTranslation;
-
-    /**
-     * Ini
-     *
-     * @var \Magento\Framework\DataObject
-     */
-    private $initialEnvironmentInfo;
-
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param \Magento\Framework\View\DesignInterface $viewDesign
-     * @param \Magento\Framework\App\DesignInterface $design
-     * @param \Magento\Framework\TranslateInterface $translate
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param ConfigInterface $inlineConfig
-     * @param \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation
-     * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
-     * @param \Psr\Log\LoggerInterface $logger
-     * @param array $data
-     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
-     */
     public function __construct(
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\View\DesignInterface $viewDesign,
-        \Magento\Framework\App\DesignInterface $design,
-        \Magento\Framework\TranslateInterface $translate,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        ConfigInterface $inlineConfig,
-        \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation,
-        \Magento\Framework\Locale\ResolverInterface $localeResolver,
-        \Psr\Log\LoggerInterface $logger,
-        array $data = []
+        \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
     ) {
-        $this->_localeResolver = $localeResolver;
-        parent::__construct($data);
-        $this->_storeManager = $storeManager;
-        $this->_viewDesign = $viewDesign;
-        $this->_design = $design;
-        $this->_translate = $translate;
-        $this->_scopeConfig = $scopeConfig;
-        $this->inlineConfig = $inlineConfig;
-        $this->inlineTranslation = $inlineTranslation;
-        $this->logger = $logger;
+        parent::__construct();
+        $this->appEmulation = $appEmulation ?? ObjectManager::getInstance()
+                ->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
     }
 
     /**
-     * Start environment emulation of the specified store
-     *
-     * Function returns information about initial store environment and emulates environment of another store
-     *
-     * @param integer $storeId
-     * @param string $area
-     * @param bool $force A true value will ensure that environment is always emulated, regardless of current store
-     * @return void
+     * {@inheritdoc}
      */
-    public function startEnvironmentEmulation(
-        $storeId,
-        $area = \Magento\Framework\App\Area::AREA_FRONTEND,
-        $force = false
-    ) {
-        // Only allow a single level of emulation
-        if ($this->isEnvironmentEmulated()) {
-            $this->logger->error(__('Environment emulation nesting is not allowed.'));
-            return;
-        }
-
-        if ($storeId == $this->_storeManager->getStore()->getStoreId() && !$force) {
-            return;
-        }
-        $this->storeCurrentEnvironmentInfo();
-
-        // emulate inline translations
-        $this->inlineTranslation->suspend($this->inlineConfig->isActive($storeId));
-
-        // emulate design
-        $storeTheme = $this->_viewDesign->getConfigurationDesignTheme($area, ['store' => $storeId]);
-        $this->_viewDesign->setDesignTheme($storeTheme, $area);
-
-        if ($area == \Magento\Framework\App\Area::AREA_FRONTEND) {
-            $designChange = $this->_design->loadChange($storeId);
-            if ($designChange->getData()) {
-                $this->_viewDesign->setDesignTheme($designChange->getDesign(), $area);
-            }
-        }
-
-        // Current store needs to be changed right before locale change and after design change
-        $this->_storeManager->setCurrentStore($storeId);
-
-        // emulate locale
-        $newLocaleCode = $this->_scopeConfig->getValue(
-            $this->_localeResolver->getDefaultLocalePath(),
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-        $this->_localeResolver->setLocale($newLocaleCode);
-        $this->_translate->setLocale($newLocaleCode);
-        $this->_translate->loadData($area);
-
-        return;
+    public function startEnvironmentEmulation($storeId, $area = Area::AREA_FRONTEND, $force = false)
+    {
+        $this->appEmulation->startEnvironmentEmulation($storeId, $area, $force);
     }
 
     /**
-     * Stop environment emulation
-     *
-     * Function restores initial store environment
-     *
-     * @return \Magento\Store\Model\App\Emulation
+     * {@inheritdoc}
      */
     public function stopEnvironmentEmulation()
     {
-        if (!$this->isEnvironmentEmulated()) {
-            return $this;
-        }
+        $this->appEmulation->stopEnvironmentEmulation();
 
-        $this->_restoreInitialInlineTranslation($this->initialEnvironmentInfo->getInitialTranslateInline());
-        $initialDesign = $this->initialEnvironmentInfo->getInitialDesign();
-        $this->_restoreInitialDesign($initialDesign);
-        // Current store needs to be changed right before locale change and after design change
-        $this->_storeManager->setCurrentStore($initialDesign['store']);
-        $this->_restoreInitialLocale($this->initialEnvironmentInfo->getInitialLocaleCode(), $initialDesign['area']);
-
-        $this->initialEnvironmentInfo = null;
         return $this;
     }
 
     /**
-     * Checks whether the environment is being emulated
-     *
-     * @return bool
-     */
-    public function isEnvironmentEmulated()
-    {
-        return $this->initialEnvironmentInfo !== null;
-    }
-
-    /**
-     * Stores current environment info
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function storeCurrentEnvironmentInfo()
     {
-        $this->initialEnvironmentInfo = new \Magento\Framework\DataObject();
-        $this->initialEnvironmentInfo->setInitialTranslateInline(
-            $this->inlineTranslation->isEnabled()
-        )->setInitialDesign(
-            [
-                'area' => $this->_viewDesign->getArea(),
-                'theme' => $this->_viewDesign->getDesignTheme(),
-                'store' => $this->_storeManager->getStore()->getStoreId(),
-            ]
-        )->setInitialLocaleCode(
-            $this->_localeResolver->getLocale()
-        );
-    }
-
-    /**
-     * Restore initial inline translation state
-     *
-     * @param bool $initialTranslate
-     * @return $this
-     */
-    protected function _restoreInitialInlineTranslation($initialTranslate)
-    {
-        $this->inlineTranslation->resume($initialTranslate);
-        return $this;
-    }
-
-    /**
-     * Restore design of the initial store
-     *
-     * @param array $initialDesign
-     * @return $this
-     */
-    protected function _restoreInitialDesign(array $initialDesign)
-    {
-        $this->_viewDesign->setDesignTheme($initialDesign['theme'], $initialDesign['area']);
-        return $this;
-    }
-
-    /**
-     * Restore locale of the initial store
-     *
-     * @param string $initialLocaleCode
-     * @param string $initialArea
-     * @return $this
-     */
-    protected function _restoreInitialLocale(
-        $initialLocaleCode,
-        $initialArea = \Magento\Framework\App\Area::AREA_ADMINHTML
-    ) {
-        $this->_localeResolver->setLocale($initialLocaleCode);
-        $this->_translate->setLocale($initialLocaleCode);
-        $this->_translate->loadData($initialArea);
-
-        return $this;
+        $this->appEmulation->storeCurrentEnvironmentInfo();
     }
 }

--- a/app/code/Magento/Store/Model/App/Emulation.php
+++ b/app/code/Magento/Store/Model/App/Emulation.php
@@ -119,7 +119,7 @@ class Emulation extends \Magento\Framework\DataObject
         $force = false
     ) {
         // Only allow a single level of emulation
-        if ($this->initialEnvironmentInfo !== null) {
+        if ($this->isEnvironmentEmulated()) {
             $this->logger->error(__('Environment emulation nesting is not allowed.'));
             return;
         }
@@ -168,7 +168,7 @@ class Emulation extends \Magento\Framework\DataObject
      */
     public function stopEnvironmentEmulation()
     {
-        if ($this->initialEnvironmentInfo === null) {
+        if (!$this->isEnvironmentEmulated()) {
             return $this;
         }
 
@@ -181,6 +181,16 @@ class Emulation extends \Magento\Framework\DataObject
 
         $this->initialEnvironmentInfo = null;
         return $this;
+    }
+
+    /**
+     * Checks whether the environment is being emulated
+     *
+     * @return bool
+     */
+    public function isEnvironmentEmulated()
+    {
+        return $this->initialEnvironmentInfo !== null;
     }
 
     /**

--- a/app/code/Magento/Store/Model/App/EmulationInterface.php
+++ b/app/code/Magento/Store/Model/App/EmulationInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Store\Model\App;
+
+use Magento\Framework\App\Area;
+
+interface EmulationInterface
+{
+    /**
+     * Start environment emulation of the specified store
+     *
+     * Function returns information about initial store environment and emulates environment of another store
+     *
+     * @param integer $storeId
+     * @param string $area
+     * @param bool $force A true value will ensure that environment is always emulated, regardless of current store
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function startEnvironmentEmulation($storeId, $area = Area::AREA_FRONTEND, $force = false);
+
+    /**
+     * Stop environment emulation
+     *
+     * Function restores initial store environment
+     *
+     * @return $this
+     */
+    public function stopEnvironmentEmulation();
+
+    /**
+     * Stores current environment info
+     *
+     * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function storeCurrentEnvironmentInfo();
+}

--- a/app/code/Magento/Store/Model/App/EmulationInterface.php
+++ b/app/code/Magento/Store/Model/App/EmulationInterface.php
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Store\Model\App;
 
 use Magento\Framework\App\Area;
 
+/**
+ * Environment emulation interface
+ */
 interface EmulationInterface
 {
     /**
@@ -18,7 +22,6 @@ interface EmulationInterface
      * @param string $area
      * @param bool $force A true value will ensure that environment is always emulated, regardless of current store
      * @return void
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function startEnvironmentEmulation($storeId, $area = Area::AREA_FRONTEND, $force = false);
 
@@ -35,7 +38,13 @@ interface EmulationInterface
      * Stores current environment info
      *
      * @return void
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function storeCurrentEnvironmentInfo();
+
+    /**
+     * Checks whether the environment is being emulated
+     *
+     * @return bool
+     */
+    public function isEnvironmentEmulated();
 }

--- a/app/code/Magento/Store/Model/App/EnvironmentEmulation.php
+++ b/app/code/Magento/Store/Model/App/EnvironmentEmulation.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Emulation model
+ */
+namespace Magento\Store\Model\App;
+
+use \Magento\Framework\App\Area;
+
+class EnvironmentEmulation extends \Magento\Framework\DataObject implements \Magento\Store\Model\App\EmulationInterface
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var \Magento\Framework\TranslateInterface
+     */
+    private $translate;
+
+    /**
+     * Core store config
+     *
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var \Magento\Framework\Locale\ResolverInterface
+     */
+    private $localeResolver;
+
+    /**
+     * @var \Magento\Framework\App\DesignInterface
+     */
+    private $design;
+
+    /**
+     * @var \Magento\Framework\View\DesignInterface
+     */
+    private $viewDesign;
+
+    /**
+     * @var \Magento\Framework\Translate\Inline\ConfigInterface
+     */
+    private $inlineConfig;
+
+    /**
+     * @var \Magento\Framework\Translate\Inline\StateInterface
+     */
+    private $inlineTranslation;
+
+    /**
+     * Ini
+     *
+     * @var \Magento\Framework\DataObject
+     */
+    private $initialEnvironmentInfo;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\View\DesignInterface $viewDesign
+     * @param \Magento\Framework\App\DesignInterface $design
+     * @param \Magento\Framework\TranslateInterface $translate
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\Translate\Inline\ConfigInterface $inlineConfig
+     * @param \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation
+     * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param array $data
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\View\DesignInterface $viewDesign,
+        \Magento\Framework\App\DesignInterface $design,
+        \Magento\Framework\TranslateInterface $translate,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Translate\Inline\ConfigInterface $inlineConfig,
+        \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation,
+        \Magento\Framework\Locale\ResolverInterface $localeResolver,
+        \Psr\Log\LoggerInterface $logger,
+        array $data = []
+    ) {
+        parent::__construct($data);
+        $this->localeResolver = $localeResolver;
+        $this->storeManager = $storeManager;
+        $this->viewDesign = $viewDesign;
+        $this->design = $design;
+        $this->translate = $translate;
+        $this->scopeConfig = $scopeConfig;
+        $this->inlineConfig = $inlineConfig;
+        $this->inlineTranslation = $inlineTranslation;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startEnvironmentEmulation($storeId, $area = Area::AREA_FRONTEND, $force = false)
+    {
+        // Only allow a single level of emulation
+        if ($this->isEnvironmentEmulated()) {
+            $this->logger->error(__('Environment emulation nesting is not allowed.'));
+            return;
+        }
+
+        if ($storeId == $this->storeManager->getStore()->getStoreId() && !$force) {
+            return;
+        }
+        $this->storeCurrentEnvironmentInfo();
+
+        // emulate inline translations
+        $this->inlineTranslation->suspend($this->inlineConfig->isActive($storeId));
+
+        // emulate design
+        $storeTheme = $this->viewDesign->getConfigurationDesignTheme($area, ['store' => $storeId]);
+        $this->viewDesign->setDesignTheme($storeTheme, $area);
+
+        if ($area == \Magento\Framework\App\Area::AREA_FRONTEND) {
+            $designChange = $this->design->loadChange($storeId);
+            if ($designChange->getData()) {
+                $this->viewDesign->setDesignTheme($designChange->getDesign(), $area);
+            }
+        }
+
+        // Current store needs to be changed right before locale change and after design change
+        $this->storeManager->setCurrentStore($storeId);
+
+        // emulate locale
+        $newLocaleCode = $this->scopeConfig->getValue(
+            $this->localeResolver->getDefaultLocalePath(),
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        $this->localeResolver->setLocale($newLocaleCode);
+        $this->translate->setLocale($newLocaleCode);
+        $this->translate->loadData($area);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stopEnvironmentEmulation()
+    {
+        if (!$this->isEnvironmentEmulated()) {
+            return $this;
+        }
+
+        $this->restoreInitialInlineTranslation($this->initialEnvironmentInfo->getInitialTranslateInline());
+        $initialDesign = $this->initialEnvironmentInfo->getInitialDesign();
+        $this->restoreInitialDesign($initialDesign);
+        // Current store needs to be changed right before locale change and after design change
+        $this->storeManager->setCurrentStore($initialDesign['store']);
+        $this->restoreInitialLocale($this->initialEnvironmentInfo->getInitialLocaleCode(), $initialDesign['area']);
+
+        $this->initialEnvironmentInfo = null;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeCurrentEnvironmentInfo()
+    {
+        $this->initialEnvironmentInfo = new \Magento\Framework\DataObject();
+        $this->initialEnvironmentInfo->setInitialTranslateInline(
+            $this->inlineTranslation->isEnabled()
+        )->setInitialDesign(
+            [
+                'area' => $this->viewDesign->getArea(),
+                'theme' => $this->viewDesign->getDesignTheme(),
+                'store' => $this->storeManager->getStore()->getStoreId(),
+            ]
+        )->setInitialLocaleCode(
+            $this->localeResolver->getLocale()
+        );
+    }
+
+    /**
+     * Checks whether the environment is being emulated
+     *
+     * @return bool
+     */
+    public function isEnvironmentEmulated()
+    {
+        return $this->initialEnvironmentInfo !== null;
+    }
+
+    /**
+     * Restore initial inline translation state
+     *
+     * @param bool $initialTranslate
+     * @return $this
+     */
+    private function restoreInitialInlineTranslation($initialTranslate)
+    {
+        $this->inlineTranslation->resume($initialTranslate);
+        return $this;
+    }
+
+    /**
+     * Restore design of the initial store
+     *
+     * @param array $initialDesign
+     * @return $this
+     */
+    private function restoreInitialDesign(array $initialDesign)
+    {
+        $this->viewDesign->setDesignTheme($initialDesign['theme'], $initialDesign['area']);
+        return $this;
+    }
+
+    /**
+     * Restore locale of the initial store
+     *
+     * @param string $initialLocaleCode
+     * @param string $initialArea
+     * @return $this
+     */
+    private function restoreInitialLocale(
+        $initialLocaleCode,
+        $initialArea = \Magento\Framework\App\Area::AREA_ADMINHTML
+    ) {
+        $this->localeResolver->setLocale($initialLocaleCode);
+        $this->translate->setLocale($initialLocaleCode);
+        $this->translate->loadData($initialArea);
+
+        return $this;
+    }
+}

--- a/app/code/Magento/Store/Model/App/EnvironmentEmulation.php
+++ b/app/code/Magento/Store/Model/App/EnvironmentEmulation.php
@@ -4,13 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/**
- * Emulation model
- */
 namespace Magento\Store\Model\App;
 
 use \Magento\Framework\App\Area;
 
+/**
+ * Environment emulation model
+ */
 class EnvironmentEmulation extends \Magento\Framework\DataObject implements \Magento\Store\Model\App\EmulationInterface
 {
     /**
@@ -188,9 +188,7 @@ class EnvironmentEmulation extends \Magento\Framework\DataObject implements \Mag
     }
 
     /**
-     * Checks whether the environment is being emulated
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isEnvironmentEmulated()
     {

--- a/app/code/Magento/Store/Test/Unit/Model/App/EmulationTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/App/EmulationTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests Magento\Store\Model\App\Emulation
+ * Tests Magento\Store\Model\App\EnvironmentEmulation
  *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -71,7 +71,7 @@ class EmulationTest extends \PHPUnit\Framework\TestCase
     const NEW_STORE_ID = 9;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation
+     * @var \Magento\Store\Model\App\EnvironmentEmulation
      */
     private $model;
 
@@ -112,7 +112,7 @@ class EmulationTest extends \PHPUnit\Framework\TestCase
 
         // Prepare SUT
         $this->model = $this->objectManager->getObject(
-            \Magento\Store\Model\App\Emulation::class,
+            \Magento\Store\Model\App\EnvironmentEmulation::class,
             [
                 'storeManager' => $this->storeManagerMock,
                 'viewDesign' => $this->viewDesignMock,

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -26,6 +26,7 @@
     <preference for="Magento\Framework\App\ScopeTreeProviderInterface" type="Magento\Store\Model\ScopeTreeProvider"/>
     <preference for="Magento\Framework\App\ScopeValidatorInterface" type="Magento\Store\Model\ScopeValidator"/>
     <preference for="Magento\Store\Model\StoreSwitcherInterface" type="Magento\Store\Model\StoreSwitcher" />
+    <preference for="Magento\Store\Model\App\EmulationInterface" type="Magento\Store\Model\App\EnvironmentEmulation" />
     <type name="Magento\Framework\App\Http\Context">
         <arguments>
             <argument name="default" xsi:type="array">

--- a/app/code/Magento/Theme/Model/Theme.php
+++ b/app/code/Magento/Theme/Model/Theme.php
@@ -90,7 +90,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     protected $inheritanceSequence;
 
     /**
-     * @var \Magento\Store\Model\App\EnvironmentEmulation
+     * @var \Magento\Store\Model\App\EmulationInterface
      */
     private $appEmulation;
 
@@ -108,7 +108,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
      * @param \Magento\Theme\Model\ResourceModel\Theme\Collection $resourceCollection
      * @param array $data
      * @param ThemeFactory $themeModelFactory
-     * @param \Magento\Store\Model\App\EnvironmentEmulation $appEmulation
+     * @param \Magento\Store\Model\App\EmulationInterface $appEmulation
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -123,7 +123,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
         ThemeCollection $resourceCollection = null,
         array $data = [],
         ThemeFactory $themeModelFactory = null,
-        \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
+        \Magento\Store\Model\App\EmulationInterface $appEmulation = null
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
         $this->_themeFactory = $themeFactory;
@@ -133,7 +133,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
         $this->_customFactory = $customizationFactory;
         $this->themeModelFactory = $themeModelFactory ?? ObjectManager::getInstance()->get(ThemeFactory::class);
         $this->appEmulation = $appEmulation ?? ObjectManager::getInstance()
-                ->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
+                ->get(\Magento\Store\Model\App\EmulationInterface::class);
         $this->addData(['type' => self::TYPE_VIRTUAL]);
     }
 

--- a/app/code/Magento/Theme/Model/Theme.php
+++ b/app/code/Magento/Theme/Model/Theme.php
@@ -90,7 +90,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     protected $inheritanceSequence;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation
+     * @var \Magento\Store\Model\App\EnvironmentEmulation
      */
     private $appEmulation;
 
@@ -108,7 +108,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
      * @param \Magento\Theme\Model\ResourceModel\Theme\Collection $resourceCollection
      * @param array $data
      * @param ThemeFactory $themeModelFactory
-     * @param \Magento\Store\Model\App\Emulation $appEmulation
+     * @param \Magento\Store\Model\App\EnvironmentEmulation $appEmulation
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -123,7 +123,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
         ThemeCollection $resourceCollection = null,
         array $data = [],
         ThemeFactory $themeModelFactory = null,
-        \Magento\Store\Model\App\Emulation $appEmulation = null
+        \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
         $this->_themeFactory = $themeFactory;
@@ -133,7 +133,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
         $this->_customFactory = $customizationFactory;
         $this->themeModelFactory = $themeModelFactory ?? ObjectManager::getInstance()->get(ThemeFactory::class);
         $this->appEmulation = $appEmulation ?? ObjectManager::getInstance()
-                ->get(\Magento\Store\Model\App\Emulation::class);
+                ->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
         $this->addData(['type' => self::TYPE_VIRTUAL]);
     }
 

--- a/app/code/Magento/Theme/Model/Theme.php
+++ b/app/code/Magento/Theme/Model/Theme.php
@@ -80,11 +80,6 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     protected $_customFactory;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation
-     */
-    protected $appEmulation;
-
-    /**
      * @var ThemeFactory
      */
     private $themeModelFactory;
@@ -93,6 +88,11 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
      * @var ThemeInterface[]
      */
     protected $inheritanceSequence;
+
+    /**
+     * @var \Magento\Store\Model\App\Emulation
+     */
+    private $appEmulation;
 
     /**
      * Initialize dependencies
@@ -104,11 +104,11 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
      * @param \Magento\Framework\View\Design\Theme\ImageFactory $imageFactory
      * @param \Magento\Framework\View\Design\Theme\Validator $validator
      * @param \Magento\Framework\View\Design\Theme\CustomizationFactory $customizationFactory
-     * @param \Magento\Store\Model\App\Emulation $appEmulation
      * @param \Magento\Theme\Model\ResourceModel\Theme $resource
      * @param \Magento\Theme\Model\ResourceModel\Theme\Collection $resourceCollection
      * @param array $data
      * @param ThemeFactory $themeModelFactory
+     * @param \Magento\Store\Model\App\Emulation $appEmulation
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -119,11 +119,11 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
         \Magento\Framework\View\Design\Theme\ImageFactory $imageFactory,
         \Magento\Framework\View\Design\Theme\Validator $validator,
         \Magento\Framework\View\Design\Theme\CustomizationFactory $customizationFactory,
-        \Magento\Store\Model\App\Emulation $appEmulation,
         \Magento\Theme\Model\ResourceModel\Theme $resource = null,
         ThemeCollection $resourceCollection = null,
         array $data = [],
-        ThemeFactory $themeModelFactory = null
+        ThemeFactory $themeModelFactory = null,
+        \Magento\Store\Model\App\Emulation $appEmulation = null
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
         $this->_themeFactory = $themeFactory;
@@ -131,8 +131,9 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
         $this->_imageFactory = $imageFactory;
         $this->_validator = $validator;
         $this->_customFactory = $customizationFactory;
-        $this->appEmulation = $appEmulation;
         $this->themeModelFactory = $themeModelFactory ?? ObjectManager::getInstance()->get(ThemeFactory::class);
+        $this->appEmulation = $appEmulation ?? ObjectManager::getInstance()
+                ->get(\Magento\Store\Model\App\Emulation::class);
         $this->addData(['type' => self::TYPE_VIRTUAL]);
     }
 

--- a/app/code/Magento/Theme/Model/View/Design.php
+++ b/app/code/Magento/Theme/Model/View/Design.php
@@ -74,7 +74,7 @@ class Design implements \Magento\Framework\View\DesignInterface
     protected $_appState;
 
     /**
-     * @var \Magento\Store\Model\App\EnvironmentEmulation
+     * @var \Magento\Store\Model\App\EmulationInterface
      */
     private $appEmulation;
 
@@ -86,7 +86,7 @@ class Design implements \Magento\Framework\View\DesignInterface
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\App\State $appState
      * @param array $themes
-     * @param \Magento\Store\Model\App\EnvironmentEmulation $appEmulation
+     * @param \Magento\Store\Model\App\EmulationInterface $appEmulation
      */
     public function __construct(
         \Magento\Store\Model\StoreManagerInterface $storeManager,
@@ -96,7 +96,7 @@ class Design implements \Magento\Framework\View\DesignInterface
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\App\State $appState,
         array $themes,
-        \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
+        \Magento\Store\Model\App\EmulationInterface $appEmulation = null
     ) {
         $this->_storeManager = $storeManager;
         $this->_flyweightFactory = $flyweightFactory;
@@ -106,7 +106,7 @@ class Design implements \Magento\Framework\View\DesignInterface
         $this->_themes = $themes;
         $this->objectManager = $objectManager;
         $this->appEmulation = $appEmulation
-            ?? $objectManager->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
+            ?? $objectManager->get(\Magento\Store\Model\App\EmulationInterface::class);
     }
 
     /**
@@ -130,7 +130,6 @@ class Design implements \Magento\Framework\View\DesignInterface
      */
     public function getArea()
     {
-        // In order to support environment emulation of area, if area is set, return it
         if ($this->_area
             && (!$this->_appState->isAreaCodeEmulated() || $this->appEmulation->isEnvironmentEmulated())
         ) {

--- a/app/code/Magento/Theme/Model/View/Design.php
+++ b/app/code/Magento/Theme/Model/View/Design.php
@@ -74,7 +74,7 @@ class Design implements \Magento\Framework\View\DesignInterface
     protected $_appState;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation
+     * @var \Magento\Store\Model\App\EnvironmentEmulation
      */
     private $appEmulation;
 
@@ -86,7 +86,7 @@ class Design implements \Magento\Framework\View\DesignInterface
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\App\State $appState
      * @param array $themes
-     * @param \Magento\Store\Model\App\Emulation $appEmulation
+     * @param \Magento\Store\Model\App\EnvironmentEmulation $appEmulation
      */
     public function __construct(
         \Magento\Store\Model\StoreManagerInterface $storeManager,
@@ -96,7 +96,7 @@ class Design implements \Magento\Framework\View\DesignInterface
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\App\State $appState,
         array $themes,
-        \Magento\Store\Model\App\Emulation $appEmulation = null
+        \Magento\Store\Model\App\EnvironmentEmulation $appEmulation = null
     ) {
         $this->_storeManager = $storeManager;
         $this->_flyweightFactory = $flyweightFactory;
@@ -105,7 +105,8 @@ class Design implements \Magento\Framework\View\DesignInterface
         $this->_appState = $appState;
         $this->_themes = $themes;
         $this->objectManager = $objectManager;
-        $this->appEmulation = $appEmulation ?? $objectManager->get(\Magento\Store\Model\App\Emulation::class);
+        $this->appEmulation = $appEmulation
+            ?? $objectManager->get(\Magento\Store\Model\App\EnvironmentEmulation::class);
     }
 
     /**

--- a/app/code/Magento/Theme/Model/View/Design.php
+++ b/app/code/Magento/Theme/Model/View/Design.php
@@ -76,7 +76,7 @@ class Design implements \Magento\Framework\View\DesignInterface
     /**
      * @var \Magento\Store\Model\App\Emulation
      */
-    protected $appEmulation;
+    private $appEmulation;
 
     /**
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
@@ -85,8 +85,8 @@ class Design implements \Magento\Framework\View\DesignInterface
      * @param \Magento\Theme\Model\ThemeFactory $themeFactory
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\App\State $appState
-     * @param \Magento\Store\Model\App\Emulation $appEmulation
      * @param array $themes
+     * @param \Magento\Store\Model\App\Emulation $appEmulation
      */
     public function __construct(
         \Magento\Store\Model\StoreManagerInterface $storeManager,
@@ -95,17 +95,17 @@ class Design implements \Magento\Framework\View\DesignInterface
         \Magento\Theme\Model\ThemeFactory $themeFactory,
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\App\State $appState,
-        \Magento\Store\Model\App\Emulation $appEmulation,
-        array $themes
+        array $themes,
+        \Magento\Store\Model\App\Emulation $appEmulation = null
     ) {
         $this->_storeManager = $storeManager;
         $this->_flyweightFactory = $flyweightFactory;
         $this->_themeFactory = $themeFactory;
         $this->_scopeConfig = $scopeConfig;
         $this->_appState = $appState;
-        $this->appEmulation = $appEmulation;
         $this->_themes = $themes;
         $this->objectManager = $objectManager;
+        $this->appEmulation = $appEmulation ?? $objectManager->get(\Magento\Store\Model\App\Emulation::class);
     }
 
     /**
@@ -125,6 +125,7 @@ class Design implements \Magento\Framework\View\DesignInterface
      * Retrieve package area
      *
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getArea()
     {

--- a/app/code/Magento/Theme/Model/View/Design.php
+++ b/app/code/Magento/Theme/Model/View/Design.php
@@ -74,12 +74,18 @@ class Design implements \Magento\Framework\View\DesignInterface
     protected $_appState;
 
     /**
+     * @var \Magento\Store\Model\App\Emulation
+     */
+    protected $appEmulation;
+
+    /**
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\View\Design\Theme\FlyweightFactory $flyweightFactory
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Theme\Model\ThemeFactory $themeFactory
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\App\State $appState
+     * @param \Magento\Store\Model\App\Emulation $appEmulation
      * @param array $themes
      */
     public function __construct(
@@ -89,6 +95,7 @@ class Design implements \Magento\Framework\View\DesignInterface
         \Magento\Theme\Model\ThemeFactory $themeFactory,
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\App\State $appState,
+        \Magento\Store\Model\App\Emulation $appEmulation,
         array $themes
     ) {
         $this->_storeManager = $storeManager;
@@ -96,6 +103,7 @@ class Design implements \Magento\Framework\View\DesignInterface
         $this->_themeFactory = $themeFactory;
         $this->_scopeConfig = $scopeConfig;
         $this->_appState = $appState;
+        $this->appEmulation = $appEmulation;
         $this->_themes = $themes;
         $this->objectManager = $objectManager;
     }
@@ -121,7 +129,9 @@ class Design implements \Magento\Framework\View\DesignInterface
     public function getArea()
     {
         // In order to support environment emulation of area, if area is set, return it
-        if ($this->_area && !$this->_appState->isAreaCodeEmulated()) {
+        if ($this->_area
+            && (!$this->_appState->isAreaCodeEmulated() || $this->appEmulation->isEnvironmentEmulated())
+        ) {
             return $this->_area;
         }
         return $this->_appState->getAreaCode();

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -64,7 +64,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
     private $themeModelFactory;
 
     /**
-     * @var \Magento\Store\Model\App\EnvironmentEmulation|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\App\EmulationInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $appEmulation;
 
@@ -91,7 +91,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
         $this->themeModelFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
         $this->validator = $this->createMock(\Magento\Framework\View\Design\Theme\Validator::class);
         $this->appState = $this->createMock(\Magento\Framework\App\State::class);
-        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\EnvironmentEmulation::class);
+        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\EmulationInterface::class);
 
         $objectManagerHelper = new ObjectManager($this);
         $arguments = $objectManagerHelper->getConstructArguments(

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -64,7 +64,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
     private $themeModelFactory;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\App\EnvironmentEmulation|\PHPUnit_Framework_MockObject_MockObject
      */
     private $appEmulation;
 
@@ -91,7 +91,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
         $this->themeModelFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
         $this->validator = $this->createMock(\Magento\Framework\View\Design\Theme\Validator::class);
         $this->appState = $this->createMock(\Magento\Framework\App\State::class);
-        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\Emulation::class);
+        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\EnvironmentEmulation::class);
 
         $objectManagerHelper = new ObjectManager($this);
         $arguments = $objectManagerHelper->getConstructArguments(

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -63,6 +63,11 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
      */
     private $themeModelFactory;
 
+    /**
+     * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $appEmulation;
+
     protected function setUp()
     {
         $customizationConfig = $this->createMock(\Magento\Theme\Model\Config\Customization::class);
@@ -86,6 +91,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
         $this->themeModelFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
         $this->validator = $this->createMock(\Magento\Framework\View\Design\Theme\Validator::class);
         $this->appState = $this->createMock(\Magento\Framework\App\State::class);
+        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\Emulation::class);
 
         $objectManagerHelper = new ObjectManager($this);
         $arguments = $objectManagerHelper->getConstructArguments(
@@ -99,7 +105,8 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
                 'domainFactory' => $this->domainFactory,
                 'validator' => $this->validator,
                 'appState' => $this->appState,
-                'themeModelFactory' => $this->themeModelFactory
+                'themeModelFactory' => $this->themeModelFactory,
+                'appEmulation' => $this->appEmulation
             ]
         );
 

--- a/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
@@ -41,7 +41,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
     protected $config;
 
     /**
-     * @var \Magento\Store\Model\App\EnvironmentEmulation|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\App\EmulationInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $appEmulation;
 
@@ -64,7 +64,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
         $this->objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
         $this->state = $this->createMock(\Magento\Framework\App\State::class);
         $themes = [Design::DEFAULT_AREA => self::THEME_NAME];
-        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\EnvironmentEmulation::class);
+        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\EmulationInterface::class);
         $this->model = new Design(
             $this->storeManager,
             $this->flyweightThemeFactory,

--- a/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
@@ -41,7 +41,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
     protected $config;
 
     /**
-     * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\App\EnvironmentEmulation|\PHPUnit_Framework_MockObject_MockObject
      */
     private $appEmulation;
 
@@ -64,7 +64,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
         $this->objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
         $this->state = $this->createMock(\Magento\Framework\App\State::class);
         $themes = [Design::DEFAULT_AREA => self::THEME_NAME];
-        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\Emulation::class);
+        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\EnvironmentEmulation::class);
         $this->model = new Design(
             $this->storeManager,
             $this->flyweightThemeFactory,

--- a/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
@@ -39,6 +39,11 @@ class DesignTest extends \PHPUnit\Framework\TestCase
     protected $config;
 
     /**
+     * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $appEmulation;
+
+    /**
      * @var string|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $defaultTheme = 'anyName4Theme';
@@ -61,6 +66,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
         $this->themeFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
         $this->objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
         $this->state = $this->createMock(\Magento\Framework\App\State::class);
+        $this->appEmulation = $this->createMock(\Magento\Store\Model\App\Emulation::class);
         $themes = [Design::DEFAULT_AREA => $this->defaultTheme];
         $this->model = new Design(
             $this->storeManager,
@@ -69,6 +75,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
             $this->themeFactory,
             $this->objectManager,
             $this->state,
+            $this->appEmulation,
             $themes
         );
     }

--- a/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
@@ -13,6 +13,8 @@ use Magento\Theme\Model\View\Design;
 
 class DesignTest extends \PHPUnit\Framework\TestCase
 {
+    const THEME_NAME = 'anyName4Theme';
+
     /**
      * @var \Magento\Framework\App\State|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -41,12 +43,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \Magento\Store\Model\App\Emulation|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $appEmulation;
-
-    /**
-     * @var string|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $defaultTheme = 'anyName4Theme';
+    private $appEmulation;
 
     /**
      * @var \Magento\Framework\ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -66,8 +63,8 @@ class DesignTest extends \PHPUnit\Framework\TestCase
         $this->themeFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
         $this->objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
         $this->state = $this->createMock(\Magento\Framework\App\State::class);
+        $themes = [Design::DEFAULT_AREA => self::THEME_NAME];
         $this->appEmulation = $this->createMock(\Magento\Store\Model\App\Emulation::class);
-        $themes = [Design::DEFAULT_AREA => $this->defaultTheme];
         $this->model = new Design(
             $this->storeManager,
             $this->flyweightThemeFactory,
@@ -140,7 +137,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
         $this->flyweightThemeFactory->expects($this->once())
             ->method('create')
-            ->with($this->defaultTheme, $area);
+            ->with(self::THEME_NAME, $area);
         $this->assertInstanceOf(get_class($this->model), $this->model->setDefaultDesignTheme());
     }
 

--- a/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
@@ -75,8 +75,8 @@ class DesignTest extends \PHPUnit\Framework\TestCase
             $this->themeFactory,
             $this->objectManager,
             $this->state,
-            $this->appEmulation,
-            $themes
+            $themes,
+            $this->appEmulation
         );
     }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
@@ -70,7 +70,7 @@ class TranslateTest extends TestCase
                     $objectManager->get(\Magento\Framework\ObjectManagerInterface::class),
                     $objectManager->get(\Magento\Framework\App\State::class),
                     ['frontend' => 'Test/default'],
-                    $objectManager->get(\Magento\Store\Model\App\Emulation::class)
+                    $objectManager->get(\Magento\Store\Model\App\EnvironmentEmulation::class)
                 ]
             )
             ->getMock();

--- a/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
@@ -70,7 +70,7 @@ class TranslateTest extends TestCase
                     $objectManager->get(\Magento\Framework\ObjectManagerInterface::class),
                     $objectManager->get(\Magento\Framework\App\State::class),
                     ['frontend' => 'Test/default'],
-                    $objectManager->get(\Magento\Store\Model\App\EnvironmentEmulation::class)
+                    $objectManager->get(\Magento\Store\Model\App\EmulationInterface::class)
                 ]
             )
             ->getMock();

--- a/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
@@ -69,6 +69,7 @@ class TranslateTest extends TestCase
                     $objectManager->get(\Magento\Theme\Model\ThemeFactory::class),
                     $objectManager->get(\Magento\Framework\ObjectManagerInterface::class),
                     $objectManager->get(\Magento\Framework\App\State::class),
+                    $objectManager->get(\Magento\Store\Model\App\Emulation::class),
                     ['frontend' => 'Test/default']
                 ]
             )

--- a/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
@@ -69,8 +69,8 @@ class TranslateTest extends TestCase
                     $objectManager->get(\Magento\Theme\Model\ThemeFactory::class),
                     $objectManager->get(\Magento\Framework\ObjectManagerInterface::class),
                     $objectManager->get(\Magento\Framework\App\State::class),
-                    $objectManager->get(\Magento\Store\Model\App\Emulation::class),
-                    ['frontend' => 'Test/default']
+                    ['frontend' => 'Test/default'],
+                    $objectManager->get(\Magento\Store\Model\App\Emulation::class)
                 ]
             )
             ->getMock();


### PR DESCRIPTION
### Description
Environment emulation inside an area emulation returns the error "Required parameter 'theme_dir' was not passed". The classes `\Magento\Theme\Model\View\Design` and `\Magento\Theme\Model\Theme` retrieve their area from the app state unless the area is emulated (see their `getArea()` method). When the environment is emulated inside an area emulation, the app state's area is used. This causes incorrect behaviour when the environment is being emulated.

### Manual testing scenarios

```php
use \Magento\Framework\App\Area;

class Emulation
{
    /**
     * @var \Magento\Store\Model\App\Emulation
     */
    protected $appEmulation;

    /**
     * @var \Magento\Framework\App\State
     */
    protected $appState;

    public function __construct(
        \Magento\Store\Model\App\Emulation $appEmulation,
        \Magento\Framework\App\State $appState
    ) {
        $this->appEmulation = $appEmulation;
        $this->appState = $appState;
    }

    public function execute()
    {
        $this->appState->emulateAreaCode(Area::AREA_ADMINHTML, function () {
            $this->appEmulation->startEnvironmentEmulation(1, Area::AREA_FRONTEND, true);
            $this->appEmulation->stopEnvironmentEmulation();
        });
    }
}
```

I've executed this class using a cronjob (the cache needs to be flushed before starting). I have a store with the id "1" (lets call this store "default"). The default store uses the theme `Magento/luma`. `startEnvironmentEmulation(..)` at some point tries to load the default store's theme. `\Magento\Theme\Model\Theme getFullPath()` gets invoked and returns `adminhtml/Magento/luma`. The theme's full path is wrong as the app state's area is being used instead of the environments area, because the app state is emulated. This then prevents the theme from being loaded and produces an error. I've added a method to also check if the environment is being emulated and used it to load the correct area. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
