### PR TITLE
[Forwardport] Fix type error in Cart/Totals.

### DIFF
--- a/app/code/Magento/Quote/Model/Cart/CartTotalRepository.php
+++ b/app/code/Magento/Quote/Model/Cart/CartTotalRepository.php
@@ -10,6 +10,7 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Catalog\Helper\Product\ConfigurationPool;
 use Magento\Framework\Api\DataObjectHelper;
+use Magento\Framework\Api\ExtensibleDataInterface;
 use Magento\Quote\Model\Cart\Totals\ItemConverter;
 use Magento\Quote\Api\CouponManagementInterface;
 
@@ -94,6 +95,7 @@ class CartTotalRepository implements CartTotalRepositoryInterface
             $addressTotalsData = $quote->getShippingAddress()->getData();
             $addressTotals = $quote->getShippingAddress()->getTotals();
         }
+        unset($addressTotalsData[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]);
 
         /** @var \Magento\Quote\Api\Data\TotalsInterface $quoteTotals */
         $quoteTotals = $this->totalsFactory->create();


### PR DESCRIPTION
### Description
Original pull request: magento-engcom/magento2ce#1186
Unset the address extension attributes before trying to create the quote totals.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12993: Type error in Cart/Totals 
2. magento/magento2#12819: CartTotalRepository cannot handle extension attributes in quote addresses in 2.2.2

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Define extension attributes for the quote billing address
2. Login as a user who has at least two addresses in his address book
3. Add a virtual product to card and proceed to checkout
4. Choose or change the billing address, click update, note no errors.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)