### PR TITLE
Add missing methods to Store API

### DIFF
--- a/app/code/Magento/Store/Api/Data/StoreInterface.php
+++ b/app/code/Magento/Store/Api/Data/StoreInterface.php
@@ -73,6 +73,28 @@ interface StoreInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     public function setStoreGroupId($storeGroupId);
 
     /**
+     * @return int
+     */
+    public function getSortOrder();
+
+    /**
+     * @param int $sortOrder
+     * @return $this
+     */
+    public function setSortOrder($sortOrder);
+
+    /**
+     * @return bool
+     */
+    public function getIsActive();
+
+    /**
+     * @param bool $isActive
+     * @return $this
+     */
+    public function setIsActive($isActive);
+
+    /**
      * Retrieve existing extension attributes object or create a new one.
      *
      * @return \Magento\Store\Api\Data\StoreExtensionInterface|null

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -24,10 +24,7 @@ use Magento\Store\Api\Data\StoreInterface;
  *
  * @api
  * @method Store setGroupId($value)
- * @method int getSortOrder()
  * @method int getStoreId()
- * @method Store setSortOrder($value)
- * @method Store setIsActive($value)
  *
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -533,6 +530,38 @@ class Store extends AbstractExtensibleModel implements
     public function setName($name)
     {
         return $this->setData('name', $name);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getIsActive()
+    {
+        return (bool)$this->_getData('is_active');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setIsActive($isActive)
+    {
+        return $this->setData('is_active', $isActive);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSortOrder()
+    {
+        return $this->_getData('sort_order');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setSortOrder($sortOrder)
+    {
+        return $this->setData('sort_order', $sortOrder);
     }
 
     /**
@@ -1225,7 +1254,7 @@ class Store extends AbstractExtensibleModel implements
      */
     public function isActive()
     {
-        return (bool)$this->_getData('is_active');
+        return $this->getIsActive();
     }
 
     /**


### PR DESCRIPTION
### Description
The PR adds missing methods to ``\Magento\Store\Api\Data\StoreInterface``:
- getSortOrder
- setSortOrder
- getIsActive
- setIsActive


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17896: Add isActive implementation to StoreInterface

### Manual testing scenarios
1. Use the ``storeStoreRepositoryV1`` REST API resource (GET `/V1/store/storeViews`) in order to retrieve the list of all stores.
2. There are two additional values should be available for each store: ``sort_order`` and ``is_active``.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
