### PR TITLE
Do not overwrite URL Key with blank value

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2409,17 +2409,9 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
      */
     private function isNeedToValidateUrlKey($rowData)
     {
-        /**
-         * If the product exists, assume it already has a URL Key and even
-         * if a name is provided in the import data, it should not be used
-         * to overwrite that existing URL Key the product already has.
-         */
-        $isSkuExist = $this->isSkuExist($rowData[self::COL_SKU]);
-        if ($isSkuExist && !array_key_exists(self::URL_KEY, $rowData)) {
-            return false;
-        }
+        $urlKey = $this->getUrlKey($rowData);
         
-        return (!empty($rowData[self::URL_KEY]) || !empty($rowData[self::COL_NAME]))
+        return (!empty($urlKey))
             && (empty($rowData[self::COL_VISIBILITY])
             || $rowData[self::COL_VISIBILITY]
             !== (string)Visibility::getOptionArray()[Visibility::VISIBILITY_NOT_VISIBLE]);

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2733,14 +2733,12 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         }
         
         /**
-         * If the product already exists, do not overwrite its
-         * URL Key with a value generated from the provided name.
+         * If the product exists, assume it already has a URL Key and even
+         * if a name is provided in the import data, it should not be used
+         * to overwrite that existing URL Key the product already has.
          */
-        if ($this->isSkuExist($rowData[self::COL_SKU])) {
-            return '';
-        }
-
-        if (!empty($rowData[self::COL_NAME])) {
+        $isSkuExist = $this->isSkuExist($rowData[self::COL_SKU]);
+        if (!$isSkuExist && !empty($rowData[self::COL_NAME])) {
             return $this->productUrl->formatUrlKey($rowData[self::COL_NAME]);
         }
 

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1561,10 +1561,6 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 }
                 $rowScope = $this->getRowScope($rowData);
 
-                /**
-                 * Only populate URL KEY if a value has been provided.
-                 * @see https://github.com/magento/magento2/issues/17023
-                 */
                 if ($urlKey = $this->getUrlKey($rowData)) {
                     $rowData[self::URL_KEY] = $urlKey;
                 }
@@ -2416,7 +2412,6 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
          * If the product exists, assume it already has a URL Key and even
          * if a name is provided in the import data, it should not be used
          * to overwrite that existing URL Key the product already has.
