### PR TITLE
[Forwardport] fix #17193 Error with translation of confirmation modal buttons

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
@@ -9,10 +9,10 @@
 define([
     'jquery',
     'underscore',
+    'mage/translate',
     'jquery/ui',
-    'Magento_Ui/js/modal/modal',
-    'mage/translate'
-], function ($, _) {
+    'Magento_Ui/js/modal/modal'
+], function ($, _, $t) {
     'use strict';
 
     $.widget('mage.confirm', $.mage.modal, {
@@ -38,7 +38,7 @@ define([
                 cancel: function () {}
             },
             buttons: [{
-                text: $.mage.__('Cancel'),
+                text: $t('Cancel'),
                 class: 'action-secondary action-dismiss',
 
                 /**
@@ -48,7 +48,7 @@ define([
                     this.closeModal(event);
                 }
             }, {
-                text: $.mage.__('OK'),
+                text: $t('OK'),
                 class: 'action-primary action-accept',
 
                 /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17275


### Description
Fixed translation issue

### Fixed Issues (if relevant)

1. magento/magento2#17193: Error with translation of confirmation modal buttons

### Manual testing scenarios


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
