### PR TITLE
17311: Make region required based on selected country

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php
@@ -5,25 +5,30 @@
  */
 namespace Magento\Customer\Block\Adminhtml\Edit\Renderer;
 
+use Magento\Backend\Block\AbstractBlock;
+use Magento\Backend\Block\Context;
+use Magento\Directory\Helper\Data;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
+
 /**
  * Customer address region field renderer
  */
-class Region extends \Magento\Backend\Block\AbstractBlock implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Region extends AbstractBlock implements RendererInterface
 {
     /**
-     * @var \Magento\Directory\Helper\Data
+     * @var Data
      */
     protected $_directoryHelper;
 
     /**
-     * @param \Magento\Backend\Block\Context $context
-     * @param \Magento\Directory\Helper\Data $directoryHelper
+     * @param Context $context
+     * @param Data $directoryHelper
      * @param array $data
      */
     public function __construct(
-        \Magento\Backend\Block\Context $context,
-        \Magento\Directory\Helper\Data $directoryHelper,
+        Context $context,
+        Data $directoryHelper,
         array $data = []
     ) {
         $this->_directoryHelper = $directoryHelper;
@@ -33,24 +38,24 @@ class Region extends \Magento\Backend\Block\AbstractBlock implements
     /**
      * Output the region element and javasctipt that makes it dependent from country element
      *
-     * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
+     * @param AbstractElement $element
      * @return string
      *
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    public function render(AbstractElement $element)
     {
-        if ($country = $element->getForm()->getElement('country_id')) {
-            $countryId = $country->getValue();
-        } else {
+        $country = $element->getForm()->getElement('country_id');
+        if (!$country) {
             return $element->getDefaultHtml();
         }
 
+        $regionRequired = $this->isRegionRequiredForCountryId($country->getValue());
         $regionId = $element->getForm()->getElement('region_id')->getValue();
 
-        $html = '<div class="field field-state required admin__field _required">';
+        $html = '<div class="field field-state admin__field'. ($regionRequired ? ' required _required' : '') .'">';
         $element->setClass('input-text admin__control-text');
-        $element->setRequired(true);
+        $element->setRequired($regionRequired);
         $html .= $element->getLabelHtml() . '<div class="control admin__field-control">';
         $html .= $element->getElementHtml();
 
@@ -60,7 +65,8 @@ class Region extends \Magento\Backend\Block\AbstractBlock implements
             $selectId .
             '" name="' .
             $selectName .
-            '" class="select required-entry admin__control-select" style="display:none">';
+            '" class="select admin__control-select'. ($regionRequired ? ' required-entry' : '') .'" 
+            style="display:none">';
         $html .= '<option value="">' . __('Please select') . '</option>';
         $html .= '</select>';
 
@@ -84,5 +90,16 @@ class Region extends \Magento\Backend\Block\AbstractBlock implements
         $html .= '</div></div>' . "\n";
 
         return $html;
+    }
+
+    /**
+     * Whether the region is required for the current selected country
+     *
+     * @param string $countryId
+     * @return bool
+     */
+    private function isRegionRequiredForCountryId(string $countryId)
+    {
+        return in_array($countryId, $this->_directoryHelper->getCountriesWithStatesRequired());
     }
 }

--- a/app/code/Magento/Customer/view/adminhtml/web/edit/tab/js/addresses.js
+++ b/app/code/Magento/Customer/view/adminhtml/web/edit/tab/js/addresses.js
@@ -442,18 +442,9 @@ define([
                 }
 
                 if (!regionRequired) {
-                    if (regionField.hasClass('required')) {
-                        regionField.removeClass('required');
-                    }
-
-                    if (currentElement.hasClass('required-entry')) {
-                        currentElement.removeClass('required-entry');
-                    }
-
-                    if (currentElement.prop('tagName').toLowerCase() === 'select' &&
-                        currentElement.hasClass('validate-select')) {
-                        currentElement.removeClass('validate-select');
-                    }
+                    regionField.removeClass('required');
+                    currentElement.removeClass('required-entry');
+                    currentElement.removeClass('validate-select');
                 } else {
                     if (regionField.hasClass('required') === false) {
                         regionField.addClass('required');
@@ -485,9 +476,7 @@ define([
                 zipField = $(zipElement).closest('.field-postcode');
 
             if (this.options.optionalZipCountries.indexOf(countryElement.value) !== -1) {
-                if ($(zipElement).hasClass('required-entry')) {
-                    $(zipElement).removeClass('required-entry');
-                }
+                $(zipElement).removeClass('required-entry');
                 $(zipField).removeClass('required');
             } else {
                 $(zipElement).addClass('required-entry');

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml
@@ -15,10 +15,8 @@ if ($block->getIsShipping()):
     ?>
     <script>
     require(["Magento_Sales/order/create/form"], function(){
-
         order.shippingAddressContainer = '<?= /* @escapeNotVerified */ $_fieldsContainerId ?>';
         order.setAddresses(<?= /* @escapeNotVerified */ $block->getAddressCollectionJson() ?>);
-
     });
     </script>
     <?php
@@ -29,6 +27,7 @@ else:
     <script>
         require(["Magento_Sales/order/create/form"], function(){
             order.billingAddressContainer = '<?= /* @escapeNotVerified */ $_fieldsContainerId ?>';
+            order.setAddresses(<?= /* @escapeNotVerified */ $block->getAddressCollectionJson() ?>);
         });
     </script>
     <?php

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -252,7 +252,7 @@ define([
                 this.saveData(data);
 
                 if (name === 'country_id' || name === 'customer_address_id') {
-                    this.loadArea(['shipping_method', 'billing_method', 'totals', 'items'], true, data);
+                    this.loadArea(['shipping_method', 'shipping_address', 'billing_method', 'billing_address', 'totals', 'items'], true, data);
                 }
             }
         },


### PR DESCRIPTION
Before this commit the region was required for every country, it did not validate the setting 'State is required for' under 'Stores > Configuration > General > General > State Options'.

By using the `getCountriesWithStatesRequired` method from the already through DI available `Magento\Directory\Helper\Data` class we can define if for the current selected country the region is required.

Removed checks if elements contain a class before removing it. It does  not matter if an element has the class or not. Removing the checks saves some Javascript time.

Also fixed in this PR:
+ Imported classes
+ Optimize if/else statement for determining if country is set

### Fixed Issues (if relevant)
1. magento/magento2#17311: Region is always required when creating a new order in the Admin area

### Manual test steps
1. Login to the backend
2. Go to create new order
3. Select/create a customer
4. Select a country where the state is not required (e.g. Netherlands)
5. See that the state is not required
6. Select a country where the state is required (e.g. United States)
7. See that the state is required
8. Create order for both cases

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
