### PR TITLE
Fix: Clicking msrp price issue on product list widget

### DIFF
--- a/app/code/Magento/Msrp/view/base/templates/product/price/msrp.phtml
+++ b/app/code/Magento/Msrp/view/base/templates/product/price/msrp.phtml
@@ -72,6 +72,8 @@ if ($product->isSaleable()) {
         } else {
             $data['addToCart']['addToCartButton'] = sprintf(
                 'form:has(input[type="hidden"][name="product"][value="%s"]) button[type="submit"]',
+                (int) $productId) . ',' . 
+                sprintf('.block.widget .price-box[data-product-id=%s]+.product-item-actions button.tocart',
                 (int) $productId
             );
         }

--- a/app/code/Magento/Msrp/view/frontend/layout/cms_index_index.xml
+++ b/app/code/Magento/Msrp/view/frontend/layout/cms_index_index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="msrp_popup"/>
+    <body/>
+</page>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request contains 2 changes:
1. Adding cms_index_index.xml in the module Magento_Msrp in a purpose of updating msrp_popup xml layout so the popup block is loaded in the homepage. 
2. Adjust the template `templates/popup.phtml` to add the selector of add-to-cart button selector. The add-to-cart buttons in the product list widget have different selector with the ones in catalog page. Previously in homepage (after fix 1 above is done), if we click the **click for price** link the button inside the popup misses the text.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15922: Click for price in home page can`t work

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Background merchandise edit product such as sample data (SKU:24-WB04) Added Manufacturer's Suggested Retail Price, which is higher than the price of the product.
2. Add Catalog Product List widget to home page.
3. The issue was when clicking the **click for price** link, nothing happens and produce this JS error in console: `msrp.js:84 Uncaught TypeError: Cannot read property 'innerHTML' of undefined (msrp.js:84)`
4. This fix solves the issue, now when we click that link the msrp popup appears as expected



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
