### PR TITLE
[Backport] Replacing Usage of Deprecated Methods for Message Manager

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Delete.php
@@ -42,12 +42,12 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Category
                 $this->_eventManager->dispatch('catalog_controller_category_delete', ['category' => $category]);
                 $this->_auth->getAuthStorage()->setDeletedPath($category->getPath());
                 $this->categoryRepository->delete($category);
-                $this->messageManager->addSuccess(__('You deleted the category.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the category.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while trying to delete the category.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while trying to delete the category.'));
                 return $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
             }
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
@@ -55,7 +55,7 @@ abstract class Attribute extends Action
         }
 
         if ($error) {
-            $this->messageManager->addError($error);
+            $this->messageManager->addErrorMessage($error);
         }
 
         return !$error;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -192,7 +192,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_eventManager->dispatch('catalog_product_to_website_change', ['products' => $productIds]);
             }
 
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) were updated.', count($this->attributeHelper->getProductIds()))
             );
 
@@ -205,9 +205,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                 $this->_productPriceIndexerProcessor->reindexList($this->attributeHelper->getProductIds());
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
@@ -68,7 +68,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attr
             $response->setError(true);
             $response->setMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Delete.php
@@ -21,23 +21,23 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             // entity type check
             $model->load($id);
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('We can\'t delete the attribute.'));
+                $this->messageManager->addErrorMessage(__('We can\'t delete the attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             try {
                 $model->delete();
-                $this->messageManager->addSuccess(__('You deleted the product attribute.'));
+                $this->messageManager->addSuccessMessage(__('You deleted the product attribute.'));
                 return $resultRedirect->setPath('catalog/*/');
             } catch (\Exception $e) {
-                $this->messageManager->addError($e->getMessage());
+                $this->messageManager->addErrorMessage($e->getMessage());
                 return $resultRedirect->setPath(
                     'catalog/*/edit',
                     ['attribute_id' => $this->getRequest()->getParam('attribute_id')]
                 );
             }
         }
-        $this->messageManager->addError(__('We can\'t find an attribute to delete.'));
+        $this->messageManager->addErrorMessage(__('We can\'t find an attribute to delete.'));
         return $resultRedirect->setPath('catalog/*/');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Edit.php
@@ -25,14 +25,14 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $model->load($id);
 
             if (!$model->getId()) {
-                $this->messageManager->addError(__('This attribute no longer exists.'));
+                $this->messageManager->addErrorMessage(__('This attribute no longer exists.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }
 
             // entity type check
             if ($model->getEntityTypeId() != $this->_entityTypeId) {
-                $this->messageManager->addError(__('This attribute cannot be edited.'));
+                $this->messageManager->addErrorMessage(__('This attribute cannot be edited.'));
                 $resultRedirect = $this->resultRedirectFactory->create();
                 return $resultRedirect->setPath('catalog/*/');
             }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -91,7 +91,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $attributeSet->setEntityTypeId($this->_entityTypeId)->load($setName, 'attribute_set_name');
             if ($attributeSet->getId()) {
                 $setName = $this->_objectManager->get(\Magento\Framework\Escaper::class)->escapeHtml($setName);
-                $this->messageManager->addError(__('An attribute set named \'%1\' already exists.', $setName));
+                $this->messageManager->addErrorMessage(__('An attribute set named \'%1\' already exists.', $setName));
 
                 $layout = $this->layoutFactory->create();
                 $layout->initMessages();

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
@@ -43,11 +43,11 @@ class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
         $product = $this->productBuilder->build($this->getRequest());
         try {
             $newProduct = $this->productCopier->copy($product);
-            $this->messageManager->addSuccess(__('You duplicated the product.'));
+            $this->messageManager->addSuccessMessage(__('You duplicated the product.'));
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true, 'id' => $newProduct->getId()]);
         } catch (\Exception $e) {
-            $this->_objectManager->get('Psr\Log\LoggerInterface')->critical($e);
-            $this->messageManager->addError($e->getMessage());
+            $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
+            $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
@@ -52,12 +52,12 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product
         if (($productId && !$product->getEntityId())) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('This product doesn\'t exist.'));
+            $this->messageManager->addErrorMessage(__('This product doesn\'t exist.'));
             return $resultRedirect->setPath('catalog/*/');
         } else if ($productId === 0) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
             $resultRedirect = $this->resultRedirectFactory->create();
-            $this->messageManager->addError(__('Invalid product id. Should be numeric value greater than 0'));
+            $this->messageManager->addErrorMessage(__('Invalid product id. Should be numeric value greater than 0'));
             return $resultRedirect->setPath('catalog/*/');
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
@@ -29,12 +29,12 @@ class Save extends \Magento\Backend\App\Action
         );
 
         if ($model->itemExists()) {
-            $this->messageManager->addError(__('A group with the same name already exists.'));
+            $this->messageManager->addErrorMessage(__('A group with the same name already exists.'));
         } else {
             try {
                 $model->save();
             } catch (\Exception $e) {
-                $this->messageManager->addError(__('Something went wrong while saving this group.'));
+                $this->messageManager->addErrorMessage(__('Something went wrong while saving this group.'));
             }
         }
     }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -56,7 +56,7 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product
         }
 
         if ($productDeleted) {
-            $this->messageManager->addSuccess(
+            $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) have been deleted.', $productDeleted)
             );
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassStatus.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassStatus.php
@@ -91,10 +91,12 @@ class MassStatus extends \Magento\Catalog\Controller\Adminhtml\Product
             $this->_validateMassStatus($productIds, $status);
             $this->_objectManager->get('Magento\Catalog\Model\Product\Action')
                 ->updateAttributes($productIds, ['status' => $status], $storeId);
