### PR TITLE
[Braintree] Added unit test for instant purchase PayPal token formatter

### DIFF
--- a/app/code/Magento/Braintree/Test/Unit/Model/InstantPurchase/PayPal/TokenFormatterTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/InstantPurchase/PayPal/TokenFormatterTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Braintree\Test\Unit\Model\InstantPurchase\Paypal;
+
+use Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter as PaypalTokenFormatter;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+
+class TokenFormatterTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var PaymentTokenInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentTokenMock;
+
+    /**
+     * @var PaypalTokenFormatter
+     */
+    private $paypalTokenFormatter;
+
+    /**
+     * @var array
+     */
+    private $tokenDetails = [
+        'type' => 'visa',
+        'maskedCC' => '4444************9999',
+        'expirationDate' => '07-07-2025'
+    ];
+
+    protected function setUp()
+    {
+        $this->paymentTokenMock = $this->getMockBuilder(PaymentTokenInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->paypalTokenFormatter = new PaypalTokenFormatter();
+    }
+
+    public function testFormatPaymentTokenWithKnownCardType()
+    {
+        $this->tokenDetails['type'] = key(PaypalTokenFormatter::$baseCardTypes);
+        $this->paymentTokenMock->expects($this->once())
+            ->method('getTokenDetails')
+            ->willReturn(json_encode($this->tokenDetails));
+
+        $formattedString = sprintf(
+            '%s: %s, %s: %s (%s: %s)',
+            __('Credit Card'),
+            reset(PaypalTokenFormatter::$baseCardTypes),
+            __('ending'),
+            $this->tokenDetails['maskedCC'],
+            __('expires'),
+            $this->tokenDetails['expirationDate']
+        );
+
+        self::assertEquals($formattedString, $this->paypalTokenFormatter->formatPaymentToken($this->paymentTokenMock));
+    }
+
+    public function testFormatPaymentTokenWithUnknownCardType()
+    {
+        $this->paymentTokenMock->expects($this->once())
+            ->method('getTokenDetails')
+            ->willReturn(json_encode($this->tokenDetails));
+
+        $formattedString = sprintf(
+            '%s: %s, %s: %s (%s: %s)',
+            __('Credit Card'),
+            $this->tokenDetails['type'],
+            __('ending'),
+            $this->tokenDetails['maskedCC'],
+            __('expires'),
+            $this->tokenDetails['expirationDate']
+        );
+
+        self::assertEquals($formattedString, $this->paypalTokenFormatter->formatPaymentToken($this->paymentTokenMock));
+    }
+
+    public function testFormatPaymentTokenWithWrongData()
+    {
+        unset($this->tokenDetails['type']);
+
+        $this->paymentTokenMock->expects($this->once())
+            ->method('getTokenDetails')
+            ->willReturn(json_encode($this->tokenDetails));
+        self::expectException('\InvalidArgumentException');
+
+        $this->paypalTokenFormatter->formatPaymentToken($this->paymentTokenMock);
+    }
+}


### PR DESCRIPTION
### Description
This PR adds unit test with different scenarios for `\Magento\Braintree\Test\Unit\Model\InstantPurchase\Paypal\TokenFormatterTest` class.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A