### PR TITLE
#17890: show correct text swatch values per store view

### DIFF
--- a/app/code/Magento/Swatches/Helper/Data.php
+++ b/app/code/Magento/Swatches/Helper/Data.php
@@ -499,10 +499,10 @@ class Data
                 && $swatches[$optionId]['type'] === $optionsArray[$currentStoreId]['type']
             ) {
                 $swatches[$optionId] = $optionsArray[$currentStoreId];
-            } else {
-                if (isset($optionsArray[self::DEFAULT_STORE_ID])) {
-                    $swatches[$optionId] = $optionsArray[self::DEFAULT_STORE_ID];
-                }
+            } elseif (isset($optionsArray[$currentStoreId])) {
+                $swatches[$optionId] = $optionsArray[$currentStoreId];
+            } elseif (isset($optionsArray[self::DEFAULT_STORE_ID])) {
+                $swatches[$optionId] = $optionsArray[self::DEFAULT_STORE_ID];
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Show correct text swatches values per store view. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17890: Magento 2.2.5 Product swatches does not shows correct value for related store view

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install fresh magento with default simple data
2. Edit swatch values for `size` attribute. 
3. Change value for default store to `XS D`. And for admin store set `XS A`  
![image](https://user-images.githubusercontent.com/1652800/44958591-050bb100-aeeb-11e8-8a29-4de6e405c021.png)
4. Run bin/magento index:reindex to reindex all indexes
5. Run bin/magento cache:clean block_html full_page
6. Open product view page on frontend SKU=MH01
7. Value of `size` attribute should have `XS D` value instead of `XS A`
![image](https://user-images.githubusercontent.com/1652800/44958841-641ef500-aeee-11e8-9e70-03bb8915dfb3.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
