### PR TITLE
[Forwardport] Remove leading Countrycode from EU-VAT-Numbers

### DIFF
--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -184,10 +184,11 @@ class Vat
 
             $requestParams = [];
             $requestParams['countryCode'] = $countryCode;
-            $this->isCountryInEU($countryCode) ? $requestParams['vatNumber'] = str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) : $requestParams['vatNumber'] = str_replace([' ', '-'], ['', ''], $vatNumber);
+            $this->isCountryInEU($countryCode) ? $vatNumberSanitized = str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) : $vatNumberSanitized = str_replace([' ', '-'], ['', ''], $vatNumber);
+            $requestParams['vatNumber'] = $vatNumberSanitized;
             $requestParams['requesterCountryCode'] = $requesterCountryCode;
-            $this->isCountryInEU($requesterCountryCode) ? $requestParams['requesterVatNumber'] = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) : $requestParams['requesterVatNumber'] = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
-
+            $this->isCountryInEU($requesterCountryCode) ? $requesterVatNumberSanitized = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) : $requesterVatNumberSanitized = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
+            $requestParams['requesterVatNumber'] = $requesterVatNumberSanitized;
             // Send request to service
             $result = $soapClient->checkVatApprox($requestParams);
 

--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -184,9 +184,9 @@ class Vat
 
             $requestParams = [];
             $requestParams['countryCode'] = $countryCode;
-            $requestParams['vatNumber'] = str_replace([' ', '-'], ['', ''], $vatNumber);
+            $this->isCountryInEU($countryCode) ? $requestParams['vatNumber'] = str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) : $requestParams['vatNumber'] = str_replace([' ', '-'], ['', ''], $vatNumber);
             $requestParams['requesterCountryCode'] = $requesterCountryCode;
-            $requestParams['requesterVatNumber'] = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
+            $this->isCountryInEU($requesterCountryCode) ? $requestParams['requesterVatNumber'] = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) : $requestParams['requesterVatNumber'] = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
 
             // Send request to service
             $result = $soapClient->checkVatApprox($requestParams);

--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -184,10 +184,14 @@ class Vat
 
             $requestParams = [];
             $requestParams['countryCode'] = $countryCode;
-            $this->isCountryInEU($countryCode) ? $vatNumberSanitized = str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) : $vatNumberSanitized = str_replace([' ', '-'], ['', ''], $vatNumber);
+            $this->isCountryInEU($countryCode) 
+                ? $vatNumberSanitized = str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) 
+                : $vatNumberSanitized = str_replace([' ', '-'], ['', ''], $vatNumber);
             $requestParams['vatNumber'] = $vatNumberSanitized;
             $requestParams['requesterCountryCode'] = $requesterCountryCode;
-            $this->isCountryInEU($requesterCountryCode) ? $requesterVatNumberSanitized = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) : $requesterVatNumberSanitized = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
+            $this->isCountryInEU($requesterCountryCode) 
+                ? $requesterVatNumberSanitized = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) 
+                : $requesterVatNumberSanitized = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
             $requestParams['requesterVatNumber'] = $requesterVatNumberSanitized;
             // Send request to service
             $result = $soapClient->checkVatApprox($requestParams);

--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -184,13 +184,13 @@ class Vat
 
             $requestParams = [];
             $requestParams['countryCode'] = $countryCode;
-            $vatNumberSanitized = $this->isCountryInEU($countryCode) 
-                ? str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) 
+            $vatNumberSanitized = $this->isCountryInEU($countryCode)
+                ? str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber)
                 : str_replace([' ', '-'], ['', ''], $vatNumber);
             $requestParams['vatNumber'] = $vatNumberSanitized;
             $requestParams['requesterCountryCode'] = $requesterCountryCode;
-            $reqVatNumSanitized = $this->isCountryInEU($requesterCountryCode) 
-                ? str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) 
+            $reqVatNumSanitized = $this->isCountryInEU($requesterCountryCode)
+                ? str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber)
                 : str_replace([' ', '-'], ['', ''], $requesterVatNumber);
             $requestParams['requesterVatNumber'] = $reqVatNumSanitized;
             // Send request to service

--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -190,9 +190,9 @@ class Vat
             $requestParams['vatNumber'] = $vatNumberSanitized;
             $requestParams['requesterCountryCode'] = $requesterCountryCode;
             $this->isCountryInEU($requesterCountryCode) 
-                ? $requesterVatNumberSanitized = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) 
-                : $requesterVatNumberSanitized = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
-            $requestParams['requesterVatNumber'] = $requesterVatNumberSanitized;
+                ? $reqVatNumSanitized = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) 
+                : $reqVatNumSanitized = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
+            $requestParams['requesterVatNumber'] = $reqVatNumSanitized;
             // Send request to service
             $result = $soapClient->checkVatApprox($requestParams);
 

--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -184,14 +184,14 @@ class Vat
 
             $requestParams = [];
             $requestParams['countryCode'] = $countryCode;
-            $this->isCountryInEU($countryCode) 
-                ? $vatNumberSanitized = str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) 
-                : $vatNumberSanitized = str_replace([' ', '-'], ['', ''], $vatNumber);
+            $vatNumberSanitized = $this->isCountryInEU($countryCode) 
+                ? str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber) 
+                : str_replace([' ', '-'], ['', ''], $vatNumber);
             $requestParams['vatNumber'] = $vatNumberSanitized;
             $requestParams['requesterCountryCode'] = $requesterCountryCode;
-            $this->isCountryInEU($requesterCountryCode) 
-                ? $reqVatNumSanitized = str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) 
-                : $reqVatNumSanitized = str_replace([' ', '-'], ['', ''], $requesterVatNumber);
+            $reqVatNumSanitized = $this->isCountryInEU($requesterCountryCode) 
+                ? str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber) 
+                : str_replace([' ', '-'], ['', ''], $requesterVatNumber);
             $requestParams['requesterVatNumber'] = $reqVatNumSanitized;
             // Send request to service
             $result = $soapClient->checkVatApprox($requestParams);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17385
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

EU-VAT-Numbers has always leading Countrycodes. To validate VAT-Number we have to remove it before sending the request.
After we've checked if country is in eu we will remove the Countrycode and send the request.

### Fixed Issues (if relevant)

EU-VAT-Numbers always invalid cause of leading Countrycodes.

### Manual testing scenarios

EU-VAT-Numbers looks like DEXXXXXXXXX for a german one.
Before change:
Giving DE 293 778 674 in Configuration->General->Store Information or in creating an Account will resullt in "Invalid VAT".
After change:
Giving DE 293 778 674 in Configuration->General->Store Information or in creating an Account will resullt in "VAT-Number is valid".

### Contribution checklist
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x ] All automated tests passed successfully (all builds on Travis CI are green)
