### PR TITLE
[Forwardport] ISSUE-17715: Duplicate event in Delete operation transa…

### DIFF
--- a/lib/internal/Magento/Framework/EntityManager/Operation/Delete.php
+++ b/lib/internal/Magento/Framework/EntityManager/Operation/Delete.php
@@ -118,7 +118,7 @@ class Delete implements DeleteInterface
             $entity = $this->deleteMain->execute($entity, $arguments);
             $this->eventManager->dispatchEntityEvent($entityType, 'delete_after', ['entity' => $entity]);
             $this->eventManager->dispatch(
-                'entity_manager_delete_before',
+                'entity_manager_delete_after',
                 [
                     'entity_type' => $entityType,
                     'entity' => $entity


### PR DESCRIPTION
### Original Pull Request

https://github.com/magento/magento2/pull/17718

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In \Magento\Framework\EntityManager\Operation\Delete::execute 'entity_manager_delete_before' event was dispatched twice.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17715: Duplicate event in Delete operation transaction "entity_manager_delete_before".

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. -

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
