### PR TITLE
Update getChildren in Magento\Catalog\Model\Category to have $asArray boolean parameter

### DIFF
--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -796,11 +796,17 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
      * @param boolean $recursive
      * @param boolean $isActive
      * @param boolean $sortByPosition
-     * @return string
+     * @param boolean $asArray return result as array instead of comma-separated list of IDs
+     * @return array|string
      */
-    public function getChildren($recursive = false, $isActive = true, $sortByPosition = false)
+    public function getChildren($recursive = false, $isActive = true, $sortByPosition = false, $asArray = false)
     {
-        return implode(',', $this->getResource()->getChildren($this, $recursive, $isActive, $sortByPosition));
+        $children = $this->getResource()->getChildren($this, $recursive, $isActive, $sortByPosition);
+        if ($asArray) {
+            return $children;
+        } else {
+            return implode(',', $children);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Give getChildren a boolean parameter, $asArray, to allow it to return a result as an array instead of as a string.

This makes it follow the same pattern as getAllChildren, which fulfils a similar purpose in the code. It also makes it possible to directly get and use an array of child IDs instead of needing to explode the returned string of child IDs (which is imploded within getChildren).

### Manual testing scenarios
1. Add a category to the database.
2. Add two subcategories.
3. Using CategoryRepository.get(), create a Category with the data of the category created in step 1.
4. Verify that the result of calling the Category's getChildren method with no parameters is a string
5. Verify that the result of calling the Category's getChildren method with $asArray = true is an array

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
