### PR TITLE
[Forwardport] declare var to fix scope error

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/js/category-checkbox-tree.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/category-checkbox-tree.js
@@ -33,7 +33,6 @@ define([
             data = {},
             parameters = {},
             root = {},
-            len = 0,
             key = '';
 
         /**
@@ -160,15 +159,15 @@ define([
              * @returns {void}
              */
             categoryLoader.buildCategoryTree = function (parent, nodeConfig) {
-                var j = 0;
+                var i = 0;
 
                 if (!nodeConfig) {
                     return null;
                 }
 
                 if (parent && nodeConfig && nodeConfig.length) {
-                    for (j = 0; j < nodeConfig.length; j++) {
-                        categoryLoader.processCategoryTree(parent, nodeConfig, j);
+                    for (i; i < nodeConfig.length; i++) {
+                        categoryLoader.processCategoryTree(parent, nodeConfig, i);
                     }
                 }
             };
@@ -180,14 +179,15 @@ define([
              * @returns {Object}
              */
             categoryLoader.buildHashChildren = function (hash, node) {
-                var j = 0;
+                var i = 0,
+                    len;
 
                 if (node.childNodes.length > 0 || node.loaded === false && node.loading === false) {
                     hash.children = [];
 
-                    for (j = 0, len = node.childNodes.length; j < len; j++) {
+                    for (i, len = node.childNodes.length; i < len; i++) {
                         hash.children = hash.children ? hash.children : [];
-                        hash.children.push(this.buildHash(node.childNodes[j]));
+                        hash.children.push(this.buildHash(node.childNodes[i]));
                     }
                 }
 


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15265

By not declaring `var i = 0`, the code is referencing the i declared in the outer function. This causes an infinite loop condition that crashes browsers since multiple methods modify i from the other scope.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. MAGETWO-91158
2. https://github.com/magento/magento2/issues/15121