### PR TITLE
Adding property mapper for product eav attribute -> search weight.

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Setup/PropertyMapper.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Setup/PropertyMapper.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\CatalogSearch\Model\ResourceModel\Setup;
+
+use Magento\Eav\Model\Entity\Setup\PropertyMapperAbstract;
+
+/**
+ * Class PropertyMapper
+ *
+ * @package Magento\CatalogSearch\Model\ResourceModel\Setup
+ */
+class PropertyMapper extends PropertyMapperAbstract
+{
+    /**
+     * Map input attribute properties to storage representation
+     *
+     * @param array $input
+     * @param int $entityTypeId
+     * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function map(array $input, $entityTypeId): array
+    {
+        return [
+            'search_weight' => $this->_getValue($input, 'search_weight', 1),
+        ];
+    }
+}

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/ResourceModel/Setup/PropertyMapperTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/ResourceModel/Setup/PropertyMapperTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\CatalogSearch\Test\Unit\Model\ResourceModel\Setup;
+
+use Magento\CatalogSearch\Model\ResourceModel\Setup\PropertyMapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class PropertyMapperTest
+ *
+ * @package Magento\CatalogSearch\Test\Unit\Model\ResourceModel\Setup
+ */
+class PropertyMapperTest extends TestCase
+{
+    /**
+     * @var PropertyMapper
+     */
+    private $propertyMapper;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->propertyMapper = new PropertyMapper();
+    }
+
+    /**
+     * @return array
+     */
+    public function caseProvider(): array
+    {
+        return [
+            [
+                ['search_weight' => 9, 'something_other' => '3'],
+                ['search_weight' => 9]
+            ],
+            [
+                ['something' => 3],
+                ['search_weight' => 1]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider caseProvider
+     *
+     * @test
+     *
+     * @param array $input
+     * @param array $result
+     * @return void
+     */
+    public function testMapCorrectlyMapsValue(array $input, array $result): void
+    {
+        //Second parameter doesn't matter as it is not used
+        $this->assertSame($result, $this->propertyMapper->map($input, 4));
+    }
+}

--- a/app/code/Magento/CatalogSearch/etc/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/di.xml
@@ -340,4 +340,11 @@
     <type name="Magento\Config\Model\Config">
         <plugin name="config_enable_eav_indexer" type="Magento\CatalogSearch\Plugin\EnableEavIndexer" />
     </type>
+    <type name="Magento\Eav\Model\Entity\Setup\PropertyMapper\Composite">
+        <arguments>
+            <argument name="propertyMappers" xsi:type="array">
+                <item name="catalog_search" xsi:type="string">Magento\CatalogSearch\Model\ResourceModel\Setup\PropertyMapper</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR creates property mapper of type `Magento\Eav\Model\Entity\Setup\PropertyMapperAbstract` to make sure, while adding new product attribute programatically its search weight is persisted into db. Apart of it, unit test for property mapper provided.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add new attribute for products programatically, setting search weight and method `magento/module-eav/Setup/EavSetup.php:addAttribute()`
2. Make sure search weight is persisted into db and it is not its default value.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
