### PR TITLE
Improve pagination exception & add total pages to page_info

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products.php
@@ -110,10 +110,10 @@ class Products implements ResolverInterface
 
         $currentPage = $searchCriteria->getCurrentPage();
         if ($searchCriteria->getCurrentPage() > $maxPages && $searchResult->getTotalCount() > 0) {
-            $currentPage = new GraphQlInputException(
+            throw new GraphQlInputException(
                 __(
-                    'currentPage value %1 specified is greater than the number of pages available.',
-                    [$maxPages]
+                    'currentPage value %1 specified is greater than the %2 page(s) available.',
+                    [$currentPage, $maxPages]
                 )
             );
         }
@@ -123,7 +123,8 @@ class Products implements ResolverInterface
             'items' => $searchResult->getProductsSearchResult(),
             'page_info' => [
                 'page_size' => $searchCriteria->getPageSize(),
-                'current_page' => $currentPage
+                'current_page' => $currentPage,
+                'total_pages' => $maxPages
             ],
             'filters' => $this->filtersDataProvider->getData($layerType)
         ];

--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -29,6 +29,7 @@ input FilterTypeInput @doc(description: "FilterTypeInput specifies which action 
 type SearchResultPageInfo @doc(description: "SearchResultPageInfo provides navigation for the query response") {
     page_size: Int @doc(description: "Specifies the maximum number of items to return")
     current_page: Int @doc(description: "Specifies which page of results to return")
+    total_pages: Int @doc(description: "Total amount of pages")
 }
 
 enum SortEnum @doc(description: "This enumeration indicates whether to return results in ascending or descending order") {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed pagination exception which used to display the wrong number on error, used the total number of pages instead of the current one.

Added pagination information by returning the total pages, making it easier to render navigation using GraphQL.

### Fixed Issues (if relevant)
None

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create GraphQL product query and query all the page_info fields, total_pages should be the number of pages available
```
page_info {
      page_size
      current_page
      total_pages
    }
```

2. Query products with a currentPage higher than the amount of available pages. You should get an exception message containing the requested page number and the total available pages


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
