### PR TITLE
[Forwardport] Fixed #16929 - Incorrect displaying Product Image Watermarks on Magento 2.2.5

### DIFF
--- a/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
@@ -425,7 +425,6 @@ class Gd2 extends \Magento\Framework\Image\Adapter\AbstractAdapter
             $col = imagecolorallocate($newWatermark, 255, 255, 255);
             imagecolortransparent($newWatermark, $col);
             imagefilledrectangle($newWatermark, 0, 0, $this->getWatermarkWidth(), $this->getWatermarkHeight(), $col);
-            imagealphablending($newWatermark, true);
             imagesavealpha($newWatermark, true);
             imagecopyresampled(
                 $newWatermark,
@@ -450,7 +449,6 @@ class Gd2 extends \Magento\Framework\Image\Adapter\AbstractAdapter
             $col = imagecolorallocate($newWatermark, 255, 255, 255);
             imagecolortransparent($newWatermark, $col);
             imagefilledrectangle($newWatermark, 0, 0, $this->_imageSrcWidth, $this->_imageSrcHeight, $col);
-            imagealphablending($newWatermark, true);
             imagesavealpha($newWatermark, true);
             imagecopyresampled(
                 $newWatermark,


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17013

### Description
Not needed to call function imagealphablending() when resize watermark size.

### Fixed Issues
1. magento/magento2#16929: Incorrect displaying Product Image Watermarks on Magento 2.2.5

### Manual testing scenarios
1. Login to Admin Panel
2. Create a simple product with any configuration and upload any product image (the image that I uploaded below)
![mb01-blue-0](https://user-images.githubusercontent.com/40271588/42928337-b21a3f6c-8b3f-11e8-9e4b-d92567ef00bf.jpg)
3. Go to Content -> Design -> Configuration
4. Click on the edit action on the Global Magento Luma theme
5. Go to the Product Image Watermarks section
6. Upload any PNG image with a transparent background for example in the small category (the image that I uploaded below)
![58480ecccef1014c0b5e492c](https://user-images.githubusercontent.com/40271588/42926131-2478ff0a-8b39-11e8-99e6-ecc56f478ba3.png)
7. Set Image Opacity to 10
8. Set Image Size to 40x50
9. Set Image Position Tile
10. Save Configuration
11. Go to the product view on store front and look at the result

### Result
![screenshot4](https://user-images.githubusercontent.com/11473750/43070832-78446270-8e8e-11e8-8c9e-16b2d0a2e8a8.png)



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