-            $this->messageManager->addSuccess(__('A total of %1 record(s) have been updated.', count($productIds)));
+            $this->messageManager->addSuccessMessage(
+                __('A total of %1 record(s) have been updated.', count($productIds))
+            );
             $this->_productPriceIndexerProcessor->reindexList($productIds);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->_getSession()->addException($e, __('Something went wrong while updating the product(s) status.'));
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Delete.php
@@ -36,10 +36,10 @@ class Delete extends \Magento\Catalog\Controller\Adminhtml\Product\Set
         $resultRedirect = $this->resultRedirectFactory->create();
         try {
             $this->attributeSetRepository->deleteById($setId);
-            $this->messageManager->addSuccess(__('The attribute set has been removed.'));
+            $this->messageManager->addSuccessMessage(__('The attribute set has been removed.'));
             $resultRedirect->setPath('catalog/*/');
         } catch (\Exception $e) {
-            $this->messageManager->addError(__('We can\'t delete this set right now.'));
+            $this->messageManager->addErrorMessage(__('We can\'t delete this set right now.'));
             $resultRedirect->setUrl($this->_redirect->getRedirectUrl($this->getUrl('*')));
         }
         return $resultRedirect;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Save.php
@@ -100,12 +100,15 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Set
                 $model->initFromSkeleton($this->getRequest()->getParam('skeleton_set'));
             }
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the attribute set.'));
+            $this->messageManager->addSuccessMessage(__('You saved the attribute set.'));
+        } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+            $hasError = true;
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $hasError = true;
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong while saving the attribute set.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong while saving the attribute set.'));
             $hasError = true;
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
@@ -135,7 +135,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product
             $response->setError(true);
             $response->setMessages([$e->getMessage()]);
         } catch (\Exception $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
             $layout = $this->layoutFactory->create();
             $layout->initMessages();
             $response->setError(true);

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Clear.php
@@ -30,12 +30,12 @@ class Clear extends \Magento\Catalog\Controller\Product\Compare
 
         try {
             $items->clear();
-            $this->messageManager->addSuccess(__('You cleared the comparison list.'));
-            $this->_objectManager->get('Magento\Catalog\Helper\Product\Compare')->calculate();
+            $this->messageManager->addSuccessMessage(__('You cleared the comparison list.'));
+            $this->_objectManager->get(\Magento\Catalog\Helper\Product\Compare::class)->calculate();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('Something went wrong  clearing the comparison list.'));
+            $this->messageManager->addExceptionMessage($e, __('Something went wrong  clearing the comparison list.'));
         }
 
         /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */

--- a/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare/Remove.php
@@ -44,7 +44,7 @@ class Remove extends \Magento\Catalog\Controller\Product\Compare
                     $item->delete();
                     $productName = $this->_objectManager->get('Magento\Framework\Escaper')
                         ->escapeHtml($product->getName());
-                    $this->messageManager->addSuccess(
+                    $this->messageManager->addSuccessMessage(
                         __('You removed product %1 from the comparison list.', $productName)
                     );
                     $this->_eventManager->dispatch(

--- a/app/code/Magento/Catalog/Controller/Product/View.php
+++ b/app/code/Magento/Catalog/Controller/Product/View.php
@@ -78,13 +78,16 @@ class View extends \Magento\Catalog\Controller\Product
 
         if ($this->getRequest()->isPost() && $this->getRequest()->getParam(self::PARAM_NAME_URL_ENCODED)) {
             $product = $this->_initProduct();
+            
             if (!$product) {
                 return $this->noProductRedirect();
             }
+            
             if ($specifyOptions) {
                 $notice = $product->getTypeInstance()->getSpecifyOptionMessage();
-                $this->messageManager->addNotice($notice);
+                $this->messageManager->addNoticeMessage($notice);
             }
+            
             if ($this->getRequest()->isAjax()) {
                 $this->getResponse()->representJson(
                     $this->_objectManager->get('Magento\Framework\Json\Helper\Data')->jsonEncode([


### PR DESCRIPTION
### Original Pull request
#16924 

Replacing usage of deprecated methods for message manager.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

Changes:

 - `addSuccess` -> `addSuccessMessage`;
 - `addError` -> `addErrorMessage`;
 - `addException` -> `addExceptionMessage`;
 - `addWarning` -> `addWarningMessage`;

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
