### PR TITLE
Sort the street array by key when saving account address

### DIFF
--- a/app/code/Magento/Customer/Controller/Address/FormPost.php
+++ b/app/code/Magento/Customer/Controller/Address/FormPost.php
@@ -95,6 +95,8 @@ class FormPost extends \Magento\Customer\Controller\Address
      * Extract address from request
      *
      * @return \Magento\Customer\Api\Data\AddressInterface
+     *
+     * @throws \Exception
      */
     protected function _extractAddress()
     {
@@ -106,7 +108,11 @@ class FormPost extends \Magento\Customer\Controller\Address
             'customer_address_edit',
             $existingAddressData
         );
-        $addressData = $addressForm->extractData($this->getRequest());
+
+        $addressData = $this->ksortStreetData(
+            $addressForm->extractData($this->getRequest())
+        );
+
         $attributeValues = $addressForm->compactData($addressData);
 
         $this->updateRegionData($attributeValues);
@@ -122,6 +128,26 @@ class FormPost extends \Magento\Customer\Controller\Address
             ->setIsDefaultShipping($this->getRequest()->getParam('default_shipping', false));
 
         return $addressDataObject;
+    }
+
+    /**
+     * Sort street data by key
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function ksortStreetData($data)
+    {
+        if (empty($data['street']) || !is_array($data['street'])) {
+            return $data;
+        }
+
+        $street = $data['street'];
+        ksort($street);
+        $data['street'] = $street;
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
### Description
This allows developers to choose any sort order for the
address fields, as long as the input element names are correct.

### Fixed Issues (if relevant)
When changing the street form fields sort order in `/customer/address/edit/`, they'd get saved in the order they appear in. So `[1 => "Central Ave", 0 => "54N"]` would still be saved as `[0 => "Central Ave", 1 => "54N"]`

### Manual testing scenarios
1. Manually create a form with action `/customer/address/formPost/id/<id>`
2. Keep the right street input names
3. Change the position of the fields
4. Save the form
5. The fields will be swapped

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
