### PR TITLE
Update catalog custom options with same SKU placed one-after-one.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -217,9 +217,9 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
         $option = $this->getOption();
 
         foreach ($this->getValues() as $value) {
-            $optionModel = $this->valueFactory->create();
+            $valueModel = $this->valueFactory->create();
 
-            $optionModel->setData(
+            $valueModel->setData(
                 $value
             )->setData(
                 'option_id',
@@ -229,13 +229,13 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
                 $option->getStoreId()
             );
 
-            if ((bool) $optionModel->getData('is_delete') === true) {
-                if ($optionModel->getId()) {
-                    $this->deleteValues($optionModel->getId());
-                    $optionModel->delete();
+            if ((bool) $valueModel->getData('is_delete') === true) {
+                if ($valueModel->getId()) {
+                    $this->deleteValues($valueModel->getId());
+                    $valueModel->delete();
                 }
             } else {
-                $optionModel->save();
+                $valueModel->save();
             }
         }
 

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -14,6 +14,7 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Catalog\Pricing\Price\BasePrice;
 use Magento\Catalog\Pricing\Price\CustomOptionPriceCalculator;
 use Magento\Catalog\Pricing\Price\RegularPrice;
+use Magento\Catalog\Model\Product\Option\ValueFactory;
 
 /**
  * Catalog product option select type model
@@ -72,13 +73,19 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
     private $customOptionPriceCalculator;
 
     /**
-     * @param \Magento\Framework\Model\Context $context
-     * @param \Magento\Framework\Registry $registry
+     * @var ValueFactory
+     */
+    private $valueFactory;
+
+    /**
+     * @param \Magento\Framework\Model\Context                                            $context
+     * @param \Magento\Framework\Registry                                                 $registry
      * @param \Magento\Catalog\Model\ResourceModel\Product\Option\Value\CollectionFactory $valueCollectionFactory
-     * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
-     * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
-     * @param array $data
-     * @param CustomOptionPriceCalculator|null $customOptionPriceCalculator
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null                $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null                          $resourceCollection
+     * @param array                                                                       $data
+     * @param CustomOptionPriceCalculator|null                                            $customOptionPriceCalculator
+     * @param \Magento\Catalog\Model\Product\Option\ValueFactory|null                     $valueFactory
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
@@ -87,12 +94,14 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
-        CustomOptionPriceCalculator $customOptionPriceCalculator = null
+        CustomOptionPriceCalculator $customOptionPriceCalculator = null,
+        ValueFactory $valueFactory = null
     ) {
         $this->_valueCollectionFactory = $valueCollectionFactory;
         $this->customOptionPriceCalculator = $customOptionPriceCalculator
             ?? \Magento\Framework\App\ObjectManager::getInstance()->get(CustomOptionPriceCalculator::class);
-
+        $this->valueFactory = $valueFactory
+            ?? \Magento\Framework\App\ObjectManager::getInstance()->get(ValueFactory::class);
         parent::__construct(
             $context,
             $registry,
@@ -208,18 +217,25 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
         $option = $this->getOption();
 
         foreach ($this->getValues() as $value) {
-            $this->isDeleted(false);
-            $this->setData($value)
-                ->setData('option_id', $option->getId())
-                ->setData('store_id', $option->getStoreId());
+            $optionModel = $this->valueFactory->create();
 
-            if ((bool) $this->getData('is_delete') === true) {
-                if ($this->getId()) {
-                    $this->deleteValues($this->getId());
-                    $this->delete();
+            $optionModel->setData(
+                $value
+            )->setData(
+                'option_id',
+                $option->getId()
+            )->setData(
+                'store_id',
+                $option->getStoreId()
+            );
+
+            if ((bool) $optionModel->getData('is_delete') === true) {
+                if ($optionModel->getId()) {
+                    $this->deleteValues($optionModel->getId());
+                    $optionModel->delete();
                 }
             } else {
-                $this->save();
+                $optionModel->save();
             }
         }
 


### PR DESCRIPTION
When working with Catalog Custom Options I found that if you're need to have two already existing custom options values (it's important, because it's not reproducing when you're adding new option values) placed one after one with the same SKU, you can't do this, because when you saving product, Magento update only first option value properly, second option value didn't have those changes after save. 
I investigated and found that it happens because all custom options values are saved thru only one object, and as saving goes via cycle, Magento everytime compares option value that we currently save in this iteration with previously saved object data, which placed in storedData property. 

### Fixed issues
https://github.com/magento/magento2/issues/5067

### Manual testing scenarios
1. Go to catalog and create product with custom field that have two options (save product before going to step 2), set them different SKU's, for example: "11111" and "22222"
2. Try to set the same SKU for those options (for example: "12345") and save product
![1](https://user-images.githubusercontent.com/42036143/44148163-c04bb168-a09f-11e8-8fb3-13e6fe32ff5c.png)

**Expected result:**
Changed will have the same SKU

**Actual result:**
We see changes in only first option, second option SKU is not updated.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
