### PR TITLE
[Forwardport] Making configurable settings for MAX_IMAGE_WIDTH and MAX_IMAGE_HEIGHT

### DIFF
--- a/app/code/Magento/Backend/Block/Media/Uploader.php
+++ b/app/code/Magento/Backend/Block/Media/Uploader.php
@@ -3,10 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Backend\Block\Media;
 
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Image\Adapter\UploadConfigInterface;
 
 /**
  * Adminhtml media library uploader
@@ -36,19 +39,28 @@ class Uploader extends \Magento\Backend\Block\Widget
     private $jsonEncoder;
 
     /**
+     * @var UploadConfigInterface
+     */
+    private $imageConfig;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\File\Size $fileSize
      * @param array $data
      * @param Json $jsonEncoder
+     * @param UploadConfigInterface $imageConfig
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\File\Size $fileSize,
         array $data = [],
-        Json $jsonEncoder = null
+        Json $jsonEncoder = null,
+        UploadConfigInterface $imageConfig = null
     ) {
         $this->_fileSizeService = $fileSize;
         $this->jsonEncoder = $jsonEncoder ?: ObjectManager::getInstance()->get(Json::class);
+        $this->imageConfig = $imageConfig ?: ObjectManager::getInstance()->get(UploadConfigInterface::class);
+
         parent::__construct($context, $data);
     }
 
@@ -88,6 +100,26 @@ class Uploader extends \Magento\Backend\Block\Widget
     public function getFileSizeService()
     {
         return $this->_fileSizeService;
+    }
+
+    /**
+     * Get Image Upload Maximum Width Config.
+     *
+     * @return int
+     */
+    public function getImageUploadMaxWidth()
+    {
+        return $this->imageConfig->getMaxWidth();
+    }
+
+    /**
+     * Get Image Upload Maximum Height Config.
+     *
+     * @return int
+     */
+    public function getImageUploadMaxHeight()
+    {
+        return $this->imageConfig->getMaxHeight();
     }
 
     /**

--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -335,6 +335,19 @@
                     </depends>
                 </field>
             </group>
+            <group id="upload_configuration" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Images Upload Configuration</label>
+                <field id="max_width" translate="label comment" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Maximum Width</label>
+                    <validate>validate-greater-than-zero validate-number required-entry</validate>
+                    <comment>Maximum allowed width for uploaded image.</comment>
+                </field>
+                <field id="max_height" translate="label comment" type="text" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Maximum Height</label>
+                    <validate>validate-greater-than-zero validate-number required-entry</validate>
+                    <comment>Maximum allowed height for uploaded image.</comment>
+                </field>
+            </group>
         </section>
         <section id="admin" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
             <label>Admin</label>

--- a/app/code/Magento/Backend/etc/config.xml
+++ b/app/code/Magento/Backend/etc/config.xml
@@ -28,6 +28,10 @@
             <dashboard>
                 <enable_charts>1</enable_charts>
             </dashboard>
+            <upload_configuration>
+                <max_width>1920</max_width>
+                <max_height>1200</max_height>
+            </upload_configuration>
         </system>
         <general>
             <validator_data>

--- a/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
@@ -13,8 +13,8 @@
     data-mage-init='{
         "Magento_Backend/js/media-uploader" : {
             "maxFileSize": <?= /* @escapeNotVerified */ $block->getFileSizeService()->getMaxFileSize() ?>,
-            "maxWidth":<?= /* @escapeNotVerified */ \Magento\Framework\File\Uploader::MAX_IMAGE_WIDTH ?> ,
-            "maxHeight": <?= /* @escapeNotVerified */ \Magento\Framework\File\Uploader::MAX_IMAGE_HEIGHT ?>
+            "maxWidth":<?= /* @escapeNotVerified */ $block->getImageUploadMaxWidth() ?> ,
+            "maxHeight": <?= /* @escapeNotVerified */ $block->getImageUploadMaxHeight() ?>
         }
     }'
 >

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -147,8 +147,8 @@ require([
             maxFileSize: <?= (int) $block->getFileSizeService()->getMaxFileSize() ?> * 10
         }, {
             action: 'resize',
-            maxWidth: <?= $block->getImageUploadMaxWidth()  ?> ,
-            maxHeight: <?= $block->getImageUploadMaxHeight()  ?>
+            maxWidth: <?= /* @escapeNotVerified */ $block->getImageUploadMaxWidth()  ?> ,
+            maxHeight: <?= /* @escapeNotVerified */ $block->getImageUploadMaxHeight()  ?>
         }, {
             action: 'save'
         }]

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -147,8 +147,8 @@ require([
             maxFileSize: <?= (int) $block->getFileSizeService()->getMaxFileSize() ?> * 10
         }, {
             action: 'resize',
-            maxWidth: <?= (float) \Magento\Framework\File\Uploader::MAX_IMAGE_WIDTH ?> ,
-            maxHeight: <?= (float) \Magento\Framework\File\Uploader::MAX_IMAGE_HEIGHT ?>
+            maxWidth: <?= $block->getImageUploadMaxWidth()  ?> ,
+            maxHeight: <?= $block->getImageUploadMaxHeight()  ?>
         }, {
             action: 'save'
         }]

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -87,6 +87,7 @@
     <preference for="Magento\Framework\View\Design\Theme\CustomizationInterface" type="Magento\Framework\View\Design\Theme\Customization" />
     <preference for="Magento\Framework\View\Asset\ConfigInterface" type="Magento\Framework\View\Asset\Config" />
     <preference for="Magento\Framework\Image\Adapter\ConfigInterface" type="Magento\Framework\Image\Adapter\Config" />
