### PR TITLE
[Backport] Fix "Confirmation request" email is sent on customer's newsletter unsubscribe action

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -4,9 +4,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Newsletter\Controller\Manage;
 
 use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
+use Magento\Newsletter\Model\Subscriber;
 
 class Save extends \Magento\Newsletter\Controller\Manage
 {
@@ -74,13 +76,29 @@ class Save extends \Magento\Newsletter\Controller\Manage
                 $customer = $this->customerRepository->getById($customerId);
                 $storeId = $this->storeManager->getStore()->getId();
                 $customer->setStoreId($storeId);
-                $this->customerRepository->save($customer);
-                if ((boolean)$this->getRequest()->getParam('is_subscribed', false)) {
-                    $this->subscriberFactory->create()->subscribeCustomerById($customerId);
-                    $this->messageManager->addSuccess(__('We saved the subscription.'));
+                $isSubscribedState = $customer->getExtensionAttributes()
+                    ->getIsSubscribed();
+                $isSubscribedParam = (boolean)$this->getRequest()
+                    ->getParam('is_subscribed', false);
+                if ($isSubscribedParam != $isSubscribedState) {
+                    $this->customerRepository->save($customer);
+                    if ($isSubscribedParam) {
+                        $subscribeModel = $this->subscriberFactory->create()
+                            ->subscribeCustomerById($customerId);
+                        $subscribeStatus = $subscribeModel->getStatus();
+                        if ($subscribeStatus == Subscriber::STATUS_SUBSCRIBED) {
+                            $this->messageManager->addSuccess(__('We saved the subscription.'));
+                        } else {
+                            $this->messageManager->addSuccess(__('The confirmation request has been sent.'));
+                        }
+                    } else {
+                        $this->subscriberFactory->create()
+                            ->unsubscribeCustomerById($customerId);
+                        $this->messageManager->addSuccess(__('We removed the subscription.'));
+                    }
                 } else {
-                    $this->subscriberFactory->create()->unsubscribeCustomerById($customerId);
-                    $this->messageManager->addSuccess(__('We removed the subscription.'));
+                    $this->_redirect('newsletter/manage/');
+                    return;
                 }
             } catch (\Exception $e) {
                 $this->messageManager->addError(__('Something went wrong while saving your subscription.'));

--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -96,9 +96,8 @@ class Save extends \Magento\Newsletter\Controller\Manage
                             ->unsubscribeCustomerById($customerId);
                         $this->messageManager->addSuccess(__('We removed the subscription.'));
                     }
-                }else{
+                } else {
                     $this->messageManager->addSuccess(__('We updated the subscription.'));
-                    return;
                 }
             } catch (\Exception $e) {
                 $this->messageManager->addError(__('Something went wrong while saving your subscription.'));

--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -80,24 +80,24 @@ class Save extends \Magento\Newsletter\Controller\Manage
                     ->getIsSubscribed();
                 $isSubscribedParam = (boolean)$this->getRequest()
                     ->getParam('is_subscribed', false);
-                if ($isSubscribedParam != $isSubscribedState) {
+                if ($isSubscribedParam !== $isSubscribedState) {
                     $this->customerRepository->save($customer);
                     if ($isSubscribedParam) {
                         $subscribeModel = $this->subscriberFactory->create()
                             ->subscribeCustomerById($customerId);
                         $subscribeStatus = $subscribeModel->getStatus();
                         if ($subscribeStatus == Subscriber::STATUS_SUBSCRIBED) {
-                            $this->messageManager->addSuccess(__('We saved the subscription.'));
+                            $this->messageManager->addSuccess(__('We have saved your subscription.'));
                         } else {
-                            $this->messageManager->addSuccess(__('The confirmation request has been sent.'));
+                            $this->messageManager->addSuccess(__('A confirmation request has been sent.'));
                         }
                     } else {
                         $this->subscriberFactory->create()
                             ->unsubscribeCustomerById($customerId);
-                        $this->messageManager->addSuccess(__('We removed the subscription.'));
+                        $this->messageManager->addSuccess(__('We have removed your newsletter subscription.'));
                     }
                 } else {
-                    $this->messageManager->addSuccess(__('We updated the subscription.'));
+                    $this->messageManager->addSuccess(__('We have updated your subscription.'));
                 }
             } catch (\Exception $e) {
                 $this->messageManager->addError(__('Something went wrong while saving your subscription.'));

--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -96,9 +96,6 @@ class Save extends \Magento\Newsletter\Controller\Manage
                             ->unsubscribeCustomerById($customerId);
                         $this->messageManager->addSuccess(__('We removed the subscription.'));
                     }
-                } else {
-                    $this->_redirect('newsletter/manage/');
-                    return;
                 }
             } catch (\Exception $e) {
                 $this->messageManager->addError(__('Something went wrong while saving your subscription.'));

--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -96,6 +96,9 @@ class Save extends \Magento\Newsletter\Controller\Manage
                             ->unsubscribeCustomerById($customerId);
                         $this->messageManager->addSuccess(__('We removed the subscription.'));
                     }
