### PR TITLE
Fix incorrect image magnifier size bug in Safari

### DIFF
--- a/lib/web/magnifier/magnify.js
+++ b/lib/web/magnifier/magnify.js
@@ -53,21 +53,14 @@ define([
 
         /**
          * Return width and height of original image
-         * @param src path for original image
+         * @param img original image node
          * @returns {{rw: number, rh: number}}
          */
-        function getImageSize(src) {
-            var img = new Image(),
-                imgSize = {
-                    rw: 0,
-                    rh: 0
-                };
-
-            img.src = src;
-            imgSize.rw = img.width;
-            imgSize.rh = img.height;
-
-            return imgSize;
+        function getImageSize(img) {
+            return {
+                rw: img.naturalWidth,
+                rh: img.naturalHeight
+            };
         }
 
         /**
@@ -192,7 +185,7 @@ define([
             if (!e.data.$image || !e.data.$image.length)
                 return;
 
-            imageSize = getImageSize($(fullscreenImageSelector)[0].src);
+            imageSize = getImageSize($(fullscreenImageSelector)[0]);
             parentWidth = e.data.$image.parent().width();
             parentHeight = e.data.$image.parent().height();
             isImageSmall = parentWidth >= imageSize.rw && parentHeight >= imageSize.rh;
@@ -331,7 +324,7 @@ define([
             if (allowZoomIn && (!transitionEnabled || !transitionActive) && (isTouchEnabled ||
                 !$(zoomInButtonSelector).hasClass(zoomInDisabled))) {
                 $image = $(fullscreenImageSelector);
-                imgOriginalSize = getImageSize($image[0].src);
+                imgOriginalSize = getImageSize($image[0]);
                 imageWidth = $image.width();
                 imageHeight = $image.height();
                 ratio = imageWidth / imageHeight;
@@ -630,7 +623,7 @@ define([
              * @param e - event object
              */
             function dblClickHandler(e) {
-                var imgOriginalSize = getImageSize($image[0].src),
+                var imgOriginalSize = getImageSize($image[0]),
                     proportions;
 
                 if (imgOriginalSize.rh < $image.parent().height() && imgOriginalSize.rw < $image.parent().width()) {


### PR DESCRIPTION
### Description

This pull request fixes a bug in the product gallery magnifier (zoom). In some cases (e.g. in the Safari browser), the image full size is calculated incorrectly, due to the image not being loaded before the dimensions are checked.

The fix makes use of the image element properties `naturalWidth` & `naturalHeight` which can check the full size of the image without needing to re-create it from the `src`. `naturalWidth` & `naturalHeight` are [supported in IE9+, and all other browsers](https://caniuse.com/#search=naturalWidth).


### Fixed Issues (if relevant)

 1. magento/magento2#17416: Product image zoom (magnifier) is broken in Safari


### Manual testing preconditions

 1. Enable the magnifier in the Luma theme in `etc/view.xml`
 2. Safari browser (v11.1.2)
 3. Remote environment (issue does not exist on local environments due to the bug being a race condition from the image loading)


### Manual testing scenarios

 1. Browse to product detail page with a large image
 2. Click the image to open the fullscreen gallery
 3. Click on the "zoom in" button


### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)