### PR TITLE
Fix creating credit memo when shipping is free

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/totals/adjustments.phtml
@@ -15,11 +15,15 @@
     <tr>
         <td class="label"><?= /* @escapeNotVerified */ $block->getShippingLabel() ?><div id="shipping_amount_adv"></div></td>
         <td>
-            <input type="text"
-                   name="creditmemo[shipping_amount]"
-                   value="<?= /* @escapeNotVerified */ $block->getShippingAmount() ?>"
-                   class="input-text admin__control-text not-negative-amount"
-                   id="shipping_amount" />
+            <?php if ($block->getShippingAmount() == 0): ?>
+                <span><?= /* @escapeNotVerified */ $block->getShippingAmount(); ?></span>
+            <?php else: ?>
+                <input type="text"
+                       name="creditmemo[shipping_amount]"
+                       value="<?= /* @escapeNotVerified */ $block->getShippingAmount() ?>"
+                       class="input-text admin__control-text not-negative-amount"
+                       id="shipping_amount" />
+            <?php endif; ?>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description
There is a division by zero if admin tries to create a credit memo for an order with free shipping and changes the "Refund Shipping" value to non-zero. The easiest solution would be not allowing admin to change the "Refund Shipping" value in this situation.

### Fixed Issues
magento/magento2#11336: Cannot refund with Refund Shipping > 0 when the order shipping amount = 0

### Manual testing scenarios
Scenario 1:
1. Create order with free shipping and total amount > 0.
2. Go to admin panel and create an invoice.
3. Go to credit memo creation.
4. The value next to "Refund Shipping" will be a text instead of input.

Scenario 2:
1. Create order with shipping amount > 0 and total amount > 0.
2. Go to admin panel and create an invoice.
3. Go to credit memo creation.
4. The value next to "Refund Shipping" will be an input.
