### PR TITLE
[Forwardport] Convert to string $option->getValue, in order to be compared with oth…

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Quote/Item/CartItemProcessor.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Quote/Item/CartItemProcessor.php
@@ -69,7 +69,7 @@ class CartItemProcessor implements CartItemProcessorInterface
             if (is_array($options)) {
                 $requestData = [];
                 foreach ($options as $option) {
-                    $requestData['super_attribute'][$option->getOptionId()] = $option->getOptionValue();
+                    $requestData['super_attribute'][$option->getOptionId()] = (string) $option->getOptionValue();
                 }
                 return $this->objectFactory->create($requestData);
             }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15720

#mm18it
…er saved options in previous cart items

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
To decide whether a product with the same options is already present in the cart, magento makes a comparison with the string that represents the buyrequest in json format with those saved in the database. When a product is added by the Rest API the option code attribute encoded in the json is a number, whereas from the frontend context it is a string. In this case, this bufix forces the option attribute value in string, creating arrays that will later be converted into json

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15028:Configurable product addtocart with restAPI not working as expected2. ...

### Manual testing scenarios
Same test performed by issue writer

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
