### PR TITLE
[Forwardport] MAGETWO-84608: Cannot perform setup:install if Redis needs a password…

### DIFF
--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -26,11 +26,13 @@ class Cache implements ConfigOptionsListInterface
     const INPUT_KEY_CACHE_BACKEND_REDIS_SERVER = 'cache-backend-redis-server';
     const INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE = 'cache-backend-redis-db';
     const INPUT_KEY_CACHE_BACKEND_REDIS_PORT = 'cache-backend-redis-port';
+    const INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD = 'cache-backend-redis-password';
 
     const CONFIG_PATH_CACHE_BACKEND = 'cache/frontend/default/backend';
     const CONFIG_PATH_CACHE_BACKEND_SERVER = 'cache/frontend/default/backend_options/server';
     const CONFIG_PATH_CACHE_BACKEND_DATABASE = 'cache/frontend/default/backend_options/database';
     const CONFIG_PATH_CACHE_BACKEND_PORT = 'cache/frontend/default/backend_options/port';
+    const CONFIG_PATH_CACHE_BACKEND_PASSWORD = 'cache/frontend/default/backend_options/password';
 
     /**
      * @var array
@@ -38,7 +40,8 @@ class Cache implements ConfigOptionsListInterface
     private $defaultConfigValues = [
         self::INPUT_KEY_CACHE_BACKEND_REDIS_SERVER => '127.0.0.1',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE => '0',
-        self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => '6379'
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => '6379',
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => ''
     ];
 
     /**
@@ -55,6 +58,7 @@ class Cache implements ConfigOptionsListInterface
         self::INPUT_KEY_CACHE_BACKEND_REDIS_SERVER => self::CONFIG_PATH_CACHE_BACKEND_SERVER,
         self::INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE => self::CONFIG_PATH_CACHE_BACKEND_DATABASE,
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_CACHE_BACKEND_PORT,
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_CACHE_BACKEND_PASSWORD
     ];
 
     /**
@@ -102,6 +106,12 @@ class Cache implements ConfigOptionsListInterface
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_CACHE_BACKEND_PORT,
                 'Redis server listen port'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_CACHE_BACKEND_PASSWORD,
+                'Redis server password'
             )
         ];
     }
@@ -189,6 +199,13 @@ class Cache implements ConfigOptionsListInterface
             : $deploymentConfig->get(
                 self::CONFIG_PATH_CACHE_BACKEND_DATABASE,
                 $this->getDefaultConfigValue(self::INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE)
+            );
+        
+        $config['password'] = isset($options[self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD])
+            ? $options[self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD]
+            : $deploymentConfig->get(
+                self::CONFIG_PATH_CACHE_BACKEND_PASSWORD,
+                $this->getDefaultConfigValue(self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD)
             );
 
         return $this->redisValidator->isValidConnection($config);

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
@@ -27,12 +27,14 @@ class PageCache implements ConfigOptionsListInterface
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE = 'page-cache-redis-db';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT = 'page-cache-redis-port';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'page-cache-redis-compress-data';
+    const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD = 'page-cache-redis-password';
 
     const CONFIG_PATH_PAGE_CACHE_BACKEND = 'cache/frontend/page_cache/backend';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_SERVER = 'cache/frontend/page_cache/backend_options/server';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_DATABASE = 'cache/frontend/page_cache/backend_options/database';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PORT = 'cache/frontend/page_cache/backend_options/port';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/page_cache/backend_options/compress_data';
+    const CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD = 'cache/frontend/page_cache/backend_options/password';
 
     /**
      * @var array
@@ -41,7 +43,8 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_SERVER => '127.0.0.1',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE => '1',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => '6379',
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => '0'
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => '0',
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => ''
     ];
 
     /**
@@ -58,7 +61,8 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_SERVER => self::CONFIG_PATH_PAGE_CACHE_BACKEND_SERVER,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE => self::CONFIG_PATH_PAGE_CACHE_BACKEND_DATABASE,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PORT,
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD
     ];
 
     /**
@@ -112,6 +116,12 @@ class PageCache implements ConfigOptionsListInterface
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
                 'Set to 1 to compress the full page cache (use 0 to disable)'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
+                'Redis server password'
             )
         ];
     }
@@ -200,6 +210,13 @@ class PageCache implements ConfigOptionsListInterface
             : $deploymentConfig->get(
                 self::CONFIG_PATH_PAGE_CACHE_BACKEND_DATABASE,
                 $this->getDefaultConfigValue(self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE)
+            );
+        
+        $config['password'] = isset($options[self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD])
+            ? $options[self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD]
+            : $deploymentConfig->get(
+                self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
+                $this->getDefaultConfigValue(self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD)
             );
 
         return $this->redisValidator->isValidConnection($config);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -56,6 +56,10 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(3, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[3]);
         $this->assertEquals('cache-backend-redis-port', $options[3]->getName());
+
+        $this->assertArrayHasKey(4, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[4]);
+        $this->assertEquals('cache-backend-redis-password', $options[4]->getName());
     }
 
     public function testCreateConfigCacheRedis()
@@ -70,7 +74,8 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                         'backend_options' => [
                             'server' => '',
                             'port' => '',
-                            'database' => ''
+                            'database' => '',
+                            'password' => ''
                         ]
                     ]
                 ]
@@ -92,7 +97,8 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                         'backend_options' => [
                             'server' => 'localhost',
                             'port' => '1234',
-                            'database' => '5'
+                            'database' => '5',
+                            'password' => ''
                         ]
                     ]
                 ]

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -60,6 +60,10 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(4, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[4]);
         $this->assertEquals('page-cache-redis-compress-data', $options[4]->getName());
+
+        $this->assertArrayHasKey(5, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[5]);
+        $this->assertEquals('page-cache-redis-password', $options[5]->getName());
     }
 
     public function testCreateConfigWithRedis()
@@ -75,7 +79,8 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'server'=> '',
                             'port' => '',
                             'database' => '',
-                            'compress_data' => ''
+                            'compress_data' => '',
+                            'password' => ''
                         ]
                     ]
                 ]
@@ -98,7 +103,8 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'server' => 'foo.bar',
                             'port' => '9000',
                             'database' => '6',
-                            'compress_data' => '1'
+                            'compress_data' => '1',
+                            'password' => ''
                         ]
                     ]
                 ]


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17078
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
--> 
Needed to perform setup on a fresh magento install using an authenticated redis instance for the cache configuration part.
Redis session password configuration works whereas the cache configuration does not take the provided configuration. 
Changed setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php and setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php to enable a configuration password during initial setup.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#MAGETWO-84608: Redis password not used when trying to validate the connection during install.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup a new magento instance with `bin/magento setup:install` with cache options in env.php as so : 
`'cache' => [
        'frontend' => [
            'default' => [
                'backend' => 'Cm_Cache_Backend_Redis',
                'backend_options' => [
                    'server' => redis_host,
                    'database' => '0',
                    'port' => 6379,
                    'password' => redis_password
                ]
            ],
            'page_cache' => [
                'backend' => 'Cm_Cache_Backend_Redis',
                'backend_options' => [
                    'server' => redis_host,
                    'port' => 6379,
                    'database' => '1',
                    'compress_data' => '0',
                    'password' => redis_password
                ]
            ]
        ]
    ],`

The setup will fail saying that the redis configuration is wrong.

### Contribution checklist
 - [X ] Pull request has a meaningful description of its purpose
 - [X ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
