### PR TITLE
17754-Fixed validation while creating new product attributes in admin

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -167,12 +167,12 @@ class Save extends Attribute
             $attributeCode = $attributeCode ?: $this->generateCode($this->getRequest()->getParam('frontend_label')[0]);
             if (strlen($attributeCode) > 0) {
                 $validatorAttrCode = new \Zend_Validate_Regex(
-                    ['pattern' => '/^[a-z\x{600}-\x{6FF}][a-z\x{600}-\x{6FF}_0-9]{0,30}$/u']
+                    ['pattern' => '/^[a-zA-Z\x{600}-\x{6FF}][a-zA-Z\x{600}-\x{6FF}_0-9]{0,30}$/u']
                 );
                 if (!$validatorAttrCode->isValid($attributeCode)) {
                     $this->messageManager->addErrorMessage(
                         __(
-                            'Attribute code "%1" is invalid. Please use only letters (a-z), ' .
+                            'Attribute code "%1" is invalid. Please use only letters (a-z or A-Z), ' .
                             'numbers (0-9) or underscore(_) in this field, first character should be a letter.',
                             $attributeCode
                         )

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/AttributeTest.php
@@ -147,7 +147,7 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
         /** @var \Magento\Framework\Message\Error $message */
         $message = $messages->getItemsByType('error')[0];
         $this->assertEquals(
-            'Attribute code "_()&&&?" is invalid. Please use only letters (a-z),'
+            'Attribute code "_()&&&?" is invalid. Please use only letters (a-z or A-Z),'
             . ' numbers (0-9) or underscore(_) in this field, first character should be a letter.',
             $message->getText()
         );

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -980,9 +980,9 @@
         ],
         'validate-code': [
             function (v) {
-                return $.mage.isEmptyNoTrim(v) || /^[a-z]+[a-z0-9_]+$/.test(v);
+                return $.mage.isEmptyNoTrim(v) || /^[a-zA-Z]+[a-zA-Z0-9_]+$/.test(v);
             },
-            $.mage.__('Please use only letters (a-z), numbers (0-9) or underscore (_) in this field, and the first character should be a letter.') //eslint-disable-line max-len
+            $.mage.__('Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field, and the first character should be a letter.') //eslint-disable-line max-len
         ],
         'validate-alphanum': [
             function (v) {


### PR DESCRIPTION
Fixed validation issues while creating the new product attribute in admin

### Description
Changed the validation logic to accept the alphabets in both lower and upper case formats

### Fixed Issues (if relevant)
1. magento/magento2#17754: Misleading error in Add Product Attribute screen

### Manual testing scenarios
1. Navigate to Admin -> Stores -> Products under Attributes
2. Create the new attribute with the code as Foo_Bar and click save
3. It should save without any error.