### PR TITLE
[Forwardport] Replace floatval() function by using direct type casting to (float)

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -82,7 +82,7 @@ class Currency extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstra
     {
         if ($data = (string)$this->_getValue($row)) {
             $currency_code = $this->_getCurrencyCode($row);
-            $data = floatval($data) * $this->_getRate($row);
+            $data = (float)$data * $this->_getRate($row);
             $sign = (bool)(int)$this->getColumn()->getShowNumberSign() && $data > 0 ? '+' : '';
             $data = sprintf("%f", $data);
             $data = $this->_localeCurrency->getCurrency($currency_code)->toCurrency($data);
@@ -118,10 +118,10 @@ class Currency extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstra
     protected function _getRate($row)
     {
         if ($rate = $this->getColumn()->getRate()) {
-            return floatval($rate);
+            return (float)$rate;
         }
         if ($rate = $row->getData($this->getColumn()->getRateField())) {
-            return floatval($rate);
+            return (float)$rate;
         }
         return $this->_defaultBaseCurrency->getRate($this->_getCurrencyCode($row));
     }

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Price.php
@@ -60,7 +60,7 @@ class Price extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
                 return $data;
             }
 
-            $data = floatval($data) * $this->_getRate($row);
+            $data = (float)$data * $this->_getRate($row);
             $data = sprintf("%f", $data);
             $data = $this->_localeCurrency->getCurrency($currencyCode)->toCurrency($data);
             return $data;
@@ -94,10 +94,10 @@ class Price extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
     protected function _getRate($row)
     {
         if ($rate = $this->getColumn()->getRate()) {
-            return floatval($rate);
+            return (float)$rate;
         }
         if ($rate = $row->getData($this->getColumn()->getRateField())) {
-            return floatval($rate);
+            return (float)$rate;
         }
         return 1;
     }

--- a/app/code/Magento/Bundle/Pricing/Price/BundleSelectionFactory.php
+++ b/app/code/Magento/Bundle/Pricing/Price/BundleSelectionFactory.php
@@ -54,7 +54,7 @@ class BundleSelectionFactory
     ) {
         $arguments['bundleProduct'] = $bundleProduct;
         $arguments['saleableItem'] = $selection;
-        $arguments['quantity'] = $quantity ? floatval($quantity) : 1.;
+        $arguments['quantity'] = $quantity ? (float)$quantity : 1.;
 
         return $this->objectManager->create(self::SELECTION_CLASS_DEFAULT, $arguments);
     }

--- a/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
@@ -935,7 +935,7 @@ abstract class AbstractType
      */
     public function prepareQuoteItemQty($qty, $product)
     {
-        return floatval($qty);
+        return (float)$qty;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ResourceModel/Layer/Filter/Price.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Layer/Filter/Price.php
@@ -112,7 +112,7 @@ class Price extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         /**
          * Check and set correct variable values to prevent SQL-injections
          */
-        $range = floatval($range);
+        $range = (float)$range;
         if ($range == 0) {
             $range = 1;
         }

--- a/app/code/Magento/Catalog/Pricing/Price/RegularPrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/RegularPrice.php
@@ -29,7 +29,7 @@ class RegularPrice extends AbstractPrice implements BasePriceProviderInterface
         if ($this->value === null) {
             $price = $this->product->getPrice();
             $priceInCurrentCurrency = $this->priceCurrency->convertAndRound($price);
-            $this->value = $priceInCurrentCurrency ? floatval($priceInCurrentCurrency) : 0;
+            $this->value = $priceInCurrentCurrency ? (float)$priceInCurrentCurrency : 0;
         }
         return $this->value;
     }

