### PR TITLE
Add shipping address API endpoints

### DIFF
--- a/app/code/Magento/Quote/Api/GuestShippingAddressManagementInterface.php
+++ b/app/code/Magento/Quote/Api/GuestShippingAddressManagementInterface.php
@@ -3,19 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Quote\Model;
+namespace Magento\Quote\Api;
 
 /**
- * Interface ShippingAddressManagementInterface
+ * Shipping address management interface for guest carts.
  * @api
  * @since 100.0.2
  */
-interface ShippingAddressManagementInterface
+interface GuestShippingAddressManagementInterface
 {
     /**
-     * Assigns a specified shipping address to a specified cart.
+     * Assign a specified shipping address to a specified cart.
      *
-     * @param int $cartId The cart ID.
+     * @param string $cartId The cart ID.
      * @param \Magento\Quote\Api\Data\AddressInterface $address The shipping address data.
      * @return int Address ID.
      * @throws \Magento\Framework\Exception\NoSuchEntityException The specified cart does not exist.
@@ -24,9 +24,9 @@ interface ShippingAddressManagementInterface
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address);
 
     /**
-     * Returns the shipping address for a specified quote.
+     * Return the shipping address for a specified quote.
      *
-     * @param int $cartId The cart ID.
+     * @param string $cartId The cart ID.
      * @return \Magento\Quote\Api\Data\AddressInterface Shipping address object.
      * @throws \Magento\Framework\Exception\NoSuchEntityException The specified cart does not exist.
      */

--- a/app/code/Magento/Quote/Api/ShippingAddressManagementInterface.php
+++ b/app/code/Magento/Quote/Api/ShippingAddressManagementInterface.php
@@ -3,19 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Quote\Model\GuestCart;
+namespace Magento\Quote\Api;
 
 /**
- * Shipping address management interface for guest carts.
+ * Interface ShippingAddressManagementInterface
  * @api
  * @since 100.0.2
  */
-interface GuestShippingAddressManagementInterface
+interface ShippingAddressManagementInterface
 {
     /**
-     * Assign a specified shipping address to a specified cart.
+     * Assigns a specified shipping address to a specified cart.
      *
-     * @param string $cartId The cart ID.
+     * @param int $cartId The cart ID.
      * @param \Magento\Quote\Api\Data\AddressInterface $address The shipping address data.
      * @return int Address ID.
      * @throws \Magento\Framework\Exception\NoSuchEntityException The specified cart does not exist.
@@ -24,9 +24,9 @@ interface GuestShippingAddressManagementInterface
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address);
 
     /**
-     * Return the shipping address for a specified quote.
+     * Returns the shipping address for a specified quote.
      *
-     * @param string $cartId The cart ID.
+     * @param int $cartId The cart ID.
      * @return \Magento\Quote\Api\Data\AddressInterface Shipping address object.
      * @throws \Magento\Framework\Exception\NoSuchEntityException The specified cart does not exist.
      */

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Quote\Model\GuestCart;
 
-use Magento\Quote\Model\GuestCart\GuestShippingAddressManagementInterface;
+use Magento\Quote\Api\GuestShippingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
-use Magento\Quote\Model\ShippingAddressManagementInterface;
+use Magento\Quote\Api\ShippingAddressManagementInterface;
 
 /**
  * Shipping address management class for guest carts.

--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface as Logger;
  * Quote shipping address write service object.
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressManagementInterface
+class ShippingAddressManagement implements \Magento\Quote\Api\ShippingAddressManagementInterface
 {
     /**
      * Quote repository.

--- a/app/code/Magento/Quote/Test/Unit/Model/GuestCart/GuestShippingAddressManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/GuestCart/GuestShippingAddressManagementTest.php
@@ -9,7 +9,7 @@ namespace Magento\Quote\Test\Unit\Model\GuestCart;
 class GuestShippingAddressManagementTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Quote\Model\GuestCart\GuestShippingAddressManagementInterface
+     * @var \Magento\Quote\Api\GuestShippingAddressManagementInterface
      */
     protected $model;
 
@@ -48,7 +48,7 @@ class GuestShippingAddressManagementTest extends \PHPUnit\Framework\TestCase
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $this->shippingAddressManagementMock = $this->createMock(
-            \Magento\Quote\Model\ShippingAddressManagementInterface::class
+            \Magento\Quote\Api\ShippingAddressManagementInterface::class
         );
         $this->quoteAddressMock = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
 

--- a/app/code/Magento/Quote/etc/di.xml
+++ b/app/code/Magento/Quote/etc/di.xml
@@ -34,7 +34,7 @@
     <preference for="Magento\Quote\Api\GuestCouponManagementInterface" type="Magento\Quote\Model\GuestCart\GuestCouponManagement" />
     <preference for="Magento\Quote\Api\GuestPaymentMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestPaymentMethodManagement" />
     <preference for="Magento\Quote\Api\GuestCartTotalRepositoryInterface" type="Magento\Quote\Model\GuestCart\GuestCartTotalRepository" />
-    <preference for="Magento\Quote\Api\GuestCart\GuestShippingAddressManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingAddressManagement" />
+    <preference for="Magento\Quote\Api\GuestShippingAddressManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingAddressManagement" />
     <preference for="Magento\Quote\Api\GuestShippingMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingMethodManagement" />
     <preference for="Magento\Quote\Api\GuestShipmentEstimationInterface" type="Magento\Quote\Model\GuestCart\GuestShippingMethodManagement" />
     <preference for="Magento\Quote\Api\GuestBillingAddressManagementInterface" type="Magento\Quote\Model\GuestCart\GuestBillingAddressManagement" />

--- a/app/code/Magento/Quote/etc/di.xml
+++ b/app/code/Magento/Quote/etc/di.xml
@@ -10,7 +10,7 @@
     <preference for="Magento\Quote\Api\ShipmentEstimationInterface" type="Magento\Quote\Model\ShippingMethodManagement" />
     <preference for="Magento\Quote\Api\Data\ShippingMethodInterface" type="Magento\Quote\Model\Cart\ShippingMethod" />
     <preference for="Magento\Quote\Api\BillingAddressManagementInterface" type="Magento\Quote\Model\BillingAddressManagement" />
-    <preference for="Magento\Quote\Model\ShippingAddressManagementInterface" type="Magento\Quote\Model\ShippingAddressManagement" />
+    <preference for="Magento\Quote\Api\ShippingAddressManagementInterface" type="Magento\Quote\Model\ShippingAddressManagement" />
     <preference for="Magento\Quote\Api\Data\AddressInterface" type="Magento\Quote\Model\Quote\Address" />
     <preference for="Magento\Quote\Api\Data\CartItemInterface" type="Magento\Quote\Model\Quote\Item" />
     <preference for="Magento\Quote\Api\Data\CartInterface" type="Magento\Quote\Model\Quote" />
@@ -34,7 +34,7 @@
     <preference for="Magento\Quote\Api\GuestCouponManagementInterface" type="Magento\Quote\Model\GuestCart\GuestCouponManagement" />
     <preference for="Magento\Quote\Api\GuestPaymentMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestPaymentMethodManagement" />
     <preference for="Magento\Quote\Api\GuestCartTotalRepositoryInterface" type="Magento\Quote\Model\GuestCart\GuestCartTotalRepository" />
-    <preference for="Magento\Quote\Model\GuestCart\GuestShippingAddressManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingAddressManagement" />
+    <preference for="Magento\Quote\Api\GuestCart\GuestShippingAddressManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingAddressManagement" />
     <preference for="Magento\Quote\Api\GuestShippingMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingMethodManagement" />
     <preference for="Magento\Quote\Api\GuestShipmentEstimationInterface" type="Magento\Quote\Model\GuestCart\GuestShippingMethodManagement" />
     <preference for="Magento\Quote\Api\GuestBillingAddressManagementInterface" type="Magento\Quote\Model\GuestCart\GuestBillingAddressManagement" />
@@ -86,7 +86,7 @@
     <preference for="Magento\Quote\Api\Data\TotalsAdditionalDataInterface" type="Magento\Quote\Model\Cart\TotalsAdditionalData" />
     <preference for="Magento\Quote\Model\Quote\Address\CustomAttributeListInterface" type="Magento\Quote\Model\Quote\Address\CustomAttributeList" />
     <preference for="Magento\Quote\Model\Quote\Address\FreeShippingInterface" type="Magento\Quote\Model\Quote\Address\FreeShipping" />
-    <preference for="Magento\Quote\Model\GuestCart\GuestShippingMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingMethodManagement" />
+    <preference for="Magento\Quote\Api\GuestCart\GuestShippingMethodManagementInterface" type="Magento\Quote\Model\GuestCart\GuestShippingMethodManagement" />
     <preference for="Magento\Quote\Model\ShippingMethodManagementInterface" type="Magento\Quote\Model\ShippingMethodManagement" />
     <preference for="Magento\Quote\Api\Data\ShippingInterface" type="Magento\Quote\Model\Shipping" />
     <preference for="Magento\Quote\Api\Data\ShippingAssignmentInterface" type="Magento\Quote\Model\ShippingAssignment" />

--- a/app/code/Magento/Quote/etc/webapi.xml
+++ b/app/code/Magento/Quote/etc/webapi.xml
@@ -376,6 +376,54 @@
         </data>
     </route>
 
+    <!-- Managing Cart Shipping address -->
+    <route url="/V1/carts/:cartId/shipping-address" method="GET">
+        <service class="Magento\Quote\Api\ShippingAddressManagementInterface" method="get"/>
+        <resources>
+            <resource ref="Magento_Cart::manage" />
+        </resources>
+    </route>
+    <route url="/V1/carts/:cartId/shipping-address" method="POST">
+        <service class="Magento\Quote\Api\ShippingAddressManagementInterface" method="assign"/>
+        <resources>
+            <resource ref="Magento_Cart::manage" />
+        </resources>
+    </route>
+
+    <!-- Managing Guest Cart Shipping address -->
+    <route url="/V1/guest-carts/:cartId/shipping-address" method="GET">
+        <service class="Magento\Quote\Api\GuestShippingAddressManagementInterface" method="get"/>
+        <resources>
+            <resource ref="anonymous" />
+        </resources>
+    </route>
+    <route url="/V1/guest-carts/:cartId/shipping-address" method="POST">
+        <service class="Magento\Quote\Api\GuestShippingAddressManagementInterface" method="assign"/>
+        <resources>
+            <resource ref="anonymous" />
+        </resources>
+    </route>
+
+    <!-- Managing My Cart Shipping address -->
+    <route url="/V1/carts/mine/shipping-address" method="GET">
+        <service class="Magento\Quote\Api\ShippingAddressManagementInterface" method="get"/>
+        <resources>
+            <resource ref="self" />
+        </resources>
+        <data>
+            <parameter name="cartId" force="true">%cart_id%</parameter>
+        </data>
+    </route>
+    <route url="/V1/carts/mine/shipping-address" method="POST">
+        <service class="Magento\Quote\Api\ShippingAddressManagementInterface" method="assign"/>
+        <resources>
+            <resource ref="self" />
+        </resources>
+        <data>
+            <parameter name="cartId" force="true">%cart_id%</parameter>
+        </data>
+    </route>
+
     <!-- Managing Cart Coupons -->
     <route url="/V1/carts/:cartId/coupons" method="GET">
         <service class="Magento\Quote\Api\CouponManagementInterface" method="get"/>

--- a/dev/tests/integration/testsuite/Magento/CheckoutAgreements/Model/Checkout/Plugin/GuestValidationTest.php
+++ b/dev/tests/integration/testsuite/Magento/CheckoutAgreements/Model/Checkout/Plugin/GuestValidationTest.php
@@ -41,7 +41,7 @@ class GuestValidationTest extends \PHPUnit\Framework\TestCase
     private $paymentMethodManagement;
 
     /**
-     * @var \Magento\Quote\Model\ShippingAddressManagementInterface
+     * @var \Magento\Quote\Api\ShippingAddressManagementInterface
      */
     private $shippingAddressManagement;
 
@@ -70,7 +70,7 @@ class GuestValidationTest extends \PHPUnit\Framework\TestCase
             \Magento\Checkout\Api\TotalsInformationManagementInterface::class
         );
         $this->shippingAddressManagement = $this->objectManager->create(
-            \Magento\Quote\Model\ShippingAddressManagementInterface::class
+            \Magento\Quote\Api\ShippingAddressManagementInterface::class
         );
     }
 

