### PR TITLE
[Forwardport] AD-HOC feat (Profiler): Allow supplying complex profiler configuration

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -54,8 +54,18 @@ if (
     && isset($_SERVER['HTTP_ACCEPT'])
     && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false
 ) {
-    \Magento\Framework\Profiler::applyConfig(
-        (isset($_SERVER['MAGE_PROFILER']) && strlen($_SERVER['MAGE_PROFILER'])) ? $_SERVER['MAGE_PROFILER'] : trim(file_get_contents(BP . '/var/profiler.flag')),
+    $profilerString = isset($_SERVER['MAGE_PROFILER']) && strlen($_SERVER['MAGE_PROFILER'])
+        ? $_SERVER['MAGE_PROFILER']
+        : trim(file_get_contents(BP . '/var/profiler.flag'));
+
+    if ($profilerString && $profilerArray = json_decode($profilerString, true)) {
+        $profilerConfig = $profilerArray;
+    } else {
+        $profilerConfig = $profilerString;
+    }
+
+    Magento\Framework\Profiler::applyConfig(
+        $profilerConfig,
         BP,
         !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest'
     );

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -54,14 +54,12 @@ if (
     && isset($_SERVER['HTTP_ACCEPT'])
     && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false
 ) {
-    $profilerString = isset($_SERVER['MAGE_PROFILER']) && strlen($_SERVER['MAGE_PROFILER'])
+    $profilerConfig = isset($_SERVER['MAGE_PROFILER']) && strlen($_SERVER['MAGE_PROFILER'])
         ? $_SERVER['MAGE_PROFILER']
         : trim(file_get_contents(BP . '/var/profiler.flag'));
 
-    if ($profilerString && $profilerArray = json_decode($profilerString, true)) {
-        $profilerConfig = $profilerArray;
-    } else {
-        $profilerConfig = $profilerString;
+    if ($profilerConfig) {
+        $profilerConfig = json_decode($profilerConfig, true) ?: $profilerConfig;
     }
 
     Magento\Framework\Profiler::applyConfig(


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15171

### Description
Magento 2 provides a primitive creating profiles of the application,
similar to those esposed by the transaction tracing community. These
allow getting a granular view of the application based on a custom set
of metrics, rather than relying on PHP callgraph profilers to determine
how an application is behaving.

It is currently possible to modify the *output* of a transaction trace.
However, it is not currently possible to modify *the transaction trace
driver*. This commit seeks to extend the configuration such that the
driver itself can be replaced, rather than simply the output.

This allows replacing the driver entirely with something like the
OpenTracing API, which can then use its own exporters to express the
code to something like the CNCF Jaeger project.

This, in turn, allows getting a granular view of the transactions in an
application.

== Design Notes ==

=== Minimal changes ===

Considerable additional work is bring prototyped with the alpha
OpenCensus APIs, however at this time this is inappropriate to be merged
into the core. The APIs are immature, and the approach for reading
transaction traces not finalised.

This allows continued experimentation up to and including deployment to
production infrastructure without committing early to supporting this
model of profiling.

=== Variables prefixed with "profiler" ===

At first glace, the variables appear to be unnecessarily verbose.
However, they are declared in the global context, and are thus
namespaced to avoid collisions.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
