### PR TITLE
[Backport] Added template as argument to the store address renderer to allow custom formatting

### DIFF
--- a/app/code/Magento/Store/Model/Address/Renderer.php
+++ b/app/code/Magento/Store/Model/Address/Renderer.php
@@ -15,6 +15,12 @@ use Magento\Framework\DataObject;
  */
 class Renderer
 {
+    const DEFAULT_TEMPLATE = "{{var name}}\n" .
+        "{{var street_line1}}\n" .
+        "{{depend street_line2}}{{var street_line2}}\n{{/depend}}" .
+        "{{depend city}}{{var city}},{{/depend}} {{var region}} {{depend postcode}}{{var postcode}},{{/depend}}\n" .
+        "{{var country}}";
+
     /**
      * @var EventManager
      */
@@ -26,17 +32,25 @@ class Renderer
     protected $filterManager;
 
     /**
+     * @var string
+     */
+    private $template;
+
+    /**
      * Constructor
      *
      * @param EventManager $eventManager
      * @param FilterManager $filterManager
+     * @param string $template
      */
     public function __construct(
         EventManager $eventManager,
-        FilterManager $filterManager
+        FilterManager $filterManager,
+        $template = self::DEFAULT_TEMPLATE
     ) {
         $this->eventManager = $eventManager;
         $this->filterManager = $filterManager;
+        $this->template = $template;
     }
 
     /**
@@ -50,8 +64,7 @@ class Renderer
     {
         $this->eventManager->dispatch('store_address_format', ['type' => $type, 'store_info' => $storeInfo]);
         $address = $this->filterManager->template(
-            "{{var name}}\n{{var street_line1}}\n{{depend street_line2}}{{var street_line2}}\n{{/depend}}"
-            . "{{var city}}, {{var region}} {{var postcode}},\n{{var country}}",
+            $this->template,
             ['variables' => $storeInfo->getData()]
         );
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
### Original Pull Request
https://github.com/magento/magento2/pull/11138

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an order as customer
2. Check email
3. On fresh Magento installation store information is missing and you should see 2 ugly meaningless comma signs in the footer of the email.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
