### PR TITLE
[Backport] Fixed review list ajax if product not exist redirect to 404 page #13102

### DIFF
--- a/app/code/Magento/Review/Controller/Product/ListAjax.php
+++ b/app/code/Magento/Review/Controller/Product/ListAjax.php
@@ -18,16 +18,12 @@ class ListAjax extends ProductController
      */
     public function execute()
     {
-        if (!$this->initProduct()) {
+       if (!$this->initProduct()) {
             /** @var \Magento\Framework\Controller\Result\Forward $resultForward */
             $resultForward = $this->resultFactory->create(ResultFactory::TYPE_FORWARD);
-            $resultForward->forward('noroute');
-            return $resultForward;
-        } else {
-            /** @var \Magento\Framework\View\Result\Layout $resultLayout */
-            $resultLayout = $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);
+            return $resultForward->forward('noroute');
         }
 
-        return $resultLayout;
+        return $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);
     }
 }

--- a/app/code/Magento/Review/Controller/Product/ListAjax.php
+++ b/app/code/Magento/Review/Controller/Product/ListAjax.php
@@ -14,12 +14,15 @@ class ListAjax extends ProductController
     /**
      * Show list of product's reviews
      *
-     * @return \Magento\Framework\View\Result\Layout
+     * @return \Magento\Framework\App\ResponseInterface|\Magento\Framework\Controller\ResultInterface|\Magento\Framework\View\Result\Layout
      */
     public function execute()
     {
         if (!$this->initProduct()) {
-            throw new LocalizedException(__('Cannot initialize product'));
+            /** @var \Magento\Framework\Controller\Result\Forward $resultForward */
+            $resultForward = $this->resultFactory->create(ResultFactory::TYPE_FORWARD);
+            $resultForward->forward('noroute');
+            return $resultForward;
         } else {
             /** @var \Magento\Framework\View\Result\Layout $resultLayout */
             $resultLayout = $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);

--- a/app/code/Magento/Review/Controller/Product/ListAjax.php
+++ b/app/code/Magento/Review/Controller/Product/ListAjax.php
@@ -18,7 +18,7 @@ class ListAjax extends ProductController
      */
     public function execute()
     {
-       if (!$this->initProduct()) {
+        if (!$this->initProduct()) {
             /** @var \Magento\Framework\Controller\Result\Forward $resultForward */
             $resultForward = $this->resultFactory->create(ResultFactory::TYPE_FORWARD);
             return $resultForward->forward('noroute');


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15369
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Issue was review list ajax call giving php error log or error number if invalid product id. It should be 404 page.

### Fixed Issues (if relevant)
1. magento/magento2#13102, Page was not redirect to 404 page.

### Manual testing scenarios
1. Use invalid product id in review list ajax
2. For example: `<Magento store url>/review/product/listAjax/id/{{non existent id}/`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
