### PR TITLE
Message list component fix: the message type is always error when parameters specified

### DIFF
--- a/app/code/Magento/Ui/view/frontend/web/js/model/messages.js
+++ b/app/code/Magento/Ui/view/frontend/web/js/model/messages.js
@@ -55,7 +55,7 @@ define([
                 return messageObj.parameters.shift();
             });
             this.clear();
-            this.errorMessages.push(message);
+            type.push(message);
 
             return true;
         },


### PR DESCRIPTION
### Description
Component: ``Magento_Ui/js/model/messageList.js`` component.
The message type is always **"error"** when specifying the ``parameters`` property.

### Fixed Issues (if relevant)
1. magento/magento2#17700: "Message list component: the message type is always error when parameters specified"

### Manual testing scenarios

1. Use message list component (``Magento_Ui/js/model/messageList.js``).
2. Add success message with parameters. E.g. 
```
messageList.addSuccessMessage({message: 'Sample %test message.', parameters: {test: 'Success'}});
```
3. The success message should be shown.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
