### PR TITLE
Prevent category image filename collisions

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -70,6 +70,7 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
 
     /**
      * Gets image name from $value array.
+     *
      * Will return empty string in a case when $value is not an array
      *
      * @param array $value Attribute value
@@ -100,7 +101,8 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     }
 
     /**
-     * Avoiding saving potential upload data to DB
+     * Avoiding saving potential upload data to DB.
+     *
      * Will set empty image attribute value if image was not uploaded
      *
      * @param \Magento\Framework\DataObject $object
@@ -128,8 +130,9 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     }
 
     /**
-     * @return \Magento\Catalog\Model\ImageUploader
+     * Get Image Uploader instance
      *
+     * @return \Magento\Catalog\Model\ImageUploader
      * @deprecated 101.0.0
      */
     private function getImageUploader()

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -170,7 +170,8 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
 
         if ($this->isTmpFileAvailable($value) && $imageName = $this->getUploadedImageName($value)) {
             try {
-                $this->getImageUploader()->moveFileFromTmp($imageName);
+                // @TODO: Assign this (possibly) new-filename to the category so it shows the correct image
+                $newImageName = $this->getImageUploader()->moveFileFromTmp($imageName);
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
             }

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -85,6 +85,21 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     }
 
     /**
+     * Get the destination image name which prevents overwriting existing images with the same name
+     *
+     * @param array $value Attribute value
+     * @return string
+     */
+    private function getFinalImageName($value)
+    {
+        if (is_array($value) && isset($value[0]['name'])) {
+            return $this->getImageUploader()->getFinalImageName($value[0]['name']);
+        }
+
+        return '';
+    }
+
+    /**
      * Avoiding saving potential upload data to DB
      * Will set empty image attribute value if image was not uploaded
      *
@@ -102,7 +117,7 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
             $value[0]['name'] = $value[0]['url'];
         }
 
-        if ($imageName = $this->getUploadedImageName($value)) {
+        if ($imageName = $this->getFinalImageName($value)) {
             $object->setData($this->additionalData . $attributeName, $value);
             $object->setData($attributeName, $imageName);
         } elseif (!is_string($value)) {
@@ -170,8 +185,7 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
 
         if ($this->isTmpFileAvailable($value) && $imageName = $this->getUploadedImageName($value)) {
             try {
-                // @TODO: Assign this (possibly) new-filename to the category so it shows the correct image
-                $newImageName = $this->getImageUploader()->moveFileFromTmp($imageName);
+                $this->getImageUploader()->moveFileFromTmp($imageName);
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
             }

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -283,6 +283,7 @@ class ImageUploader
 
     /**
      * Get the final filename to use when the image is saved
+     *
      * @param string $imageName
      * @return string
      */

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Catalog\Model;
 
+use Magento\Framework\File\Uploader;
+
 /**
  * Catalog image uploader
  */
@@ -192,7 +194,7 @@ class ImageUploader
      *
      * @param string $imageName
      *
-     * @return string
+     * @return string $destinationImageName saved filename
      *
      * @throws \Magento\Framework\Exception\LocalizedException
      */
@@ -201,7 +203,14 @@ class ImageUploader
         $baseTmpPath = $this->getBaseTmpPath();
         $basePath = $this->getBasePath();
 
-        $baseImagePath = $this->getFilePath($basePath, $imageName);
+        /**
+         * Get the absolute path to the new destination and then retrieve a new filename to prevent overwriting
+         * existing category images with the same filename
+         */
+        $absolutePath = $this->mediaDirectory->getAbsolutePath($this->getFilePath($basePath, $imageName));
+        $destinationImageName = Uploader::getNewFileName($absolutePath);
+
+        $baseImagePath = $this->getFilePath($basePath, $destinationImageName);
         $baseTmpImagePath = $this->getFilePath($baseTmpPath, $imageName);
 
         try {
@@ -219,7 +228,7 @@ class ImageUploader
             );
         }
 
-        return $imageName;
+        return $destinationImageName;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -203,12 +203,7 @@ class ImageUploader
         $baseTmpPath = $this->getBaseTmpPath();
         $basePath = $this->getBasePath();
 
-        /**
-         * Get the absolute path to the new destination and then retrieve a new filename to prevent overwriting
-         * existing category images with the same filename
-         */
-        $absolutePath = $this->mediaDirectory->getAbsolutePath($this->getFilePath($basePath, $imageName));
-        $destinationImageName = Uploader::getNewFileName($absolutePath);
+        $destinationImageName = $this->getFinalImageName($imageName);
 
         $baseImagePath = $this->getFilePath($basePath, $destinationImageName);
         $baseTmpImagePath = $this->getFilePath($baseTmpPath, $imageName);
@@ -284,5 +279,23 @@ class ImageUploader
         }
 
         return $result;
+    }
+
+    /**
+     * Get the final filename to use when the image is saved
+     * @param string $imageName
+     * @return string
+     */
+    public function getFinalImageName($imageName)
+    {
+        $basePath = $this->getBasePath();
+
+        /**
+         * Get the absolute path to the new destination and then retrieve a new filename to prevent overwriting
+         * existing category images with the same filename
+         */
+        $absolutePath = $this->mediaDirectory->getAbsolutePath($this->getFilePath($basePath, $imageName));
+
+        return Uploader::getNewFileName($absolutePath);
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -282,7 +282,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $objectManagerMock->expects($this->any())
             ->method('get')
             ->will($this->returnCallback(function ($class, $params = []) use ($imageUploaderMock) {
-                if ($class == "Magento\Catalog\CategoryImageUpload") {
+                if ($class === Magento\Catalog\CategoryImageUpload::class) {
                     return $imageUploaderMock;
                 }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -218,7 +218,8 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             ]
         ]);
 
-        $this->imageUploader->expects($this->any())->method('getFinalImageName')->willReturn('/pub/media/wysiwyg/test123.jpg');
+        $this->imageUploader->expects($this->any())->method('getFinalImageName')
+            ->willReturn('/pub/media/wysiwyg/test123.jpg');
 
         $model->beforeSave($object);
 
@@ -243,7 +244,10 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             ]
         ]);
 
-        $this->imageUploader->expects($this->any())->method('getFinalImageName')->willReturn(['name' => 'test123.jpg', 'tmp_name' => 'abc123', 'url' => 'http://www.example.com/test123.jpg']);
+        $this->imageUploader->expects($this->any())->method('getFinalImageName')
+            ->willReturn(
+                ['name' => 'test123.jpg', 'tmp_name' => 'abc123', 'url' => 'http://www.example.com/test123.jpg']
+            );
 
         $model->beforeSave($object);
 


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
I've added a check to prevent saving a new category image over an already existing one. See: #17661 

**Help wanted**
_This fix introduces a new issue: the image file name is already set on the category model before the file is actually moved to it's final destination. A `@TODO` is added for this. Could you tell me how to handle this? I wanted to create a new event but I'm not quite sure if it's the way to go._
**Update 20-08-2018**: Fixed the incorrect attribute value
### Fixed Issues (if relevant)

1. magento/magento2#17661


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
