### PR TITLE
[Forwardport] "Multiple Select" product attributes do not render HTML tags on the storefront view

### DIFF
--- a/app/code/Magento/Catalog/Helper/Output.php
+++ b/app/code/Magento/Catalog/Helper/Output.php
@@ -164,8 +164,8 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
             }
         }
         if ($attributeHtml !== null
-            && $attribute->getIsHtmlAllowedOnFront()
-            && $attribute->getIsWysiwygEnabled()
+            && ($attribute->getIsHtmlAllowedOnFront()
+            || $attribute->getIsWysiwygEnabled())
             && $this->isDirectivesExists($attributeHtml)
         ) {
             $attributeHtml = $this->_getTemplateProcessor()->filter($attributeHtml);

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -154,7 +154,7 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     public function getOptionText($value)
     {
         $isMultiple = false;
-        if (strpos($value, ',')) {
+        if (strpos($value, ',') !== false) {
             $isMultiple = true;
             $value = explode(',', $value);
         }

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -7,6 +7,7 @@ namespace Magento\Eav\Model\Entity\Attribute\Source;
 
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Escaper;
 
 /**
  * @api
@@ -37,16 +38,24 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     private $storeManager;
 
     /**
+     * @var Escaper
+     */
+    private $escaper;
+
+    /**
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\OptionFactory $attrOptionFactory
+     * @param Escaper|null $escaper
      * @codeCoverageIgnore
      */
     public function __construct(
         \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory,
-        \Magento\Eav\Model\ResourceModel\Entity\Attribute\OptionFactory $attrOptionFactory
+        \Magento\Eav\Model\ResourceModel\Entity\Attribute\OptionFactory $attrOptionFactory,
+        Escaper $escaper = null
     ) {
         $this->_attrOptionCollectionFactory = $attrOptionCollectionFactory;
         $this->_attrOptionFactory = $attrOptionFactory;
+        $this->escaper = $escaper ?: ObjectManager::getInstance()->get(Escaper::class);
     }
 
     /**
@@ -145,28 +154,31 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     public function getOptionText($value)
     {
         $isMultiple = false;
-        if (strpos($value, ',') !== false) {
+        if (strpos($value, ',')) {
             $isMultiple = true;
             $value = explode(',', $value);
         }
 
         $options = $this->getSpecificOptions($value, false);
 
-        if ($isMultiple) {
-            $values = [];
-            foreach ($options as $item) {
-                if (in_array($item['value'], $value)) {
-                    $values[] = $item['label'];
-                }
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+        $optionsText = [];
+        foreach ($options as $item) {
+            if (in_array($item['value'], $value)) {
+                $optionsText[] = ($this->_attribute->getIsHtmlAllowedOnFront())
+                    ? $item['label']
+                    : $this->escaper->escapeHtml($item['label']);
             }
-            return $values;
         }
 
-        foreach ($options as $item) {
-            if ($item['value'] == $value) {
-                return $item['label'];
-            }
+        if ($isMultiple) {
+            return $optionsText;
+        } elseif ($optionsText) {
+            return $optionsText[0];
         }
+
         return false;
     }
 

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/TableTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/TableTest.php
@@ -11,8 +11,11 @@ use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\Collection as Attrib
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Escaper;
 
 /**
+ * Tests \Magento\Eav\Model\Entity\Attribute\Source\Table.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class TableTest extends \PHPUnit\Framework\TestCase
@@ -58,6 +61,11 @@ class TableTest extends \PHPUnit\Framework\TestCase
      */
     private $attributeOptionCollectionMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|Escaper
+     */
+    private $escaper;
+
     protected function setUp()
     {
         $objectManager = new ObjectManager($this);
@@ -99,11 +107,16 @@ class TableTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
+        $this->escaper = $this->getMockBuilder(Escaper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->model = $objectManager->getObject(
             \Magento\Eav\Model\Entity\Attribute\Source\Table::class,
             [
                 'attrOptionCollectionFactory' => $this->collectionFactory,
-                'attrOptionFactory' => $this->attrOptionFactory
+                'attrOptionFactory' => $this->attrOptionFactory,
+                'escaper' => $this->escaper,
             ]
         );
         $this->model->setAttribute($this->abstractAttributeMock);
@@ -207,7 +220,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider getOptionTextProvider
-     * @param array $optionsIds
+     * @param array|string $optionsIds
      * @param array|string $value
      * @param array $options
      * @param array|string $expectedResult
@@ -248,6 +261,10 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->collectionFactory->expects($this->once())
             ->method('toOptionArray')
             ->willReturn($options);
+        $this->escaper
+            ->expects($this->atLeastOnce())
+            ->method('escapeHtml')
+            ->willReturnArgument(0);
 
         $this->assertEquals($expectedResult, $this->model->getOptionText($value));
     }
@@ -261,11 +278,24 @@ class TableTest extends \PHPUnit\Framework\TestCase
             [
                 ['1', '2'],
                 '1,2',
-                [['label' => 'test label 1', 'value' => '1'], ['label' => 'test label 2', 'value' => '1']],
+                [
+                    ['label' => 'test label 1', 'value' => '1'],
+                    ['label' => 'test label 2', 'value' => '1'],
+                ],
                 ['test label 1', 'test label 2'],
             ],
-            ['1', '1', [['label' => 'test label', 'value' => '1']], 'test label'],
-            ['5', '5', [['label' => 'test label', 'value' => '5']], 'test label']
+            [
+                '1',
+                '1',
+                [['label' => 'test label', 'value' => '1']],
+                'test label',
+            ],
+            [
+                '5',
+                '5',
+                [['label' => 'test label', 'value' => '5']],
+                'test label',
+            ],
         ];
     }
 


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15687

Issue fix for: https://github.com/magento/magento2/issues/15393
1. Fixed the check for allowed HTML tags OR wysiwyg for textarea attribute types.
2. Fix for options so that they can be rendered as HTML as well.