### PR TITLE
Update time12h javascript validation rule to be compatible with js minify

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -224,7 +224,7 @@ define([
         ],
         'time12h': [
             function (value) {
-                return utils.isEmpty(value) || /^((0?[1-9]|1[012])(:[0-5]\d){0,2}(\ [AP]M))$/i.test(value);
+                return utils.isEmpty(value) || /^((0?[1-9]|1[012])(:[0-5]\d){0,2}(\s[AP]M))$/i.test(value);
             },
             $.mage.__('Please enter a valid time, between 00:00 am and 12:00 pm')
         ],


### PR DESCRIPTION
Update time12h javascript validation rule to be compatible with js minify

Fix for issue https://github.com/magento/magento2/issues/17648

### Description
The space in the validation rule causes this rule to not work correctly when js minify is enabled, as it strips the space out of the validation rule regex.

### Fixed Issues (if relevant)
1. magento/magento2#17648: UI validation rule for valid time am/pm doesn't work when js is minified

### Manual testing scenarios
1. Validation rule with space doesn't work if js minify is enabled

### Contribution checklist
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x ] All automated tests passed successfully (all builds on Travis CI are green)
