### PR TITLE
 Fix array output format for "null" values in config.php and env.php 

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -80,6 +80,9 @@ class PhpFormatter implements FormatterInterface
      */
     private function varExportShort($var, int $depth = 0): string
     {
+        if ($var === null) {
+            return 'null';
+        }
         if (!is_array($var)) {
             return var_export($var, true);
         }

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/Writer/PhpFormatterTest.php
@@ -43,7 +43,8 @@ class PhpFormatterTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'ns3' => 'just text',
-            'ns4' => 'just text'
+            'ns4' => 'just text',
+            'ns5' => null
         ];
         $comments1 = ['ns2' => 'comment for namespace 2'];
         $comments2 = [
@@ -51,7 +52,8 @@ class PhpFormatterTest extends \PHPUnit\Framework\TestCase
             'ns2' => "comment for namespace 2.\nNext comment for' namespace 2",
             'ns3' => 'comment for" namespace 3',
             'ns4' => 'comment for namespace 4',
-            'ns5' => 'comment for unexisted namespace 5',
+            'ns5' => 'comment for namespace 5',
+            'ns6' => 'comment for unexisted namespace 6',
         ];
         $expectedResult1 = <<<TEXT
 <?php
@@ -77,6 +79,7 @@ return [
     ],
     'ns3' => 'just text',
     'ns4' => 'just text',
+    'ns5' => null,
 ];
 
 TEXT;
@@ -117,6 +120,11 @@ return [
      * comment for namespace 4
      */
     'ns4' => 'just text',
+    /**
+     * For the section: ns5
+     * comment for namespace 5
+     */
+    'ns5' => null,
 ];
 
 TEXT;
@@ -140,7 +148,8 @@ return [
         ]
     ],
     'ns3' => 'just text',
-    'ns4' => 'just text'
+    'ns4' => 'just text',
+    'ns5' => null
 ];
 
 TEXT;


### PR DESCRIPTION
### Description
This PR fixes a wrong formatting in the auto-generated files `app/etc/config.php` or `app/etc/env.php`.

### Fixed Issues (if relevant)
If the `app/etc/config.php` or `app/etc/env.php` is regenerated by Magento, `null` values are transformed to uppercase `NULL`. This violates the phpcs standards.

### Manual testing scenarios
1. Add a configuration value `null` to the `app/etc/config.php`, i.e. as follows:

```
(...)
        'Magento_Wishlist' => 1,
        'Magento_WishlistAnalytics' => 1
    ],
    'system' => [
        'default' => [
            'general' => [
                'country' => [
                    'destinations' => null
                ]
            ]
        ]
    ]
];
```
2. Disable any module via the command line, i.e. `bin/magento module:enable Magento_WebapiSecurity`, so that the `config.php` is being regenerated.
3. Without this PR, the content of `config.php` is `'destinations' => NULL`
4. With this PR, the content of `config.php` is `'destinations' => null`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