--- a/dev/tests/integration/testsuite/Magento/Persistent/Model/Checkout/GuestPaymentInformationManagementPluginTest.php
+++ b/dev/tests/integration/testsuite/Magento/Persistent/Model/Checkout/GuestPaymentInformationManagementPluginTest.php
@@ -62,7 +62,7 @@ class GuestPaymentInformationManagementPluginTest extends \PHPUnit\Framework\Tes
     protected $billingAddressManagement;
 
     /**
-     * @var \Magento\Quote\Model\ShippingAddressManagementInterface
+     * @var \Magento\Quote\Api\ShippingAddressManagementInterface
      */
     protected $shippingAddressManagement;
 
@@ -107,7 +107,7 @@ class GuestPaymentInformationManagementPluginTest extends \PHPUnit\Framework\Tes
             \Magento\Checkout\Api\TotalsInformationManagementInterface::class
         );
         $this->shippingAddressManagement = $this->objectManager->create(
-            \Magento\Quote\Model\ShippingAddressManagementInterface::class
+            \Magento\Quote\Api\ShippingAddressManagementInterface::class
         );
     }
 


### PR DESCRIPTION
### Description
Made API endpoints available to set shipping address on a quote similar to setting a billing address. No functionality is changed, it is simply exposed via the API. The reason for doing this is that the existing endpoint to set a shipping address requires you to set a shipping method at the same time, which is not always what you want to do.

### Fixed Issues (if relevant)
1. magento/magento2#6599: Impossible to just save the shipping address using the REST v1 API

### Manual testing scenarios
1. Test via swagger: https://pr-17384.engcom.dev.magento.com/swagger#/

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
