### PR TITLE
Improve sales rule label of option 'Fixed amount discount'

### DIFF
--- a/app/code/Magento/SalesRule/Model/Rule/Metadata/ValueProvider.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Metadata/ValueProvider.php
@@ -77,7 +77,7 @@ class ValueProvider
         $customerGroups = $this->groupRepository->getList($this->searchCriteriaBuilder->create())->getItems();
         $applyOptions = [
             ['label' => __('Percent of product price discount'), 'value' =>  Rule::BY_PERCENT_ACTION],
-            ['label' => __('Fixed amount discount'), 'value' => Rule::BY_FIXED_ACTION],
+            ['label' => __('Fixed amount per product discount'), 'value' => Rule::BY_FIXED_ACTION],
             ['label' => __('Fixed amount discount for whole cart'), 'value' => Rule::CART_FIXED_ACTION],
             ['label' => __('Buy X get Y free (discount amount is Y)'), 'value' => Rule::BUY_X_GET_Y_ACTION]
         ];

--- a/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Metadata/_files/MetaData.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Metadata/_files/MetaData.php
@@ -94,7 +94,7 @@ return [
                                                         'value' => 'by_percent',
                                                     ],
                                                     [
-                                                        'label' => __('Fixed amount discount'),
+                                                        'label' => __('Fixed amount per product discount'),
                                                         'value' => 'by_fixed',
                                                     ],
                                                     [

--- a/app/code/Magento/SalesRule/i18n/en_US.csv
+++ b/app/code/Magento/SalesRule/i18n/en_US.csv
@@ -109,7 +109,7 @@ is,is
 "is not one of","is not one of"
 "If %1 %2 %3 for a subselection of items in cart matching %4 of these conditions:","If %1 %2 %3 for a subselection of items in cart matching %4 of these conditions:"
 "Percent of product price discount","Percent of product price discount"
-"Fixed amount discount","Fixed amount discount"
+"Fixed amount per product discount","Fixed amount per product discount"
 "Fixed amount discount for whole cart","Fixed amount discount for whole cart"
 "Buy X get Y free (discount amount is Y)","Buy X get Y free (discount amount is Y)"
 Active,Active


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
The option 'Fixed amount discount' applies to every matching product in the cart. But this is not clear if you only read the label and can cause confusion for the user. If we rename the label to 'Fixed amount per product discount' this will be a lot clearer. 'Fixed amount per product discount' is also more consistent with the third label 'Fixed amount discount for whole cart' and allows users to spot the differences between the options more easily.

![10_-_kortingscoupon_bij_aankoop_van_een_naaimachine___promotions___marketing___magento_admin](https://user-images.githubusercontent.com/14849044/44349321-1d1c1300-a49d-11e8-81ed-8da206af1618.png)


<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
None

### Manual testing scenarios
None

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
