### PR TITLE
Solved: #17442-Order getCreatedAtFormatted has bad params

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1855,6 +1855,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      */
     public function getCreatedAtFormatted($format)
     {
+        $format = (is_string($format)) ? $this->getDateFormatValue($format) : $format;
         return $this->timezone->formatDateTime(
             new \DateTime($this->getCreatedAt()),
             $format,
@@ -4375,6 +4376,32 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     public function setShippingMethod($shippingMethod)
     {
         return $this->setData('shipping_method', $shippingMethod);
+    }
+    
+    /**
+     * Get date format value for relative string
+     * 
+     * @param string $format
+     * @return int|null
+     */
+    protected function getDateFormatValue($format)
+    {
+        if(empty($this->_dateFormatValues)){
+            $this->setDateFormatValues();
+        }
+        return array_key_exists($format, $this->_dateFormatValues) ? $this->_dateFormatValues[$format] : null;
+    }
+    
+    /**
+     * Map Date formats with its relative values
+     */
+    protected function setDateFormatValues(){
+        $this->_dateFormatValues = [
+            'full' => \IntlDateFormatter::FULL,
+            'short' => \IntlDateFormatter::SHORT,
+            'medium' => \IntlDateFormatter::MEDIUM,
+            'long' => \IntlDateFormatter::LONG
+        ];
     }
 
     //@codeCoverageIgnoreEnd

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -4380,13 +4380,13 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     
     /**
      * Get date format value for relative string
-     * 
+     *
      * @param string $format
      * @return int|null
      */
     protected function getDateFormatValue($format)
     {
-        if(empty($this->_dateFormatValues)){
+        if (empty($this->_dateFormatValues)) {
             $this->setDateFormatValues();
         }
         return array_key_exists($format, $this->_dateFormatValues) ? $this->_dateFormatValues[$format] : null;
@@ -4395,7 +4395,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Map Date formats with its relative values
      */
-    protected function setDateFormatValues(){
+    protected function setDateFormatValues()
+    {
         $this->_dateFormatValues = [
             'full' => \IntlDateFormatter::FULL,
             'short' => \IntlDateFormatter::SHORT,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Added date format string and value mapper functionality to map date format string with its relative magento date format value.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
1. magento/magento2#17442: Order getCreatedAtFormatted has bad params - date #17442
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. On any order, call getCreatedAtFormatted($format)
2. Set string format as expected (short|medium|long|full)
3. Date displayed in defined format

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