-         * @see https://github.com/magento/magento2/issues/17023
          */
         $isSkuExist = $this->isSkuExist($rowData[self::COL_SKU]);
         if ($isSkuExist && !array_key_exists(self::URL_KEY, $rowData)) {
@@ -2739,7 +2734,6 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         /**
          * If the product already exists, do not overwrite its
          * URL Key with a value generated from the provided name.
-         * @see https://github.com/magento/magento2/issues/17023
          */
         if ($this->isSkuExist($rowData[self::COL_SKU])) {
             return false;

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1561,7 +1561,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 }
                 $rowScope = $this->getRowScope($rowData);
 
-                if ($urlKey = $this->getUrlKey($rowData)) {
+                $urlKey = $this->getUrlKey($rowData);
+                if (!empty($urlKey)) {
                     $rowData[self::URL_KEY] = $urlKey;
                 }
 
@@ -2722,7 +2723,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
 
     /**
      * @param array $rowData
-     * @return string|bool
+     * @return string
      * @since 100.0.3
      */
     protected function getUrlKey($rowData)
@@ -2736,14 +2737,14 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
          * URL Key with a value generated from the provided name.
          */
         if ($this->isSkuExist($rowData[self::COL_SKU])) {
-            return false;
+            return '';
         }
 
         if (!empty($rowData[self::COL_NAME])) {
             return $this->productUrl->formatUrlKey($rowData[self::COL_NAME]);
         }
 
-        return false;
+        return '';
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1568,15 +1568,24 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
 
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple_with_url_key.php
-     * @magentoDbIsolation enabled
+     * @magentoDbIsolation disabled
      * @magentoAppIsolation enabled
      */
     public function testImportWithoutUrlKeys()
     {
+        $productRepository = $this->objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+        
         /**
          * Products `simple1` and `simple2` are created by fixture so already
          * have a URL Key, whereas `simple3` is a new product so won't have one.
+         * Therefore we delete `simple3` to ensure other tests do not impact this.
          */
+        try {
+            $productRepository->deleteById('simple3');
+        } catch (\Exception $e) {
+            // nothing to do, the product already does not exist
+        }
+        
         $products = [
             'simple1' => 'url-key',
             'simple2' => 'url-key2',
@@ -1601,7 +1610,6 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         $this->assertTrue($errors->getErrorsCount() == 0);
         $this->_model->importData();
 
-        $productRepository = $this->objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
         foreach ($products as $productSku => $productUrlKey) {
             $this->assertEquals($productUrlKey, $productRepository->get($productSku)->getUrlKey());
         }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1573,9 +1573,6 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
      */
     public function testImportWithoutUrlKeys()
     {
-        /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
-        $productRepository = $this->objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
-        
         /**
          * Products `simple1` and `simple2` are created by fixture so already
          * have a URL Key, whereas `new-simple` is a new product so the import
@@ -1605,8 +1602,9 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         $this->assertTrue($errors->getErrorsCount() == 0);
         $this->_model->importData();
 
+        $productRepository = $this->objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
         foreach ($products as $productSku => $productUrlKey) {
-            $this->assertEquals($productUrlKey, $productRepository->get($productSku, false, null, true)->getUrlKey());
+            $this->assertEquals($productUrlKey, $productRepository->get($productSku)->getUrlKey());
         }
     }
 

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1578,19 +1578,13 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         
         /**
          * Products `simple1` and `simple2` are created by fixture so already
-         * have a URL Key, whereas `simple3` is a new product so won't have one.
-         * Therefore we delete `simple3` to ensure other tests do not impact this.
+         * have a URL Key, whereas `new-simple` is a new product so the import
+         * will generate it's URL Key from the name provided in the CSV.
          */
-        try {
-            $productRepository->deleteById('simple3');
-        } catch (\Exception $e) {
-            // nothing to do, the product already does not exist
-        }
-        
         $products = [
-            'simple1' => 'url-key',
-            'simple2' => 'url-key2',
-            'simple3' => 'simple-3',
+            'simple1'    => 'url-key',
+            'simple2'    => 'url-key2',
+            'new-simple' => 'new-simple',
         ];
         $filesystem = $this->objectManager->create(\Magento\Framework\Filesystem::class);
         $directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1568,7 +1568,7 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
 
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple_with_url_key.php
-     * @magentoDbIsolation disabled
+     * @magentoDbIsolation enabled
      * @magentoAppIsolation enabled
      */
     public function testImportWithoutUrlKeys()

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1573,6 +1573,7 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
      */
     public function testImportWithoutUrlKeys()
     {
+        /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
         $productRepository = $this->objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
         
         /**
@@ -1611,7 +1612,7 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         $this->_model->importData();
 
         foreach ($products as $productSku => $productUrlKey) {
-            $this->assertEquals($productUrlKey, $productRepository->get($productSku)->getUrlKey());
+            $this->assertEquals($productUrlKey, $productRepository->get($productSku, false, null, true)->getUrlKey());
         }
     }
 

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1573,9 +1573,14 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
      */
     public function testImportWithoutUrlKeys()
     {
+        /**
+         * Products `simple1` and `simple2` are created by fixture so already
+         * have a URL Key, whereas `simple3` is new so will use the product
+         * name provided in the CSV import for its URL Key.
+         */
         $products = [
-            'simple1' => 'simple-1',
-            'simple2' => 'simple-2',
+            'simple1' => 'url-key',
+            'simple2' => 'url-key2',
             'simple3' => 'simple-3'
         ];
         $filesystem = $this->objectManager->create(\Magento\Framework\Filesystem::class);

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1568,20 +1568,19 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
 
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple_with_url_key.php
-     * @magentoDbIsolation disabled
+     * @magentoDbIsolation enabled
      * @magentoAppIsolation enabled
      */
     public function testImportWithoutUrlKeys()
     {
         /**
          * Products `simple1` and `simple2` are created by fixture so already
-         * have a URL Key, whereas `simple3` is new so will use the product
-         * name provided in the CSV import for its URL Key.
+         * have a URL Key, whereas `simple3` is a new product so won't have one.
          */
         $products = [
             'simple1' => 'url-key',
             'simple2' => 'url-key2',
-            'simple3' => 'simple-3'
+            'simple3' => 'simple-3',
         ];
         $filesystem = $this->objectManager->create(\Magento\Framework\Filesystem::class);
         $directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_without_url_keys.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_without_url_keys.csv
@@ -2,3 +2,4 @@ sku,product_type,store_view_code,name,price,attribute_set_code,url_key
 simple1,simple,,"simple 1",25,Default,""
 simple2,simple,,"simple 2",34,Default,""
 simple3,simple,,"simple 3",58,Default,""
+new-simple,simple,,"new simple",25,Default,""


### PR DESCRIPTION
### Description
- do not update existing products with a blank URL Key if no `url_key` value is provided in the import data
- do not update existing products with a new URL Key if a `name` but no `url_key` value is provided in the import data

### Fixed Issues
- magento/magento2#17023: CSV Import of `sku,attribute` empties `url_key` value

### Manual testing scenarios
See issue for details. Essentially if importing a CSV with `sku,name` or `sku,description` only, the result is the unexpected update or removal of the URL Key of the product.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)