+    <preference for="Magento\Framework\Image\Adapter\UploadConfigInterface" type="Magento\Framework\Image\Adapter\Config" />
     <preference for="Magento\Framework\View\Design\Theme\Image\PathInterface" type="Magento\Theme\Model\Theme\Image\Path" />
     <preference for="Magento\Framework\Session\Config\ConfigInterface" type="Magento\Framework\Session\Config" />
     <preference for="Magento\Framework\Session\SidResolverInterface" type="Magento\Framework\Session\SidResolver\Proxy" />

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -136,12 +136,16 @@ class Uploader
     const TMP_NAME_EMPTY = 666;
 
     /**
-     * Max Image Width resolution in pixels. For image resizing on client side
+     * Maximum Image Width resolution in pixels. For image resizing on client side
+     * @deprecated
+     * @see \Magento\Framework\Image\Adapter\UploadConfigInterface::getMaxWidth()
      */
     const MAX_IMAGE_WIDTH = 1920;
 
     /**
-     * Max Image Height resolution in pixels. For image resizing on client side
+     * Maximum Image Height resolution in pixels. For image resizing on client side
+     * @deprecated
+     * @see \Magento\Framework\Image\Adapter\UploadConfigInterface::getMaxHeight()
      */
     const MAX_IMAGE_HEIGHT = 1200;
 

--- a/lib/internal/Magento/Framework/Image/Adapter/Config.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Config.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Image\Adapter;
 
 class Config implements ConfigInterface, UploadConfigInterface
@@ -53,7 +55,7 @@ class Config implements ConfigInterface, UploadConfigInterface
      *
      * @return int
      */
-    public function getMaxWidth()
+    public function getMaxWidth(): int
     {
         return (int)$this->config->getValue(self::XML_PATH_MAX_WIDTH_IMAGE);
     }
@@ -63,7 +65,7 @@ class Config implements ConfigInterface, UploadConfigInterface
      *
      * @return int
      */
-    public function getMaxHeight()
+    public function getMaxHeight(): int
     {
         return (int)$this->config->getValue(self::XML_PATH_MAX_HEIGHT_IMAGE);
     }

--- a/lib/internal/Magento/Framework/Image/Adapter/Config.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Config.php
@@ -5,11 +5,15 @@
  */
 namespace Magento\Framework\Image\Adapter;
 
-class Config implements \Magento\Framework\Image\Adapter\ConfigInterface
+class Config implements ConfigInterface, UploadConfigInterface
 {
     const XML_PATH_IMAGE_ADAPTER = 'dev/image/default_adapter';
 
     const XML_PATH_IMAGE_ADAPTERS = 'dev/image/adapters';
+
+    const XML_PATH_MAX_WIDTH_IMAGE = 'system/upload_configuration/max_width';
+
+    const XML_PATH_MAX_HEIGHT_IMAGE = 'system/upload_configuration/max_height';
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
@@ -42,5 +46,25 @@ class Config implements \Magento\Framework\Image\Adapter\ConfigInterface
     public function getAdapters()
     {
         return $this->config->getValue(self::XML_PATH_IMAGE_ADAPTERS);
+    }
+
+    /**
+     * Get Maximum Image Width resolution in pixels. For image resizing on client side.
+     *
+     * @return int
+     */
+    public function getMaxWidth()
+    {
+        return (int)$this->config->getValue(self::XML_PATH_MAX_WIDTH_IMAGE);
+    }
+
+    /**
+     * Get Maximum Image Height resolution in pixels. For image resizing on client side.
+     *
+     * @return int
+     */
+    public function getMaxHeight()
+    {
+        return (int)$this->config->getValue(self::XML_PATH_MAX_HEIGHT_IMAGE);
     }
 }

--- a/lib/internal/Magento/Framework/Image/Adapter/UploadConfigInterface.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/UploadConfigInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Image\Adapter;
+
+/**
+ * Interface UploadConfigInterface
+ */
+interface UploadConfigInterface
+{
+    /**
+     * @return int
+     */
+    public function getMaxWidth();
+
+    /**
+     * @return int
+     */
+    public function getMaxHeight();
+}

--- a/lib/internal/Magento/Framework/Image/Adapter/UploadConfigInterface.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/UploadConfigInterface.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Image\Adapter;
 
 /**
@@ -13,10 +15,10 @@ interface UploadConfigInterface
     /**
      * @return int
      */
-    public function getMaxWidth();
+    public function getMaxWidth(): int;
 
     /**
      * @return int
      */
-    public function getMaxHeight();
+    public function getMaxHeight(): int;
 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15942

### Description

It was added a new system fieldset, where the max-width and max-height can be set.
`Stores / Configuration / Advanced / System / Images Configuration`

So these 2 values are more flexible now for those which need to have bigger images in their shops.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13747: Wysiwyg > Image Uploader >Max width/height
2. ...

### Manual testing scenarios
1. Get an image of 3000x700
https://dummyimage.com/3000x700
2. Open any wysiwyg editor
3. Upload an image
4. The uploaded image should have maximum configured size

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
