### PR TITLE
pushing code for Upload category image with same image name #17661

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -167,10 +167,13 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     public function afterSave($object)
     {
         $value = $object->getData($this->additionalData . $this->getAttribute()->getName());
-
+        
         if ($this->isTmpFileAvailable($value) && $imageName = $this->getUploadedImageName($value)) {
             try {
-                $this->getImageUploader()->moveFileFromTmp($imageName);
+                $imageName = $this->getImageUploader()->moveFileFromTmp($imageName);                
+                $attributeName = $this->getAttribute()->getName();                                              
+                $object->setData($attributeName, $imageName);                                
+                $this->getAttribute()->getEntity()->saveAttribute($object, $attributeName);                                
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
             }

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -167,13 +167,15 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     public function afterSave($object)
     {
         $value = $object->getData($this->additionalData . $this->getAttribute()->getName());
-        
+               
         if ($this->isTmpFileAvailable($value) && $imageName = $this->getUploadedImageName($value)) {
             try {
-                $imageName = $this->getImageUploader()->moveFileFromTmp($imageName);                
-                $attributeName = $this->getAttribute()->getName();                                              
-                $object->setData($attributeName, $imageName);                                
-                $this->getAttribute()->getEntity()->saveAttribute($object, $attributeName);                                
+                $newImageName = $this->getImageUploader()->moveFileFromTmp($imageName);
+                if($newImageName!==$imageName){
+                    $attributeName = $this->getAttribute()->getName();
+                    $object->setData($attributeName, $newImageName);
+                    $this->getAttribute()->getEntity()->saveAttribute($object, $attributeName);
+                }
             } catch (\Exception $e) {
                 $this->_logger->critical($e);
             }

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -204,9 +204,9 @@ class ImageUploader
         $baseImagePath = $this->getFilePath($basePath, $imageName);
         $baseTmpImagePath = $this->getFilePath($baseTmpPath, $imageName);
         
-        $destinationFileAbsolutePath = $this->mediaDirectory->getAbsolutePath($baseImagePath);
-        $fileInfo = pathinfo($destinationFileAbsolutePath);
-        if (file_exists($destinationFileAbsolutePath)) {
+        $destinationFile = $this->mediaDirectory->getAbsolutePath($baseImagePath);
+        $fileInfo = pathinfo($destinationFile);
+        if (file_exists($destinationFile)) {
             $index = 1;
             $imageName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
             while (file_exists($fileInfo['dirname'] . '/' . $imageName)) {

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -298,12 +298,10 @@ class ImageUploader
             while (file_exists($fileInfo['dirname'] . '/' . $baseName)) {
                 $baseName = $fileInfo['filename'] . '_' . $index . '.' . $fileInfo['extension'];
                 $index++;
-            }
-            $destFileName = $baseName;
-        } else {
-            return $fileInfo['basename'];
-        }
-
-        return $destFileName;
+            }            
+            return $baseName;
+        } 
+        
+        return $fileInfo['basename'];               
     }
 }

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -201,20 +201,11 @@ class ImageUploader
         $baseTmpPath = $this->getBaseTmpPath();
         $basePath = $this->getBasePath();
         
-        $baseImagePath = $this->getFilePath($basePath, $imageName);
+        $destinationImageName = $this->getNewFileName($imageName);
+
+        $baseImagePath = $this->getFilePath($basePath, $destinationImageName);
         $baseTmpImagePath = $this->getFilePath($baseTmpPath, $imageName);
-        
-        $destinationFile = $this->mediaDirectory->getAbsolutePath($baseImagePath);
-        $fileInfo = pathinfo($destinationFile);
-        if (file_exists($destinationFile)) {
-            $index = 1;
-            $imageName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
-            while (file_exists($fileInfo['dirname'] . '/' . $imageName)) {
-                $imageName = $fileInfo['filename'] . '_' . $index . '.' . $fileInfo['extension'];
-                $index++;
-            }            
-            $baseImagePath = $this->getFilePath($basePath, $imageName);
-        }           
+       
         try {
             $this->coreFileStorageDatabase->copyFile(
                 $baseTmpImagePath,
@@ -286,5 +277,33 @@ class ImageUploader
         }
 
         return $result;
+    }
+    
+    /**
+     * Get new file name if the same is already exists
+     *
+     * @param string $imageName
+     * @return string
+     */
+    
+    public function getNewFileName($imageName)
+    {
+        $basePath = $this->getBasePath();
+        $destinationFile = $this->mediaDirectory->getAbsolutePath($this->getFilePath($basePath, $imageName));
+        
+        $fileInfo = pathinfo($destinationFile);
+        if (file_exists($destinationFile)) {
+            $index = 1;
+            $baseName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
+            while (file_exists($fileInfo['dirname'] . '/' . $baseName)) {
+                $baseName = $fileInfo['filename'] . '_' . $index . '.' . $fileInfo['extension'];
+                $index++;
+            }
+            $destFileName = $baseName;
+        } else {
+            return $fileInfo['basename'];
+        }
+
+        return $destFileName;
     }
 }

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -298,10 +298,10 @@ class ImageUploader
             while (file_exists($fileInfo['dirname'] . '/' . $baseName)) {
                 $baseName = $fileInfo['filename'] . '_' . $index . '.' . $fileInfo['extension'];
                 $index++;
-            }            
+            }
             return $baseName;
