### PR TITLE
Make RemoveAccentsTest pass on Alpine Linux

### DIFF
--- a/lib/internal/Magento/Framework/Filter/RemoveAccents.php
+++ b/lib/internal/Magento/Framework/Filter/RemoveAccents.php
@@ -176,9 +176,12 @@ class RemoveAccents implements \Zend_Filter_Interface
             }
         }
 
+        $mbstringSubstituteCharacter = ini_get('mbstring.substitute_character');
+        ini_set('mbstring.substitute_character', 'none');
         // convert string from default database format (UTF-8)
         // to encoding which replacement arrays made with (ISO-8859-1)
-        $convertedString = @iconv('UTF-8', 'ISO-8859-1//IGNORE', $string);
+        $convertedString = mb_convert_encoding($string, 'ISO-8859-1', 'UTF-8');
+        ini_set('mbstring.substitute_character', $mbstringSubstituteCharacter);
         if ($convertedString) {
             $string = $convertedString;
         }


### PR DESCRIPTION
This makes unit tests able to pass on Alpine Linux

### Description
The usages of `//IGNORE` with iconv makes `lib/internal/Magento/Framework/Filter/RemoveAccents.php` fail on system compiled with a iconv implementations that don't have this feature.

One of the library without `//IGNORE` is musl which is default for Alpine Linux and by extend also default for the [official Alpine Linux based PHP](https://hub.docker.com/_/php/) Docker images 

This pull request makes the unit test able to pass on PHP compiled with musl

The use of `//IGNORE` is also other places in Magento 2's code base but they are not making unit test fails so is only handling this case

### Manual testing scenarios

To run the examples you need Docker installed and working

#### Confirm that the current code works on glibc compiled PHP as expected
```
docker run -it --rm php:7.1-cli-stretch php -r "
$(
    curl -s https://raw.githubusercontent.com/magento/magento2/2.2.5/lib/internal/Magento/Framework/Filter/RemoveAccents.php |
    sed 's/ implements \\Zend_Filter_Interface//' |
    egrep -v '^<\?php'
)

\$filter = new RemoveAccents(true);
echo \$filter->filter('äöüÄÖÜß'), PHP_EOL;
"
```
Expected output: `aeoeueAeOeUess`

#### See the failing result when the code is run on Alpine Linux/musl compiled PHP
```
docker run -it --rm php:7.1.21-cli-alpine3.8 php -r "
$(
    curl -s https://raw.githubusercontent.com/magento/magento2/2.2.5/lib/internal/Magento/Framework/Filter/RemoveAccents.php |
    sed 's/ implements \\Zend_Filter_Interface//' |
    egrep -v '^<\?php'
)

\$filter = new RemoveAccents(true);
echo \$filter->filter('äöüÄÖÜß'), PHP_EOL;
"
```
Expected output: `A�A�A�A�A�AoeA�`

#### See the changes to the code give the expected result on Alpine Linux/musl compiled PHP
```
docker run -it --rm php:7.1.21-cli-alpine3.8 php -r "
$(
    curl -s https://raw.githubusercontent.com/magento/magento2/2.2.5/lib/internal/Magento/Framework/Filter/RemoveAccents.php |
    sed 's/ implements \\Zend_Filter_Interface//' |
    egrep -v '^<\?php' |
    sed 's!\$convertedString = @iconv.*;!ini_set("mbstring.substitute_character", "none"); $convertedString = mb_convert_encoding(\$string, "ISO-8859-1", "UTF-8");!g'
)

\$filter = new RemoveAccents(true);
echo \$filter->filter('äöüÄÖÜß'), PHP_EOL;
"
```
Expected output: `aeoeueAeOeUess`

