### PR TITLE
[Forwardport] Enhancements to module:status command

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Setup\Console\Command;
 
 use Magento\Framework\Module\FullModuleList;

--- a/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Setup\Console\Command;
 
+use Magento\Framework\Module\FullModuleList;
+use Magento\Framework\Module\ModuleList;
 use Magento\Setup\Model\ObjectManagerProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
 
 /**
  * Command for displaying status of modules
@@ -38,7 +42,10 @@ class ModuleStatusCommand extends AbstractSetupCommand
     protected function configure()
     {
         $this->setName('module:status')
-            ->setDescription('Displays status of modules');
+            ->setDescription('Displays status of modules')
+            ->addArgument('module', InputArgument::OPTIONAL, 'Optional module name')
+            ->addOption('enabled', null, null, 'Print only enabled modules')
+            ->addOption('disabled', null, null, 'Print only disabled modules');
         parent::configure();
     }
 
@@ -47,24 +54,102 @@ class ModuleStatusCommand extends AbstractSetupCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $moduleList = $this->objectManagerProvider->get()->create(\Magento\Framework\Module\ModuleList::class);
-        $output->writeln('<info>List of enabled modules:</info>');
-        $enabledModules = $moduleList->getNames();
-        if (count($enabledModules) === 0) {
-            $output->writeln('None');
-        } else {
-            $output->writeln(join("\n", $enabledModules));
+        $moduleName = (string)$input->getArgument('module');
+        if ($moduleName) {
+            return $this->showSpecificModule($moduleName, $output);
         }
+
+        $onlyEnabled = $input->getOption('enabled');
+        if ($onlyEnabled) {
+            return $this->showEnabledModules($output);
+        }
+
+        $onlyDisabled = $input->getOption('disabled');
+        if ($onlyDisabled) {
+            return $this->showDisabledModules($output);
+        }
+
+        $output->writeln('<info>List of enabled modules:</info>');
+        $this->showEnabledModules($output);
         $output->writeln('');
 
-        $fullModuleList = $this->objectManagerProvider->get()->create(\Magento\Framework\Module\FullModuleList::class);
         $output->writeln("<info>List of disabled modules:</info>");
-        $disabledModules = array_diff($fullModuleList->getNames(), $enabledModules);
-        if (count($disabledModules) === 0) {
+        $this->showDisabledModules($output);
+        $output->writeln('');
+    }
+
+    /**
+     * @param string $moduleName
+     * @param OutputInterface $output
+     */
+    private function showSpecificModule(string $moduleName, OutputInterface $output)
+    {
+        $allModules = $this->getAllModules();
+        if (!in_array($moduleName, $allModules->getNames())) {
+            $output->writeln('<error>Module does not exist</error>');
+            return;
+        }
+
+        $enabledModules = $this->getEnabledModules();
+        if (in_array($moduleName, $enabledModules->getNames())) {
+            $output->writeln('<info>Module is enabled</info>');
+            return;
+        }
+
+        $output->writeln('<info>Module is disabled</info>');
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    private function showEnabledModules(OutputInterface $output)
+    {
+        $enabledModules = $this->getEnabledModules();
+        $enabledModuleNames = $enabledModules->getNames();
+        if (count($enabledModuleNames) === 0) {
             $output->writeln('None');
         } else {
-            $output->writeln(join("\n", $disabledModules));
+            $output->writeln(join("\n", $enabledModuleNames));
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    private function showDisabledModules(OutputInterface $output)
+    {
+        $disabledModuleNames = $this->getDisabledModuleNames();
+        if (count($disabledModuleNames) === 0) {
+            $output->writeln('None');
+        } else {
+            $output->writeln(join("\n", $disabledModuleNames));
         }
         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * @return FullModuleList
+     */
+    private function getAllModules(): FullModuleList
+    {
+        return $this->objectManagerProvider->get()->create(FullModuleList::class);
+    }
+
+    /**
+     * @return ModuleList
+     */
+    private function getEnabledModules(): ModuleList
+    {
+        return $this->objectManagerProvider->get()->create(ModuleList::class);
+    }
+
+    /**
+     * @return array
+     */
+    private function getDisabledModuleNames(): array
+    {
+        $fullModuleList = $this->getAllModules();
+        $enabledModules = $this->getEnabledModules();
+        return array_diff($fullModuleList->getNames(), $enabledModules->getNames());
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
@@ -100,6 +100,7 @@ class ModuleStatusCommand extends AbstractSetupCommand
         }
 
         $output->writeln('<info>Module is disabled</info>');
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**
@@ -115,6 +116,7 @@ class ModuleStatusCommand extends AbstractSetupCommand
         }
 
         $output->writeln(join("\n", $enabledModuleNames));
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**
@@ -129,6 +131,7 @@ class ModuleStatusCommand extends AbstractSetupCommand
         }
 
         $output->writeln(join("\n", $disabledModuleNames));
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**

--- a/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleStatusCommand.php
@@ -11,6 +11,7 @@ namespace Magento\Setup\Console\Command;
 use Magento\Framework\Module\FullModuleList;
 use Magento\Framework\Module\ModuleList;
 use Magento\Setup\Model\ObjectManagerProvider;
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -89,13 +90,13 @@ class ModuleStatusCommand extends AbstractSetupCommand
         $allModules = $this->getAllModules();
         if (!in_array($moduleName, $allModules->getNames())) {
             $output->writeln('<error>Module does not exist</error>');
-            return;
+            return Cli::RETURN_FAILURE;
         }
 
         $enabledModules = $this->getEnabledModules();
         if (in_array($moduleName, $enabledModules->getNames())) {
             $output->writeln('<info>Module is enabled</info>');
-            return;
+            return Cli::RETURN_FAILURE;
         }
 
         $output->writeln('<info>Module is disabled</info>');
@@ -110,9 +111,10 @@ class ModuleStatusCommand extends AbstractSetupCommand
         $enabledModuleNames = $enabledModules->getNames();
         if (count($enabledModuleNames) === 0) {
             $output->writeln('None');
-        } else {
-            $output->writeln(join("\n", $enabledModuleNames));
+            return Cli::RETURN_FAILURE;
         }
+
+        $output->writeln(join("\n", $enabledModuleNames));
     }
 
     /**
@@ -123,10 +125,10 @@ class ModuleStatusCommand extends AbstractSetupCommand
         $disabledModuleNames = $this->getDisabledModuleNames();
         if (count($disabledModuleNames) === 0) {
             $output->writeln('None');
-        } else {
-            $output->writeln(join("\n", $disabledModuleNames));
+            return Cli::RETURN_FAILURE;
         }
-        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+
+        $output->writeln(join("\n", $disabledModuleNames));
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15543

### Description
The CLI command `module:status` provides a listing of all enabled and disabled modules. However, it is hard to determine whether a certain module is enabled or disabled: You always need scrolling and the output is not easily parsed for further automation. This PR adds a couple of things:

First of all, you can inspect the status of a specific module using a command `module:status Foo_Bar` which either reports `Module is enabled` or `Module is disabled` or a warning `Module does not exist`.

Second, you can add `--enabled` or `--disabled` to only list either enabled modules or disabled modules. I didn't make this bastard-proof, so specifying both options at once (`--enabled --disabled`) will just run (the `enabled` flag is interpreted first in PHP.

The original behaviour of `bin/magento module:status` remains untouched. The entire CLI class is cleaned up: Importing namespaces, PHP 7 argument hinting and method extraction.

### Fixed Issues (if relevant)
Not relevant.

### Manual testing scenarios
With this PR you are able to run the commands as described above.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
