### PR TITLE
Make sure all linked products (related, upsells, crosssells) show up …

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
@@ -47,22 +47,20 @@ class CollectionProvider
 
         $products = $this->providers[$type]->getLinkedProducts($product);
         $converter = $this->converterPool->getConverter($type);
-        $output = [];
         $sorterItems = [];
         foreach ($products as $item) {
-            $output[$item->getId()] = $converter->convert($item);
+            $itemId = $item->getId();
+            $sorterItems[$itemId] = $converter->convert($item);
+            $sorterItems[$itemId]['position'] = $sorterItems[$itemId]['position'] ?? 0;
         }
 
-        foreach ($output as $item) {
-            $itemPosition = $item['position'];
-            if (!isset($sorterItems[$itemPosition])) {
-                $sorterItems[$itemPosition] = $item;
-            } else {
-                $newPosition = $itemPosition + 1;
-                $sorterItems[$newPosition] = $item;
-            }
-        }
-        ksort($sorterItems);
+        usort($sorterItems, function ($itemA, $itemB) {
+            $posA = intval($itemA['position']);
+            $posB = intval($itemB['position']);
+
+            return $posA <=> $posB;
+        });
+
         return $sorterItems;
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/CollectionProviderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CollectionProviderTest.php
@@ -57,10 +57,14 @@ class CollectionProviderTest extends \PHPUnit\Framework\TestCase
         $linkedProductOneMock = $this->createMock(Product::class);
         $linkedProductTwoMock = $this->createMock(Product::class);
         $linkedProductThreeMock = $this->createMock(Product::class);
+        $linkedProductFourMock = $this->createMock(Product::class);
+        $linkedProductFiveMock = $this->createMock(Product::class);
 
         $linkedProductOneMock->expects($this->once())->method('getId')->willReturn(1);
         $linkedProductTwoMock->expects($this->once())->method('getId')->willReturn(2);
         $linkedProductThreeMock->expects($this->once())->method('getId')->willReturn(3);
+        $linkedProductFourMock->expects($this->once())->method('getId')->willReturn(4);
+        $linkedProductFiveMock->expects($this->once())->method('getId')->willReturn(5);
 
         $this->converterPoolMock->expects($this->once())
             ->method('getConverter')
@@ -71,9 +75,11 @@ class CollectionProviderTest extends \PHPUnit\Framework\TestCase
             [$linkedProductOneMock, ['name' => 'Product One', 'position' => 10]],
             [$linkedProductTwoMock, ['name' => 'Product Two', 'position' => 2]],
             [$linkedProductThreeMock, ['name' => 'Product Three', 'position' => 2]],
+            [$linkedProductFourMock, ['name' => 'Product Four', 'position' => null]],
+            [$linkedProductFiveMock, ['name' => 'Product Five']],
         ];
 
-        $this->converterMock->expects($this->exactly(3))->method('convert')->willReturnMap($map);
+        $this->converterMock->expects($this->exactly(5))->method('convert')->willReturnMap($map);
 
         $this->providerMock->expects($this->once())
             ->method('getLinkedProducts')
@@ -82,14 +88,18 @@ class CollectionProviderTest extends \PHPUnit\Framework\TestCase
                 [
                     $linkedProductOneMock,
                     $linkedProductTwoMock,
-                    $linkedProductThreeMock
+                    $linkedProductThreeMock,
+                    $linkedProductFourMock,
+                    $linkedProductFiveMock,
                 ]
             );
 
         $expectedResult = [
-            2 => ['name' => 'Product Two', 'position' => 2],
-            3 => ['name' => 'Product Three', 'position' => 2],
-            10 => ['name' => 'Product One', 'position' => 10],
+            0 => ['name' => 'Product Four', 'position' => 0],
+            1 => ['name' => 'Product Five', 'position' => 0],
+            2 => ['name' => 'Product Three', 'position' => 2],
+            3 => ['name' => 'Product Two', 'position' => 2],
+            4 => ['name' => 'Product One', 'position' => 10],
         ];
 
         $actualResult = $this->model->getCollection($this->productMock, 'crosssell');


### PR DESCRIPTION
…in the backend grids and in the correct order. Fixes #13720

### Description
This is a re-take of https://github.com/magento/magento2/pull/15251
This fixes https://github.com/magento/magento2/issues/13720 & https://github.com/magento/magento2/issues/14050
The problem was introduced in https://github.com/magento/magento2/commit/168701cc4706f2a7aac8aa3bc4f65edc8ac962dd & https://github.com/magento/magento2/commit/308b70baf1144f16ea062c74e96aab832a2a06eb

The fact that product link positions can be the same probably happens by importing products, you probably can't get to this state by just managing related, upsell or crosssell products in the adminhtml.

Next to the fix, I've also added two extra cases in the unit tests for when either the position isn't defined or doesn't exist, these are edge cases which will probably never happen, but I feel like this makes the code more robust. When the position isn't defined or doesn't exist, I've opted to set the position to `0` and this will cause those products to show up as the first ones in the list.

There is a small change in the result of the `$sorterItems` variable, in that the array keys no longer follow the position exactly. But in my testing this doesn't seem to have any negative effect.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13720: Only 2 related products are showing in backend
2. https://github.com/magento/magento2/issues/14050: Import related products issue


### Manual testing scenarios
1. Have a product with 5 to 10 related products
2. Go into the database and look at the table `catalog_product_link_attribute_int`
3. All positions (`value` column, for `product_link_attribute_id` == 1) should be unique if you created those related products through the backend
4. To simulate a product import where the positions can end up being non-unique, run the following query: `UPDATE catalog_product_link_attribute_int SET value = 1 WHERE product_link_attribute_id = 1;`
5. Take a look at the product in the adminhtml and open the `Related Products, Up-Sells, and Cross-Sells` section.
6. Without this fix, you'll only see 2 products, not the full list, with this fix all products show up in the correct sort order.
7. Also check the frontend, before and after the fix, the sort order will be the same over there, so frontend sort order isn't affected by this change.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
