### PR TITLE
Prevent empty string as useless product URL key on product imports

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1561,8 +1561,9 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 }
                 $rowScope = $this->getRowScope($rowData);
 
-                if ($urlKey = $this->getUrlKey($rowData))
-                    $rowData[self::URL_KEY] = $urlKey;
+                if ($this->getUrlKey($rowData)) {
+                    $rowData[self::URL_KEY] = $this->getUrlKey($rowData);
+                }
 
                 $rowSku = $rowData[self::COL_SKU];
 

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1561,7 +1561,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 }
                 $rowScope = $this->getRowScope($rowData);
 
-                $rowData[self::URL_KEY] = $this->getUrlKey($rowData);
+                if ($urlKey = $this->getUrlKey($rowData))
+                    $rowData[self::URL_KEY] = $urlKey;
 
                 $rowSku = $rowData[self::COL_SKU];
 


### PR DESCRIPTION
Using the given class for product import processes leads to comulative problems of handling product url key related processes.

### Description
Since 2.4 at least the url key for the sku, which is given in an import file's row, is set to an empty string, if there is no corresponding url key or name column given. This leads to a variety of problems:

a) if no url key is given on import, it leads to changing the url key to Magento 2 standards by using the value in the name column. this totally ignores the fact that url keys get customized a lot of times and overwrites all efforts before. furthermore causing SEO problems, if as a consequence the url rewrites get adjusted accordingly. a product, which was exported to google shopping may not be reachable anymore by the link given to google or loose all linked SEO data by the next export given (if no 301 redirect is given).
b) if nor url key or name column is given on import, the url key is set as an empty string, which is even worse. this leads to several products having the same empty string as an url key, causing problems, when regenerating or reindexing url rewrites, because of duplicate entries. and so on and so on. furthermore an empty string as an url key is just useless.

### Fixed Issue
if no url key or name column is given in the import file, this change prevents any url key to be set as or updated to an empty string, which is useless and causes even more problems in the aftermath.

### Manual testing scenarios
1. create an import file (csv) to update a product via sku and have no corresponding name or url key column in it
2. check product url key before
3. run import in backend or via an extension, which uses the given class
4. check product url key again

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
