### PR TITLE
Sales Rule: Add unit tests for model classes

### DIFF
--- a/app/code/Magento/SalesRule/Test/Unit/Model/CouponGeneratorTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/CouponGeneratorTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\SalesRule\Test\Unit\Model;
+
+use Magento\SalesRule\Api\Data\CouponGenerationSpecInterface;
+use Magento\SalesRule\Api\Data\CouponGenerationSpecInterfaceFactory;
+use Magento\SalesRule\Model\CouponGenerator;
+use Magento\SalesRule\Model\Service\CouponManagementService;
+
+/**
+ * @covers \Magento\SalesRule\Model\CouponGenerator
+ */
+class CouponGeneratorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var CouponGenerator
+     */
+    private $couponGenerator;
+
+    /**
+     * @var CouponManagementService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $couponManagementServiceMock;
+
+    /**
+     * @var CouponGenerationSpecInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $generationSpecFactoryMock;
+
+    /**
+     * @var CouponGenerationSpecInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $generationSpecMock;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->generationSpecFactoryMock = $this->getMockBuilder(CouponGenerationSpecInterfaceFactory::class)
+            ->disableOriginalConstructor()->setMethods(['create'])->getMock();
+        $this->couponManagementServiceMock = $this->createMock(CouponManagementService::class);
+        $this->generationSpecMock = $this->createMock(CouponGenerationSpecInterface::class);
+        $this->couponGenerator = new CouponGenerator(
+            $this->couponManagementServiceMock,
+            $this->generationSpecFactoryMock
+        );
+    }
+
+    /**
+     * Test beforeSave method
+     *
+     * @return void
+     */
+    public function testBeforeSave()
+    {
+        $expected = ['test'];
+        $this->generationSpecFactoryMock->expects($this->once())->method('create')
+            ->willReturn($this->generationSpecMock);
+        $this->couponManagementServiceMock->expects($this->once())->method('generate')
+            ->with($this->generationSpecMock)->willReturn($expected);
+        $actual = $this->couponGenerator->generateCodes([]);
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/app/code/Magento/SalesRule/Test/Unit/Model/Quote/ChildrenValidationLocatorTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/Quote/ChildrenValidationLocatorTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\SalesRule\Test\Unit\Model\Quote;
+
+use Magento\Catalog\Model\Product;
+use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
+use Magento\SalesRule\Api\Data\CouponGenerationSpecInterfaceFactory;
+use Magento\SalesRule\Model\Quote\ChildrenValidationLocator;
+
+/**
+ * @covers \Magento\SalesRule\Model\Quote\ChildrenValidationLocator
+ */
+class ChildrenValidationLocatorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var ChildrenValidationLocator
+     */
+    private $childrenValidationLocator;
+
+    /**
+     * @var QuoteItem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $itemMock;
+
+    /**
+     * @var Product|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $productMock;
+
+    /**
+     * @var array
+     */
+    private $productTypeChildrenValidationMap = [
+        'simple' => false,
+        'bundle' => true,
+    ];
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->itemMock = $this->createMock(QuoteItem::class);
+        $this->productMock = $this->createMock(Product::class);
+        $this->childrenValidationLocator = new ChildrenValidationLocator($this->productTypeChildrenValidationMap);
+    }
+
+    /**
+     * Test isChildrenValidationRequired method
+     *
+     * @dataProvider childrenValidationDataProvider
+     *
+     * @param string $typeId
+     * @param bool $isValidationRequired
+     *
+     * @return void
+     */
+    public function testIsChildrenValidationRequired($typeId, $isValidationRequired)
+    {
+        $this->productMock->expects($this->once())->method('getTypeId')->willReturn($typeId);
+        $this->itemMock->expects($this->once())->method('getProduct')->willReturn($this->productMock);
+        $actual = $this->childrenValidationLocator->isChildrenValidationRequired($this->itemMock);
+        $expected = $isValidationRequired;
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return array
+     */
+    public function childrenValidationDataProvider()
+    {
+        return [
+            ['simple', $this->productTypeChildrenValidationMap['simple']],
+            ['bundle', $this->productTypeChildrenValidationMap['bundle']],
+            ['configurable', true],
+        ];
+    }
+}


### PR DESCRIPTION
### Description
This PR adds missing unit tests for Sales Rule model classes:
- `\Magento\SalesRule\Model\CouponGenerator`
- `\Magento\SalesRule\Model\Quote\ChildrenValidationLocator`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
