### PR TITLE
Enable autocomplete for admin login form

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/login.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/login.phtml
@@ -27,7 +27,7 @@
                        value=""
                        data-validate="{required:true}"
                        placeholder="<?= /* @escapeNotVerified */ __('user name') ?>"
-                       autocomplete="off"
+                       autocomplete="on"
                     />
             </div>
         </div>
@@ -43,7 +43,7 @@
                        data-validate="{required:true}"
                        value=""
                        placeholder="<?= /* @escapeNotVerified */ __('password') ?>"
-                       autocomplete="new-password"
+                       autocomplete="current-password"
                     />
             </div>
         </div>


### PR DESCRIPTION
Browsers have an autocomplete functionality with permissions for every site separately. It is a user's decision - enable/disable autocomplete for the certain site, not developer's.

![image](https://user-images.githubusercontent.com/5052385/44574699-d24b1580-a792-11e8-80f8-85d58816de6a.png)
