### PR TITLE
[Forwardport] fix: remove disabled attribute on region list

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -188,6 +188,8 @@ define([
 
                     if (!this.options.optionalRegionAllowed) { //eslint-disable-line max-depth
                         regionList.attr('disabled', 'disabled');
+                    } else {
+                        regionList.removeAttr('disabled');
                     }
                 }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16955
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

By default when a list is not populated at the beginning (eg for UK) and when we switch to another country (eg Germany) and get a populated list, the list is still disabled and we can not select any option.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. 
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to /customer/account/create/
2. switch from a country with an empty region list to a country with a region list
3. try to select a region (does not work as the input is still disabled)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
