### PR TITLE
Declare module namespace before template path name

### DIFF
--- a/app/code/Magento/Backend/Block/System/Store/Delete/Group.php
+++ b/app/code/Magento/Backend/Block/System/Store/Delete/Group.php
@@ -19,7 +19,7 @@ class Group extends \Magento\Backend\Block\Template
     {
         $itemId = $this->getRequest()->getParam('group_id');
 
-        $this->setTemplate('system/store/delete_group.phtml');
+        $this->setTemplate('Magento_Backend::system/store/delete_group.phtml');
         $this->setAction($this->getUrl('adminhtml/*/deleteGroupPost', ['group_id' => $itemId]));
         $this->addChild(
             'confirm_deletion_button',

--- a/app/code/Magento/Backend/Block/System/Store/Delete/Website.php
+++ b/app/code/Magento/Backend/Block/System/Store/Delete/Website.php
@@ -19,7 +19,7 @@ class Website extends \Magento\Backend\Block\Template
     {
         $itemId = $this->getRequest()->getParam('website_id');
 
-        $this->setTemplate('system/store/delete_website.phtml');
+        $this->setTemplate('Magento_Backend::system/store/delete_website.phtml');
         $this->setAction($this->getUrl('adminhtml/*/deleteWebsitePost', ['website_id' => $itemId]));
         $this->addChild(
             'confirm_deletion_button',

--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Checkboxes/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Checkboxes/Tree.php
@@ -30,7 +30,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\Tree
      */
     protected function _prepareLayout()
     {
-        $this->setTemplate('catalog/category/checkboxes/tree.phtml');
+        $this->setTemplate('Magento_Catalog::catalog/category/checkboxes/tree.phtml');
     }
 
     /**

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
@@ -41,7 +41,7 @@ class Serializer extends \Magento\Framework\View\Element\Template
     public function _construct()
     {
         parent::_construct();
-        $this->setTemplate('catalog/product/edit/serializer.phtml');
+        $this->setTemplate('Magento_Catalog::catalog/product/edit/serializer.phtml');
         return $this;
     }
 

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Cart.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Cart.php
@@ -82,7 +82,7 @@ class Cart extends \Magento\Backend\Block\Widget\Grid\Extended
         parent::_construct();
         $this->setUseAjax(true);
         $this->_parentTemplate = $this->getTemplate();
-        $this->setTemplate('tab/cart.phtml');
+        $this->setTemplate('Magento_Customer::tab/cart.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Adminhtml/System/Config/Validatevat.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/System/Config/Validatevat.php
@@ -99,7 +99,7 @@ class Validatevat extends \Magento\Config\Block\System\Config\Form\Field
     {
         parent::_prepareLayout();
         if (!$this->getTemplate()) {
-            $this->setTemplate('system/config/validatevat.phtml');
+            $this->setTemplate('Magento_Customer::system/config/validatevat.phtml');
         }
         return $this;
     }

--- a/app/code/Magento/Customer/Block/Widget/Company.php
+++ b/app/code/Magento/Customer/Block/Widget/Company.php
@@ -69,7 +69,7 @@ class Company extends AbstractWidget
         parent::_construct();
 
         // default template location
-        $this->setTemplate('widget/company.phtml');
+        $this->setTemplate('Magento_Customer::widget/company.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Widget/Dob.php
+++ b/app/code/Magento/Customer/Block/Widget/Dob.php
@@ -66,7 +66,7 @@ class Dob extends AbstractWidget
     public function _construct()
     {
         parent::_construct();
-        $this->setTemplate('widget/dob.phtml');
+        $this->setTemplate('Magento_Customer::widget/dob.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Widget/Fax.php
+++ b/app/code/Magento/Customer/Block/Widget/Fax.php
@@ -69,7 +69,7 @@ class Fax extends AbstractWidget
         parent::_construct();
 
         // default template location
-        $this->setTemplate('widget/fax.phtml');
+        $this->setTemplate('Magento_Customer::widget/fax.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Widget/Gender.php
+++ b/app/code/Magento/Customer/Block/Widget/Gender.php
@@ -59,7 +59,7 @@ class Gender extends AbstractWidget
     public function _construct()
     {
         parent::_construct();
-        $this->setTemplate('widget/gender.phtml');
+        $this->setTemplate('Magento_Customer::widget/gender.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Widget/Name.php
+++ b/app/code/Magento/Customer/Block/Widget/Name.php
@@ -62,7 +62,7 @@ class Name extends AbstractWidget
         parent::_construct();
 
         // default template location
-        $this->setTemplate('widget/name.phtml');
+        $this->setTemplate('Magento_Customer::widget/name.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Widget/Taxvat.php
+++ b/app/code/Magento/Customer/Block/Widget/Taxvat.php
@@ -41,7 +41,7 @@ class Taxvat extends AbstractWidget
     public function _construct()
     {
         parent::_construct();
-        $this->setTemplate('widget/taxvat.phtml');
+        $this->setTemplate('Magento_Customer::widget/taxvat.phtml');
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Widget/Telephone.php
+++ b/app/code/Magento/Customer/Block/Widget/Telephone.php
@@ -69,7 +69,7 @@ class Telephone extends AbstractWidget
         parent::_construct();
 
         // default template location
-        $this->setTemplate('widget/telephone.phtml');
+        $this->setTemplate('Magento_Customer::widget/telephone.phtml');
     }
 
     /**

--- a/app/code/Magento/Dhl/Block/Adminhtml/Unitofmeasure.php
+++ b/app/code/Magento/Dhl/Block/Adminhtml/Unitofmeasure.php
@@ -86,7 +86,7 @@ class Unitofmeasure extends Field
             )
         );
 
-        $this->setTemplate('unitofmeasure.phtml');
+        $this->setTemplate('Magento_Dhl::unitofmeasure.phtml');
     }
 
     /**

--- a/app/code/Magento/Paypal/Block/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Iframe.php
@@ -110,13 +110,13 @@ class Iframe extends \Magento\Payment\Block\Form
         if (in_array($paymentCode, $this->_hssHelper->getHssMethods())) {
             $this->_paymentMethodCode = $paymentCode;
             $templatePath = str_replace('_', '', $paymentCode);
-            $templateFile = "{$templatePath}/iframe.phtml";
+            $templateFile = "Magento_Paypal::{$templatePath}/iframe.phtml";
             $directory = $this->readFactory->create($this->reader->getModuleDir('', 'Magento_Paypal'));
             $file = $this->resolver->getTemplateFileName($templateFile, ['module' => 'Magento_Paypal']);
             if ($file && $directory->isExist($directory->getRelativePath($file))) {
                 $this->setTemplate($templateFile);
             } else {
-                $this->setTemplate('hss/iframe.phtml');
+                $this->setTemplate('Magento_Paypal::hss/iframe.phtml');
             }
         }
     }
@@ -198,7 +198,7 @@ class Iframe extends \Magento\Payment\Block\Form
     protected function _toHtml()
     {
         if ($this->_isAfterPaymentSave()) {
-            $this->setTemplate('hss/js.phtml');
+            $this->setTemplate('Magento_Paypal::hss/js.phtml');
             return parent::_toHtml();
         }
         if (!$this->_shouldRender) {

--- a/app/code/Magento/Review/Block/Form.php
+++ b/app/code/Magento/Review/Block/Form.php
@@ -139,7 +139,7 @@ class Form extends \Magento\Framework\View\Element\Template
             );
         }
 
-        $this->setTemplate('form.phtml');
+        $this->setTemplate('Magento_Review::form.phtml');
     }
 
     /**

--- a/app/code/Magento/Review/Block/Rating/Entity/Detailed.php
+++ b/app/code/Magento/Review/Block/Rating/Entity/Detailed.php
@@ -49,7 +49,7 @@ class Detailed extends \Magento\Framework\View\Element\Template
         $reviewsCount = $this->_ratingFactory->create()->getTotalReviews($entityId, true);
         if ($reviewsCount == 0) {
             #return __('Be the first to review this product');
-            $this->setTemplate('empty.phtml');
+            $this->setTemplate('Magento_Review::empty.phtml');
             return parent::_toHtml();
         }
 

--- a/app/code/Magento/UrlRewrite/Block/Edit.php
+++ b/app/code/Magento/UrlRewrite/Block/Edit.php
@@ -65,7 +65,7 @@ class Edit extends \Magento\Backend\Block\Widget\Container
      */
     protected function _prepareLayout()
     {
-        $this->setTemplate('edit.phtml');
+        $this->setTemplate('Magento_UrlRewrite::edit.phtml');
 
         $this->_addBackButton();
         $this->_prepareLayoutFeatures();

--- a/app/code/Magento/User/Block/Role/Tab/Users.php
+++ b/app/code/Magento/User/Block/Role/Tab/Users.php
@@ -45,7 +45,7 @@ class Users extends \Magento\Backend\Block\Widget\Tabs
         $roleId = $this->getRequest()->getParam('rid', false);
         /** @var \Magento\User\Model\ResourceModel\User\Collection $users */
         $users = $this->_userCollectionFactory->create()->load();
-        $this->setTemplate('role/users.phtml')
+        $this->setTemplate('Magento_User::role/users.phtml')
              ->assign('users', $users->getItems())
              ->assign('roleId', $roleId);
     }

--- a/lib/internal/Magento/Framework/Search/Adapter/Mysql/Adapter.php
+++ b/lib/internal/Magento/Framework/Search/Adapter/Mysql/Adapter.php
@@ -7,7 +7,6 @@ namespace Magento\Framework\Search\Adapter\Mysql;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Ddl\Table;
-use Magento\Framework\DB\Select;
 use Magento\Framework\Search\Adapter\Mysql\Aggregation\Builder as AggregationBuilder;
 use Magento\Framework\Search\AdapterInterface;
 use Magento\Framework\Search\RequestInterface;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When we override block history(Magento\Sales\Block\Order\History) to my custom module.
It throws an error and finding order/history.phtml in my custom module.
I tried to extend Block Magento\Sales\Block\Order\History from my custom module.

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\ValidatorException): Invalid template file: 'order/history.phtml' in module: 'Vendor_Module' block's name: 'sales.order.history'
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17172: Declare module namespace before template path name(Magento_Sales::order/history.phtml).

### Manual testing scenarios
1. I override history block
`<preference for="Magento\Sales\Block\Order\History" type="Vendor\Module\Block\Order\History" />`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
