### PR TITLE
Fix for ProductLink - setterName was incorrectly being set

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductLink/Repository.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/Repository.php
@@ -178,7 +178,7 @@ class Repository implements \Magento\Catalog\Api\ProductLinkRepositoryInterface
                     foreach ($item['custom_attributes'] as $option) {
                         $name = $option['attribute_code'];
                         $value = $option['value'];
-                        $setterName = 'set'.ucfirst($name);
+                        $setterName = 'set'.str_replace('_', '', ucwords($name, '_'));
                         // Check if setter exists
                         if (method_exists($productLinkExtension, $setterName)) {
                             call_user_func([$productLinkExtension, $setterName], $value);


### PR DESCRIPTION
Fix for ProductLink - setterName was incorrectly being set to an ucfirst instead of converting to camel case, which doesn't work as expected on attributes with underscores in their names.

To replicate, add a custom product link attribute in an extension that has an underscore in it. The normal expected setter routines in camel case do not work.