### PR TITLE
[Braintree] Removed unnecessary unsets from models

### DIFF
--- a/app/code/Magento/Braintree/Gateway/Http/Client/TransactionRefund.php
+++ b/app/code/Magento/Braintree/Gateway/Http/Client/TransactionRefund.php
@@ -17,8 +17,6 @@ class TransactionRefund extends AbstractTransaction
     protected function process(array $data)
     {
         $storeId = $data['store_id'] ?? null;
-        // sending store id and other additional keys are restricted by Braintree API
-        unset($data['store_id']);
 
         return $this->adapterFactory->create($storeId)
             ->refund($data['transaction_id'], $data[PaymentDataBuilder::AMOUNT]);

--- a/app/code/Magento/Braintree/Gateway/Http/Client/TransactionSubmitForSettlement.php
+++ b/app/code/Magento/Braintree/Gateway/Http/Client/TransactionSubmitForSettlement.php
@@ -19,8 +19,6 @@ class TransactionSubmitForSettlement extends AbstractTransaction
     protected function process(array $data)
     {
         $storeId = $data['store_id'] ?? null;
-        // sending store id and other additional keys are restricted by Braintree API
-        unset($data['store_id']);
 
         return  $this->adapterFactory->create($storeId)
             ->submitForSettlement($data[CaptureDataBuilder::TRANSACTION_ID], $data[PaymentDataBuilder::AMOUNT]);

--- a/app/code/Magento/Braintree/Gateway/Http/Client/TransactionVoid.php
+++ b/app/code/Magento/Braintree/Gateway/Http/Client/TransactionVoid.php
@@ -15,8 +15,6 @@ class TransactionVoid extends AbstractTransaction
     protected function process(array $data)
     {
         $storeId = $data['store_id'] ?? null;
-        // sending store id and other additional keys are restricted by Braintree API
-        unset($data['store_id']);
 
         return $this->adapterFactory->create($storeId)->void($data['transaction_id']);
     }


### PR DESCRIPTION
### Description
This PR is a simple code cleanup. In the modified classes we don't need to unset the `store_id` from the array since it does not make sense. We don't pass the entire `$data` array like we do in `\Magento\Braintree\Gateway\Http\Client\TransactionSale::process`. Instead, we pass only particular array values. So, the unset operation for the array element is simply redundant.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A
