### PR TITLE
Don't format Special Price value for Bundle Product

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -399,10 +399,7 @@ class Eav extends AbstractModifier
 
             foreach ($attributes as $attribute) {
                 if (null !== ($attributeValue = $this->setupAttributeData($attribute))) {
-                    if ($attribute->getFrontendInput() === 'price'
-                        && is_scalar($attributeValue)
-                        && !$this->isBundleSpecialPrice($attribute)
-                    ) {
+                    if ($this->isPriceAttribute($attribute, $attributeValue)) {
                         $attributeValue = $this->formatPrice($attributeValue);
                     }
                     $data[$productId][self::DATA_SOURCE_DEFAULT][$attribute->getAttributeCode()] = $attributeValue;
@@ -411,6 +408,20 @@ class Eav extends AbstractModifier
         }
 
         return $data;
+    }
+
+    /**
+     * Obtain if given attribute is a price
+     *
+     * @param \Magento\Catalog\Api\Data\ProductAttributeInterface $attribute
+     * @param string|integer $attributeValue
+     * @return bool
+     */
+    private function isPriceAttribute(ProductAttributeInterface $attribute, $attributeValue)
+    {
+        return $attribute->getFrontendInput() === 'price'
+            && is_scalar($attributeValue)
+            && !$this->isBundleSpecialPrice($attribute);
     }
 
     /**

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -399,12 +399,11 @@ class Eav extends AbstractModifier
 
             foreach ($attributes as $attribute) {
                 if (null !== ($attributeValue = $this->setupAttributeData($attribute))) {
-                    if ($attribute->getFrontendInput() === 'price' && is_scalar($attributeValue)) {
-                        if ($this->locator->getProduct()->getTypeId() !== ProductType::TYPE_BUNDLE
-                            || $attribute->getAttributeCode() !== ProductAttributeInterface::CODE_SPECIAL_PRICE
-                        ) {
-                            $attributeValue = $this->formatPrice($attributeValue);
-                        }
+                    if ($attribute->getFrontendInput() === 'price'
+                        && is_scalar($attributeValue)
+                        && !$this->isBundleSpecialPrice($attribute)
+                    ) {
+                        $attributeValue = $this->formatPrice($attributeValue);
                     }
                     $data[$productId][self::DATA_SOURCE_DEFAULT][$attribute->getAttributeCode()] = $attributeValue;
                 }
@@ -412,6 +411,18 @@ class Eav extends AbstractModifier
         }
 
         return $data;
+    }
+
+    /**
+     * Obtain if current product is bundle and given attribute is special_price
+     *
+     * @param \Magento\Catalog\Api\Data\ProductAttributeInterface $attribute
+     * @return bool
+     */
+    private function isBundleSpecialPrice(ProductAttributeInterface $attribute)
+    {
+        return $this->locator->getProduct()->getTypeId() === ProductType::TYPE_BUNDLE
+            && $attribute->getAttributeCode() === ProductAttributeInterface::CODE_SPECIAL_PRICE;
     }
 
     /**

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -32,6 +32,7 @@ use Magento\Ui\Component\Form\Fieldset;
 use Magento\Ui\DataProvider\Mapper\FormElement as FormElementMapper;
 use Magento\Ui\DataProvider\Mapper\MetaProperties as MetaPropertiesMapper;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory as AttributeCollectionFactory;
+use \Magento\Catalog\Model\Product\Type as ProductType;
 
 /**
  * Class Eav
@@ -399,7 +400,11 @@ class Eav extends AbstractModifier
             foreach ($attributes as $attribute) {
                 if (null !== ($attributeValue = $this->setupAttributeData($attribute))) {
                     if ($attribute->getFrontendInput() === 'price' && is_scalar($attributeValue)) {
-                        $attributeValue = $this->formatPrice($attributeValue);
+                        if ($this->locator->getProduct()->getTypeId() !== ProductType::TYPE_BUNDLE
+                            || $attribute->getAttributeCode() !== ProductAttributeInterface::CODE_SPECIAL_PRICE
+                        ) {
+                            $attributeValue = $this->formatPrice($attributeValue);
+                        }
                     }
                     $data[$productId][self::DATA_SOURCE_DEFAULT][$attribute->getAttributeCode()] = $attributeValue;
                 }


### PR DESCRIPTION
### Description
Pull Request solves the problem with incorrect rounding of Special Price in case of Bundle Product. In Bundle Products, Special Price is a percentage value, not a price that can be formatted (such as rounding).
The solution is not to format the value in this case as a price.

### Fixed Issues (if relevant)

1. magento/magento2#17638: Bundle Special Prices not correctly rounded

### Manual testing scenarios
Same as in the issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
