### PR TITLE
[2.2] return $this from setters in Analytics/ReportXml/DB/SelectBuilder.php

### DIFF
--- a/app/code/Magento/Analytics/ReportXml/DB/SelectBuilder.php
+++ b/app/code/Magento/Analytics/ReportXml/DB/SelectBuilder.php
@@ -87,11 +87,13 @@ class SelectBuilder
      * Set joins conditions
      *
      * @param array $joins
-     * @return void
+     * @return $this
      */
     public function setJoins($joins)
     {
         $this->joins = $joins;
+
+        return $this;
     }
 
     /**
@@ -108,11 +110,13 @@ class SelectBuilder
      * Set connection name
      *
      * @param string $connectionName
-     * @return void
+     * @return $this
      */
     public function setConnectionName($connectionName)
     {
         $this->connectionName = $connectionName;
+
+        return $this;
     }
 
     /**
@@ -129,11 +133,13 @@ class SelectBuilder
      * Set columns
      *
      * @param array $columns
-     * @return void
+     * @return $this
      */
     public function setColumns($columns)
     {
         $this->columns = $columns;
+
+        return $this;
     }
 
     /**
@@ -150,11 +156,13 @@ class SelectBuilder
      * Set filters
      *
      * @param array $filters
-     * @return void
+     * @return $this
      */
     public function setFilters($filters)
     {
         $this->filters = $filters;
+
+        return $this;
     }
 
     /**
@@ -171,11 +179,13 @@ class SelectBuilder
      * Set from condition
      *
      * @param array $from
-     * @return void
+     * @return $this
      */
     public function setFrom($from)
     {
         $this->from = $from;
+
+        return $this;
     }
 
     /**
@@ -238,11 +248,13 @@ class SelectBuilder
      * Set group
      *
      * @param array $group
-     * @return void
+     * @return $this
      */
     public function setGroup($group)
     {
         $this->group = $group;
+
+        return $this;
     }
 
     /**
@@ -259,11 +271,13 @@ class SelectBuilder
      * Set parameters
      *
      * @param array $params
-     * @return void
+     * @return $this
      */
     public function setParams($params)
     {
         $this->params = $params;
+
+        return $this;
     }
 
     /**
@@ -280,10 +294,12 @@ class SelectBuilder
      * Set having condition
      *
      * @param array $having
-     * @return void
+     * @return $this
      */
     public function setHaving($having)
     {
         $this->having = $having;
+
+        return $this;
     }
 }

--- a/app/code/Magento/Analytics/Test/Unit/ReportXml/DB/SelectBuilderTest.php
+++ b/app/code/Magento/Analytics/Test/Unit/ReportXml/DB/SelectBuilderTest.php
@@ -67,12 +67,12 @@ class SelectBuilderTest extends \PHPUnit\Framework\TestCase
             ['link-type' => 'right', 'table' => 'attribute', 'condition' => 'neq'],
         ];
         $groups = ['id', 'name'];
-        $this->selectBuilder->setConnectionName($connectionName);
-        $this->selectBuilder->setFrom($from);
-        $this->selectBuilder->setColumns($columns);
-        $this->selectBuilder->setFilters([$filter]);
-        $this->selectBuilder->setJoins($joins);
-        $this->selectBuilder->setGroup($groups);
+        $this->selectBuilder->setConnectionName($connectionName)
+            ->setFrom($from)
+            ->setColumns($columns)
+            ->setFilters([$filter])
+            ->setJoins($joins)
+            ->setGroup($groups);
         $this->resourceConnectionMock->expects($this->once())
             ->method('getConnection')
             ->with($connectionName)


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When setters return `this` then we can call methods in the chain,


