### PR TITLE
POST rest API '/V1/carts/mine/estimate-shipping-methods-by-address-id' is not called at checkout to get the shipping methods

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -204,6 +204,7 @@
     <preference for="Magento\Framework\MessageQueue\ExchangeFactoryInterface" type="Magento\Framework\MessageQueue\ExchangeFactory" />
     <preference for="Magento\Framework\MessageQueue\Bulk\ExchangeFactoryInterface" type="Magento\Framework\MessageQueue\Bulk\ExchangeFactory" />
     <preference for="Magento\Framework\MessageQueue\QueueFactoryInterface" type="Magento\Framework\MessageQueue\QueueFactory" />
+    <preference for="Magento\Framework\Bulk\BulkManagementInterface" type="Magento\AsynchronousOperations\Model\BulkManagement" />
     <preference for="Magento\Framework\App\Request\ValidatorInterface"
                 type="Magento\Framework\App\Request\CsrfValidator" />
     <preference for="Magento\Framework\Search\Request\IndexScopeResolverInterface" type="Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver"/>
@@ -1691,6 +1692,18 @@
     <type name="Magento\Framework\Session\Config">
         <arguments>
             <argument name="scopeType" xsi:type="const">Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT</argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\MessageQueue\PublisherPool">
+        <arguments>
+            <argument name="publishers" xsi:type="array">
+                <item name="async" xsi:type="array">
+                    <item name="amqp" xsi:type="object">Magento\Framework\MessageQueue\Publisher</item>
+                </item>
+                <item name="sync" xsi:type="array">
+                    <item name="amqp" xsi:type="object">Magento\Framework\MessageQueue\Rpc\Publisher</item>
+                </item>
+            </argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
### Description

By not setting the preference for the 'Magento\Framework\Bulk\BulkManagementInterface' interface in 'src/www/app/etc/di.xml' Object Manager will create a Fatal PHP error when attempts to instantiate this interface.

In addition, by not setting the third argument to the class constructor 'Magento\Framework\MessageQueue\PublisherPool' in 'src www/app/etc/di.xml', Object Manager will pass null as the third argument and therefore get a Fatal PHP error.

Due to these two errors, the POST rest API '/V1/carts/mine/estimate-shipping-methods-by-address-id' is never called at checkout to get the shipping methods, so the message "sorry, no quotes are available for this order at this time" will be displayed instead of the list of shipping methods.