### PR TITLE
[Backport] Fix incorrect image magnifier size bug in Safari

### DIFF
--- a/lib/web/magnifier/magnify.js
+++ b/lib/web/magnifier/magnify.js
@@ -53,21 +53,14 @@ define([
 
         /**
          * Return width and height of original image
-         * @param src path for original image
+         * @param img original image node
          * @returns {{rw: number, rh: number}}
          */
-        function getImageSize(src) {
-            var img = new Image(),
-                imgSize = {
-                    rw: 0,
-                    rh: 0
-                };
-
-            img.src = src;
-            imgSize.rw = img.width;
-            imgSize.rh = img.height;
-
-            return imgSize;
+        function getImageSize(img) {
+            return {
+                rw: img.naturalWidth,
+                rh: img.naturalHeight
+            };
         }
 
         /**
@@ -192,7 +185,7 @@ define([
             if (!e.data.$image || !e.data.$image.length)
                 return;
 
-            imageSize = getImageSize($(fullscreenImageSelector)[0].src);
+            imageSize = getImageSize($(fullscreenImageSelector)[0]);
             parentWidth = e.data.$image.parent().width();
             parentHeight = e.data.$image.parent().height();
             isImageSmall = parentWidth >= imageSize.rw && parentHeight >= imageSize.rh;
@@ -331,7 +324,7 @@ define([
             if (allowZoomIn && (!transitionEnabled || !transitionActive) && (isTouchEnabled ||
                 !$(zoomInButtonSelector).hasClass(zoomInDisabled))) {
                 $image = $(fullscreenImageSelector);
-                imgOriginalSize = getImageSize($image[0].src);
+                imgOriginalSize = getImageSize($image[0]);
                 imageWidth = $image.width();
                 imageHeight = $image.height();
                 ratio = imageWidth / imageHeight;
@@ -630,7 +623,7 @@ define([
              * @param e - event object
              */
             function dblClickHandler(e) {
-                var imgOriginalSize = getImageSize($image[0].src),
+                var imgOriginalSize = getImageSize($image[0]),
                     proportions;
 
                 if (imgOriginalSize.rh < $image.parent().height() && imgOriginalSize.rw < $image.parent().width()) {


### PR DESCRIPTION
### Description
Back-port pull request https://github.com/magento/magento2/pull/17426

### Fixed Issues
1. magento/magento2#17416: Product image zoom (magnifier) is broken in Safari

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)