### PR TITLE
Fix #17579 Typo in Gallery.php

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php
@@ -145,7 +145,7 @@ class Gallery extends \Magento\Framework\View\Element\AbstractBlock
         $content->setId($this->getHtmlId() . '_content')->setElement($this);
         $content->setFormName($this->formName);
         $galleryJs = $content->getJsObjectName();
-        $content->getUploader()->getConfig()->setMegiaGallery($galleryJs);
+        $content->getUploader()->getConfig()->setMediaGallery($galleryJs);
         return $content->toHtml();
     }
 


### PR DESCRIPTION
### Description
This PR fixes a typo in Gallery.php, setMegiaGallery should be setMediaGallery.
### Fixed issue
see #17579

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
