### PR TITLE
Menu does not work when you change from Mobile to Desktop mode #5402

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -481,6 +481,8 @@ define([
         _toggleDesktopMode: function () {
             var categoryParent, html;
 
+            $(this.element).off('mouseenter mouseleave click');
+
             this._on({
                 /**
                  * Prevent focus from sticking to links inside menu after clicking


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#5402: Menu does not work when you change from Mobile to Desktop mode
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create Parent category, and sub-category as part of the parent in Admin
2. Navigate to frontend.
3. Observe newly created category on desktop browser.
4. Resize browser to be mobile (width < 760px)
5. Resize browser back to be show full menu.
6. Click on any of the top level category links from the menu.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
