### PR TITLE
Use the correct way to make the page title translatable

### DIFF
--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
@@ -6,12 +6,9 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <head>
-        <title>Forgot Your Password</title>
-    </head>
     <body>
-        <referenceBlock name="root">
-            <action method="setHeaderTitle">
+        <referenceBlock name="page.main.title">
+            <action method="setPageTitle">
                 <argument translate="true" name="title" xsi:type="string">Password forgotten</argument>
             </action>
         </referenceBlock>


### PR DESCRIPTION
### Description
The page title always showed English, because the wrong method was being used to make it translatable.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
