### PR TITLE
Prevent rendering of "Ship here" button if it is not needed

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
@@ -30,7 +30,9 @@
         <span data-bind="i18n: 'Edit'"></span>
     </button>
     <!-- /ko -->
+    <!-- ko if: (!isSelected()) -->
     <button type="button" data-bind="click: selectAddress" class="action action-select-shipping-item">
         <span data-bind="i18n: 'Ship Here'"></span>
     </button>
+    <!-- /ko -->
 </div>

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -98,11 +98,6 @@
                     text-align: center;
                     top: 0;
                 }
-
-                .action-select-shipping-item {
-                    &:extend(.abs-no-display-s all);
-                    visibility: hidden;
-                }
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Prevent rendering of "Ship here" button to select a shipping item if it is already selected.

Currently the button gets rendered and is only hidden with css, but if the item is already selected the button must not be rendered.

- checks if the item is selected, if it is it does not render the button
- removes the css which hides the button currently, because it is not needed anymore

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
none
### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
none

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
