### PR TITLE
[Forwardport] Resolved : Wishlist icon cut on Shopping cart page in mobile view #17851 #27

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Wishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Wishlist/web/css/source/_module.less
@@ -277,6 +277,9 @@
             @_icon-font-color-hover: @primary__color,
             @_icon-font-color-active: @minicart-icons-color
             );
+            &:before {
+                overflow: visible;
+            }
         }
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17877
### Summary

Wishlist icon cut on Shopping cart page in mobile view.

Issue : https://github.com/magento/magento2/issues/17851

### Preconditions
1. Magento 2x - This issue reproduce in all version.


### Steps to reproduce
1. Login in your frontend.
2. Add any product in Cart.
3. Go to Shopping cart.
4. Switch mobile view.

### Expected result
<!--- Tell us what should happen -->
1. Wishlist icon should not cut in mobile view.
![screen shot 2018-08-29 at 17 16 32](https://user-images.githubusercontent.com/23443991/44785672-50eaed00-abaf-11e8-84db-226a4c0a1353.png)


### Actual result
<!--- Tell us what happens instead -->
1. Wishlist icon cut in mobile view.

![wishlist-icon](https://user-images.githubusercontent.com/23443991/44782289-5c84e680-aba4-11e8-9bf0-026fcf8f5a2f.png)

