### PR TITLE
[Backport] #15308 removed extraneous margin

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_listings.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_listings.less
@@ -156,11 +156,11 @@
     .column.main {
         .product {
             &-items {
-                margin-left: -@indent__base;
+                margin-left: 0;
             }
             
             &-item {
-                padding-left: @indent__base;
+                padding-left: 0;
             }
         }
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15936
removed extraneous margin and compensated padding and set both to 0, which creates the same effect

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Change in the theme which gives the same effect, but removes the negative margin which was compensated with a padding. 

### Fixed Issues (if relevant)
1. magento/magento2/issues/15308: extraneous margins on product list and product list items


### Manual testing scenarios
1. open list view of products on a page
2. inspect the list .column.main .product-items and one product .products-list .product-item
3. check if the negative margin and positive padding are replaced by 0 and if the styling is still correct

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
