### PR TITLE
[Forwardport] Fixed review list ajax if product not exist redirect to 404 page

### DIFF
--- a/app/code/Magento/Review/Controller/Product/ListAjax.php
+++ b/app/code/Magento/Review/Controller/Product/ListAjax.php
@@ -3,9 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Review\Controller\Product;
 
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\View\Result\Layout;
 use Magento\Review\Controller\Product as ProductController;
 use Magento\Framework\Controller\ResultFactory;
 
@@ -14,17 +17,16 @@ class ListAjax extends ProductController
     /**
      * Show list of product's reviews
      *
-     * @return \Magento\Framework\View\Result\Layout
+     * @return ResponseInterface|ResultInterface|Layout
      */
     public function execute()
     {
         if (!$this->initProduct()) {
-            throw new LocalizedException(__("The product can't be initialized."));
-        } else {
-            /** @var \Magento\Framework\View\Result\Layout $resultLayout */
-            $resultLayout = $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);
+            /** @var \Magento\Framework\Controller\Result\Forward $resultForward */
+            $resultForward = $this->resultFactory->create(ResultFactory::TYPE_FORWARD);
+            return $resultForward->forward('noroute');
         }
 
-        return $resultLayout;
+        return $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);
     }
 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15369
### Description
Issue was review list ajax call giving php error log or error number if invalid product id. It should be 404 page.

### Fixed Issues (if relevant)
1. magento/magento2#13102, Page was not redirect to 404 page.

### Manual testing scenarios
1. Use invalid product id in review list ajax
2. For example: `<Magento store url>/review/product/listAjax/id/{{non existent id}/`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
