### PR TITLE
[Forwardport] Fix #10687 - Product image roles disappearing

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -514,8 +514,13 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             $newEntries = $mediaGalleryEntries;
         }
 
-        $this->getMediaGalleryProcessor()->clearMediaAttribute($product, array_keys($product->getMediaAttributes()));
         $images = $product->getMediaGallery('images');
+        if ($images) {
+            $images = $this->determineImageRoles($product, $images);
+        }
+
+        $this->getMediaGalleryProcessor()->clearMediaAttribute($product, array_keys($product->getMediaAttributes()));
+
         if ($images) {
             foreach ($images as $image) {
                 if (!isset($image['removed']) && !empty($image['types'])) {
@@ -756,6 +761,32 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     {
         $this->instances = null;
         $this->instancesById = null;
+    }
+
+    /**
+     * Ascertain image roles, if they are not set against the gallery entries
+     *
+     * @param ProductInterface $product
+     * @param array $images
+     * @return array
+     */
+    private function determineImageRoles(ProductInterface $product, array $images)
+    {
+        $imagesWithRoles = [];
+        foreach ($images as $image) {
+            if (!isset($image['types'])) {
+                $image['types'] = [];
+                if (isset($image['file'])) {
+                    foreach (array_keys($product->getMediaAttributes()) as $attribute) {
+                        if ($image['file'] == $product->getData($attribute)) {
+                            $image['types'][] = $attribute;
+                        }
+                    }
+                }
+            }
+            $imagesWithRoles[] = $image;
+        }
+        return $imagesWithRoles;
     }
 
     /**


### PR DESCRIPTION
Original PR https://github.com/magento/magento2/pull/15606

To fix #10687 - adds the 'types' key to the images array to provide existing image roles, which are reset after clearMediaAttribute() is called.

### Description
This PR is to fix the issue outlined in #10687 - image roles being removed when saving by the ProductRepository.

### Fixed Issues (if relevant)
1. magento/magento2#10687: Product image roles randomly disappear

### Manual testing scenarios
1. Initially save a product using the ProductRepostory, setting an image in the gallery with roles.
2. Save the product again, without setting the media gallery at all. Roles should persist after second save.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
