### PR TITLE
[Backport] Fix proxy generation return type

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Proxy.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Proxy.php
@@ -165,6 +165,7 @@ class Proxy extends \Magento\Framework\Code\Generator\EntityAbstract
             'parameters' => $parameters,
             'body' => $this->_getMethodBody($method->getName(), $parameterNames),
             'docblock' => ['shortDescription' => '{@inheritdoc}'],
+            'returnType' => $method->getReturnType(),
         ];
 
         return $methodInfo;

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/Sample.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/Sample.php
@@ -17,6 +17,11 @@ class Sample
     protected $messages = [];
 
     /**
+     * @var array
+     */
+    private $config = [];
+
+    /**
      * @param array $messages
      */
     public function setMessages(array $messages)
@@ -30,5 +35,21 @@ class Sample
     public function getMessages()
     {
         return $this->messages;
+    }
+
+    /**
+     * @param array $config
+     */
+    public function setConfig(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
     }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/SampleProxy.txt
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/_files/SampleProxy.txt
@@ -101,4 +101,20 @@ class Sample_Proxy extends \Magento\Framework\ObjectManager\Code\Generator\Sampl
     {
         return $this->_getSubject()->getMessages();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfig(array $config)
+    {
+        return $this->_getSubject()->setConfig($config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfig() : array
+    {
+        return $this->_getSubject()->getConfig();
+    }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17552
This PR attempts to fix Proxy generation when return type is defined in class.

### Description
Code generator for Proxy is missing returnType in the method info definition. Another neighbour generator classes already have this defined, but it seems it was forgotten here.

### Fixed Issues (if relevant)
I've been looking through the issues but it seems nobody has reported this bug.

### Manual testing scenarios
1. Use provided Gist to create a file in the project root folder: https://gist.github.com/adrian-martinez-interactiv4/38bca4531085093f3c99553ff936d478
2. Execute it, ensuring you delete generated/code folder each time you are executing it.

### Actual output

<img width="1387" alt="captura de pantalla 2018-08-12 a las 20 36 27" src="https://user-images.githubusercontent.com/17545750/44005182-7aaf600a-9e6f-11e8-9830-560cb839f45c.png">


### Expected output

<img width="1399" alt="captura de pantalla 2018-08-12 a las 20 37 45" src="https://user-images.githubusercontent.com/17545750/44005191-9b9f15c6-9e6f-11e8-96b8-d75088142320.png">


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
