### PR TITLE
magento/magento2#3795: Validation messages missing from datepicker fo…

### DIFF
--- a/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
@@ -287,6 +287,7 @@
             <settings>
                 <validation>
                     <rule name="validate-date" xsi:type="boolean">true</rule>
+                    <rule name="validate-date-range" xsi:type="string">custom_theme_from</rule>
                 </validation>
                 <dataType>text</dataType>
                 <label translate="true">To</label>

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -778,6 +778,13 @@ define([
             },
             $.mage.__('Please enter a valid date.')
         ],
+        'validate-date-range': [
+            function (value, params, additionalParams) {
+                var from_date = jQuery( "input[name*='" + params + "']" ).val();
+                return moment.utc(value).unix() >= moment.utc(from_date).unix();
+            },
+            $.mage.__('Make sure the To Date is later than or the same as the From Date.')
+        ],
         'validate-identifier': [
             function (value) {
                 return utils.isEmptyNoTrim(value) || /^[a-z0-9][a-z0-9_\/-]+(\.[a-z0-9_-]+)?$/.test(value);


### PR DESCRIPTION
…rm elements

- New validation rule implemented to validate date range and added in to the cms page add/edit from

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#3795: Validation messages missing from datepicker form elements

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Edit a CMS Page 
2. Under custom design template section, select "To date" as an earlier date than "From date"
3. Then try to Save


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
