### PR TITLE
Fix Image Model can't get custom image attributes

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -483,8 +483,8 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             'store_id IN (?)',
             $storeIds
         )->where(
-            'attribute_code IN (?)',
-            ['small_image', 'thumbnail', 'image']
+            'attr.frontend_input = ?',
+            'media_image'
         );
 
         return $this->getConnection()->fetchAll($select);


### PR DESCRIPTION
### Description

Usually, We can get Media Entries use `$product->getMediaGalleryEntries()`. Some reason I want to get raw Image Record from Database, so I use `\Magento\Catalog\Model\ResourceModel\Product\Gallery` resource model to access Data, Here is the problem: when I use a method  `getProductImages`, It should get all of the images including custom attribute images, but it just returns these three types `('small_image', 'thumbnail', 'image')`.
So I modify some code and let it get all images in this product.


### Fixed Issues (if relevant)
1. N/A

### Manual testing scenarios
1. N/A

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
