### PR TITLE
Improvements in UI MassActions component

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/multiselect.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/multiselect.js
@@ -230,6 +230,15 @@ define([
         },
 
         /**
+        * Selects or deselects all records on the current page.
+        *
+        * @returns {Multiselect} Chainable.
+        */
+        togglePage: function () {
+            return this.isPageSelected() ? this.deselectPage() : this.selectPage();
+        },
+
+        /**
          * Clears the array of not selected records.
          *
          * @returns {Multiselect} Chainable.

--- a/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
@@ -176,10 +176,13 @@ define([
          */
         _confirm: function (action, callback) {
             var confirmData = action.confirm;
+            var data = this.getSelections();
+            var total = data.total ? data.total : 0;
+            var confirmMessage = confirmData.message + ' (' + total + ' record' + (total > 1 ? 's' : '') + ')';
 
             confirm({
                 title: confirmData.title,
-                content: confirmData.message,
+                content: confirmMessage,
                 actions: {
                     confirm: callback
                 }

--- a/app/code/Magento/Ui/view/base/web/templates/grid/columns/multiselect.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/columns/multiselect.html
@@ -11,7 +11,7 @@
             data-bind="
                 checked: allSelected(),
                 attr: {id: ++ko.uid},
-                event: { change: toggleSelectAll },
+                event: { change: togglePage },
                 css: { '_indeterminate': indetermine },
                 enable: totalRecords">
         <label attr="for: ko.uid"/>


### PR DESCRIPTION
### Description
This improvements makes work with UI Grids and MassActions (which are using together) more comfortable. I had experienced cases when admin user accidentally delete all data when working with grids in backend (example: customers, orders, content, catalog) because by default when you're clicking on top checkbox in MassActions component, it's selects not only **visible on page records** (which is expectable), but **all the records**. 

#### List of changes:
- Changed default behavior when clicking on checkbox on the top of grid from select all records to select all visible records in modules: Catalog, Sales, Customers, Users, Content.
- Changed popup message when doing mass action (example - deleting records) in modules Catalog, Sales, Customers, Users, Content. Now you can see number of records which will be affected.

### Manual testing scenarios
1. Login as admin user
2. Go to module which contain UI Grid (example:  Catalog, Sales, Customers, Users, Content)
2. Click on the top checkox in grid header
3. Ensure that you selected only visible on page records, but not all the records that you have in grid.
4. After selecting records, choose mass action "Delete" and ensure that in popup message now you will see count of records which will be affected.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
