### PR TITLE
[Backport] GoogleAnalytics: Added unit test for order success observer

### DIFF
--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Braintree\Test\Unit\Gateway\Http\Client;
+
+use Braintree\Result\Successful;
+use Magento\Braintree\Gateway\Http\Client\TransactionRefund;
+use Magento\Braintree\Model\Adapter\BraintreeAdapter;
+use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Payment\Gateway\Http\ConverterException;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Braintree\Gateway\Request\PaymentDataBuilder;
+use Magento\Payment\Model\Method\Logger;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class TransactionRefundTest
+ */
+class TransactionRefundTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var TransactionRefund
+     */
+    private $transactionRefundModel;
+
+    /**
+     * @var BraintreeAdapter|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        /** @var LoggerInterface|MockObject $criticalLoggerMock */
+        $criticalLoggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+        /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $loggerMock */
+        $loggerMock = $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->adapterMock = $this->getMockBuilder(BraintreeAdapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var BraintreeAdapterFactory|MockObject $adapterFactoryMock */
+        $adapterFactoryMock = $this->getMockBuilder(BraintreeAdapterFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterFactoryMock->method('create')
+            ->willReturn($this->adapterMock);
+
+        $this->transactionRefundModel = new TransactionRefund($criticalLoggerMock, $loggerMock, $adapterFactoryMock);
+    }
+
+    /**
+     * @throws ClientException
+     * @throws ConverterException
+     */
+    public function testRefundRequestWithStoreId()
+    {
+        $transactionId = '11223344';
+        $refundAmount = 10;
+        $data = [
+            'store_id' => 0,
+            'transaction_id' => $transactionId,
+            PaymentDataBuilder::AMOUNT => $refundAmount
+        ];
+        $successfulResponse = new Successful();
+
+        /** @var TransferInterface|\PHPUnit_Framework_MockObject_MockObject $transferObjectMock */
+        $transferObjectMock = $this->createMock(TransferInterface::class);
+        $transferObjectMock->method('getBody')
+            ->willReturn($data);
+        $this->adapterMock->expects($this->once())
+            ->method('refund')
+            ->with($transactionId, $refundAmount)
+            ->willReturn($successfulResponse);
+
+        $response = $this->transactionRefundModel->placeRequest($transferObjectMock);
+
+        self::assertEquals($successfulResponse, $response['object']);
+    }
+}

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionVoidTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionVoidTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Braintree\Test\Unit\Gateway\Http\Client;
+
+use Braintree\Result\Successful;
+use Magento\Braintree\Gateway\Http\Client\TransactionVoid;
+use Magento\Braintree\Model\Adapter\BraintreeAdapter;
+use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Payment\Gateway\Http\ConverterException;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Model\Method\Logger;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class TransactionVoidTest
+ */
+class TransactionVoidTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var TransactionVoid
+     */
+    private $transactionVoidModel;
+
+    /**
+     * @var BraintreeAdapter|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        /** @var LoggerInterface|MockObject $criticalLoggerMock */
+        $criticalLoggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
+        /** @var Logger|\PHPUnit_Framework_MockObject_MockObject $loggerMock */
+        $loggerMock = $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->adapterMock = $this->getMockBuilder(BraintreeAdapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var BraintreeAdapterFactory|MockObject $adapterFactoryMock */
+        $adapterFactoryMock = $this->getMockBuilder(BraintreeAdapterFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adapterFactoryMock->method('create')
+            ->willReturn($this->adapterMock);
+
+        $this->transactionVoidModel = new TransactionVoid($criticalLoggerMock, $loggerMock, $adapterFactoryMock);
+    }
+
+    /**
+     * @throws ClientException
+     * @throws ConverterException
+     */
+    public function testVoidRequestWithStoreId()
+    {
+        $transactionId = '11223344';
+        $data = [
+            'store_id' => 0,
+            'transaction_id' => $transactionId
+        ];
+        $successfulResponse = new Successful();
+
+        /** @var TransferInterface|\PHPUnit_Framework_MockObject_MockObject $transferObjectMock */
+        $transferObjectMock = $this->createMock(TransferInterface::class);
+        $transferObjectMock->method('getBody')
+            ->willReturn($data);
+        $this->adapterMock->expects($this->once())
+            ->method('void')
+            ->with($transactionId)
+            ->willReturn($successfulResponse);
+
+        $response = $this->transactionVoidModel->placeRequest($transferObjectMock);
+
+        self::assertEquals($successfulResponse, $response['object']);
+    }
+}

