### PR TITLE
[Forwardport] Introduce Block Config Source

### DIFF
--- a/app/code/Magento/Cms/Model/Config/Source/Block.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Block.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Model\Config\Source;
+
+use Magento\Cms\Model\ResourceModel\Block\CollectionFactory;
+
+/**
+ * Class Block
+ */
+class Block implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory
+    ) {
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * To option array
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        if (!$this->options) {
+            $this->options = $this->collectionFactory->create()->toOptionIdArray();
+        }
+        return $this->options;
+    }
+}

--- a/app/code/Magento/Cms/Model/Config/Source/Block.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Block.php
@@ -3,14 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Cms\Model\Config\Source;
 
 use Magento\Cms\Model\ResourceModel\Block\CollectionFactory;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * Class Block
  */
-class Block implements \Magento\Framework\Option\ArrayInterface
+class Block implements OptionSourceInterface
 {
     /**
      * @var array
@@ -18,12 +21,12 @@ class Block implements \Magento\Framework\Option\ArrayInterface
     private $options;
 
     /**
-     * @var CollectionFactory
+     * @var \Magento\Cms\Model\ResourceModel\Block\CollectionFactory
      */
     private $collectionFactory;
 
     /**
-     * @param CollectionFactory $collectionFactory
+     * @param \Magento\Cms\Model\ResourceModel\Block\CollectionFactory $collectionFactory
      */
     public function __construct(
         CollectionFactory $collectionFactory
@@ -32,15 +35,14 @@ class Block implements \Magento\Framework\Option\ArrayInterface
     }
 
     /**
-     * To option array
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function toOptionArray()
     {
         if (!$this->options) {
             $this->options = $this->collectionFactory->create()->toOptionIdArray();
         }
+
         return $this->options;
     }
 }

--- a/app/code/Magento/Cms/Model/ResourceModel/AbstractCollection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/AbstractCollection.php
@@ -176,4 +176,32 @@ abstract class AbstractCollection extends \Magento\Framework\Model\ResourceModel
 
         return $countSelect;
     }
+
+    /**
+     * Returns pairs identifier - title for unique identifiers
+     * and pairs identifier|entity_id - title for non-unique after first
+     *
+     * @return array
+     */
+    public function toOptionIdArray()
+    {
+        $res = [];
+        $existingIdentifiers = [];
+        foreach ($this as $item) {
+            $identifier = $item->getData('identifier');
+
+            $data['value'] = $identifier;
+            $data['label'] = $item->getData('title');
+
+            if (in_array($identifier, $existingIdentifiers)) {
+                $data['value'] .= '|' . $item->getData($this->getIdFieldName());
+            } else {
+                $existingIdentifiers[] = $identifier;
+            }
+
+            $res[] = $data;
+        }
+
+        return $res;
+    }
 }

--- a/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page/Collection.php
@@ -52,34 +52,6 @@ class Collection extends AbstractCollection
     }
 
     /**
-     * Returns pairs identifier - title for unique identifiers
-     * and pairs identifier|page_id - title for non-unique after first
-     *
-     * @return array
-     */
-    public function toOptionIdArray()
-    {
-        $res = [];
-        $existingIdentifiers = [];
-        foreach ($this as $item) {
-            $identifier = $item->getData('identifier');
-
-            $data['value'] = $identifier;
-            $data['label'] = $item->getData('title');
-
-            if (in_array($identifier, $existingIdentifiers)) {
-                $data['value'] .= '|' . $item->getData('page_id');
-            } else {
-                $existingIdentifiers[] = $identifier;
-            }
-
-            $res[] = $data;
-        }
-
-        return $res;
-    }
-
-    /**
      * Set first store flag
      *
      * @param bool $flag

--- a/app/code/Magento/Cms/Test/Unit/Model/Config/Source/BlockTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/Config/Source/BlockTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Cms\Test\Unit\Model\Config\Source;
+
+/**
+ * Class BlockTest
+ */
+class BlockTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Cms\Model\ResourceModel\Block\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $collectionFactory;
+
+    /**
+     * @var \Magento\Cms\Model\Config\Source\Block
+     */
+    protected $block;
+
+    /**
+     * Set up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->collectionFactory = $this->createPartialMock(
+            \Magento\Cms\Model\ResourceModel\Block\CollectionFactory::class,
+            ['create']
+        );
+
+        $this->block = $objectManager->getObject(
+            \Magento\Cms\Model\Config\Source\Block::class,
+            [
+                'collectionFactory' => $this->collectionFactory,
+            ]
+        );
+    }
+
+    /**
+     * Run test toOptionArray method
+     *
+     * @return void
+     */
+    public function testToOptionArray()
+    {
+        $blockCollectionMock = $this->createMock(\Magento\Cms\Model\ResourceModel\Block\Collection::class);
+
+        $this->collectionFactory->expects($this->once())
+            ->method('create')
+            ->will($this->returnValue($blockCollectionMock));
+
+        $blockCollectionMock->expects($this->once())
+            ->method('toOptionIdArray')
+            ->will($this->returnValue('return-value'));
+
+        $this->assertEquals('return-value', $this->block->toOptionArray());
+    }
+}

--- a/app/code/Magento/Cms/Test/Unit/Model/Config/Source/BlockTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/Config/Source/BlockTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Cms\Test\Unit\Model\Config\Source;
 
 /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16021

Add a new OptionSource of Blocks

### Description
Pages config source is useful to create custom configuration, for example to set page. The same for the block could be useful too.
So I suggest to add the blocks config source.