### PR TITLE
Backport of MAGETWO-60258 for Magento 2.1 - Product position set in t…

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -8,13 +8,6 @@ namespace Magento\Catalog\Model\Indexer\Category\Product\Action;
 class Full extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractAction
 {
     /**
-     * Whether to use main or temporary index table
-     *
-     * @var bool
-     */
-    protected $useTempTable = false;
-
-    /**
      * Refresh entities index
      *
      * @return $this

--- a/app/code/Magento/Catalog/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Catalog/Setup/UpgradeSchema.php
@@ -37,6 +37,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->addSourceEntityIdToProductEavIndex($setup);
         }
 
+        if (version_compare($context->getVersion(), '2.1.4.1', '<')) {
+            $this->recreateCatalogCategoryProductIndexTmpTable($setup);
+        }
+
         $setup->endSetup();
     }
 
@@ -327,5 +331,75 @@ class UpgradeSchema implements UpgradeSchemaInterface
         foreach ($fields as $filedInfo) {
             $connection->dropColumn($setup->getTable($filedInfo['table']), $filedInfo['column']);
         }
+    }
+
+    /**
+     * Drop and recreate catalog_category_product_index_tmp table
+     *
+     * Before this update the catalog_category_product_index_tmp table was created without usage of PK
+     * and with engine=MEMORY. Such structure of catalog_category_product_index_tmp table causes
+     * issues with MySQL DB replication.
+     *
+     * To avoid replication issues this method drops catalog_category_product_index_tmp table
+     * and creates new one with PK and engine=InnoDB
+     *
+     * @param SchemaSetupInterface $setup
+     * @return void
+     */
+    private function recreateCatalogCategoryProductIndexTmpTable(SchemaSetupInterface $setup)
+    {
+        $tableName = $setup->getTable('catalog_category_product_index_tmp');
+
+        // Drop catalog_category_product_index_tmp table
+        $setup->getConnection()->dropTable($tableName);
+
+        // Create catalog_category_product_index_tmp table with PK and engine=InnoDB
+        $table = $setup->getConnection()
+            ->newTable($tableName)
+            ->addColumn(
+                'category_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true, 'default' => '0'],
+                'Category ID'
+            )
+            ->addColumn(
+                'product_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true, 'default' => '0'],
+                'Product ID'
+            )
+            ->addColumn(
+                'position',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['nullable' => false, 'default' => '0'],
+                'Position'
+            )
+            ->addColumn(
+                'is_parent',
+                \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'default' => '0'],
+                'Is Parent'
+            )
+            ->addColumn(
+                'store_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true, 'default' => '0'],
+                'Store ID'
+            )
+            ->addColumn(
+                'visibility',
+                \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                null,
+                ['unsigned' => true, 'nullable' => false],
+                'Visibility'
+            )
+            ->setComment('Catalog Category Product Indexer temporary table');
+
+        $setup->getConnection()->createTable($table);
     }
 }

--- a/app/code/Magento/Catalog/etc/module.xml
+++ b/app/code/Magento/Catalog/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Catalog" setup_version="2.1.4">
+    <module name="Magento_Catalog" setup_version="2.1.4.1">
         <sequence>
             <module name="Magento_Eav"/>
             <module name="Magento_Cms"/>


### PR DESCRIPTION
…he admin is not honored in the category when seen in the Frontend

(cherry picked from commit a02b063ac43aceacc5e3aedc369253d217912aaf)
(cherry picked from commit 3bd35a438727dc3445f9d17e9fce6d29898d22ce)

Also increased setup_version from 2.1.4 to 2.1.4.1


### Description
This is a pretty complicated issue which not a lot of people will run into, but we did.
This is an issue we've been having on a Magento 2.1 shop for almost 2 years now and this backport finally fixes it.

This only happens when you have a database mysql replication setup in a master-master setup and you have the mysql variable `binlog_format` set to `ROW`.
We had this problem using Percona versions 5.6.32 & 5.7.16, but probably every Mysql version is affected.

So the actual issue: we have a whole lot of products and categories, we sort the products in the categories with the position field. But when reindexing the `catalog_category_product` indexer, we noticed that the resulting positions of products in a category in the table `catalog_category_product_index` ended up being incorrect and completely out of whack.
Eventually we found out this was caused by the mysql setting `binlog_format` which was set to `ROW`, which is the recommended and default setting. We then switched this to `MIXED` which solved the problem.
But since a few months, we've been running into a lot of DEADLOCKS which seem to happen out of the blue, and according to our hosting partner, it was caused by the `MIXED` setting. And they advised us to switch back to `ROW`. But then we had to first figure out a solution for the incorrect product positions in categories, and then we suddenly found the [MAGETWO-60258](https://github.com/magento/magento2/search?q=MAGETWO-60258&type=Commits) commits in the github history of Magento 2.2 which had an exact description of our problem.
So we've patched that solution in our 2.1 shop and switched back to `ROW` and now the problem is gone. This has been running for a week now and the initial problem is fixed by this.

Hence the backport, to help people who also run into this same problem with Magento 2.1.
Also: if this PR isn't allowed for some reason, I hope the description in here helps people find a solution if they run into this same problem, because this was really hard to find for us.

#### Further remarks
I've changed the version of this migration from 2.1.4 to 2.1.4.1, since [2.1.4](https://github.com/magento/magento2/blob/2.1.14/app/code/Magento/Catalog/etc/module.xml#L9) is already used in Magento 2.1, and the same migration in Magento 2.2 is using version [2.1.5](https://github.com/magento/magento2/blob/2.2.5/app/code/Magento/Catalog/Setup/UpgradeSchema.php#L71) for this migration.
I'm not sure if there is some kind of policy for using a specific version numbering schema when backporting database migrations, so feel free to tell me if this isn't correct.
Since this drops and recreates a temporary table it shouldn't cause problems when going from Magento 2.1 to 2.2 later on. It will just do the exact same action again.

Then just informational, the mysql table `catalog_category_product_index_tmp` format will change from:
```sql
CREATE TABLE `catalog_category_product_index_tmp` (
  `category_id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Category ID',
  `product_id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Product ID',
  `position` int(11) NOT NULL DEFAULT '0' COMMENT 'Position',
  `is_parent` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Is Parent',
  `store_id` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Store ID',
  `visibility` smallint(5) unsigned NOT NULL COMMENT 'Visibility',
  KEY `CAT_CTGR_PRD_IDX_TMP_PRD_ID_CTGR_ID_STORE_ID` (`product_id`,`category_id`,`store_id`)
) ENGINE=MEMORY DEFAULT CHARSET=utf8 COMMENT='Catalog Category Product Indexer Temp Table';
```

to:
```sql
CREATE TABLE `catalog_category_product_index_tmp` (
  `category_id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Category ID',
  `product_id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Product ID',
  `position` int(11) NOT NULL DEFAULT '0' COMMENT 'Position',
  `is_parent` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Is Parent',
  `store_id` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Store ID',
  `visibility` smallint(5) unsigned NOT NULL COMMENT 'Visibility',
  PRIMARY KEY (`category_id`,`product_id`,`store_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Catalog Category Product Indexer temporary table';
```

### Fixed Issues (if relevant)
None that I could find

### Manual testing scenarios
1. Magento 2.1.12
2. Mysql master-master replication setup with `binlog_format` set to `ROW`
3. Have a category with a whole lot of products where each has a different position inside the category
4. Reindex the `catalog_category_product` indexer
5. Notice that the product positions in the `catalog_category_product_index` don't follow the positions set in the backend of Magento and thus also the sort order of products on the frontend becomes incorrect.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