--- a/app/code/Magento/Braintree/Test/Unit/Model/InstantPurchase/PayPal/TokenFormatterTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/InstantPurchase/PayPal/TokenFormatterTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Braintree\Test\Unit\Model\InstantPurchase\Paypal;
+
+use Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter as PaypalTokenFormatter;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+
+class TokenFormatterTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var PaymentTokenInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentTokenMock;
+
+    /**
+     * @var PaypalTokenFormatter
+     */
+    private $paypalTokenFormatter;
+
+    /**
+     * @var array
+     */
+    private $tokenDetails = [
+        'type' => 'visa',
+        'maskedCC' => '4444************9999',
+        'expirationDate' => '07-07-2025'
+    ];
+
+    protected function setUp()
+    {
+        $this->paymentTokenMock = $this->getMockBuilder(PaymentTokenInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->paypalTokenFormatter = new PaypalTokenFormatter();
+    }
+
+    public function testFormatPaymentTokenWithKnownCardType()
+    {
+        $this->tokenDetails['type'] = key(PaypalTokenFormatter::$baseCardTypes);
+        $this->paymentTokenMock->expects($this->once())
+            ->method('getTokenDetails')
+            ->willReturn(json_encode($this->tokenDetails));
+
+        $formattedString = sprintf(
+            '%s: %s, %s: %s (%s: %s)',
+            __('Credit Card'),
+            reset(PaypalTokenFormatter::$baseCardTypes),
+            __('ending'),
+            $this->tokenDetails['maskedCC'],
+            __('expires'),
+            $this->tokenDetails['expirationDate']
+        );
+
+        self::assertEquals($formattedString, $this->paypalTokenFormatter->formatPaymentToken($this->paymentTokenMock));
+    }
+
+    public function testFormatPaymentTokenWithUnknownCardType()
+    {
+        $this->paymentTokenMock->expects($this->once())
+            ->method('getTokenDetails')
+            ->willReturn(json_encode($this->tokenDetails));
+
+        $formattedString = sprintf(
+            '%s: %s, %s: %s (%s: %s)',
+            __('Credit Card'),
+            $this->tokenDetails['type'],
+            __('ending'),
+            $this->tokenDetails['maskedCC'],
+            __('expires'),
+            $this->tokenDetails['expirationDate']
+        );
+
+        self::assertEquals($formattedString, $this->paypalTokenFormatter->formatPaymentToken($this->paymentTokenMock));
+    }
+
+    public function testFormatPaymentTokenWithWrongData()
+    {
+        unset($this->tokenDetails['type']);
+
+        $this->paymentTokenMock->expects($this->once())
+            ->method('getTokenDetails')
+            ->willReturn(json_encode($this->tokenDetails));
+        self::expectException('\InvalidArgumentException');
+
+        $this->paypalTokenFormatter->formatPaymentToken($this->paymentTokenMock);
+    }
+}

--- a/app/code/Magento/GoogleAnalytics/Test/Unit/Observer/SetGoogleAnalyticsOnOrderSuccessPageViewObserverTest.php
+++ b/app/code/Magento/GoogleAnalytics/Test/Unit/Observer/SetGoogleAnalyticsOnOrderSuccessPageViewObserverTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GoogleAnalytics\Test\Unit\Block;
+
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\View\Element\AbstractBlock;
+use Magento\Framework\View\LayoutInterface;
+use Magento\GoogleAnalytics\Helper\Data as GaDataHelper;
+use Magento\GoogleAnalytics\Observer\SetGoogleAnalyticsOnOrderSuccessPageViewObserver;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class SetGoogleAnalyticsOnOrderSuccessPageViewObserverTest extends TestCase
+{
+    /**
+     * @var Event|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventMock;
+
+    /**
+     * @var Observer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var GaDataHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $googleAnalyticsDataMock;
+
+    /**
+     * @var LayoutInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $layoutMock;
+
+    /**
+     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var SetGoogleAnalyticsOnOrderSuccessPageViewObserver
+     */
+    private $orderSuccessObserver;
+
+    protected function setUp()
+    {
+        $this->googleAnalyticsDataMock = $this->getMockBuilder(GaDataHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->layoutMock = $this->getMockBuilder(LayoutInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->observerMock = $this->getMockBuilder(Observer::class)->getMock();
+        $this->eventMock = $this->getMockBuilder(Event::class)->getMock();
+
+
+        $objectManager = new ObjectManager($this);
+
+        $this->orderSuccessObserver = $objectManager->getObject(
+            SetGoogleAnalyticsOnOrderSuccessPageViewObserver::class,
+            [
+                'storeManager' => $this->storeManagerMock,
+                'layout' => $this->layoutMock,
+                'googleAnalyticsData' => $this->googleAnalyticsDataMock
+            ]
+        );
+    }
+
+    public function testExecuteWithNoOrderIds()
+    {
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+        $this->eventMock->expects($this->once())
+            ->method('__call')
+            ->with(
+                $this->equalTo('getOrderIds')
+            )
+            ->willReturn([]);
+        $this->layoutMock->expects($this->never())
+            ->method('getBlock');
+
+        $this->orderSuccessObserver->execute($this->observerMock);
+    }
+
+    public function testExecuteWithOrderIds()
+    {
+        $blockMock = $this->getMockBuilder(AbstractBlock::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $orderIds = [8];
+
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+        $this->eventMock->expects($this->once())
+            ->method('__call')
+            ->with(
+                $this->equalTo('getOrderIds')
+            )
+            ->willReturn($orderIds);
+        $this->layoutMock->expects($this->once())
+            ->method('getBlock')
+            ->willReturn($blockMock);
+        $blockMock->expects($this->once())
+            ->method('__call')
+            ->with(
+                $this->equalTo('setOrderIds'),
+                $this->equalTo([$orderIds])
+            );
+
+        $this->orderSuccessObserver->execute($this->observerMock);
+    }
+}

--- a/app/code/Magento/GoogleAnalytics/Test/Unit/Observer/SetGoogleAnalyticsOnOrderSuccessPageViewObserverTest.php
+++ b/app/code/Magento/GoogleAnalytics/Test/Unit/Observer/SetGoogleAnalyticsOnOrderSuccessPageViewObserverTest.php
@@ -63,7 +63,6 @@ class SetGoogleAnalyticsOnOrderSuccessPageViewObserverTest extends TestCase
         $this->observerMock = $this->getMockBuilder(Observer::class)->getMock();
         $this->eventMock = $this->getMockBuilder(Event::class)->getMock();
 
-
         $objectManager = new ObjectManager($this);
 
         $this->orderSuccessObserver = $objectManager->getObject(


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17137
### Description
This PR adds missing unit test for `Magento\GoogleAnalytics\Observer\SetGoogleAnalyticsOnOrderSuccessPageViewObserver` class

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A