### PR TITLE
Honouring $_SYSTEM['MAGE_DIR'] in environment variables within Setup Module

### DIFF
--- a/setup/config/autoload/global.php
+++ b/setup/config/autoload/global.php
@@ -10,13 +10,13 @@ use Magento\Setup\Mvc\Bootstrap\InitParamListener;
 
 return [
     InitParamListener::BOOTSTRAP_PARAM => array_merge(
-        $_SERVER,
         [
             Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS => [
                 DirectoryList::ROOT => [
                     DirectoryList::PATH => BP
                 ]
             ]
-        ]
+        ],
+        $_SERVER
     )
 ];


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When a user defines a base path in the $_SYSTEM variables, we want to honour that at all times. The Setup module doesn't do that due to the array_merge ordering.

### Fixed Issues (if relevant)
No officially logged issues. But when the base path was changed, I was receiving this error:

```
[centos@ip-10-0-13-51 httpdocs]$ sudo -u magento_user php /usr/share/magento-core/latest/bin/magento setup:di:compile -vv
PHP Fatal error:  Uncaught Error: Cannot instantiate interface Symfony\Component\Console\Output\OutputInterface in /usr/share/magento-core/build-67/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php:111
Stack trace:
#0 /usr/share/magento-core/build-67/vendor/magento/framework/ObjectManager/Factory/Compiled.php(108): Magento\Framework\ObjectManager\Factory\AbstractFactory->createObject('Symfony\\Compone...', Array)
#1 /usr/share/magento-core/build-67/vendor/magento/framework/ObjectManager/ObjectManager.php(70): Magento\Framework\ObjectManager\Factory\Compiled->create('Symfony\\Compone...')
#2 /usr/share/magento-core/build-67/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(144): Magento\Framework\ObjectManager\ObjectManager->get('Symfony\\Compone...')
#3 /usr/share/magento-core/build-67/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(230): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgument(Array, 'Symfony\\Compone...', NULL, 'output', 'Magento\nager/Factory/AbstractFactory.php on line 111
```

This patch corrected that error.
