### PR TITLE
[Forwardport] Fix unstable session manager

### DIFF
--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -5,9 +5,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Session;
 
 use Magento\Framework\Session\Config\ConfigInterface;
@@ -18,6 +15,11 @@ use Magento\Framework\Session\Config\ConfigInterface;
  */
 class SessionManager implements SessionManagerInterface
 {
+   /**
+    * Session destroyed threshold in seconds
+    */
+    const SESSION_DESTROYED_THRESHOLD = 300;
+    
     /**
      * Default options when a call destroy()
      *
@@ -193,7 +195,7 @@ class SessionManager implements SessionManagerInterface
             $this->setSessionId($sid);
             session_start();
             if (isset($_SESSION['destroyed'])) {
-                if ($_SESSION['destroyed'] < time() - 300) {
+                if ($_SESSION['destroyed'] < time() - self::SESSION_DESTROYED_THRESHOLD) {
                     $this->destroy(['clear_storage' => true]);
                 }
             }
@@ -511,25 +513,21 @@ class SessionManager implements SessionManagerInterface
             return $this;
         }
 
+        // @codingStandardsIgnoreStart
         if ($this->isSessionExists()) {
             // Regenerate the session
             session_regenerate_id();
             $newSessionId = session_id();
-
             $_SESSION['new_session_id'] = $newSessionId;
-
             // Set destroy timestamp
             $_SESSION['destroyed'] = time();
-
             // Write and close current session;
             session_commit();
             // Called after destroy()
             $oldSession = $_SESSION;
             // Start session with new session ID
             session_id($newSessionId);
-            ini_set('session.use_strict_mode', 0);
             session_start();
-            ini_set('session.use_strict_mode', 1);
             $_SESSION = $oldSession;
             // New session does not need them
             unset($_SESSION['destroyed']);
@@ -537,6 +535,7 @@ class SessionManager implements SessionManagerInterface
         } else {
             session_start();
         }
+        // @codingStandardsIgnoreEnd
         $this->storage->init(isset($_SESSION) ? $_SESSION : []);
 
         if ($this->sessionConfig->getUseCookies()) {

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -510,7 +510,6 @@ class SessionManager implements SessionManagerInterface
         }
 
         if ($this->isSessionExists()) {
-
             // Regenerate the session
             session_regenerate_id();
             $newSessionId = session_id();

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -180,10 +180,21 @@ class SessionManager implements SessionManagerInterface
             // Need to apply the config options so they can be ready by session_start
             $this->initIniOptions();
             $this->registerSaveHandler();
+            if (isset($_SESSION['new_session_id'])) {
+                // Not fully expired yet. Could be lost cookie by unstable network.
+                session_commit();
+                session_id($_SESSION['new_session_id']);
+            }
             $sid = $this->sidResolver->getSid($this);
             // potential custom logic for session id (ex. switching between hosts)
             $this->setSessionId($sid);
             session_start();
+            if (isset($_SESSION['destroyed'])) {
+                if ($_SESSION['destroyed'] < time() - 300) {
+                    $this->destroy(['clear_storage' => true]);
+
+                }
+            }
             $this->validator->validate($this);
             $this->renewCookie($sid);
 
@@ -498,7 +509,31 @@ class SessionManager implements SessionManagerInterface
             return $this;
         }
 
-        $this->isSessionExists() ? session_regenerate_id(true) : session_start();
+        if ($this->isSessionExists()) {
+            //regenerate the session
+            session_regenerate_id();
+            $new_session_id = session_id();
+
+            $_SESSION['new_session_id'] = $new_session_id;
+
+            // Set destroy timestamp
+            $_SESSION['destroyed'] = time();
+
+            // Write and close current session;
+            session_commit();
+            $oldSession = $_SESSION;   //called after destroy - see destroy!
+            // Start session with new session ID
+            session_id($new_session_id);
+            ini_set('session.use_strict_mode', 0);
+            session_start();
+            ini_set('session.use_strict_mode', 1);
+            $_SESSION = $oldSession;
+            // New session does not need them
+            unset($_SESSION['destroyed']);
+            unset($_SESSION['new_session_id']);
+        } else {
+            session_start();
+        }
         $this->storage->init(isset($_SESSION) ? $_SESSION : []);
 
         if ($this->sessionConfig->getUseCookies()) {

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -511,18 +511,20 @@ class SessionManager implements SessionManagerInterface
         if ($this->isSessionExists()) {
             //regenerate the session
             session_regenerate_id();
-            $new_session_id = session_id();
+            $newSessionId = session_id();
 
-            $_SESSION['new_session_id'] = $new_session_id;
+            $_SESSION['new_session_id'] = $newSessionId;
 
             // Set destroy timestamp
             $_SESSION['destroyed'] = time();
 
             // Write and close current session;
             session_commit();
-            $oldSession = $_SESSION;   //called after destroy - see destroy!
+            
+            //called after destroy()
+            $oldSession = $_SESSION;
             // Start session with new session ID
-            session_id($new_session_id);
+            session_id($newSessionId);
             ini_set('session.use_strict_mode', 0);
             session_start();
             ini_set('session.use_strict_mode', 1);

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -192,7 +192,6 @@ class SessionManager implements SessionManagerInterface
             if (isset($_SESSION['destroyed'])) {
                 if ($_SESSION['destroyed'] < time() - 300) {
                     $this->destroy(['clear_storage' => true]);
-
                 }
             }
             $this->validator->validate($this);

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -5,6 +5,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+// @codingStandardsIgnoreFile
+
 namespace Magento\Framework\Session;
 
 use Magento\Framework\Session\Config\ConfigInterface;
@@ -509,7 +512,7 @@ class SessionManager implements SessionManagerInterface
         }
 
         if ($this->isSessionExists()) {
-            //regenerate the session
+            // Regenerate the session
             session_regenerate_id();
             $newSessionId = session_id();
 
@@ -520,8 +523,7 @@ class SessionManager implements SessionManagerInterface
 
             // Write and close current session;
             session_commit();
-            
-            //called after destroy()
+            // Called after destroy()
             $oldSession = $_SESSION;
             // Start session with new session ID
             session_id($newSessionId);

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -15,11 +15,6 @@ use Magento\Framework\Session\Config\ConfigInterface;
  */
 class SessionManager implements SessionManagerInterface
 {
-   /**
-    * Session destroyed threshold in seconds
-    */
-    const SESSION_DESTROYED_THRESHOLD = 300;
-    
     /**
      * Default options when a call destroy()
      *
@@ -194,11 +189,12 @@ class SessionManager implements SessionManagerInterface
             // potential custom logic for session id (ex. switching between hosts)
             $this->setSessionId($sid);
             session_start();
-            if (isset($_SESSION['destroyed'])) {
-                if ($_SESSION['destroyed'] < time() - self::SESSION_DESTROYED_THRESHOLD) {
-                    $this->destroy(['clear_storage' => true]);
-                }
+            if (isset($_SESSION['destroyed'])
+                && $_SESSION['destroyed'] < time() - $this->sessionConfig->getCookieLifetime()
+            ) {
+                $this->destroy(['clear_storage' => true]);
             }
+
             $this->validator->validate($this);
             $this->renewCookie($sid);
 
@@ -513,29 +509,34 @@ class SessionManager implements SessionManagerInterface
             return $this;
         }
 
-        // @codingStandardsIgnoreStart
         if ($this->isSessionExists()) {
+
             // Regenerate the session
             session_regenerate_id();
             $newSessionId = session_id();
             $_SESSION['new_session_id'] = $newSessionId;
+
             // Set destroy timestamp
             $_SESSION['destroyed'] = time();
+
             // Write and close current session;
             session_commit();
+
             // Called after destroy()
             $oldSession = $_SESSION;
+
             // Start session with new session ID
             session_id($newSessionId);
             session_start();
             $_SESSION = $oldSession;
+
             // New session does not need them
             unset($_SESSION['destroyed']);
             unset($_SESSION['new_session_id']);
         } else {
             session_start();
         }
-        // @codingStandardsIgnoreEnd
+
         $this->storage->init(isset($_SESSION) ? $_SESSION : []);
 
         if ($this->sessionConfig->getUseCookies()) {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14973

### Description

Fix of the unstable behaviour of the session management with high volume of concurrent sessions.

### Fixed Issues
1. magento/magento2#12362: Concurrent (quick reload) requests on checkout cause cart to empty - related to session_regenerate_id

### Manual testing scenarios

1. Reach the checkout page with products in the cart
2. Press CMD+R or ALT+F5 multiple times to refresh the page, after the fix the user is not being logged out and redirected to the empty cart page.

We already deployed the fix on our high traffic website and the issue is fixed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
