### PR TITLE
addExpressionFieldToSelect has to be called after all addFieldToSelect bug fix

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
@@ -346,7 +346,9 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
             $fullExpression = str_replace('{{' . $fieldKey . '}}', $fieldItem, $fullExpression);
         }
 
-        $this->getSelect()->columns([$alias => $fullExpression]);
+        $fullExpression = new \Zend_Db_Expr($fullExpression);
+        $this->_fieldsToSelect[$alias] = $fullExpression;
+        $this->_fieldsToSelectChanged = true;
 
         return $this;
     }


### PR DESCRIPTION

### Description
lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
addExpressionFieldToSelect() method added it's result to getSelect()->columns. When you called addFieldToSelect() method after addExpressionFieldToSelect() expressions where removed from columns. Your select was overwriten by addFieldToSelect(). To avoid that i changed the addExpressionFieldToSelect() method to insert it's result into $this->_fieldsToSelect array as \Zend_Db_Expr. This way it does not get overwritten and you get results from both methods in your collection no matter the order you call them in.
### Fixed Issues (if relevant)
1. magento/magento2#17635
### Manual testing scenarios
- create a collection
- before the change the following code will only show finish_date in collection:
$bookingCollection = $this->_bookingCollectionFactory->create();
$bookingCollection->addExpressionFieldToSelect('stime_part', 'time(start_time)', []);
$bookingCollection->addFieldToSelect('finish_time', 'finish_date');
-after proposed change you will see both stime_part and finish_date

