### PR TITLE
[Forwordport] fix: cache count() results for loops

### DIFF
--- a/app/code/Magento/Paypal/Model/Report/Settlement.php
+++ b/app/code/Magento/Paypal/Model/Report/Settlement.php
@@ -409,8 +409,9 @@ class Settlement extends \Magento\Framework\Model\AbstractModel
     private function getBodyItems(array $line, array $sectionColumns, array $rowMap)
     {
         $bodyItem = [];
-        for ($i = 1, $count = count($line); $i < $count; $i++) {
-            if (isset($rowMap[$sectionColumns[$i]])) {
+        $lineCount = count($line);
+        for ($i = 1, $count = $lineCount; $i < $count; $i++) {
+            if(isset($rowMap[$sectionColumns[$i]])) {
                 if (in_array($rowMap[$sectionColumns[$i]], $this->dateTimeColumns)) {
                     $line[$i] = $this->formatDateTimeColumns($line[$i]);
                 }

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/AddCompareProductsTest.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/AddCompareProductsTest.php
@@ -76,7 +76,8 @@ class AddCompareProductsTest extends AbstractCompareProductsTest
     {
         $this->cmsIndex->open();
         $this->cmsIndex->getLinksBlock()->openLink("Compare Products");
-        for ($i = 1; $i <= count($this->products); $i++) {
+        $productsCount = count($this->products);
+        for ($i = 1; $i <= $productsCount; $i++) {
             $this->catalogProductCompare->getCompareProductsBlock()->removeProduct();
         }
     }

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/ShoppingCartPerCustomerTest.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/ShoppingCartPerCustomerTest.php
@@ -95,7 +95,8 @@ class ShoppingCartPerCustomerTest extends Injectable
 
         $customers = [];
         $cartFixtures = [];
-        for ($i = 0; $i < count($checkoutData); $i++) {
+        $checkoutDataCount = count($checkoutData);
+        for ($i = 0; $i < $checkoutDataCount; $i++) {
             $customers[$i] = $this->fixtureFactory->createByCode('customer', ['dataset' => $customerDataset]);
             $customers[$i]->persist();
 

--- a/dev/tests/functional/tests/app/Magento/Multishipping/Test/TestStep/FillShippingInformationStep.php
+++ b/dev/tests/functional/tests/app/Magento/Multishipping/Test/TestStep/FillShippingInformationStep.php
@@ -58,7 +58,8 @@ class FillShippingInformationStep implements TestStepInterface
     public function run()
     {
         $shippingMethods = [];
-        for ($i = 0; $i < count($this->customer->getAddress()); $i++) {
+        $addressCount = $this->customer->getAddress();
+        for ($i = 0; $i < $addressCount; $i++) {
             $shippingMethods[] = $this->shippingMethod;
         }
         $this->shippingInformation->getShippingBlock()->selectShippingMethod($shippingMethods);

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertProductsQtyAfterOrderCancel.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertProductsQtyAfterOrderCancel.php
@@ -52,7 +52,8 @@ class AssertProductsQtyAfterOrderCancel extends AbstractConstraint
         AssertProductForm $assertProductForm,
         AssertConfigurableProductForm $assertConfigurableProductForm
     ) {
-        for ($i = 0; $i < count($order->getEntityId()['products']); $i++) {
+        $productsCount = count($order->getEntityId()['products']);
+        for ($i = 0; $i < $productsCount; $i++) {
             $product = $order->getEntityId()['products'][$i];
             $productData = $product->getData();
             if ($product instanceof BundleProduct) {

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/AlgorithmBaseTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/AlgorithmBaseTest.php
@@ -112,7 +112,8 @@ class AlgorithmBaseTest extends \PHPUnit\Framework\TestCase
         $items = $model->calculateSeparators($interval);
         $this->assertEquals(array_keys($intervalItems), array_keys($items));
 
-        for ($i = 0; $i < count($intervalItems); ++$i) {
+        $intervalItemsCount = count($intervalItems);
+        for ($i = 0; $i < $intervalItemsCount; ++$i) {
             $this->assertInternalType('array', $items[$i]);
             $this->assertEquals($intervalItems[$i]['from'], $items[$i]['from']);
             $this->assertEquals($intervalItems[$i]['to'], $items[$i]['to']);

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Sniffs/Translation/ConstantUsageSniffTest.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Sniffs/Translation/ConstantUsageSniffTest.php
@@ -67,7 +67,8 @@ class ConstantUsageSniffTest extends \PHPUnit\Framework\TestCase
         $lineNumber = 1;
         $tokens = token_get_all($fileContent);
         $snifferTokens = [];
-        for ($i = 0; $i < count($tokens); $i++) {
+        $tokensCount = count($tokens);
+        for ($i = 0; $i < $tokensCount; $i++) {
             $content = is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
             $snifferTokens[$i]['line'] = $lineNumber;
             $snifferTokens[$i]['content'] = $content;

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteCodeTest.php
@@ -501,8 +501,9 @@ class ObsoleteCodeTest extends \PHPUnit\Framework\TestCase
     {
         $classPathParts = explode('\\', $class);
         $classPartialPath = '';
-        for ($i = count($classPathParts) - 1; $i >= 0; $i--) {
-            if ($i === (count($classPathParts) - 1)) {
+        $classPathPartsCount = count($classPathParts);
+        for ($i = $classPathPartsCount - 1; $i >= 0; $i--) {
+            if ($i === ($classPathPartsCount - 1)) {
                 $classPartialPath = $classPathParts[$i] . $classPartialPath;
             } else {
                 $classPartialPath = $classPathParts[$i] . '\\' . $classPartialPath;

--- a/lib/internal/Magento/Framework/App/Test/Unit/Language/DictionaryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Language/DictionaryTest.php
@@ -52,7 +52,8 @@ class DictionaryTest extends \PHPUnit\Framework\TestCase
         }
 
         $file = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\File\ReadInterface::class);
-        for ($i = 0; $i < count($data); $i++) {
+        $dataCount = count($data);
+        for ($i = 0; $i < $dataCount; $i++) {
             $file->expects($this->at($i))->method('readCsv')->will($this->returnValue($data[$i]));
         }
         $file->expects($this->at($i))->method('readCsv')->will($this->returnValue(false));

--- a/lib/internal/Magento/Framework/Archive.php
+++ b/lib/internal/Magento/Framework/Archive.php
@@ -96,14 +96,15 @@ class Archive
     {
         $archivers = $this->_getArchivers($destination);
         $interimSource = '';
-        for ($i = 0; $i < count($archivers); $i++) {
-            if ($i == count($archivers) - 1) {
+        $archiversCount = count($archivers);
+        for ($i = 0; $i < $archiversCount; $i++) {
+            if ($i == $archiversCount - 1) {
                 $packed = $destination;
             } else {
                 $packed = dirname($destination) . '/~tmp-' . microtime(true) . $archivers[$i] . '.' . $archivers[$i];
             }
             $source = $this->_getArchiver($archivers[$i])->pack($source, $packed, $skipRoot);
-            if ($interimSource && $i < count($archivers)) {
+            if ($interimSource && $i < $archiversCount) {
                 unlink($interimSource);
             }
             $interimSource = $source;

--- a/lib/internal/Magento/Framework/Cache/Backend/Memcached.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/Memcached.php
@@ -84,7 +84,8 @@ class Memcached extends \Zend_Cache_Backend_Memcached implements \Zend_Cache_Bac
         if (is_string($data) && strlen($data) > $this->_options['slab_size']) {
             $dataChunks = str_split($data, $this->_options['slab_size']);
 
-            for ($i = 0, $cnt = count($dataChunks); $i < $cnt; $i++) {
+            $dataChunksCount = count($dataChunks);
+            for ($i = 0, $cnt = $dataChunksCount; $i < $cnt; $i++) {
                 $chunkId = $this->_getChunkId($id, $i);
 
                 if (!parent::save($dataChunks[$i], $chunkId, $tags, $specificLifetime)) {

--- a/lib/internal/Magento/Framework/Filter/Template.php
+++ b/lib/internal/Magento/Framework/Filter/Template.php
@@ -374,7 +374,8 @@ class Template implements \Zend_Filter_Interface
         $stackVars = $tokenizer->tokenize();
         $result = $default;
         $last = 0;
-        for ($i = 0; $i < count($stackVars); $i++) {
+        $stackVarsCount = count($stackVars);
+        for ($i = 0; $i < $stackVarsCount; $i++) {
             if ($i == 0 && isset($this->templateVars[$stackVars[$i]['name']])) {
                 // Getting of template value
                 $stackVars[$i]['variable'] = & $this->templateVars[$stackVars[$i]['name']];

--- a/lib/internal/Magento/Framework/System/Ftp.php
+++ b/lib/internal/Magento/Framework/System/Ftp.php
@@ -56,7 +56,8 @@ class Ftp
         $dir = explode("/", $path);
         $path = "";
         $ret = true;
-        for ($i = 0; $i < count($dir); $i++) {
+        $dirCount = count($dir);
+        for ($i = 0; $i < $dirCount; $i++) {
             $path .= "/" . $dir[$i];
             if (!@ftp_chdir($this->_conn, $path)) {
                 @ftp_chdir($this->_conn, "/");

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -31,7 +31,8 @@ class Html extends AbstractAdapter
 
         $results = [];
         preg_match_all(Filter::CONSTRUCTION_PATTERN, $data, $results, PREG_SET_ORDER);
-        for ($i = 0; $i < count($results); $i++) {
+        $resultsCount = count($results);
+        for ($i = 0; $i < $resultsCount; $i++) {
             if ($results[$i][1] === Filter::TRANS_DIRECTIVE_NAME) {
                 $directive = [];
                 if (preg_match(Filter::TRANS_DIRECTIVE_REGEX, $results[$i][2], $directive) !== 1) {
@@ -43,7 +44,8 @@ class Html extends AbstractAdapter
         }
 
         preg_match_all(self::HTML_FILTER, $data, $results, PREG_SET_ORDER);
-        for ($i = 0; $i < count($results); $i++) {
+        $resultsCount = count($results);
+        for ($i = 0; $i < $resultsCount; $i++) {
             if (!empty($results[$i]['value'])) {
                 $this->_addPhrase($results[$i]['value']);
             }

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Js.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Js.php
@@ -22,7 +22,8 @@ class Js extends AbstractAdapter
             $fileRow = fgets($fileHandle, 4096);
             $results = [];
             preg_match_all('/mage\.__\(\s*([\'"])(.*?[^\\\])\1.*?[),]/', $fileRow, $results, PREG_SET_ORDER);
-            for ($i = 0; $i < count($results); $i++) {
+            $resultsCount = count($results);
+            for ($i = 0; $i < $resultsCount; $i++) {
                 if (isset($results[$i][2])) {
                     $quote = $results[$i][1];
                     $this->_addPhrase($quote . $results[$i][2] . $quote, $lineNumber);
@@ -30,7 +31,8 @@ class Js extends AbstractAdapter
             }
 
             preg_match_all('/\\$t\(\s*([\'"])(.*?[^\\\])\1.*?[),]/', $fileRow, $results, PREG_SET_ORDER);
-            for ($i = 0; $i < count($results); $i++) {
+            $resultsCount = count($results);
+            for ($i = 0; $i < $resultsCount; $i++) {
                 if (isset($results[$i][2])) {
                     $quote = $results[$i][1];
                     $this->_addPhrase($quote . $results[$i][2] . $quote, $lineNumber);


### PR DESCRIPTION
### Original Pull Request
#15507
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This improves the performance of a few loops which were running`count()` in every iteration.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
