### PR TITLE
Fix for #15041 Adding a new fieldset to the admin category editor changes the position of the 'General' fieldset

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
@@ -42,7 +42,7 @@
             </settings>
         </dataProvider>
     </dataSource>
-    <fieldset name="general">
+    <fieldset name="general" sortOrder="5">
         <settings>
             <collapsible>false</collapsible>
             <label/>


### PR DESCRIPTION
### Description
When a custom fieldset is added to the admin category editor, the General section (the one with "Enable category", "Include in Menu" and "Category Name") moves to the last position of the form.
Full description in https://github.com/magento/magento2/issues/15041

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/15041
![image](https://user-images.githubusercontent.com/13456702/43992709-f61f314c-9d8a-11e8-8488-814eed9433bf.png)


### Manual testing scenarios
Provided in https://github.com/magento/magento2/issues/15041

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
