### PR TITLE
Fixing typo in method name for Magento_Paypal method.

### DIFF
--- a/app/code/Magento/Paypal/Model/AbstractConfig.php
+++ b/app/code/Magento/Paypal/Model/AbstractConfig.php
@@ -224,7 +224,18 @@ abstract class AbstractConfig implements ConfigInterface
      */
     public function shouldUseUnilateralPayments()
     {
-        return $this->getValue('business_account') && !$this->isWppApiAvailabe();
+        return $this->getValue('business_account') && !$this->isWppApiAvailable();
+    }
+
+    /**
+     * Check whether WPP API credentials are available for this method
+     *
+     * @deprecated
+     * @return bool
+     */
+    public function isWppApiAvailabe()
+    {
+        return $this->isWppApiAvailable();
     }
 
     /**
@@ -232,7 +243,7 @@ abstract class AbstractConfig implements ConfigInterface
      *
      * @return bool
      */
-    public function isWppApiAvailabe()
+    public function isWppApiAvailable()
     {
         return $this->getValue('api_username')
         && $this->getValue('api_password')

--- a/app/code/Magento/Paypal/Model/Config.php
+++ b/app/code/Magento/Paypal/Model/Config.php
@@ -677,7 +677,7 @@ class Config extends AbstractConfig
                 }
                 break;
             case self::METHOD_BILLING_AGREEMENT:
-                $result = $this->isWppApiAvailabe();
+                $result = $this->isWppApiAvailable();
                 break;
         }
         return $result;

--- a/app/code/Magento/Paypal/Test/Unit/Model/AbstractConfigTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/AbstractConfigTest.php
@@ -189,14 +189,14 @@ class AbstractConfigTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider isWppApiAvailabeDataProvider
      */
-    public function testIsWppApiAvailabe($returnMap, $expectedValue)
+    public function testIsWppApiAvailable($returnMap, $expectedValue)
     {
         $this->config->setMethod('paypal_express');
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
             ->willReturnMap($returnMap);
 
-        $this->assertEquals($expectedValue, $this->config->isWppApiAvailabe());
+        $this->assertEquals($expectedValue, $this->config->isWppApiAvailable());
     }
 
     /**


### PR DESCRIPTION
Fixing typo in method name for Magento_Paypal method.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
