### PR TITLE
[Forwardport] Fixed "Shop By" button disabling broken on the search page #13445

### DIFF
--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/catalogsearch_result_index.xml
@@ -7,6 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
+        <attribute name="class" value="page-with-filter"/>
         <referenceContainer name="sidebar.main">
             <block class="Magento\LayeredNavigation\Block\Navigation\Search" name="catalogsearch.leftnav" before="-" template="Magento_LayeredNavigation::layer/view.phtml">
                 <block class="Magento\LayeredNavigation\Block\Navigation\State" name="catalogsearch.navigation.state" as="state" />


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15650

### Description
Added the class "page-with-filter" in the catalogsearch_result_index.xml for fixing the issue.

### Fixed Issues (if relevant)
1. magento/magento2 [#13445](https://github.com/magento/magento2/issues/13445): "Shop By" button disabling broken on the search page

### Manual testing scenarios
1. click on the "Search" icon and search for "jacket";
2. resize the window to a mobile size;
3. click on "Shop By" and choose a filter with one product (e.g. "Category -> Gear");

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
