### PR TITLE
[Forwardport] Validate that the PO Number is set on the payment instance.

### DIFF
--- a/app/code/Magento/OfflinePayments/Model/Purchaseorder.php
+++ b/app/code/Magento/OfflinePayments/Model/Purchaseorder.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\OfflinePayments\Model;
 
+use Magento\Framework\Exception\LocalizedException;
+
 /**
  * Class Purchaseorder
  *
@@ -46,11 +48,29 @@ class Purchaseorder extends \Magento\Payment\Model\Method\AbstractMethod
      *
      * @param \Magento\Framework\DataObject|mixed $data
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function assignData(\Magento\Framework\DataObject $data)
     {
         $this->getInfoInstance()->setPoNumber($data->getPoNumber());
+        return $this;
+    }
+
+    /**
+     * Validate payment method information object
+     *
+     * @return $this
+     * @throws LocalizedException
+     * @api
+     */
+    public function validate()
+    {
+        parent::validate();
+
+        if (empty($this->getInfoInstance()->getPoNumber())) {
+            throw new LocalizedException(__('Purchase order number is a required field.'));
+        }
+
         return $this;
     }
 }

--- a/app/code/Magento/OfflinePayments/Test/Unit/Model/PurchaseorderTest.php
+++ b/app/code/Magento/OfflinePayments/Test/Unit/Model/PurchaseorderTest.php
@@ -5,10 +5,21 @@
  */
 namespace Magento\OfflinePayments\Test\Unit\Model;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\OfflinePayments\Model\Purchaseorder;
+use Magento\Payment\Helper\Data as PaymentHelper;
+use Magento\Payment\Model\Info as PaymentInfo;
+use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order\Payment;
+
 class PurchaseorderTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\OfflinePayments\Model\Purchaseorder
+     * @var Purchaseorder
      */
     protected $_object;
 
@@ -19,15 +30,15 @@ class PurchaseorderTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $eventManager = $this->createMock(\Magento\Framework\Event\ManagerInterface::class);
-        $paymentDataMock = $this->createMock(\Magento\Payment\Helper\Data::class);
+        $objectManagerHelper = new ObjectManager($this);
+        $eventManager = $this->createMock(EventManagerInterface::class);
+        $paymentDataMock = $this->createMock(PaymentHelper::class);
         $this->_scopeConfig = $this->createPartialMock(
-            \Magento\Framework\App\Config\ScopeConfigInterface::class,
+            ScopeConfigInterface::class,
             ['getValue', 'isSetFlag']
         );
         $this->_object = $objectManagerHelper->getObject(
-            \Magento\OfflinePayments\Model\Purchaseorder::class,
+            Purchaseorder::class,
             [
                 'eventManager' => $eventManager,
                 'paymentData' => $paymentDataMock,
@@ -38,13 +49,37 @@ class PurchaseorderTest extends \PHPUnit\Framework\TestCase
 
     public function testAssignData()
     {
-        $data = new \Magento\Framework\DataObject([
+        $data = new DataObject([
             'po_number' => '12345'
         ]);
 
-        $instance = $this->createMock(\Magento\Payment\Model\Info::class);
+        $instance = $this->createMock(PaymentInfo::class);
         $this->_object->setData('info_instance', $instance);
         $result = $this->_object->assignData($data);
         $this->assertEquals($result, $this->_object);
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage Purchase order number is a required field.
+     */
+    public function testValidate()
+    {
+        $data = new DataObject([]);
+
+        $addressMock = $this->createMock(OrderAddressInterface::class);
+        $addressMock->expects($this->once())->method('getCountryId')->willReturn('UY');
+
+        $orderMock = $this->createMock(OrderInterface::class);
+        $orderMock->expects($this->once())->method('getBillingAddress')->willReturn($addressMock);
+
+        $instance = $this->createMock(Payment::class);
+
+        $instance->expects($this->once())->method('getOrder')->willReturn($orderMock);
+
+        $this->_object->setData('info_instance', $instance);
+        $this->_object->assignData($data);
+
+        $this->_object->validate();
     }
 }

--- a/app/code/Magento/OfflinePayments/i18n/en_US.csv
+++ b/app/code/Magento/OfflinePayments/i18n/en_US.csv
@@ -11,6 +11,7 @@ Enabled,Enabled
 "New Order Status","New Order Status"
 "Sort Order","Sort Order"
 Title,Title
+"Purchase order number is a required field.","Purchase order number is a required field."
 "Payment from Applicable Countries","Payment from Applicable Countries"
 "Payment from Specific Countries","Payment from Specific Countries"
 "Make Check Payable to","Make Check Payable to"

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CancelCreatedOrderTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CancelCreatedOrderTest.xml
@@ -48,6 +48,7 @@
         <variation name="CancelCreatedOrderTestVariationWithPurchaseOrderPaymentMethod" summary="Cancel order with purchase order payment method and check status on storefront">
             <data name="order/dataset" xsi:type="string">default</data>
             <data name="order/data/payment_auth_expiration/method" xsi:type="string">purchaseorder</data>
+            <data name="order/data/payment_auth_expiration/po_number" xsi:type="string">po_number</data>
             <data name="status" xsi:type="string">Canceled</data>
             <data name="configData" xsi:type="string">purchaseorder</data>
             <constraint name="Magento\Sales\Test\Constraint\AssertOrderCancelSuccessMessage" />

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateCreditMemoEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateCreditMemoEntityTest.xml
@@ -104,6 +104,7 @@
             </data>
             <data name="order/dataset" xsi:type="string">default</data>
             <data name="order/data/payment_auth_expiration/method" xsi:type="string">purchaseorder</data>
+            <data name="order/data/payment_auth_expiration/po_number" xsi:type="string">po_number</data>
             <data name="order/data/price/dataset" xsi:type="string">full_refund_with_zero_shipping_refund</data>
             <data name="configData" xsi:type="string">purchaseorder</data>
             <constraint name="Magento\Sales\Test\Constraint\AssertRefundSuccessCreateMessage" />

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateInvoiceEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestCase/CreateInvoiceEntityTest.xml
@@ -88,6 +88,7 @@
             <data name="order/data/entity_id/products" xsi:type="string">catalogProductSimple::product_100_dollar</data>
             <data name="order/data/total_qty_ordered/0" xsi:type="string">-</data>
             <data name="order/data/payment_auth_expiration/method" xsi:type="string">purchaseorder</data>
+            <data name="order/data/payment_auth_expiration/po_number" xsi:type="string">po_number</data>
             <data name="order/data/invoice" xsi:type="array">
                 <item name="0" xsi:type="array">
                     <item name="items_data" xsi:type="array">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14393

### Description
Validate that the `po_number` is set on the info instance.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6585

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Available on the issue description.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
