### PR TITLE
[Backport] Specify the table when adding field in massAction filter

### DIFF
--- a/app/code/Magento/Ui/Component/MassAction/Filter.php
+++ b/app/code/Magento/Ui/Component/MassAction/Filter.php
@@ -129,12 +129,12 @@ class Filter
         try {
             if (is_array($excluded) && !empty($excluded)) {
                 $this->filterBuilder->setConditionType('nin')
-                    ->setField($dataProvider->getPrimaryFieldName())
+                    ->setField('main_table.'.$dataProvider->getPrimaryFieldName())
                     ->setValue($excluded);
                 $dataProvider->addFilter($this->filterBuilder->create());
             } elseif (is_array($selected) && !empty($selected)) {
                 $this->filterBuilder->setConditionType('in')
-                    ->setField($dataProvider->getPrimaryFieldName())
+                    ->setField('main_table.'.$dataProvider->getPrimaryFieldName())
                     ->setValue($selected);
                 $dataProvider->addFilter($this->filterBuilder->create());
             }


### PR DESCRIPTION
Hi!
About the MassAction in admin Grid. When have a custom grid and apply custom \Magento\Sales\Model\ResourceModel\Order\Grid\Collection and override _initSelect for add join group etc ...
So, when we join some tables, we have the error 'ambiguous column name'.

### Fixed Issues (if relevant)
1. magento/magento2#17863: Specify the table when adding field when applySelectionOnTargetProvider() in Magento\Ui\Component\MassAction\Filter.php

### Manual testing scenarios
1. Have a custom collection grid like :
class Collection extends \Magento\Sales\Model\ResourceModel\Order\Grid\Collection { protected function _initSelect() { parent::_initSelect(); $this->getSelect() ->join('XXXXXX') ->group("XXXXX"); return $this; } }
2. Try to apply a mass action

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/17864