### PR TITLE
[Backport] Fix #10687 - Product image roles disappearing

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -455,18 +455,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                     $newEntries[] = $entry;
                 }
             }
-            foreach ($existingMediaGallery as $key => &$existingEntry) {
-                if (isset($entriesById[$existingEntry['value_id']])) {
-                    $updatedEntry = $entriesById[$existingEntry['value_id']];
-                    if ($updatedEntry['file'] === null) {
-                        unset($updatedEntry['file']);
-                    }
-                    $existingMediaGallery[$key] = array_merge($existingEntry, $updatedEntry);
-                } else {
-                    //set the removed flag
-                    $existingEntry['removed'] = true;
-                }
-            }
+            $existingMediaGallery = $this->processingExistingImages($existingMediaGallery, $entriesById);
             $product->setData('media_gallery', ["images" => $existingMediaGallery]);
         } else {
             $newEntries = $mediaGalleryEntries;
@@ -487,25 +476,8 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             }
         }
 
-        foreach ($newEntries as $newEntry) {
-            if (!isset($newEntry['content'])) {
-                throw new InputException(__('The image content is not valid.'));
-            }
-            /** @var ImageContentInterface $contentDataObject */
-            $contentDataObject = $this->contentFactory->create()
-                ->setName($newEntry['content']['data'][ImageContentInterface::NAME])
-                ->setBase64EncodedData($newEntry['content']['data'][ImageContentInterface::BASE64_ENCODED_DATA])
-                ->setType($newEntry['content']['data'][ImageContentInterface::TYPE]);
-            $newEntry['content'] = $contentDataObject;
-            $this->processNewMediaGalleryEntry($product, $newEntry);
+        $this->processingNewEntries($newEntries, $product, $entriesById);
 
-            $finalGallery = $product->getData('media_gallery');
-            $newEntryId = key(array_diff_key($product->getData('media_gallery')['images'], $entriesById));
-            $newEntry = array_replace_recursive($newEntry, $finalGallery['images'][$newEntryId]);
-            $entriesById[$newEntryId] = $newEntry;
-            $finalGallery['images'][$newEntryId] = $newEntry;
-            $product->setData('media_gallery', $finalGallery);
-        }
         return $this;
     }
 
@@ -759,5 +731,59 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 ->get(\Magento\Catalog\Model\Product\Gallery\Processor::class);
         }
         return $this->mediaGalleryProcessor;
+    }
+
+    /**
+     * @param $existingMediaGallery
+     * @param $entriesById
+     * @return mixed
+     */
+    private function processingExistingImages($existingMediaGallery, $entriesById)
+    {
+        foreach ($existingMediaGallery as $key => &$existingEntry) {
+            if (isset($entriesById[$existingEntry['value_id']])) {
+                $updatedEntry = $entriesById[$existingEntry['value_id']];
+                if ($updatedEntry['file'] === null) {
+                    unset($updatedEntry['file']);
+                }
+                $existingMediaGallery[$key] = array_merge($existingEntry, $updatedEntry);
+            } else {
+                //set the removed flag
+                $existingEntry['removed'] = true;
+            }
+        }
+
+        return $existingMediaGallery;
+    }
+
+    /**
+     * @param $newEntries
+     * @param $product
+     * @param $entriesById
+     * @throws InputException
+     * @throws LocalizedException
+     * @throws StateException
+     */
+    private function processingNewEntries($newEntries, $product, $entriesById)
+    {
+        foreach ($newEntries as $newEntry) {
+            if (!isset($newEntry['content'])) {
+                throw new InputException(__('The image content is not valid.'));
+            }
+            /** @var ImageContentInterface $contentDataObject */
+            $contentDataObject = $this->contentFactory->create()
+                ->setName($newEntry['content']['data'][ImageContentInterface::NAME])
+                ->setBase64EncodedData($newEntry['content']['data'][ImageContentInterface::BASE64_ENCODED_DATA])
+                ->setType($newEntry['content']['data'][ImageContentInterface::TYPE]);
+            $newEntry['content'] = $contentDataObject;
+            $this->processNewMediaGalleryEntry($product, $newEntry);
+
+            $finalGallery = $product->getData('media_gallery');
+            $newEntryId = key(array_diff_key($product->getData('media_gallery')['images'], $entriesById));
+            $newEntry = array_replace_recursive($newEntry, $finalGallery['images'][$newEntryId]);
+            $entriesById[$newEntryId] = $newEntry;
+            $finalGallery['images'][$newEntryId] = $newEntry;
+            $product->setData('media_gallery', $finalGallery);
+        }
     }
 }

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -734,11 +734,11 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     }
 
     /**
-     * @param $existingMediaGallery
-     * @param $entriesById
-     * @return mixed
+     * @param array $existingMediaGallery
+     * @param array $entriesById
+     * @return array
      */
-    private function processingExistingImages($existingMediaGallery, $entriesById)
+    private function processingExistingImages(array $existingMediaGallery, array $entriesById)
     {
         foreach ($existingMediaGallery as $key => &$existingEntry) {
             if (isset($entriesById[$existingEntry['value_id']])) {
@@ -757,14 +757,15 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     }
 
     /**
-     * @param $newEntries
-     * @param $product
-     * @param $entriesById
+     * @param array $newEntries
+     * @param ProductInterface $product
+     * @param array $entriesById
+     * @return void
      * @throws InputException
      * @throws LocalizedException
      * @throws StateException
      */
-    private function processingNewEntries($newEntries, $product, $entriesById)
+    private function processingNewEntries(array $newEntries, ProductInterface $product, array $entriesById)
     {
         foreach ($newEntries as $newEntry) {
             if (!isset($newEntry['content'])) {


### PR DESCRIPTION
Original PR #15606 

To fix #10687 - adds the 'types' key to the images array to provide existing image roles, which are reset after clearMediaAttribute() is called.

### Description
This PR is to fix the issue outlined in #10687 - image roles being removed when saving by the ProductRepository.

### Fixed Issues (if relevant)
1. magento/magento2#10687: Product image roles randomly disappear

### Manual testing scenarios
1. Initially save a product using the ProductRepostory, setting an image in the gallery with roles.
2. Save the product again, without setting the media gallery at all. Roles should persist after second save.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
