### PR TITLE
Fixed wrong asset urls in transactional email.

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -92,16 +92,16 @@ class Repository
 
     /**
      * Repository constructor.
-     * @param UrlInterface                                       $baseUrl
-     * @param \Magento\Framework\View\DesignInterface            $design
+     * @param UrlInterface $baseUrl
+     * @param \Magento\Framework\View\DesignInterface $design
      * @param \Magento\Framework\View\Design\Theme\ListInterface $themeList
-     * @param \Magento\Framework\View\Asset\Source               $assetSource
-     * @param \Magento\Framework\App\Request\Http                $request
-     * @param FileFactory                                        $fileFactory
-     * @param File\FallbackContextFactory                        $fallbackContextFactory
-     * @param File\ContextFactory                                $contextFactory
-     * @param RemoteFactory                                      $remoteFactory
-     * @param \Magento\Store\Model\StoreManagerInterface         $storeManager
+     * @param \Magento\Framework\View\Asset\Source $assetSource
+     * @param \Magento\Framework\App\Request\Http $request
+     * @param FileFactory $fileFactory
+     * @param File\FallbackContextFactory $fallbackContextFactory
+     * @param File\ContextFactory $contextFactory
+     * @param RemoteFactory $remoteFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
     public function __construct(
         \Magento\Framework\UrlInterface $baseUrl,
@@ -204,7 +204,7 @@ class Repository
      * Create a file asset that's subject of fallback system
      *
      * @param string $fileId
-     * @param array  $params
+     * @param array $params
      * @return File
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
@@ -280,9 +280,9 @@ class Repository
      */
     private function getFallbackContext($urlType, $isSecure, $area, $themePath, $locale)
     {
-        $secureKey   = null === $isSecure ? 'null' : (int)$isSecure;
+        $secureKey = null === $isSecure ? 'null' : (int)$isSecure;
         $baseDirType = DirectoryList::STATIC_VIEW;
-        $cacheId     = implode('|', [
+        $cacheId = implode('|', [
             $baseDirType,
             $urlType,
             $secureKey,
@@ -323,7 +323,7 @@ class Repository
     /**
      * Create a file asset similar to an existing local asset by using its context
      *
-     * @param string         $fileId
+     * @param string $fileId
      * @param LocalInterface $similarTo
      * @return File
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -401,7 +401,7 @@ class Repository
     /**
      * Create a file asset with path relative to specified local asset
      *
-     * @param string         $fileId
+     * @param string $fileId
      * @param LocalInterface $relativeTo
      * @return File
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -449,7 +449,7 @@ class Repository
      * To omit parameters and have them automatically determined from application state, use getUrl()
      *
      * @param string $fileId
-     * @param array  $params
+     * @param array $params
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -293,11 +293,11 @@ class Repository
         $secureKey   = null === $isSecure ? 'null' : (int)$isSecure;
         $baseDirType = DirectoryList::STATIC_VIEW;
         $storeId     = $this->storeManager->getStore()->getId();
-        $id          = implode('|', [$baseDirType, $urlType, $secureKey, $area, $themePath, $storeId, $locale]);
+        $cacheId     = implode('|', [$baseDirType, $urlType, $secureKey, $area, $themePath, $storeId, $locale]);
 
-        if (!isset($this->fallbackContext[$id])) {
+        if (!isset($this->fallbackContext[$cacheId])) {
             $url = $this->baseUrlFactory->create()->getBaseUrl(['_type' => $urlType, '_secure' => $isSecure]);
-            $this->fallbackContext[$id] = $this->fallbackContextFactory->create(
+            $this->fallbackContext[$cacheId] = $this->fallbackContextFactory->create(
                 [
                     'baseUrl' => $url,
                     'areaType' => $area,
@@ -307,7 +307,7 @@ class Repository
             );
         }
 
-        return $this->fallbackContext[$id];
+        return $this->fallbackContext[$cacheId];
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -91,11 +91,6 @@ class Repository
     private $storeManager;
 
     /**
-     * @var \Magento\Framework\UrlInterfaceFactory
-     */
-    private $baseUrlFactory;
-
-    /**
      * Repository constructor.
      * @param UrlInterface                                       $baseUrl
      * @param \Magento\Framework\View\DesignInterface            $design
@@ -107,7 +102,6 @@ class Repository
      * @param File\ContextFactory                                $contextFactory
      * @param RemoteFactory                                      $remoteFactory
      * @param \Magento\Store\Model\StoreManagerInterface         $storeManager
-     * @param \Magento\Framework\UrlInterfaceFactory|null        $baseUrlFactory
      */
     public function __construct(
         \Magento\Framework\UrlInterface $baseUrl,

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -71,6 +71,11 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Framework\View\Asset\RemoteFactory|\PHPUnit_Framework_MockObject_MockObject
      */
     private $remoteFactoryMock;
+    
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
 
     /**
      * {@inheritDoc}
@@ -111,6 +116,9 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
+        $this->storeManagerMock = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $repositoryMapMock = $this->createPartialMock(\Magento\Framework\View\Asset\File::class, ['getMap']);
         $repositoryMapMock->method('getMap')->willReturn([]);
@@ -128,7 +136,8 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
             'fileFactory' => $this->fileFactoryMock,
             'fallbackContextFactory' => $this->fallbackFactoryMock,
             'contextFactory' => $this->contextFactoryMock,
-            'remoteFactory' => $this->remoteFactoryMock
+            'remoteFactory' => $this->remoteFactoryMock,
+            'storeManager' => $this->storeManagerMock
         ]);
     }
 


### PR DESCRIPTION
Wrong asset urls in transactional email.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fixed the issue #15559. Please check notes on issue for more information.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<15559>: Wrong asset urls in transactional email

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
