### PR TITLE
[Backport] Fixes black background for png images in wysiwyg editors.

### DIFF
--- a/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
@@ -63,6 +63,16 @@ class Gd2 extends \Magento\Framework\Image\Adapter\AbstractAdapter
         }
         $this->imageDestroy();
         $this->_imageHandler = call_user_func($this->_getCallback('create'), $this->_fileName);
+        $fileType = $this->getImageType();
+        if (in_array($fileType, [IMAGETYPE_PNG, IMAGETYPE_GIF])) {
+            $this->_keepTransparency = true;
+            if ($this->_imageHandler) {
+                $isAlpha = $this->checkAlpha($this->_fileName);
+                if ($isAlpha) {
+                    $this->_fillBackgroundColor($this->_imageHandler);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16733

### Description
This PR fixes the black background for png images, which are uploaded in wysiwyg editors. This issue appears only for GD2 image processing library.

### Fixed Issues (if relevant)
1. magento/magento2#14248: Transparent background becomes black for thumbnails of PNG into Wysiwyg editor

### Manual testing scenarios
1. Upload a png image from any wysiwyg editor
2. The background while previewing of this image should be transparent.
![61eb1dd578](https://user-images.githubusercontent.com/15868188/42616173-ecacb6ee-85b5-11e8-9071-77b0c193cbb5.jpg)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
