### PR TITLE
Fix for invalid JSON if image label contains HTML markup, example &quot;

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
+++ b/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
@@ -34,7 +34,7 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode() : 'to
      class="gallery"
      data-mage-init='{"openVideoModal":{}}'
      data-parent-component="<?= $block->escapeHtml($block->getData('config/parentComponent')) ?>"
-     data-images="<?= $block->escapeHtml($block->getImagesJson()) ?>"
+     data-images="<?= $block->escapeHtmlAttr($block->getImagesJson()) ?>"
      data-types="<?= $block->escapeHtml(
          $this->helper('Magento\Framework\Json\Helper\Data')->jsonEncode($block->getImageTypes())
      ) ?>"


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
We experienced an issue with invalid JSON in the adminhtml when an image label contains html markup (example `&quot;`). This resulted in an error when opening the images and videos tab when editing an product.

### Fixed Issues (if relevant)
1. I do not know any current issues for this problem

### Manual testing scenarios
1. add a new image to an product in the adminhtml with an label containing " `&quot;` "
2. save the product 
3. check if you can open your images and video tab in the adminhtml

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
