### PR TITLE
17656- Show free shipping method with error if method not applicable

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -90,7 +90,6 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
             $error->setErrorMessage($errorMsg);
 
             return $error;
-
         } else if ($request->getFreeShipping() || $request->getBaseSubtotalInclTax() >= $this->getConfigData(
             'free_shipping_subtotal'
         )

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -80,7 +80,18 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
 
         $this->_updateFreeMethodQuote($request);
 
-        if ($request->getFreeShipping() || $request->getBaseSubtotalInclTax() >= $this->getConfigData(
+        if ($request->getBaseSubtotalInclTax() < $this->getConfigData('free_shipping_subtotal')
+            && $this->getConfigData('showmethod')) {
+            /** @var Error $error */
+            $error = $this->_rateErrorFactory->create();
+            $error->setCarrier($this->_code);
+            $error->setCarrierTitle($this->getConfigData('title'));
+            $errorMsg = $this->getConfigData('specificerrmsg');
+            $error->setErrorMessage($errorMsg);
+
+            return $error;
+
+        } else if ($request->getFreeShipping() || $request->getBaseSubtotalInclTax() >= $this->getConfigData(
             'free_shipping_subtotal'
         )
         ) {

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -80,7 +80,8 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
 
         $this->_updateFreeMethodQuote($request);
 
-        if ($request->getBaseSubtotalInclTax() < $this->getConfigData('free_shipping_subtotal') && $this->getConfigData('showmethod')) {
+        if ($request->getBaseSubtotalInclTax() < $this->getConfigData('free_shipping_subtotal')
+            && $this->getConfigData('showmethod')) {
             /** @var Error $error */
             $error = $this->_rateErrorFactory->create();
             $error->setCarrier($this->_code);

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -80,8 +80,7 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
 
         $this->_updateFreeMethodQuote($request);
 
-        if ($request->getBaseSubtotalInclTax() < $this->getConfigData('free_shipping_subtotal')
-            && $this->getConfigData('showmethod')) {
+        if ($request->getBaseSubtotalInclTax() < $this->getConfigData('free_shipping_subtotal') && $this->getConfigData('showmethod')) {
             /** @var Error $error */
             $error = $this->_rateErrorFactory->create();
             $error->setCarrier($this->_code);


### PR DESCRIPTION

### Description

Display error message and show free shipping method in checkout if the Show Shipping Method if not applicable option is enabled.

### Fixed Issues (if relevant)
1. magento/magento2#17656: Magento 2.2.4 Free Shipping Enable “Show Method” do not show
2. magento/magento2#16312: Magento 2.2.4 Free Shipping Enable “Show Method” do not show

### Manual testing scenarios

1. Navigate to Admin => Stores => Configuration => Sales => Shipping Methods.
2. Enable Free shipping
3. Add the product to cart
4. Set the minimum amount greater than the cart amount in free shipping method settings.
5. Set Show Method if Not Applicable options as Yes
6. Set Ship to Applicable Countries option as All Allowed Countries
5. Go to checkout page. It should show the shipping method with error.
