### PR TITLE
Fix wrong return type in StockRegistryInterface::getLowStockItems() API

### DIFF
--- a/app/code/Magento/CatalogInventory/Api/StockRegistryInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockRegistryInterface.php
@@ -72,7 +72,7 @@ interface StockRegistryInterface
      * @param float $qty
      * @param int $currentPage
      * @param int $pageSize
-     * @return \Magento\CatalogInventory\Api\Data\StockStatusCollectionInterface
+     * @return \Magento\CatalogInventory\Api\Data\StockItemCollectionInterface
      */
     public function getLowStockItems($scopeId, $qty, $currentPage = 1, $pageSize = 0);
 


### PR DESCRIPTION
### Description
Full description in https://github.com/magento/magento2/issues/15085.

Fixes wrong return type of `StockRegistryInterface :: getLowStockItems()` when using REST API `/V1/stockItems/lowStock/`

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/15085

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
