### PR TITLE
increase length of sequence_table column in sales_sequence_meta table

### DIFF
--- a/app/code/Magento/SalesSequence/etc/db_schema.xml
+++ b/app/code/Magento/SalesSequence/etc/db_schema.xml
@@ -41,7 +41,7 @@
         <column xsi:type="varchar" name="entity_type" nullable="false" length="32" comment="Prefix"/>
         <column xsi:type="smallint" name="store_id" padding="5" unsigned="true" nullable="false" identity="false"
                 comment="Store Id"/>
-        <column xsi:type="varchar" name="sequence_table" nullable="false" length="32" comment="table for sequence"/>
+        <column xsi:type="varchar" name="sequence_table" nullable="false" length="64" comment="table for sequence"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="meta_id"/>
         </constraint>


### PR DESCRIPTION
### Description

Having a too small length for the sequence_table column can lead to integrity constraint errors on setup:upgrade, because longer table names will be cut off (at least the store id suffix of those sales sequence table names).
In our case it was the PostfinanceCW extension, which lead to the tables "sequence_postfinancecw_transaction_0", "sequence_postfinancecw_transaction_1",... and so on (for each store id one table), which are 36 characters long.
So the names for the admin store view (id 0) got cut off in the sales_sequence_meta table and as a consequence lead to an integrity constrained, when the recurring script in the Magento_SalesSequence module tries to add the meta data for the sequence_postfinancecw_transaction_1 table.

So a character length of only 32 is definitely not long enough. I guess 50 character should suffice though. ¯\_(ツ)_/¯