### PR TITLE
Fix translations of category design theme not being applied

### DIFF
--- a/app/code/Magento/Catalog/Model/Design.php
+++ b/app/code/Magento/Catalog/Model/Design.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Catalog\Model;
 
+use \Magento\Framework\TranslateInterface;
+
 /**
  * Catalog Custom Category design Model
  *
@@ -32,6 +34,11 @@ class Design extends \Magento\Framework\Model\AbstractModel
     protected $_localeDate;
 
     /**
+     * @var TranslateInterface
+     */
+    private $translator;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
@@ -47,10 +54,13 @@ class Design extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\View\DesignInterface $design,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        TranslateInterface $translator = null
     ) {
         $this->_localeDate = $localeDate;
         $this->_design = $design;
+        $this->translator = $translator ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(TranslateInterface::class);
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
     }
 
@@ -63,6 +73,7 @@ class Design extends \Magento\Framework\Model\AbstractModel
     public function applyCustomDesign($design)
     {
         $this->_design->setDesignTheme($design);
+        $this->translator->loadData(null, true);
         return $this;
     }
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/DesignTest.php
@@ -32,8 +32,12 @@ class DesignTest extends \PHPUnit\Framework\TestCase
         $design = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
             \Magento\Framework\View\DesignInterface::class
         );
+        $translate = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Framework\TranslateInterface::class
+        );
         $this->assertEquals('package', $design->getDesignTheme()->getPackageCode());
         $this->assertEquals('theme', $design->getDesignTheme()->getThemeCode());
+        $this->assertEquals('themepackage/theme', $translate->getTheme());
     }
 
     /**


### PR DESCRIPTION
### Description
Currently if you enable custom design theme for category the translations of selected theme are not used. This commit fixes the problem.

### Fixed Issues (if relevant)
magento/magento2#17625

### Manual testing scenarios
(Copied from #17625 )
1. Enable Magento_Blank for the website
2. Create a category and set Magento_Luma as it's theme
3. Add a translation to the /i18n/ directory of Magento_Luma
4. Flush caches
5. The translation is now not applied.
Commit changes point 5. so the translation is being applied

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
