### PR TITLE
Ensure that both the layout and page layout have been cached before accessing

### DIFF
--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -427,10 +427,13 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
 
         $cacheId = $this->getCacheId();
         $cacheIdPageLayout = $cacheId . '_' . self::PAGE_LAYOUT_CACHE_SUFFIX;
-        $result = $this->_loadCache($cacheId);
-        if ($result) {
-            $this->addUpdate($result);
-            $this->pageLayout = $this->_loadCache($cacheIdPageLayout);
+
+        $layoutCache = $this->_loadCache($cacheId);
+        $pageLayoutCache = $this->_loadCache($cacheIdPageLayout);
+
+        if ($layoutCache && $pageLayoutCache) {
+            $this->addUpdate($layoutCache);
+            $this->pageLayout = $pageLayoutCache;
             foreach ($this->getHandles() as $handle) {
                 $this->allHandles[$handle] = $this->handleProcessed;
             }


### PR DESCRIPTION
### Description
The core code in lib/internal/Magento/Framework/View/Model/Layout/Merge.php -> load() assumes that if the layout has successfully retrieved from cache, that the page layout can also be successfully retrieved from cache. It's a fair assumption given that both caches are saved one after the other toward the end of the load() method, but it's an assumption nonetheless. This leaves the door open for race conditions, especially in a multi-web-node configuration with redis replication.

The code should be verifying that the page layout has actually been successfully retrieved from cache before using the value. 

### Manual testing scenarios
1. Load a product listing page.
2. In redis remove the page layout cached object for that page.
3. Reload the product listing page. 

### Expected Result (prior to code change)
The page layout cache object for that page is regenerated and the page is rendered in its entirety.

### Actual Result (prior to code change)
The page layout cache object for that page is not regenerated, the value set to $this->pageLayout in the code is 'false', and only the HTML body of the page is rendered (no html tags or head tags). The page is rendered broken.

### Contribution checklist
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds on Travis CI are green)
