### PR TITLE
Added checkout_cart_product_add_before event

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -373,7 +373,7 @@ class Cart extends DataObject implements CartInterface
             try {
                 $this->_eventManager->dispatch(
                     'checkout_cart_product_add_before',
-                    ['quote_item' => $result, 'product' => $product]
+                    ['quote_item' => $this->getQuote()->getItems(), 'product' => $product]
                 );
 
                 $result = $this->getQuote()->addProduct($product, $request);

--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -371,6 +371,11 @@ class Cart extends DataObject implements CartInterface
 
         if ($productId) {
             try {
+                $this->_eventManager->dispatch(
+                    'checkout_cart_product_add_before',
+                    ['quote_item' => $result, 'product' => $product]
+                );
+
                 $result = $this->getQuote()->addProduct($product, $request);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->_checkoutSession->setUseNotice(false);


### PR DESCRIPTION
This  PR will add checkout_cart_product_add_before event.

### Fixed Issues (if relevant)
1. magento/magento2#17830: Add checkout_cart_product_add_before event


### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
