### PR TITLE
Missing "_" in property $_collectionFactory

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Orders.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Orders.php
@@ -32,7 +32,7 @@ class Orders extends \Magento\Backend\Block\Widget\Grid\Extended
     /**
      * @var  \Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory
      */
-    protected $collectionFactory;
+    protected $_collectionFactory;
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context


### PR DESCRIPTION
The property $_collectionFactory missed the "_" character in its definition

### Description
Wrong:
protected $collectionFactory;
Right:
protected $_collectionFactory;

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
