### PR TITLE
Fix the issue with the redundant translation of category title

### DIFF
--- a/app/code/Magento/Catalog/Block/Category/View.php
+++ b/app/code/Magento/Catalog/Block/Category/View.php
@@ -84,6 +84,9 @@ class View extends \Magento\Framework\View\Element\Template implements \Magento\
             }
 
             $pageMainTitle = $this->getLayout()->getBlock('page.main.title');
+
+            // The automatic translation is not necessary since the category title can be set per store view
+            $pageMainTitle->setUseTranslations(false);
             if ($pageMainTitle) {
                 $pageMainTitle->setPageTitle($this->getCurrentCategory()->getName());
             }

--- a/app/code/Magento/Theme/Block/Html/Title.php
+++ b/app/code/Magento/Theme/Block/Html/Title.php
@@ -27,6 +27,13 @@ class Title extends Template
     protected $pageTitle;
 
     /**
+     * Defines whether the i18n translation should be applied for title
+     *
+     * @var bool
+     */
+    protected $useTranslation = true;
+
+    /**
      * Provide own page title or pick it from Head Block
      *
      * @return string
@@ -34,9 +41,11 @@ class Title extends Template
     public function getPageTitle()
     {
         if (!empty($this->pageTitle)) {
-            return $this->pageTitle;
+            return $this->useTranslation ? __($this->pageTitle) : $this->pageTitle;
         }
-        return __($this->pageConfig->getTitle()->getShort());
+
+        $shortTitle = $this->pageConfig->getTitle()->getShort();
+        return $this->useTranslation ? __($shortTitle) : $shortTitle;
     }
 
     /**
@@ -47,9 +56,11 @@ class Title extends Template
     public function getPageHeading()
     {
         if (!empty($this->pageTitle)) {
-            return __($this->pageTitle);
+            return $this->useTranslation ? __($this->pageTitle) : $this->pageTitle;
         }
-        return __($this->pageConfig->getTitle()->getShortHeading());
+
+        $shortHeading = $this->pageConfig->getTitle()->getShortHeading();
+        return $this->useTranslation ? __($shortHeading) : $shortHeading;
     }
 
     /**
@@ -61,5 +72,17 @@ class Title extends Template
     public function setPageTitle($pageTitle)
     {
         $this->pageTitle = $pageTitle;
+    }
+
+    /**
+     * Define whether the i18n translation should be applied for title
+     * E.g. the additional translations should be disabled for the category title specified on store view level
+     *
+     * @param bool $useTranslation
+     * @return void
+     */
+    public function setUseTranslations($useTranslation)
+    {
+        $this->useTranslation = $useTranslation;
     }
 }


### PR DESCRIPTION
The automatic translation is not necessary since the category title can be set per store view.

### Description
Category title which has translations for every store, translated one more time from I18n files on category view page. So in situation when we have similar words in different language it could be translated twice.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17591: Category name translated twice

### Manual testing scenarios
1. Create 2 stores with locale en_US and nn_NO
2. Create categories: "Moped", "Scooter"
3. Set tranlations for nn_NO store in admin as "Moped" => "Scooter",  "Scooter" => "Sparkesykkel"
4. Add nn_NO tranlations to I18n files as "Moped" => "Scooter",  "Scooter" => "Sparkesykkel"
5. Open "Moped" category view page on nn_NO store

Expected result
1. To see properly translated category name, which is "Scooter".

Actual result
1. Category name translated twice, and you see "Sparkesykkel"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds on Travis CI are green)