-        } 
+        }
         
-        return $fileInfo['basename'];               
+        return $fileInfo['basename'];
     }
 }

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -200,10 +200,21 @@ class ImageUploader
     {
         $baseTmpPath = $this->getBaseTmpPath();
         $basePath = $this->getBasePath();
-
+        
         $baseImagePath = $this->getFilePath($basePath, $imageName);
         $baseTmpImagePath = $this->getFilePath($baseTmpPath, $imageName);
-
+        
+        $destinationFileAbsolutePath = $this->mediaDirectory->getAbsolutePath($baseImagePath);
+        $fileInfo = pathinfo($destinationFileAbsolutePath);
+        if (file_exists($destinationFileAbsolutePath)) {
+            $index = 1;
+            $imageName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
+            while (file_exists($fileInfo['dirname'] . '/' . $imageName)) {
+                $imageName = $fileInfo['filename'] . '_' . $index . '.' . $fileInfo['extension'];
+                $index++;
+            }            
+            $baseImagePath = $this->getFilePath($basePath, $imageName);
+        }           
         try {
             $this->coreFileStorageDatabase->copyFile(
                 $baseTmpImagePath,

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -67,7 +67,10 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
         $this->imageUploader = $this->createPartialMock(
             \Magento\Catalog\Model\ImageUploader::class,
-            ['moveFileFromTmp']
+            [   
+                'moveFileFromTmp',
+                'getNewFileName',
+            ]
         );
 
         $this->filesystem = $this->getMockBuilder(\Magento\Framework\Filesystem::class)->disableOriginalConstructor()
@@ -146,9 +149,11 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      */
     public function testBeforeSaveAttributeFileName()
     {
-        $model = $this->objectManager->getObject(\Magento\Catalog\Model\Category\Attribute\Backend\Image::class);
+        $model = $this->setUpModelForBeforeSave();
         $model->setAttribute($this->attribute);
 
+        $this->imageUploader->expects($this->any())->method('getNewFileName')->willReturn('test123.jpg');
+        
         $object = new \Magento\Framework\DataObject([
             'test_attribute' => [
                 ['name' => 'test123.jpg']
@@ -159,18 +164,41 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('test123.jpg', $object->getTestAttribute());
     }
-
+    
+    /**
+     * @return \Magento\Catalog\Model\Category\Attribute\Backend\Image
+     */
+    private function setUpModelForBeforeSave()
+    {
+        $objectManagerMock = $this->createPartialMock(\Magento\Framework\App\ObjectManager::class, ['get']);
+        $imageUploaderMock = $this->imageUploader;
+        $objectManagerMock->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($class, $params = []) use ($imageUploaderMock) {
+                if ($class === "Magento\Catalog\CategoryImageUpload") {
+                    return $imageUploaderMock;
+                }
+                return $this->objectManager->get($class, $params);
+            }));
+        $model = $this->objectManager->getObject(\Magento\Catalog\Model\Category\Attribute\Backend\Image::class, [
+            'objectManager' => $objectManagerMock,
+            'logger' => $this->logger,
+            'filesystem' => $this->filesystem
+        ]);
+        $this->objectManager->setBackwardCompatibleProperty($model, 'imageUploader', $this->imageUploader);
+        return $model->setAttribute($this->attribute);
+    }
+    
+    
     /**
      * Test beforeSaveAttributeFileNameOutsideOfCategoryDir.
      */
     public function testBeforeSaveAttributeFileNameOutsideOfCategoryDir()
     {
-        $model = $this->objectManager->getObject(\Magento\Catalog\Model\Category\Attribute\Backend\Image::class, [
-            'filesystem' => $this->filesystem
-        ]);
+        $model = $this->setUpModelForBeforeSave();
 
         $model->setAttribute($this->attribute);
-
+        
         $this->filesystem
             ->expects($this->once())
             ->method('getUri')
@@ -185,7 +213,10 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 ]
             ]
         ]);
-
+        
+        $this->imageUploader->expects($this->any())->method('getNewFileName')
+                ->willReturn('/pub/media/wysiwyg/test123.jpg');
+        
         $model->beforeSave($object);
 
         $this->assertEquals('/pub/media/wysiwyg/test123.jpg', $object->getTestAttribute());
@@ -200,7 +231,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      */
     public function testBeforeSaveTemporaryAttribute()
     {
-        $model = $this->objectManager->getObject(\Magento\Catalog\Model\Category\Attribute\Backend\Image::class);
+        $model = $this->setUpModelForBeforeSave();
         $model->setAttribute($this->attribute);
 
         $object = new \Magento\Framework\DataObject([
@@ -208,7 +239,12 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 ['name' => 'test123.jpg', 'tmp_name' => 'abc123', 'url' => 'http://www.example.com/test123.jpg']
             ]
         ]);
-
+        
+        $this->imageUploader->expects($this->any())->method('getNewFileName')
+            ->willReturn(
+                ['name' => 'test123.jpg', 'tmp_name' => 'abc123', 'url' => 'http://www.example.com/test123.jpg']
+            );
+        
         $model->beforeSave($object);
 
         $this->assertEquals([

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -67,7 +67,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
         $this->imageUploader = $this->createPartialMock(
             \Magento\Catalog\Model\ImageUploader::class,
-            [   
+            [
                 'moveFileFromTmp',
                 'getNewFileName',
             ]
@@ -188,8 +188,8 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $this->objectManager->setBackwardCompatibleProperty($model, 'imageUploader', $this->imageUploader);
         return $model->setAttribute($this->attribute);
     }
-    
-    
+
+
     /**
      * Test beforeSaveAttributeFileNameOutsideOfCategoryDir.
      */

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -188,8 +188,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $this->objectManager->setBackwardCompatibleProperty($model, 'imageUploader', $this->imageUploader);
         return $model->setAttribute($this->attribute);
     }
-
-
+    
     /**
      * Test beforeSaveAttributeFileNameOutsideOfCategoryDir.
      */


### PR DESCRIPTION


### Description
Currently, when we upload two different category images with the same name in different categories it is replacing the existing image with the latest uploaded image. So I am adding a piece of code to check if the image already exists with the same name then I am updating the uploading image name then save it in the directory and update category image name with the new image name.

### Fixed Issues (if relevant)
1. magento/magento2#17661: Upload category image with same image name


### Manual testing scenarios

1. Take a category.
2. Upload Category image.
3. Save your category.
4. Take another Category and upload an image with another image but same image name.
5. Save your category.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