+                }else{
+                    $this->messageManager->addSuccess(__('We updated the subscription.'));
+                    return;
                 }
             } catch (\Exception $e) {
                 $this->messageManager->addError(__('Something went wrong while saving your subscription.'));

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -549,9 +549,19 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         $isConfirmNeed = 1 === (int)$this->_scopeConfig->getValue(
             self::XML_PATH_CONFIRMATION_FLAG,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        );
-        $status = $this->getSubscriptionStatus($subscribe, $isConfirmNeed, $customerId);
-        if ($status == self::STATUS_SUBSCRIBED && $customerData->getConfirmation() === null) {
+        ) == 1 ? true : false;
+        if ($subscribe) {
+            if (AccountManagementInterface::ACCOUNT_CONFIRMATION_REQUIRED
+                == $this->customerAccountManagement->getConfirmationStatus($customerId)
+            ) {
+                $status = self::STATUS_UNCONFIRMED;
+            } elseif ($isConfirmNeed) {
+                if ($this->getStatus() != self::STATUS_SUBSCRIBED) {
+                    $status = self::STATUS_NOT_ACTIVE;
+                }
+            }
+        } elseif (($this->getStatus() == self::STATUS_UNCONFIRMED) && ($customerData->getConfirmation() === null)) {
+            $status = self::STATUS_SUBSCRIBED;
             $sendInformationEmail = true;
         }
         /**

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/ManageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/ManageTest.php
@@ -67,6 +67,7 @@ class ManageTest extends \Magento\TestFramework\TestCase\AbstractController
      */
     public function testSaveActionRemoveSubscription()
     {
+
         $this->getRequest()
             ->setParam('form_key', 'formKey')
             ->setParam('is_subscribed', '0');
@@ -83,7 +84,7 @@ class ManageTest extends \Magento\TestFramework\TestCase\AbstractController
          * Check that success message
          */
         $this->assertSessionMessages(
-            $this->equalTo(['We removed the subscription.']),
+            $this->equalTo(['We updated the subscription.']),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/ManageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/ManageTest.php
@@ -57,7 +57,7 @@ class ManageTest extends \Magento\TestFramework\TestCase\AbstractController
          * Check that success message
          */
         $this->assertSessionMessages(
-            $this->equalTo(['We saved the subscription.']),
+            $this->equalTo(['We have saved your subscription.']),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
     }
@@ -84,7 +84,7 @@ class ManageTest extends \Magento\TestFramework\TestCase\AbstractController
          * Check that success message
          */
         $this->assertSessionMessages(
-            $this->equalTo(['We updated the subscription.']),
+            $this->equalTo(['We have updated your subscription.']),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15464
### Description
This fix related to https://github.com/magento/magento2/issues/15218
Skip update customer subscribe status from save subscribe action from my account when nothing is changed.

### Fixed Issues (if relevant)
1. Skip update customer subscribe status from save subscribe action from my account when nothing is changed.

### Manual testing scenarios
1. Activate "Need to Confirm" for the newsletter subscription
2. Register a new customer
3. Subscribe to the newsletter
4. Confirm the newsletter subscription.
5. Login as created customer
6. Unsubscribe from the newsletter from the customer area

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