--- a/app/code/Magento/Catalog/Pricing/Price/TierPrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/TierPrice.php
@@ -80,7 +80,7 @@ class TierPrice extends AbstractPrice implements TierPriceInterface, BasePricePr
         GroupManagementInterface $groupManagement,
         CustomerGroupRetrieverInterface $customerGroupRetriever = null
     ) {
-        $quantity = floatval($quantity) ? $quantity : 1;
+        $quantity = (float)$quantity ? $quantity : 1;
         parent::__construct($saleableItem, $quantity, $calculator, $priceCurrency);
         $this->customerSession = $customerSession;
         $this->groupManagement = $groupManagement;

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/PriceTest.php
@@ -152,7 +152,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $this->productCollection->expects($this->once())
             ->method('getMaxPrice')
             ->will($this->returnValue($maxPrice));
-        $this->assertSame(floatval($maxPrice), $this->target->getMaxPrice());
+        $this->assertSame((float)$maxPrice, $this->target->getMaxPrice());
     }
 
     /**

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -206,7 +206,7 @@ class Item extends AbstractExtensibleModel implements StockItemInterface
      */
     public function getQty()
     {
-        return null === $this->_getData(static::QTY) ? null : floatval($this->_getData(static::QTY));
+        return null === $this->_getData(static::QTY) ? null : (float)$this->_getData(static::QTY);
     }
 
     /**

--- a/app/code/Magento/CatalogRule/Pricing/Price/CatalogRulePrice.php
+++ b/app/code/Magento/CatalogRule/Pricing/Price/CatalogRulePrice.php
@@ -89,7 +89,7 @@ class CatalogRulePrice extends AbstractPrice implements BasePriceProviderInterfa
     {
         if (null === $this->value) {
             if ($this->product->hasData(self::PRICE_CODE)) {
-                $this->value = floatval($this->product->getData(self::PRICE_CODE)) ?: false;
+                $this->value = (float)$this->product->getData(self::PRICE_CODE) ?: false;
             } else {
                 $this->value = $this->getRuleResource()
                     ->getRulePrice(
@@ -98,7 +98,7 @@ class CatalogRulePrice extends AbstractPrice implements BasePriceProviderInterfa
                         $this->customerSession->getCustomerGroupId(),
                         $this->product->getId()
                     );
-                $this->value = $this->value ? floatval($this->value) : false;
+                $this->value = $this->value ? (float)$this->value : false;
             }
             if ($this->value) {
                 $this->value = $this->priceCurrency->convertAndRound($this->value);

--- a/app/code/Magento/Checkout/Helper/Data.php
+++ b/app/code/Magento/Checkout/Helper/Data.php
@@ -164,7 +164,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
         $qty = $item->getQty() ? $item->getQty() : ($item->getQtyOrdered() ? $item->getQtyOrdered() : 1);
         $taxAmount = $item->getTaxAmount() + $item->getDiscountTaxCompensation();
-        $price = floatval($qty) ? ($item->getRowTotal() + $taxAmount) / $qty : 0;
+        $price = (float)$qty ? ($item->getRowTotal() + $taxAmount) / $qty : 0;
         return $this->priceCurrency->round($price);
     }
 
@@ -191,7 +191,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $qty = $item->getQty() ? $item->getQty() : ($item->getQtyOrdered() ? $item->getQtyOrdered() : 1);
         $taxAmount = $item->getBaseTaxAmount() + $item->getBaseDiscountTaxCompensation();
-        $price = floatval($qty) ? ($item->getBaseRowTotal() + $taxAmount) / $qty : 0;
+        $price = (float)$qty ? ($item->getBaseRowTotal() + $taxAmount) / $qty : 0;
         return $this->priceCurrency->round($price);
     }
 

--- a/app/code/Magento/Config/Model/Config/Structure/Mapper/Sorting.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Mapper/Sorting.php
@@ -55,11 +55,11 @@ class Sorting extends \Magento\Config\Model\Config\Structure\AbstractMapper
     {
         $sortIndexA = 0;
         if ($this->_hasValue('sortOrder', $elementA)) {
-            $sortIndexA = floatval($elementA['sortOrder']);
+            $sortIndexA = (float)$elementA['sortOrder'];
         }
         $sortIndexB = 0;
         if ($this->_hasValue('sortOrder', $elementB)) {
-            $sortIndexB = floatval($elementB['sortOrder']);
+            $sortIndexB = (float)$elementB['sortOrder'];
         }
 
         if ($sortIndexA == $sortIndexB) {

--- a/app/code/Magento/Directory/Model/Currency.php
+++ b/app/code/Magento/Directory/Model/Currency.php
@@ -225,7 +225,7 @@ class Currency extends \Magento\Framework\Model\AbstractModel
         if ($toCurrency === null) {
             return $price;
         } elseif ($rate = $this->getRate($toCurrency)) {
-            return floatval($price) * floatval($rate);
+            return (float)$price * (float)$rate;
         }
 
         throw new \Exception(__(

--- a/app/code/Magento/GroupedProduct/Pricing/Price/ConfiguredRegularPrice.php
+++ b/app/code/Magento/GroupedProduct/Pricing/Price/ConfiguredRegularPrice.php
@@ -82,7 +82,7 @@ class ConfiguredRegularPrice extends AbstractPrice implements ConfiguredPriceInt
             if ($this->value === null) {
                 $price = $this->product->getPrice();
                 $priceInCurrentCurrency = $this->priceCurrency->convertAndRound($price);
-                $this->value = $priceInCurrentCurrency ? floatval($priceInCurrentCurrency) : false;
+                $this->value = $priceInCurrentCurrency ? (float)$priceInCurrentCurrency : false;
             }
 
             return $this->value;

--- a/app/code/Magento/Reports/Block/Adminhtml/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Grid/Column/Renderer/Currency.php
@@ -30,7 +30,7 @@ class Currency extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Curren
             return $data;
         }
 
-        $data = floatval($data) * $this->_getRate($row);
+        $data = (float)$data * $this->_getRate($row);
         $data = sprintf("%f", $data);
         $data = $this->_localeCurrency->getCurrency($currencyCode)->toCurrency($data);
         return $data;

--- a/app/code/Magento/Sales/Model/Order/StateResolver.php
+++ b/app/code/Magento/Sales/Model/Order/StateResolver.php
@@ -39,7 +39,7 @@ class StateResolver implements OrderStateResolverInterface
     {
         /** @var $order Order|OrderInterface */
         $forceCreditmemo = in_array(self::FORCED_CREDITMEMO, $arguments);
