### PR TITLE
[Backport] Corrected block name in Magento_Framework's test xml file.

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/group.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/group.xml
@@ -9,17 +9,17 @@
     <block class="Magento\Framework\View\Element\Text" name="block1">
         <block class="Magento\Framework\View\Element\Text" name="block2" group="group1">
             <arguments>
-                <argument xsi:type="string" name="text">blok2</argument>
+                <argument xsi:type="string" name="text">block2</argument>
             </arguments>
         </block>
         <block class="Magento\Framework\View\Element\Text" name="block3" group="group1" >
             <arguments>
-                <argument xsi:type="string" name="text">blok3</argument>
+                <argument xsi:type="string" name="text">block3</argument>
             </arguments>
         </block>
         <block class="Magento\Framework\View\Element\Text" name="block4">
             <arguments>
-                <argument xsi:type="string" name="text">blok4</argument>
+                <argument xsi:type="string" name="text">block4</argument>
             </arguments>
         </block>
         </block>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16646
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Corrected block name in **Magento_Framework**'s test XML file. block name was written wrong in **group.xml** file.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
