### PR TITLE
[Backport] Fix sending duplicate emails

### DIFF
--- a/app/code/Magento/Sales/Model/EmailSenderHandler.php
+++ b/app/code/Magento/Sales/Model/EmailSenderHandler.php
@@ -68,6 +68,9 @@ class EmailSenderHandler
         if ($this->globalConfig->getValue('sales_email/general/async_sending')) {
             $this->entityCollection->addFieldToFilter('send_email', ['eq' => 1]);
             $this->entityCollection->addFieldToFilter('email_sent', ['null' => true]);
+            $this->entityCollection->setPageSize(
+                $this->globalConfig->getValue('sales_email/general/sending_limit')
+            );
 
             /** @var \Magento\Sales\Model\AbstractModel $item */
             foreach ($this->entityCollection->getItems() as $item) {

--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -132,6 +132,14 @@
                     <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
                     <backend_model>Magento\Sales\Model\Config\Backend\Email\AsyncSending</backend_model>
                 </field>
+                <field id="sending_limit" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Limit per cron run</label>
+                    <comment>Limit how many entities (orders/shipments/etc) will be processed during one cron run.</comment>
+                    <validate>required-number validate-number validate-greater-than-zero</validate>
+                    <depends>
+                        <field id="async_sending">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="order" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Order</label>

--- a/app/code/Magento/Sales/etc/config.xml
+++ b/app/code/Magento/Sales/etc/config.xml
@@ -29,6 +29,7 @@
         <sales_email>
             <general>
                 <async_sending>0</async_sending>
+                <sending_limit>50</sending_limit>
             </general>
             <order>
                 <enabled>1</enabled>

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -341,43 +341,43 @@
 
     <virtualType name="SalesOrderSendEmailsObserver" type="Magento\Sales\Observer\Virtual\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderSendEmails</argument>
         </arguments>
     </virtualType>
     <virtualType name="SalesOrderInvoiceSendEmailsObserver" type="Magento\Sales\Observer\Virtual\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderInvoiceSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderInvoiceSendEmails</argument>
         </arguments>
     </virtualType>
     <virtualType name="SalesOrderShipmentSendEmailsObserver" type="Magento\Sales\Observer\Virtual\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderShipmentSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderShipmentSendEmails</argument>
         </arguments>
     </virtualType>
     <virtualType name="SalesOrderCreditmemoSendEmailsObserver" type="Magento\Sales\Observer\Virtual\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderCreditmemoSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderCreditmemoSendEmails</argument>
         </arguments>
     </virtualType>
 
     <virtualType name="SalesOrderSendEmailsCron" type="Magento\Sales\Cron\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderSendEmails</argument>
         </arguments>
     </virtualType>
     <virtualType name="SalesInvoiceSendEmailsCron" type="Magento\Sales\Cron\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderInvoiceSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderInvoiceSendEmails</argument>
         </arguments>
     </virtualType>
     <virtualType name="SalesShipmentSendEmailsCron" type="Magento\Sales\Cron\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderShipmentSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderShipmentSendEmails</argument>
         </arguments>
     </virtualType>
     <virtualType name="SalesCreditmemoSendEmailsCron" type="Magento\Sales\Cron\SendEmails">
         <arguments>
-            <argument name="emailSenderHandler" xsi:type="object">SalesOrderCreditmemoSendEmails</argument>
+            <argument name="emailSenderHandler" xsi:type="object" shared="false">SalesOrderCreditmemoSendEmails</argument>
         </arguments>
     </virtualType>
     <type name="Magento\SalesSequence\Model\EntityPool">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17484
### Preconditions
1. Magento 2.2.4 or 2.2.5
2. Wyomind Cron Scheduler v1.4.0 

### Description
We installed Wyomind Cron Scheduler v1.4.0 and in the result, we have duplicates email (5-6 emails for 1 order).
This hotfix warns against similar situations with sending duplicate emails and adds a limit of 50 emails per cronjob.

### Steps to reproduce:
1. Disable crontab
2. Make 2 or more orders
3. Enable crontab

### Expected result
No duplicate Emails.

### Actual result
Duplicate Emails.
