### PR TITLE
fix inversed logic for adding stockstatus for configurable product subitems

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
@@ -45,7 +45,7 @@ class StockStatusBaseSelectProcessor implements BaseSelectProcessorInterface
      */
     public function process(Select $select)
     {
-        if ($this->stockConfig->isShowOutOfStock()) {
+        if (!$this->stockConfig->isShowOutOfStock()) {
             $select->joinInner(
                 ['stock' => $this->stockStatusResource->getMainTable()],
                 sprintf(

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Product/StockStatusBaseSelectProcessorTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Product/StockStatusBaseSelectProcessorTest.php
@@ -73,7 +73,7 @@ class StockStatusBaseSelectProcessorTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        if ($isShowOutOfStock) {
+        if (!$isShowOutOfStock) {
             $selectMock->expects($this->once())
                 ->method('joinInner')
                 ->with(


### PR DESCRIPTION
### Description
* the current logic is inversed as it will add the filter for stock only elements when the option is activated

### Fixed Issues (if relevant)
1. magento/magento2#16069: Configurable product price is not displayed if all children are out of stock and even if Display Out of Stock Products is set to "yes"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
