### PR TITLE
[Forwardport] Magento PayPal checkout fails if email sending fails / other payment does not

### DIFF
--- a/app/code/Magento/Paypal/Model/Express/Checkout.php
+++ b/app/code/Magento/Paypal/Model/Express/Checkout.php
@@ -809,8 +809,12 @@ class Checkout
             case \Magento\Sales\Model\Order::STATE_PROCESSING:
             case \Magento\Sales\Model\Order::STATE_COMPLETE:
             case \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW:
-                if (!$order->getEmailSent()) {
-                    $this->orderSender->send($order);
+                try {
+                    if (!$order->getEmailSent()) {
+                        $this->orderSender->send($order);
+                    }
+                } catch (\Exception $e) {
+                    $this->_logger->critical($e);
                 }
                 $this->_checkoutSession->start();
                 break;


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/13133
### Description
If PayPal checkout is used and, for whatever reason, the email sender throws an exception (maybe third-party integration fails to send), the PayPal order is still placed but the user is shown Something went wrong message and ends up in review page.

This is in contrast to a cash payment or other payment method where the order is placed successfully.

This is because other payment methods run through this checkout, that wraps orderSender in a try/catch:
https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Checkout/Model/Type/Onepage.php#L731

This PR replicates that try/catch for PayPal.

### Manual testing scenarios
1. Edit OrderSender to throw an Exception to simulate failed integration email send
2. Checkout with PayPal
3. Order is created but you are sent with error to review page
4. Do same with cash checkout
5. Order is successful

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)