### PR TITLE
Fix translations of category design theme not being applied

### DIFF
--- a/app/code/Magento/Catalog/Model/Design.php
+++ b/app/code/Magento/Catalog/Model/Design.php
@@ -32,10 +32,22 @@ class Design extends \Magento\Framework\Model\AbstractModel
     protected $_localeDate;
 
     /**
+     * @var \Magento\Framework\TranslateInterface
+     */
+    protected $_translator;
+
+    /**
+     * @var \Magento\Framework\View\Design\ThemeInterfaceFactory
+     */
+    protected $_themeFactory;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
      * @param \Magento\Framework\View\DesignInterface $design
+     * @param \Magento\Framework\TranslateInterface $translator
+     * @param \Magento\Framework\View\Design\ThemeInterfaceFactory $themeFactory
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
@@ -45,12 +57,16 @@ class Design extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\Registry $registry,
         \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate,
         \Magento\Framework\View\DesignInterface $design,
+        \Magento\Framework\TranslateInterface $translator,
+        \Magento\Framework\View\Design\ThemeInterfaceFactory $themeFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->_localeDate = $localeDate;
         $this->_design = $design;
+        $this->_translator = $translator;
+        $this->_themeFactory = $themeFactory;
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
     }
 
@@ -63,6 +79,13 @@ class Design extends \Magento\Framework\Model\AbstractModel
     public function applyCustomDesign($design)
     {
         $this->_design->setDesignTheme($design);
+        $this->applyCustomDesingTranslations($design);
+        return $this;
+    }
+
+    protected function applyCustomDesingTranslations($design) {
+        $theme = $this->_themeFactory->create()->load($design)->getThemePath();
+        $this->_translator->setTheme($theme)->loadData(null, true);
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/Test/Unit/TranslateTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/TranslateTest.php
@@ -313,6 +313,12 @@ class TranslateTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('themeTheme Title', $this->translate->getTheme());
     }
 
+    public function testSetTheme()
+    {
+        $this->translate->setTheme('Magento/blank');
+        $this->assertEquals('themeMagento/blank', $this->translate->getTheme());
+    }
+
     public function testLoadDataNoTheme()
     {
         $forceReload = true;

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -30,6 +30,13 @@ class Translate implements \Magento\Framework\TranslateInterface
     protected $_localeCode;
 
     /**
+     * Theme
+     *
+     * @var string
+     */
+    protected $_theme;
+
+    /**
      * Translator configuration array
      *
      * @var array
@@ -458,6 +465,19 @@ class Translate implements \Magento\Framework\TranslateInterface
             return self::CONFIG_THEME_KEY . $this->getConfig(self::CONFIG_THEME_KEY);
         }
         return self::CONFIG_THEME_KEY . $theme['theme_title'];
+    }
+
+    /**
+     * Set theme
+     *
+     * @param string $theme
+     * @return \Magento\Framework\TranslateInterface
+     */
+    public function setTheme($theme)
+    {
+        $this->_theme = $theme;
+        $this->_config[self::CONFIG_THEME_KEY] = $theme;
+        return $this;
     }
 
     /**

--- a/lib/internal/Magento/Framework/TranslateInterface.php
+++ b/lib/internal/Magento/Framework/TranslateInterface.php
@@ -52,4 +52,12 @@ interface TranslateInterface
      * @return string
      */
     public function getTheme();
+
+    /**
+     * Set theme
+     *
+     * @param string $theme
+     * @return \Magento\Framework\TranslateInterface
+     */
+    public function setTheme($theme);
 }


### PR DESCRIPTION
### Description
Currently if you enable custom design theme for category the translations of selected theme are not used. This commit fixes the problem.

### Fixed Issues (if relevant)
magento/magento2#17625

### Manual testing scenarios
(Copied from #17625 )
1. Enable Magento_Blank for the website
2. Create a category and set Magento_Luma as it's theme
3. Add a translation to the /i18n/ directory of Magento_Luma
4. Flush caches
5. The translation is now not applied.
Commit changes point 5. so the translation is being applied

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
