### PR TITLE
Fix Mini Cart: Display Cart Summary - "Display item quantities" count not working as expected

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
@@ -29,11 +29,11 @@
         <div class="items-total">
             <span class="count" if="maxItemsToDisplay < getCartLineItemsCount()" text="maxItemsToDisplay"/>
             <translate args="'of'" if="maxItemsToDisplay < getCartLineItemsCount()"/>
-            <span class="count" text="getCartLineItemsCount()"/>
-                <!-- ko if: (getCartLineItemsCount() === 1) -->
+            <span class="count" text="getCartParam('summary_count')"/>
+                <!-- ko if: (getCartParam('summary_count') === 1) -->
                     <span translate="'Item in Cart'"/>
                 <!--/ko-->
-                <!-- ko if: (getCartLineItemsCount() > 1) -->
+                <!-- ko if: (getCartParam('summary_count') > 1) -->
                     <span translate="'Items in Cart'"/>
                 <!--/ko-->
         </div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
    Fixing Cart Count in Header mini cart. Minicart KO template changes only.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14586: Mini Cart: Display Cart Summary - "Display item quantities" count not working as expected

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set Sales -> Checkout -> My Cart Link -> Display item quantities
2. Add 1 item to the cart with qty of 1
3. Add a second item to the cart of qty 2
4. Cart Count in Header state 3
5. Cart Count within Minicart state 3

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
