### PR TITLE
Typo in Magento\Cms\Model\Wysiwyg\Images\Storage function resizeFile()

### DIFF
--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -566,10 +566,10 @@ class Storage extends \Magento\Framework\DataObject
      * Create thumbnail for image and save it to thumbnails directory
      *
      * @param string $source Image path to be resized
-     * @param bool $keepRation Keep aspect ratio or not
+     * @param bool $keepRatio Keep aspect ratio or not
      * @return bool|string Resized filepath or false if errors were occurred
      */
-    public function resizeFile($source, $keepRation = true)
+    public function resizeFile($source, $keepRatio = true)
     {
         $realPath = $this->_directory->getRelativePath($source);
         if (!$this->_directory->isFile($realPath) || !$this->_directory->isExist($realPath)) {
@@ -586,7 +586,7 @@ class Storage extends \Magento\Framework\DataObject
         }
         $image = $this->_imageFactory->create();
         $image->open($source);
-        $image->keepAspectRatio($keepRation);
+        $image->keepAspectRatio($keepRatio);
         $image->resize($this->_resizeParameters['width'], $this->_resizeParameters['height']);
         $dest = $targetDir . '/' . pathinfo($source, PATHINFO_BASENAME);
         $image->save($dest);


### PR DESCRIPTION
### Description
Fixed a typo: The parameter $keepRation should be called $keepRatio

### Fixed Issues (if relevant)
1. magento/magento2#17587: Typo in Magento\Cms\Model\Wysiwyg\Images\Storage function resizeFile($source, $keepRation = true)

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
