### PR TITLE
[Forwardport] Allows modules with underscores in name to set custom a frontend_model in system.xml

### DIFF
--- a/app/code/Magento/Config/etc/system_file.xsd
+++ b/app/code/Magento/Config/etc/system_file.xsd
@@ -474,7 +474,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z0-9\\:]+" />
+            <xs:pattern value="[A-Za-z0-9_\\:]+" />
             <xs:minLength value="5" />
         </xs:restriction>
     </xs:simpleType>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14397

This issue is the same as [this issue]( https://github.com/magento/magento2/pull/11765) except that it applies to the system.xml file rather than layout XML files.

### Description
Currently it's not possible to set a custom frontend_model value in system.xml if the module you're using has an underscore in the module name. This limit is put in place via a regular expression defined in the app/code/Magento/Config/etc/system_file.xsd file.

The supplied fix simply adds the underscore character to the regular expression.

### Manual testing scenarios
To test simply create a configuration option that uses a custom frontend_model.