-        if (floatval($order->getTotalRefunded()) || !$order->getTotalRefunded() && $forceCreditmemo) {
+        if ((float)$order->getTotalRefunded() || !$order->getTotalRefunded() && $forceCreditmemo) {
             return true;
         }
         return false;

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -29,7 +29,7 @@ class State
                     $order->setState(Order::STATE_COMPLETE)
                         ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_COMPLETE));
                 }
-            } elseif (floatval($order->getTotalRefunded())
+            } elseif ((float)$order->getTotalRefunded()
                 || !$order->getTotalRefunded() && $order->hasForcedCanCreditmemo()
             ) {
                 if ($order->getState() !== Order::STATE_CLOSED) {

--- a/app/code/Magento/Tax/Helper/Data.php
+++ b/app/code/Magento/Tax/Helper/Data.php
@@ -733,7 +733,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $orderItemId = $orderItem->getId();
             $orderItemTax = $orderItem->getTaxAmount();
             $itemTax = $item->getTaxAmount();
-            if (!$itemTax || !floatval($orderItemTax)) {
+            if (!$itemTax || !(float)$orderItemTax) {
                 continue;
             }
             //An invoiced item or credit memo item can have a different qty than its order item qty
@@ -761,7 +761,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $shippingTaxAmount = $salesItem->getShippingTaxAmount();
         $originalShippingTaxAmount = $order->getShippingTaxAmount();
         if ($shippingTaxAmount && $originalShippingTaxAmount &&
-            $shippingTaxAmount != 0 && floatval($originalShippingTaxAmount)
+            $shippingTaxAmount != 0 && (float)$originalShippingTaxAmount
         ) {
             //An invoice or credit memo can have a different qty than its order
             $shippingRatio = $shippingTaxAmount / $originalShippingTaxAmount;

--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -887,7 +887,7 @@ XMLRequest;
 
                         if ($successConversion) {
                             $costArr[$code] = $cost;
-                            $priceArr[$code] = $this->getMethodPrice(floatval($cost), $code);
+                            $priceArr[$code] = $this->getMethodPrice((float)$cost, $code);
                         }
                     }
                 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16848

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Direct type casting is **up to 6x faster** than using casting functions like` floatval()`. So this pull request replaces the `floatval()` functions by direct type casting to `(float)`.

**Similar PR:** 

>https://github.com/magento/magento2/pull/16422 Replace intval() function by using direct type casting to (int) where no default value is needed 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)