### PR TITLE
[Forwardport] Solution for User role issue with customer group

### DIFF
--- a/app/code/Magento/Customer/etc/acl.xml
+++ b/app/code/Magento/Customer/etc/acl.xml
@@ -12,6 +12,7 @@
                 <resource id="Magento_Customer::customer" title="Customers" translate="title" sortOrder="40">
                     <resource id="Magento_Customer::manage" title="All Customers" translate="title" sortOrder="10" />
                     <resource id="Magento_Customer::online" title="Now Online" translate="title" sortOrder="20" />
+                    <resource id="Magento_Customer::group" title="Customer Groups" translate="title" sortOrder="30" />
                 </resource>
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
@@ -19,10 +20,7 @@
                             <resource id="Magento_Customer::config_customer" title="Customers Section" translate="title" sortOrder="50" />
                         </resource>
                     </resource>
-                    <resource id="Magento_Backend::stores_other_settings">
-                        <resource id="Magento_Customer::group" title="Customer Groups" translate="title" sortOrder="10" />
-                    </resource>
-                </resource>
+                   </resource>
             </resource>
         </resources>
     </acl>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17515

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Now the “customer group” menu is displayed under "customers" menu on the admin side and store menu is invisible for new user. issue was is ACL file.
In ACL file 'Customer group should be in 'Magento_Customer::customer' instead of 'Magento_Backend::stores_other_settings'.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16499: User role issue with customer group #16499


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1 .System > Permission > User Roles.
2. Create a user role with 'customer group' permission which is specified in issue steps.
3. Login with new user credential. now only customer menu is enabled and store menu is not visible for new user.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)