### PR TITLE
Fix currency symbol setting back to default #17567

### DIFF
--- a/app/code/Magento/CurrencySymbol/Model/System/Currencysymbol.php
+++ b/app/code/Magento/CurrencySymbol/Model/System/Currencysymbol.php
@@ -192,9 +192,11 @@ class Currencysymbol
      */
     public function setCurrencySymbolsData($symbols = [])
     {
-        foreach ($this->getCurrencySymbolsData() as $code => $values) {
-            if (isset($symbols[$code]) && ($symbols[$code] == $values['parentSymbol'] || empty($symbols[$code]))) {
-                unset($symbols[$code]);
+        if (!$this->_storeManager->isSingleStoreMode()) {
+            foreach ($this->getCurrencySymbolsData() as $code => $values) {
+                if (isset($symbols[$code]) && ($symbols[$code] == $values['parentSymbol'] || empty($symbols[$code]))) {
+                    unset($symbols[$code]);
+                }
             }
         }
         $value = [];

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
@@ -23,10 +23,9 @@
             </label>
             <div class="admin__field-control">
                 <input id="custom_currency_symbol<?= /* @escapeNotVerified */ $code ?>"
-                       class="required-entry admin__control-text"
+                       class="required-entry admin__control-text <?= $data['inherited'] ? 'disabled' : '' ?>"
                        type="text"
                        value="<?= $block->escapeHtmlAttr($data['displaySymbol']) ?>"
-                       <?= $data['inherited'] ? ' disabled="disabled"' : '' ?>
                        name="custom_currency_symbol[<?= /* @escapeNotVerified */ $code ?>]">
                 <div class="admin__field admin__field-option">
                     <input id="custom_currency_symbol_inherit<?= /* @escapeNotVerified */ $code ?>"
@@ -49,16 +48,18 @@ require(['jquery', "mage/mage", 'prototype'], function(jQuery){
 
     function toggleUseDefault(code, value)
     {
-        checkbox = $('custom_currency_symbol_inherit'+code);
-        input = $('custom_currency_symbol'+code);
-        if (checkbox.checked) {
-            input.value = value;
-            input.disabled = true;
+        checkbox = jQuery('#custom_currency_symbol_inherit'+code);
+        input = jQuery('#custom_currency_symbol'+code);
+
+        if (checkbox.is(':checked')) {
+            input.addClass('disabled');
+            input.val(value);
+            input.prop('readonly', true);
         } else {
-            input.disabled = false;
+            input.removeClass('disabled');
+            input.prop('readonly', false);
         }
     }
-
     window.toggleUseDefault = toggleUseDefault;
 });
 </script>

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -166,6 +166,13 @@
     .admin__control-text,
     .admin__control-textarea {
         width: 100%;
+        &.disabled {
+            background-color: #e9e9e9;
+            border-color: #adadad;
+            color: #303030;
+            cursor: not-allowed;
+            opacity: .5;
+        }
     }
 }
 


### PR DESCRIPTION
### Description
Fixed currency Symbol setting back to default

### Fixed Issues

1. magento/magento2#17567: Currency symbol cannot be changed back to default value from admin panel in Single-store mode
  
### Manual testing scenarios

1. Set mode to Single-store in admin panel.
2. Go to currency symbols section.
3. Set custom currency symbol, then set it back to default.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
