### PR TITLE
[Backport] Magento 2.2.5: Year-to-date dropdown in Stores>Configuration>General>Reports>Dashboard #17289

### DIFF
--- a/app/code/Magento/Reports/Block/Adminhtml/Config/Form/Field/YtdStart.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Config/Form/Field/YtdStart.php
@@ -23,9 +23,8 @@ class YtdStart extends \Magento\Config\Block\System\Config\Form\Field
     {
         $_months = [];
         for ($i = 1; $i <= 12; $i++) {
-            $_months[$i] = $this->_localeDate->date(mktime(null, null, null, $i))->format('m');
+            $_months[$i] = $this->_localeDate->date(mktime(null, null, null, $i,1))->format('m');
         }
-
         $_days = [];
         for ($i = 1; $i <= 31; $i++) {
             $_days[$i] = $i < 10 ? '0' . $i : $i;

--- a/app/code/Magento/Reports/Block/Adminhtml/Config/Form/Field/YtdStart.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Config/Form/Field/YtdStart.php
@@ -23,7 +23,7 @@ class YtdStart extends \Magento\Config\Block\System\Config\Form\Field
     {
         $_months = [];
         for ($i = 1; $i <= 12; $i++) {
-            $_months[$i] = $this->_localeDate->date(mktime(null, null, null, $i,1))->format('m');
+            $_months[$i] = $this->_localeDate->date(mktime(null, null, null, $i, 1))->format('m');
         }
         $_days = [];
         for ($i = 1; $i <= 31; $i++) {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17383
### Description
Fix month dropdown on field Year-to-date in Stores>Configuration>General>Reports>Dashboard

### Fixed Issues (if relevant)
1. magento/magento2#17289: Magento 2.2.5: Year-to-date dropdown in Stores>Configuration>General>Reports>Dashboard #17289 

### Manual testing scenarios
This bug just happen on date 30 or 31 every months because of "bug" mktime php
1. Set our local computer date to 30 or 31 to produce this issue 
2. Go to Stores>Configuration>General>Reports>Dashboard
3. Check Year-to-date Starts on first field
4. Before fixed, it will show wrong sequence of months. eg. 01,03,03,05,05,07,07,09,09,10,10,11,11,12,12
This issue caused by set month without date. So if current date is 31, on second month it will set into 31 February. Because 31 February not exist, mktime will set it into 2 March. When we get the month, so it will show 03 instead of 02. So I add 1 on date parameter because we must set date on mktime to get accurate month.

### Contribution checklist
 - Pull request has a meaningful description of its purpose
 - All commits are accompanied by meaningful commit messages
 - All new or changed code is covered with unit/integration tests (if applicable)
 - All automated tests passed successfully (all builds on Travis CI are green)
