### PR TITLE
[Forwardport] Fixing the address checkbox being unchecked on payment step.

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -247,6 +247,7 @@ define([
          */
         setShippingInformation: function () {
             if (this.validateShippingInformation()) {
+                checkoutDataResolver.resolveBillingAddress();
                 setShippingInformationAction().done(
                     function () {
                         stepNavigator.next();


### PR DESCRIPTION
Original PR https://github.com/magento/magento2/pull/17593

### Description
When an offline custom payment method is used, the 'My billing and shipping address are the same' checkbox from payment step is unchecked, if the shipping address is updated. 

Please check the issue's description for more details.

### Fixed Issues (if relevant)
1. magento/magento2#14819: Custom Payment Method doesn't uncheck 'My billing and shipping address are the same'


### Manual testing scenarios
<!---
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Create an offline payment method
2. Add a product to cart
3. Go to Checkout
4. Fill in the shipping address
5. Go to Payment Step
6. We have our new payment method, and one more - Checkmo
7. Select Checkmo
8. Under Selected Payment Method -  _My billing and shipping address are the same_ is checked and below we have the billing address = shipping address
![4d0833cc22](https://user-images.githubusercontent.com/15868188/39127239-1890c85a-470d-11e8-9387-3c302485a71e.jpg)
9. Go back to shipping step and change some fields
10. Come back on the Payment Step

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
