### PR TITLE
[Backport] Changed property position at directory country source class

### DIFF
--- a/app/code/Magento/Directory/Model/Config/Source/Country.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Country.php
@@ -15,19 +15,19 @@ class Country implements \Magento\Framework\Option\ArrayInterface
     protected $_countryCollection;
 
     /**
+     * Options array
+     *
+     * @var array
+     */
+    protected $_options;
+
+    /**
      * @param \Magento\Directory\Model\ResourceModel\Country\Collection $countryCollection
      */
     public function __construct(\Magento\Directory\Model\ResourceModel\Country\Collection $countryCollection)
     {
         $this->_countryCollection = $countryCollection;
     }
-
-    /**
-     * Options array
-     *
-     * @var array
-     */
-    protected $_options;
 
     /**
      * Return options array


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17444
A property wasn't in the best place

### Description

Property `$_options` wasn't in the best place at `\Magento\Directory\Model\Config\Source\Country` class so I moved it where it should be

### Fixed Issues (if relevant)

Code style improvement

### Manual testing scenarios

N/A

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
