### PR TITLE
Change error message about low stock

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
+++ b/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
@@ -160,7 +160,7 @@ class StockStateProvider implements StockStateProviderInterface
         }
 
         if (!$this->checkQty($stockItem, $summaryQty) || !$this->checkQty($stockItem, $qty)) {
-            $message = __('We don\'t have as many "%1" as you requested.', $stockItem->getProductName());
+            $message = __('The requested qty is not available');
             $result->setHasError(true)->setMessage($message)->setQuoteMessage($message)->setQuoteMessageIndex('qty');
             return $result;
         } else {
@@ -212,7 +212,7 @@ class StockStateProvider implements StockStateProviderInterface
                         }
                     } elseif ($stockItem->getShowDefaultNotificationMessage()) {
                         $result->setMessage(
-                            __('We don\'t have as many "%1" as you requested.', $stockItem->getProductName())
+                            __('The requested qty is not available')
                         );
                     }
                 }

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/Cart/UpdateItemQtyTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/Cart/UpdateItemQtyTest.php
@@ -113,7 +113,7 @@ class UpdateItemQtyTest extends \Magento\TestFramework\TestCase\AbstractControll
                 'request' => ['qty' => 230],
                 'response' => [
                     'success' => false,
-                    'error_message' => 'We don\'t have as many "Simple Product" as you requested.']
+                    'error_message' => 'The requested qty is not available']
             ],
         ];
     }

--- a/dev/tests/integration/testsuite/Magento/Multishipping/Controller/Checkout/CheckItemsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Multishipping/Controller/Checkout/CheckItemsTest.php
@@ -163,7 +163,7 @@ class CheckItemsTest extends \Magento\TestFramework\TestCase\AbstractController
                 'request' => ['qty' => 101],
                 'response' => [
                     'success' => false,
-                    'error_message' => 'We don\'t have as many "Simple Product" as you requested.']
+                    'error_message' => 'The requested qty is not available']
             ],
             [
                 'request' => ['qty' => 230],

--- a/dev/tests/integration/testsuite/Magento/Quote/Model/QuoteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Quote/Model/QuoteTest.php
@@ -324,7 +324,7 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $quote->getItemsQty());
 
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
-        $this->expectExceptionMessage('We don\'t have as many "Simple Product" as you requested.');
+        $this->expectExceptionMessage('The requested qty is not available');
         $updateParams['qty'] = $productStockQty + 1;
         $quote->updateItem($updateParams['id'], $updateParams);
     }

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_info.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_info.php
@@ -85,6 +85,9 @@ $invoiceFactory = $objectManager->get(\Magento\Sales\Api\InvoiceManagementInterf
 $invoice = $invoiceFactory->prepareInvoice($order, [$item->getId() => 10]);
 $invoice->register();
 $invoice->save();
+$order->save();
+
+$invoice = $objectManager->get(\Magento\Sales\Api\InvoiceRepositoryInterface::class)->get($invoice->getId());
 
 /** @var \Magento\Sales\Model\Order\CreditmemoFactory $creditmemoFactory */
 $creditmemoFactory = $objectManager->get(\Magento\Sales\Model\Order\CreditmemoFactory::class);


### PR DESCRIPTION
Change error message about low stock from `We don\'t have as many "{product name}" as you requested.` to `The requested qty is not available`.

## Why this change is required?

[MSI project](https://github.com/magento-engcom/msi/wiki) introduces a new mechanism of inventory management for Magento 2. Now MSI and Magento Open Source have different error messages that may introduce difficulties for switching from current inventory management to MSI and complicate test suite.

## Why core is fixed instead of MSI?

MSI implementation strongly follows SOLID principles. At the point where an error message is created no information about a product available. Any possible fixes will break encapsulation, introduce undesirable coupling and lead to performance degradation.

Change of messages in core has no cost and no significant impact on user experience