### PR TITLE
Magento 2.3.x correct ConfigurableProduct setup dependencies. Fixes #17836

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/InstallInitialConfigurableAttributes.php
+++ b/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/InstallInitialConfigurableAttributes.php
@@ -6,6 +6,7 @@
 
 namespace Magento\ConfigurableProduct\Setup\Patch\Data;
 
+use Magento\Catalog\Setup\Patch\Data\InstallDefaultCategories;
 use Magento\Eav\Setup\EavSetup;
 use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\App\ResourceConnection;
@@ -13,6 +14,7 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Msrp\Setup\Patch\Data\InitializeMsrpAttributes;
 
 /**
  * Class InstallInitialConfigurableAttributes
@@ -85,7 +87,10 @@ class InstallInitialConfigurableAttributes implements DataPatchInterface, PatchV
      */
     public static function getDependencies()
     {
-        return [];
+        return [
+            InstallDefaultCategories::class,
+            InitializeMsrpAttributes::class,
+        ];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Updates setup dependencies of `Magento\ConfigurableProduct\Setup\Patch\Data\InstallInitialConfigurableAttributes` and fixes magento/magento2#17836.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17836: Magento 2.3.x incomplete ConfigurableProduct setup dependencies.
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
