### PR TITLE
Fix displaying Special Price excluding tax

### DIFF
--- a/app/code/Magento/Tax/Pricing/Render/Adjustment.php
+++ b/app/code/Magento/Tax/Pricing/Render/Adjustment.php
@@ -173,4 +173,17 @@ class Adjustment extends AbstractAdjustment
     {
         return $this->taxHelper->displayPriceExcludingTax();
     }
+
+    /**
+     * Obtain a value for data-price-type attribute
+     *
+     * @return string
+     */
+    public function getDataPriceType()
+    {
+        if ($priceType = $this->getData('price_type')) {
+            return 'base' . ucfirst($priceType);
+        }
+        return 'basePrice';
+    }
 }

--- a/app/code/Magento/Tax/view/base/templates/pricing/adjustment.phtml
+++ b/app/code/Magento/Tax/view/base/templates/pricing/adjustment.phtml
@@ -14,7 +14,7 @@
     <span id="<?= /* @escapeNotVerified */ $block->buildIdWithPrefix('price-excluding-tax-') ?>"
           data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>"
           data-price-amount="<?= /* @escapeNotVerified */ $block->getRawAmount() ?>"
-          data-price-type="basePrice"
+          data-price-type="<?= /* @escapeNotVerified */ $block->getDataPriceType() ?>"
           class="price-wrapper price-excluding-tax">
         <span class="price"><?= /* @escapeNotVerified */ $block->getDisplayAmountExclTax() ?></span></span>
 <?php endif; ?>


### PR DESCRIPTION
### Description
Whenever a Special Price and a Regular Price was displayed with tax and without, the amount of the Special Price without tax was changed into one equal to the amount of Regular Price without tax.

### Fixed Issues (if relevant)

1. magento/magento2#11998: Old price excluding TAX is incorrectly replaced by JavaScript

### Manual testing scenarios
Same as Fixed Issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)