### PR TITLE
Fix for missing url_key after product import

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1561,7 +1561,10 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 }
                 $rowScope = $this->getRowScope($rowData);
 
-                $rowData[self::URL_KEY] = $this->getUrlKey($rowData);
+                $urlKey = $this->getUrlKey($rowData);
+                if (!empty($urlKey)) {
+                    $rowData[self::URL_KEY] = $urlKey;
+                }
 
                 $rowSku = $rowData[self::COL_SKU];
 


### PR DESCRIPTION
### Description
This fix will protect import for overwriting url_key when this is not specified in the import file.
`$this->getUrlKey($rowData);` This returns `url_key` when this is specified in the file or create it based on `name`, but in the situation when these 2 fields are missing in file empty string will be returned and used to overwrite url_key for imported products.

### Fixed Issues (if relevant)
1. magento/magento2#17023>: CSV Import of `sku,attribute` empties `url_key` value

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
