### PR TITLE
round function called in AbstractAggregateCalculator.php if round is false

### DIFF
--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -101,7 +101,10 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
         $discountTaxCompensationAmount = 0;
 
         // Calculate $rowTotal
-        $price = $this->calculationTool->round($item->getUnitPrice());
+        $price = $item->getUnitPrice();
+        if ($round) {
+            $price = $this->calculationTool->round($item->getUnitPrice());
+        }
         $rowTotal = $price * $quantity;
         $rowTaxes = [];
         $rowTaxesBeforeDiscount = [];


### PR DESCRIPTION
### Description
In the `calculateWithTaxNotInPrice` function in the `AbstractAggregateCalculator.php` file is `$this->calculationTool->round` called on the unit price. The `calculateWithTaxNotInPrice` accepts a param $round when this param is false rounding is not wanted. In line 152/154 there is a check for this, so this check can be used here also.

