### PR TITLE
Adding and implementing interfaces to make possible to add extension attributes to cms page and block.

### DIFF
--- a/app/code/Magento/Cms/Api/Data/BlockExtensibleInterface.php
+++ b/app/code/Magento/Cms/Api/Data/BlockExtensibleInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Cms\Api\Data;
+
+use Magento\Cms\Api\Data\BlockExtensibleExtensionInterface;
+use Magento\Framework\Api\ExtensibleDataInterface;
+
+/**
+ * Interface BlockExtensibleInterface
+ * @package Magento\Cms\Api\Data
+ */
+interface BlockExtensibleInterface extends BlockInterface, ExtensibleDataInterface
+{
+    /**
+     * Get store ids
+     *
+     * @return int[]
+     */
+    public function getStores(): array;
+
+    /**
+     * Get extension attributes
+     *
+     * @return \Magento\Cms\Api\Data\BlockExtensibleExtensionInterface|null
+     */
+    public function getExtensionAttributes(): ?BlockExtensibleExtensionInterface;
+
+    /**
+     * Set extension attributes
+     *
+     * @param \Magento\Cms\Api\Data\BlockExtensibleExtensionInterface $extensionAttributes
+     *
+     * @return void
+     */
+    public function setExtensionAttributes(BlockExtensibleExtensionInterface $extensionAttributes): void;
+}

--- a/app/code/Magento/Cms/Api/Data/PageExtensibleInterface.php
+++ b/app/code/Magento/Cms/Api/Data/PageExtensibleInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Cms\Api\Data;
+
+use Magento\Cms\Api\Data\PageExtensibleExtensionInterface;
+use Magento\Framework\Api\ExtensibleDataInterface;
+
+/**
+ * Interface PageExtensibleInterface
+ * @package Magento\Cms\Api\Data
+ */
+interface PageExtensibleInterface extends PageInterface, ExtensibleDataInterface
+{
+    /**
+     * Get store ids
+     *
+     * @return int[]
+     */
+    public function getStores(): array;
+
+    /**
+     * Get extension attributes
+     *
+     * @return \Magento\Cms\Api\Data\PageExtensibleExtensionInterface|null
+     */
+    public function getExtensionAttributes(): ?PageExtensibleExtensionInterface;
+
+    /**
+     * Set extension attributes
+     *
+     * @param \Magento\Cms\Api\Data\PageExtensibleExtensionInterface $extensionAttributes
+     *
+     * @return void
+     */
+    public function setExtensionAttributes(PageExtensibleExtensionInterface $extensionAttributes): void;
+}

--- a/app/code/Magento/Cms/Model/BlockExtensible.php
+++ b/app/code/Magento/Cms/Model/BlockExtensible.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Cms\Model;
+
+use Magento\Cms\Api\Data\BlockExtensibleExtensionInterface;
+use Magento\Cms\Api\Data\BlockExtensibleInterface;
+use Magento\Cms\Model\ResourceModel\Block as BlockResource;
+use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\AbstractExtensibleModel;
+
+/**
+ * Class BlockExtensible
+ *
+ * @package Magento\Cms\Model
+ *
+ * TODO: Maybe this should be part of interface and we get rid of magic here
+ *
+ * TODO: Fix getters so they won't return any data set through $model->setData($key, $value)
+ *
+ * @method Block setStoreId(array $storeId)
+ * @method array getStoreId()
+ */
+class BlockExtensible extends AbstractExtensibleModel implements BlockExtensibleInterface, IdentityInterface
+{
+    /**
+     * @var string
+     */
+    public const CACHE_TAG = 'cms_b';
+
+    /**
+     * @var int
+     */
+    public const STATUS_ENABLED = 1;
+
+    /**
+     * @var int
+     */
+    public const STATUS_DISABLED = 0;
+
+    /**
+     * @var string
+     */
+    protected $_cacheTag = self::CACHE_TAG;
+
+    /**
+     * @var string
+     */
+    protected $_eventPrefix = 'cms_block';
+
+    /**
+     * Init
+     *
+     * @return void
+     */
+    protected function _construct(): void
+    {
+        $this->_init(BlockResource::class);
+    }
+
+    /**
+     * Prevent blocks recursion
+     *
+     * @return BlockExtensible
+     * @throws LocalizedException
+     */
+    public function beforeSave(): self
+    {
+        if ($this->hasDataChanges()) {
+            $this->setUpdateTime(null);
+        }
+
+        $needle = 'block_id="' . $this->getId() . '"';
+
+        if (strstr((string) $this->getContent(), $needle) == false) {
+            return parent::beforeSave();
+        }
+
+        throw new LocalizedException(
+            __('Make sure that static block content does not reference the block itself.')
+        );
+    }
+
+    /**
+     * Get identities
+     *
+     * @return array
+     */
+    public function getIdentities(): array
+    {
+        return [self::CACHE_TAG . '_' . $this->getId(), self::CACHE_TAG . '_' . $this->getIdentifier()];
+    }
+
+    /**
+     * Get id
+     *
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        $id = $this->getData(self::BLOCK_ID);
+        return empty($id) ? null : (int) $id;
+    }
+
+    /**
+     * Get identifier
+     *
+     * @return string|null
+     */
+    public function getIdentifier(): ?string
+    {
+        return $this->getData(self::IDENTIFIER);
+    }
+
+    /**
+     * Get title
+     *
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->getData(self::TITLE);
+    }
+
+    /**
+     * Get content
+     *
+     * @return string|null
+     */
+    public function getContent(): ?string
+    {
+        return $this->getData(self::CONTENT);
+    }
+
+    /**
+     * Get creation time
+     *
+     * @return string|null
+     */
+    public function getCreationTime(): ?string
+    {
+        return $this->getData(self::CREATION_TIME);
+    }
+
+    /**
+     * Get update time
+     *
+     * @return string|null
+     */
+    public function getUpdateTime(): ?string
+    {
+        return $this->getData(self::UPDATE_TIME);
+    }
+
+    /**
+     * Is active
+     *
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return (bool) $this->getData(self::IS_ACTIVE);
+    }
+
+    /**
+     * Set id
+     *
+     * @param int|mixed $id
+     * @return BlockExtensibleInterface
+     */
+    public function setId($id): BlockExtensibleInterface
+    {
+        $this->setData(self::BLOCK_ID, (int) $id);
+        return $this;
+    }
+
+    /**
+     * Set identifier
+     *
+     * @param string $identifier
+     *
+     * @return BlockExtensibleInterface
+     */
+    public function setIdentifier($identifier): BlockExtensibleInterface
+    {
+        $this->setData(self::IDENTIFIER, $identifier);
+        return $this;
+    }
+
+    /**
+     * Set title
+     *
+     * @param string $title
+     *
+     * @return BlockExtensibleInterface
+     */
+    public function setTitle($title): BlockExtensibleInterface
+    {
+        $this->setData(self::TITLE, $title);
+        return $this;
+    }
+
+    /**
+     * Set content
+     *
+     * @param string $content
+     *
+     * @return BlockExtensibleInterface
+     */
+    public function setContent($content): BlockExtensibleInterface
+    {
+        $this->setData(self::CONTENT, $content);
+        return $this;
+    }
+
+    /**
+     * Set creation time
+     *
+     * @param string $creationTime
+     *
+     * @return BlockExtensibleInterface
+     */
+    public function setCreationTime($creationTime): BlockExtensibleInterface
+    {
+        $this->setData(self::CREATION_TIME, $creationTime);
+        return $this;
+    }
+
+    /**
+     * Set update time
+     *
+     * @param string $updateTime
+     *
+     * @return BlockExtensibleInterface
+     */
+    public function setUpdateTime($updateTime): BlockExtensibleInterface
+    {
+        $this->setData(self::UPDATE_TIME, $updateTime);
+        return $this;
+    }
+
+    /**
+     * Set is active
+     *
+     * @param bool|int $isActive
+     *
+     * @return BlockExtensibleInterface
+     */
+    public function setIsActive($isActive): BlockExtensibleInterface
+    {
+        $this->setData(self::IS_ACTIVE, $isActive);
+        return $this;
+    }
+
+    /**
+     * Get stores
+     *
+     * @return int[]
+     */
+    public function getStores(): array
+    {
+        $storeDataByStoresKey = $this->getData('stores');
+        $storeDataByStoreIdKey = $this->getData('store_id');
+
+        if (!empty($storeDataByStoresKey)) {
+            return is_array($storeDataByStoresKey) ? $storeDataByStoresKey : [$storeDataByStoresKey];
+        } elseif (!empty($storeDataByStoreIdKey)) {
+            return is_array($storeDataByStoreIdKey) ? $storeDataByStoreIdKey : [$storeDataByStoreIdKey];
+        }
+
+        return [];
+    }
+
+    /**
+     * TODO: Move to separate OptionSourceInterface instance
+     *
+     * Prepare block's statuses.
+     *
+     * @return array
+     * @deprecated
+     */
+    public function getAvailableStatuses(): array
+    {
+        return [self::STATUS_ENABLED => __('Enabled'), self::STATUS_DISABLED => __('Disabled')];
+    }
+
+    /**
+     * Get extension attributes
+     *
+     * @return \Magento\Cms\Api\Data\BlockExtensibleExtensionInterface|null
+     *
+     * @codeCoverageIgnore
+     */
+    public function getExtensionAttributes(): ?BlockExtensibleExtensionInterface
+    {
+        return $this->_getExtensionAttributes();
+    }
+
+    /**
+     * Set extension attributes
+     *
+     * @param BlockExtensibleExtensionInterface $extensionAttributes
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    public function setExtensionAttributes(BlockExtensibleExtensionInterface $extensionAttributes): void
+    {
+        $this->_setExtensionAttributes($extensionAttributes);
+    }
+}

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -8,6 +8,8 @@ namespace Magento\Cms\Model;
 
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Cms\Api\Data;
+use Magento\Cms\Api\Data\BlockInterface;
+use Magento\Cms\Api\Data\BlockInterfaceFactory;
 use Magento\Cms\Model\ResourceModel\Block as ResourceBlock;
 use Magento\Cms\Model\ResourceModel\Block\CollectionFactory as BlockCollectionFactory;
 use Magento\Framework\Api\DataObjectHelper;
@@ -55,7 +57,7 @@ class BlockRepository implements BlockRepositoryInterface
     protected $dataObjectProcessor;
 
     /**
-     * @var \Magento\Cms\Api\Data\BlockInterfaceFactory
+     * @var BlockInterfaceFactory
      */
     protected $dataBlockFactory;
 
@@ -72,7 +74,7 @@ class BlockRepository implements BlockRepositoryInterface
     /**
      * @param ResourceBlock $resource
      * @param BlockFactory $blockFactory
-     * @param Data\BlockInterfaceFactory $dataBlockFactory
+     * @param BlockInterfaceFactory $dataBlockFactory
      * @param BlockCollectionFactory $blockCollectionFactory
      * @param Data\BlockSearchResultsInterfaceFactory $searchResultsFactory
      * @param DataObjectHelper $dataObjectHelper
@@ -83,7 +85,7 @@ class BlockRepository implements BlockRepositoryInterface
     public function __construct(
         ResourceBlock $resource,
         BlockFactory $blockFactory,
-        \Magento\Cms\Api\Data\BlockInterfaceFactory $dataBlockFactory,
+        BlockInterfaceFactory $dataBlockFactory,
         BlockCollectionFactory $blockCollectionFactory,
         Data\BlockSearchResultsInterfaceFactory $searchResultsFactory,
         DataObjectHelper $dataObjectHelper,
@@ -105,11 +107,11 @@ class BlockRepository implements BlockRepositoryInterface
     /**
      * Save Block data
      *
-     * @param \Magento\Cms\Api\Data\BlockInterface $block
+     * @param BlockInterface $block
      * @return Block
      * @throws CouldNotSaveException
      */
-    public function save(Data\BlockInterface $block)
+    public function save(BlockInterface $block)
     {
         if (empty($block->getStoreId())) {
             $block->setStoreId($this->storeManager->getStore()->getId());
@@ -132,7 +134,8 @@ class BlockRepository implements BlockRepositoryInterface
      */
     public function getById($blockId)
     {
-        $block = $this->blockFactory->create();
+        $block = $this->dataBlockFactory->create();
+        /** @var $block BlockInterface|BlockExtensible */
         $this->resource->load($block, $blockId);
         if (!$block->getId()) {
             throw new NoSuchEntityException(__('The CMS block with the "%1" ID doesn\'t exist.', $blockId));
@@ -166,11 +169,11 @@ class BlockRepository implements BlockRepositoryInterface
     /**
      * Delete Block
      *
-     * @param \Magento\Cms\Api\Data\BlockInterface $block
+     * @param BlockInterface $block
      * @return bool
      * @throws CouldNotDeleteException
      */
-    public function delete(Data\BlockInterface $block)
+    public function delete(BlockInterface $block)
     {
         try {
             $this->resource->delete($block);

--- a/app/code/Magento/Cms/Model/PageExtensible.php
+++ b/app/code/Magento/Cms/Model/PageExtensible.php
@@ -1,0 +1,722 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Cms\Model;
+
+use Magento\Cms\Api\Data\PageExtensibleExtensionInterface;
+use Magento\Cms\Api\Data\PageExtensibleInterface;
+use Magento\Cms\Helper\Page as PageHelper;
+use Magento\Cms\Model\ResourceModel\Page as PageResource;
+use Magento\Framework\Api\AttributeValueFactory;
+use Magento\Framework\Api\ExtensionAttributesFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\AbstractExtensibleModel;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Registry;
+
+/**
+ * TODO: Add missing unit tests
+ *
+ * TODO: Fix getters so they won't return any data set through $model->setData($key, $value)
+ *
+ * Class PageExtensible
+ *
+ * @package Magento\Cms\Model
+ */
+class PageExtensible extends AbstractExtensibleModel implements PageExtensibleInterface, IdentityInterface
+{
+    /**
+     * @var string
+     */
+    public const NOROUTE_PAGE_ID = 'no-route';
+
+    /**
+     * @var int
+     */
+    public const STATUS_ENABLED = 1;
+
+    /**
+     * @var int
+     */
+    public const STATUS_DISABLED = 0;
+
+    /**
+     * @var string
+     */
+    public const CACHE_TAG = 'cms_p';
+
+    /**
+     * @var string
+     */
+    protected $_cacheTag = self::CACHE_TAG;
+
+    /**
+     * @var string
+     */
+    protected $_eventPrefix = 'cms_page';
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * Init
+     *
+     * @return void
+     */
+    protected function _construct(): void
+    {
+        $this->_init(PageResource::class);
+    }
+
+    /**
+     * PageExtensible constructor.
+     *
+     * @param Context $context
+     * @param Registry $registry
+     * @param ExtensionAttributesFactory $extensionFactory
+     * @param AttributeValueFactory $customAttributeFactory
+     * @param ScopeConfigInterface $scopeConfig
+     * @param ResourceModel\Page $resource
+     * @param ResourceModel\Page\Collection $resourceCollection
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ExtensionAttributesFactory $extensionFactory,
+        AttributeValueFactory $customAttributeFactory,
+        ScopeConfigInterface $scopeConfig,
+        ResourceModel\Page $resource,
+        ResourceModel\Page\Collection $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct(
+            $context,
+            $registry,
+            $extensionFactory,
+            $customAttributeFactory,
+            $resource,
+            $resourceCollection,
+            $data
+        );
+
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Load
+     *
+     * @param int|null $id
+     * @param string|null $field
+     *
+     * @return PageExtensible
+     *
+     * @deprecated
+     *
+     * @see \Magento\Cms\Model\ResourceModel\Page::load
+     *
+     * @codeCoverageIgnore
+     */
+    public function load($id, $field = null): self
+    {
+        if ($id === null) {
+            return $this->noRoutePage();
+        }
+
+        $this->_resource->load($this, $id, $field);
+        return $this;
+    }
+
+    /**
+     * TODO: Should this be part of interface?
+     *
+     * No route page
+     *
+     * @return self
+     *
+     * @deprecated
+     */
+    public function noRoutePage(): self
+    {
+        return $this->load(self::NOROUTE_PAGE_ID, $this->getIdFieldName());
+    }
+
+    /**
+     * Before save
+     *
+     * @return PageExtensible
+     *
+     * @throws LocalizedException
+     *
+     * @codeCoverageIgnore
+     */
+    public function beforeSave(): self
+    {
+        $originalIdentifier = $this->getOrigData(self::IDENTIFIER);
+        $currentIdentifier = $this->getIdentifier();
+
+        if ($this->hasDataChanges()) {
+            $this->setUpdateTime(null);
+        }
+
+        if (!$this->getId() || $originalIdentifier === $currentIdentifier) {
+            return parent::beforeSave();
+        }
+
+        switch ($originalIdentifier) {
+            case $this->scopeConfig->getValue(PageHelper::XML_PATH_NO_ROUTE_PAGE):
+                throw new LocalizedException(
+                    __('This identifier is reserved for "CMS No Route Page" in configuration.')
+                );
+            case $this->scopeConfig->getValue(PageHelper::XML_PATH_HOME_PAGE):
+                throw new LocalizedException(__('This identifier is reserved for "CMS Home Page" in configuration.'));
+            case $this->scopeConfig->getValue(PageHelper::XML_PATH_NO_COOKIES_PAGE):
+                throw new LocalizedException(
+                    __('This identifier is reserved for "CMS No Cookies Page" in configuration.')
+                );
+        }
+
+        return parent::beforeSave();
+    }
+
+    /**
+     * TODO: Should this be part of interface? Using public function not in available in interface makes us depend on
+     *
+     * TODO: concrete implementation - maybe this should be marked as depracted and moved to separte service contract?
+     *
+     * @param string $identifier
+     * @param int $storeId
+     *
+     * @return int
+     *
+     * @throws LocalizedException
+     *
+     * @deprecated
+     *
+     * @see \Magento\Cms\Api\GetPageByIdentifierInterface::execute
+     */
+    public function checkIdentifier(string $identifier, int $storeId): int
+    {
+        return (int) $this->_resource->checkIdentifier($identifier, $storeId);
+    }
+
+    /**
+     * TODO: Move to separate OptionSourceInterface instance
+     *
+     * Prepare page's statuses.
+     * Available event cms_page_get_available_statuses to customize statuses.
+     *
+     * @return array
+     *
+     * @deprecated
+     *
+     * @codeCoverageIgnore
+     */
+    public function getAvailableStatuses(): array
+    {
+        return [self::STATUS_ENABLED => __('Enabled'), self::STATUS_DISABLED => __('Disabled')];
+    }
+
+    /**
+     * Get identities
+     *
+     * @return array
+     */
+    public function getIdentities(): array
+    {
+        return [self::CACHE_TAG . '_' . $this->getId()];
+    }
+
+    /**
+     * Get id
+     *
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        $id = $this->getData(self::PAGE_ID);
+        return empty($id) ? null : (int) $id;
+    }
+
+    /**
+     * Get identifier
+     *
+     * @return string|null
+     */
+    public function getIdentifier(): ?string
+    {
+        return $this->getData(self::IDENTIFIER);
+    }
+
+    /**
+     * Get title
+     *
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->getData(self::TITLE);
+    }
+
+    /**
+     * Get Page layout
+     *
+     * @return string|null
+     */
+    public function getPageLayout(): ?string
+    {
+        return $this->getData(self::PAGE_LAYOUT);
+    }
+
+    /**
+     * Get meta title
+     *
+     * @return string|null
+     */
+    public function getMetaTitle(): ?string
+    {
+        return $this->getData(self::META_TITLE);
+    }
+
+    /**
+     * Get meta keywords
+     *
+     * @return string|null
+     */
+    public function getMetaKeywords(): ?string
+    {
+        return $this->getData(self::META_KEYWORDS);
+    }
+
+    /**
+     * Get meta description
+     *
+     * @return string|null
+     */
+    public function getMetaDescription(): ?string
+    {
+        return $this->getData(self::META_DESCRIPTION);
+    }
+
+    /**
+     * Get content heading
+     *
+     * @return string|null
+     */
+    public function getContentHeading(): ?string
+    {
+        return $this->getData(self::CONTENT_HEADING);
+    }
+
+    /**
+     * Get content
+     *
+     * @return string|null
+     */
+    public function getContent(): ?string
+    {
+        return $this->getData(self::CONTENT);
+    }
+
+    /**
+     * Get creation time
+     *
+     * @return string|null
+     */
+    public function getCreationTime(): ?string
+    {
+        return $this->getData(self::CREATION_TIME);
+    }
+
+    /**
+     * Get update time
+     *
+     * @return string|null
+     */
+    public function getUpdateTime(): ?string
+    {
+        return $this->getData(self::UPDATE_TIME);
+    }
+
+    /**
+     * Get sort order
+     *
+     * @return string|null
+     */
+    public function getSortOrder(): ?string
+    {
+        return $this->getData(self::SORT_ORDER);
+    }
+
+    /**
+     * Get Layout update xml
+     *
+     * @return string|null
+     */
+    public function getLayoutUpdateXml(): ?string
+    {
+        return $this->getData(self::LAYOUT_UPDATE_XML);
+    }
+
+    /**
+     * Get custom theme
+     *
+     * @return string|null
+     */
+    public function getCustomTheme(): ?string
+    {
+        return $this->getData(self::CUSTOM_THEME);
+    }
+
+    /**
+     * Get custom root template
+     *
+     * @return string|null
+     */
+    public function getCustomRootTemplate(): ?string
+    {
+        return $this->getData(self::CUSTOM_ROOT_TEMPLATE);
+    }
+
+    /**
+     * Get custom layout update xml
+     *
+     * @return string|null
+     */
+    public function getCustomLayoutUpdateXml(): ?string
+    {
+        return $this->getData(self::CUSTOM_LAYOUT_UPDATE_XML);
+    }
+
+    /**
+     * Get custom theme from
+     *
+     * @return string|null
+     */
+    public function getCustomThemeFrom(): ?string
+    {
+        return $this->getData(self::CUSTOM_THEME_FROM);
+    }
+
+    /**
+     * Get custom theme
+     *
+     * @return string|null
+     */
+    public function getCustomThemeTo(): ?string
+    {
+        return $this->getData(self::CUSTOM_THEME_TO);
+    }
+
+    /**
+     * Is active
+     *
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return (bool) $this->getData(self::IS_ACTIVE);
+    }
+
+    /**
+     * Set id
+     *
+     * @param int|mixed $id
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setId($id): PageExtensibleInterface
+    {
+        $this->setData(self::PAGE_ID, $id);
+        return $this;
+    }
+
+    /**
+     * Set identifier
+     *
+     * @param string $identifier
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setIdentifier($identifier): PageExtensibleInterface
+    {
+        $this->setData(self::IDENTIFIER, $identifier);
+        return $this;
+    }
+
+    /**
+     * Set title
+     *
+     * @param string $title
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setTitle($title): PageExtensibleInterface
+    {
+        $this->setData(self::TITLE, $title);
+        return $this;
+    }
+
+    /**
+     * Set page layout
+     *
+     * @param string $pageLayout
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setPageLayout($pageLayout): PageExtensibleInterface
+    {
+        $this->setData(self::PAGE_LAYOUT, $pageLayout);
+        return $this;
+    }
+
+    /**
+     * Set meta title
+     *
+     * @param string $metaTitle
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setMetaTitle($metaTitle): PageExtensibleInterface
+    {
+        $this->setData(self::META_TITLE, $metaTitle);
+        return $this;
+    }
+
+    /**
+     * Set meta keywords
+     *
+     * @param string $metaKeywords
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setMetaKeywords($metaKeywords): PageExtensibleInterface
+    {
+        $this->setData(self::META_KEYWORDS, $metaKeywords);
+        return $this;
+    }
+
+    /**
+     * Set meta description
+     *
+     * @param string $metaDescription
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setMetaDescription($metaDescription): PageExtensibleInterface
+    {
+        $this->setData(self::META_DESCRIPTION, $metaDescription);
+        return $this;
+    }
+
+    /**
+     * Set content heading
+     *
+     * @param string $contentHeading
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setContentHeading($contentHeading): PageExtensibleInterface
+    {
+        $this->setData(self::CONTENT_HEADING, $contentHeading);
+        return $this;
+    }
+
+    /**
+     * Set content
+     *
+     * @param string $content
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setContent($content): PageExtensibleInterface
+    {
+        $this->setData(self::CONTENT, $content);
+        return $this;
+    }
+
+    /**
+     * Set creation time
+     *
+     * @param string $creationTime
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setCreationTime($creationTime): PageExtensibleInterface
+    {
+        $this->setData(self::CREATION_TIME, $creationTime);
+        return $this;
+    }
+
+    /**
+     * Set update time
+     *
+     * @param string|null $updateTime
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setUpdateTime($updateTime): PageExtensibleInterface
+    {
+        $this->setData(self::UPDATE_TIME, $updateTime);
+        return $this;
+    }
+
+    /**
+     * Set sort order
+     *
+     * @param string $sortOrder
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setSortOrder($sortOrder): PageExtensibleInterface
+    {
+        $this->setData(self::SORT_ORDER, $sortOrder);
+        return $this;
+    }
+
+    /**
+     * Set layout update xml
+     *
+     * @param string $layoutUpdateXml
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setLayoutUpdateXml($layoutUpdateXml): PageExtensibleInterface
+    {
+        $this->setData(self::LAYOUT_UPDATE_XML, $layoutUpdateXml);
+        return $this;
+    }
+
+    /**
+     * Set custom theme
+     *
+     * @param string $customTheme
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setCustomTheme($customTheme): PageExtensibleInterface
+    {
+        $this->setData(self::CUSTOM_THEME, $customTheme);
+        return $this;
+    }
+
+    /**
+     * Set custom root template
+     *
+     * @param string $customRootTemplate
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setCustomRootTemplate($customRootTemplate): PageExtensibleInterface
+    {
+        $this->setData(self::CUSTOM_ROOT_TEMPLATE, $customRootTemplate);
+        return $this;
+    }
+
+    /**
+     * Set custom layout update xml
+     *
+     * @param string $customLayoutUpdateXml
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setCustomLayoutUpdateXml($customLayoutUpdateXml): PageExtensibleInterface
+    {
+        $this->setData(self::CUSTOM_LAYOUT_UPDATE_XML, $customLayoutUpdateXml);
+        return $this;
+    }
+
+    /**
+     * Set custom theme from
+     *
+     * @param string $customThemeFrom
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setCustomThemeFrom($customThemeFrom): PageExtensibleInterface
+    {
+        $this->setData(self::CUSTOM_THEME_FROM, $customThemeFrom);
+        return $this;
+    }
+
+    /**
+     * Set custom theme to
+     *
+     * @param string $customThemeTo
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setCustomThemeTo($customThemeTo): PageExtensibleInterface
+    {
+        $this->setData(self::CUSTOM_THEME_TO, $customThemeTo);
+        return $this;
+    }
+
+    /**
+     * Set is active
+     *
+     * @param bool $isActive
+     *
+     * @return PageExtensibleInterface
+     */
+    public function setIsActive($isActive): PageExtensibleInterface
+    {
+        $this->setData(self::IS_ACTIVE, $isActive);
+        return $this;
+    }
+
+    /**
+     * Set stores
+     *
+     * @return int[]
+     */
+    public function getStores(): array
+    {
+        $storeDataByStoresKey = $this->getData('stores');
+        $storeDataByStoreIdKey = $this->getData('store_id');
+
+        if (!empty($storeDataByStoresKey)) {
+            return is_array($storeDataByStoresKey) ? $storeDataByStoresKey : [$storeDataByStoresKey];
+        } elseif (!empty($storeDataByStoreIdKey)) {
+            return is_array($storeDataByStoreIdKey) ? $storeDataByStoreIdKey : [$storeDataByStoreIdKey];
+        }
+
+        return [];
+    }
+
+    /**
+     * Get extension attributes
+     *
+     * @return \Magento\Cms\Api\Data\PageExtensibleExtensionInterface|null
+     *
+     * @codeCoverageIgnore
+     */
+    public function getExtensionAttributes(): ?PageExtensibleExtensionInterface
+    {
+        return $this->_getExtensionAttributes();
+    }
+
+    /**
+     * Set extension attributes
+     *
+     * @param \Magento\Cms\Api\Data\PageExtensibleExtensionInterface $extensionAttributes
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    public function setExtensionAttributes(PageExtensibleExtensionInterface $extensionAttributes): void
+    {
+        $this->_setExtensionAttributes($extensionAttributes);
+    }
+}

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -198,12 +198,13 @@ class PageRepository implements PageRepositoryInterface
      * Load Page data by given Page Identity
      *
      * @param string $pageId
-     * @return Page
+     * @return Data\PageInterface
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function getById($pageId)
     {
-        $page = $this->pageFactory->create();
+        $page = $this->dataPageFactory->create();
+        /** @var $page PageExtensible */
         $page->load($pageId);
         if (!$page->getId()) {
             throw new NoSuchEntityException(__('The CMS page with the "%1" ID doesn\'t exist.', $pageId));

--- a/app/code/Magento/Cms/Test/Unit/Model/BlockExtensibleTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/BlockExtensibleTest.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Cms\Test\Unit\Model;
+
+use Magento\Cms\Model\Block;
+use Magento\Cms\Model\BlockExtensible;
+use Magento\Cms\Model\ResourceModel\Block as BlockResource;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * Class BlockExtensibleTest
+ * @package Magento\Cms\Test\Unit\Model
+ */
+class BlockExtensibleTest extends TestCase
+{
+    /**
+     * @var BlockExtensible
+     */
+    private $blockExtensible;
+
+    /**
+     * @var BlockResource|MockObject
+     */
+    private $resourceMock;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->resourceMock = $this->createMock(BlockResource::class);
+        $this->objectManager = new ObjectManager($this);
+        $this->blockExtensible = $this->objectManager->getObject(
+            BlockExtensible::class,
+            [
+                'resource' => $this->resourceMock,
+            ]
+        );
+    }
+
+    /**
+     * Test beforeSave method
+     *
+     * @return void
+     *
+     * @throws LocalizedException
+     */
+    public function testBeforeSave(): void
+    {
+        $blockId = 7;
+        $this->blockExtensible->setData(Block::BLOCK_ID, $blockId);
+        $this->blockExtensible->setData(Block::CONTENT, 'test');
+
+        $this->objectManager->setBackwardCompatibleProperty(
+            $this->blockExtensible,
+            '_hasDataChanges',
+            true
+        );
+
+        $this->assertSame($this->blockExtensible, $this->blockExtensible->beforeSave());
+    }
+
+    /**
+     * Test beforeSave method
+     *
+     * @return void
+     *
+     * @throws LocalizedException
+     */
+    public function testBeforeSaveWhenBlockContentHasReferenceToItself(): void
+    {
+        $blockId = 10;
+        $this->blockExtensible->setData(Block::BLOCK_ID, $blockId);
+        $this->blockExtensible->setData(Block::CONTENT, 'Test block_id="' . $blockId . '".');
+
+        $this->objectManager->setBackwardCompatibleProperty(
+            $this->blockExtensible,
+            '_hasDataChanges',
+            false
+        );
+
+        $this->expectException(LocalizedException::class);
+        $this->blockExtensible->beforeSave();
+    }
+
+    /**
+     * Test getIdentities method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetIdentities()
+    {
+        $result = $this->blockExtensible->getIdentities();
+        $this->assertInternalType('array', $result);
+    }
+
+    /**
+     * Test getId method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetId()
+    {
+        $blockId = 12;
+        $this->blockExtensible->setData(Block::BLOCK_ID, $blockId);
+        $expected = $blockId;
+        $actual = $this->blockExtensible->getId();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getIdentifier method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetIdentifier()
+    {
+        $identifier = 'test01';
+        $this->blockExtensible->setData(Block::IDENTIFIER, $identifier);
+        $expected = $identifier;
+        $actual = $this->blockExtensible->getIdentifier();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getTitle method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetTitle()
+    {
+        $title = 'test02';
+        $this->blockExtensible->setData(Block::TITLE, $title);
+        $expected = $title;
+        $actual = $this->blockExtensible->getTitle();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getContent method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetContent()
+    {
+        $content = 'test03';
+        $this->blockExtensible->setData(Block::CONTENT, $content);
+        $expected = $content;
+        $actual = $this->blockExtensible->getContent();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getCreationTime method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetCreationTime()
+    {
+        $creationTime = 'test04';
+        $this->blockExtensible->setData(Block::CREATION_TIME, $creationTime);
+        $expected = $creationTime;
+        $actual = $this->blockExtensible->getCreationTime();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getUpdateTime method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetUpdateTime()
+    {
+        $updateTime = 'test05';
+        $this->blockExtensible->setData(Block::UPDATE_TIME, $updateTime);
+        $expected = $updateTime;
+        $actual = $this->blockExtensible->getUpdateTime();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test isActive method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testIsActive()
+    {
+        $isActive = true;
+        $this->blockExtensible->setData(Block::IS_ACTIVE, $isActive);
+        $result = $this->blockExtensible->isActive();
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test setId method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetId()
+    {
+        $blockId = 15;
+        $this->blockExtensible->setId($blockId);
+        $expected = $blockId;
+        $actual = $this->blockExtensible->getData(Block::BLOCK_ID);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test setIdentifier method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetIdentifier()
+    {
+        $identifier = 'test06';
+        $this->blockExtensible->setIdentifier($identifier);
+        $expected = $identifier;
+        $actual = $this->blockExtensible->getData(Block::IDENTIFIER);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test setTitle method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetTitle()
+    {
+        $title = 'test07';
+        $this->blockExtensible->setTitle($title);
+        $expected = $title;
+        $actual = $this->blockExtensible->getData(Block::TITLE);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test setContent method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetContent()
+    {
+        $content = 'test08';
+        $this->blockExtensible->setContent($content);
+        $expected = $content;
+        $actual = $this->blockExtensible->getData(Block::CONTENT);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test setCreationTime method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetCreationTime()
+    {
+        $creationTime = 'test09';
+        $this->blockExtensible->setCreationTime($creationTime);
+        $expected = $creationTime;
+        $actual = $this->blockExtensible->getData(Block::CREATION_TIME);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test setUpdateTime method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetUpdateTime()
+    {
+        $updateTime = 'test10';
+        $this->blockExtensible->setUpdateTime($updateTime);
+        $expected = $updateTime;
+        $actual = $this->blockExtensible->getData(Block::UPDATE_TIME);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test setIsActive method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testSetIsActive()
+    {
+        $this->blockExtensible->setIsActive(false);
+        $result = $this->blockExtensible->getData(Block::IS_ACTIVE);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test getStores method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetStoresWhenDataIsStoredUnderStoresKey()
+    {
+        $stores = [1, 4, 9];
+        $this->blockExtensible->setData('stores', $stores);
+        $expected = $stores;
+        $actual = $this->blockExtensible->getStores();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getStores method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetStoresWhenDataIsStoreIdKey()
+    {
+        $stores = [1, 4, 9];
+        $this->blockExtensible->setData('store_id', $stores);
+        $expected = $stores;
+        $actual = $this->blockExtensible->getStores();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getStores method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetStoresWhenThereIsNoStoreData()
+    {
+        $actual = $this->blockExtensible->getStores();
+        $this->assertSame([], $actual);
+    }
+
+    /**
+     * Test getAvailableStatuses method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetAvailableStatuses()
+    {
+        $result = $this->blockExtensible->getAvailableStatuses();
+        $this->assertInternalType('array', $result);
+    }
+}

--- a/app/code/Magento/Cms/Test/Unit/Model/BlockRepositoryTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/BlockRepositoryTest.php
@@ -5,15 +5,35 @@
  */
 namespace Magento\Cms\Test\Unit\Model;
 
+use Exception;
+use Magento\Cms\Api\Data\BlockInterface;
+use Magento\Cms\Api\Data\BlockInterfaceFactory;
+use Magento\Cms\Api\Data\BlockSearchResultsInterface;
+use Magento\Cms\Api\Data\BlockSearchResultsInterfaceFactory;
+use Magento\Cms\Model\BlockExtensible;
+use Magento\Cms\Model\BlockFactory;
 use Magento\Cms\Model\BlockRepository;
+use Magento\Cms\Model\ResourceModel\Block;
+use Magento\Cms\Model\ResourceModel\Block\Collection;
+use Magento\Cms\Model\ResourceModel\Block\CollectionFactory;
+use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Reflection\DataObjectProcessor;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for Magento\Cms\Model\BlockRepository
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
+class BlockRepositoryTest extends TestCase
 {
     /**
      * @var BlockRepository
@@ -21,47 +41,52 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
     protected $repository;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Cms\Model\ResourceModel\Block
+     * @var MockObject|Block
      */
     protected $blockResource;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Cms\Model\Block
+     * @var MockObject|Block
      */
     protected $block;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Cms\Api\Data\BlockInterface
+     * @var MockObject|BlockExtensible
+     */
+    protected $blockExtensible;
+
+    /**
+     * @var MockObject|BlockInterface
      */
     protected $blockData;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Cms\Api\Data\BlockSearchResultsInterface
+     * @var MockObject|BlockSearchResultsInterface
      */
     protected $blockSearchResult;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Api\DataObjectHelper
+     * @var MockObject|DataObjectHelper
      */
     protected $dataHelper;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Reflection\DataObjectProcessor
+     * @var MockObject|DataObjectProcessor
      */
     protected $dataObjectProcessor;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Cms\Model\ResourceModel\Block\Collection
+     * @var MockObject|Collection
      */
     protected $collection;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Store\Model\StoreManagerInterface
+     * @var MockObject|StoreManagerInterface
      */
     private $storeManager;
 
     /**
-     * @var CollectionProcessorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var CollectionProcessorInterface|MockObject
      */
     private $collectionProcessor;
 
@@ -70,45 +95,46 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        $this->blockResource = $this->getMockBuilder(\Magento\Cms\Model\ResourceModel\Block::class)
+        $this->blockResource = $this->getMockBuilder(Block::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->dataObjectProcessor = $this->getMockBuilder(\Magento\Framework\Reflection\DataObjectProcessor::class)
+        $this->dataObjectProcessor = $this->getMockBuilder(DataObjectProcessor::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $blockFactory = $this->getMockBuilder(\Magento\Cms\Model\BlockFactory::class)
+        $blockFactory = $this->getMockBuilder(BlockFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
-        $blockDataFactory = $this->getMockBuilder(\Magento\Cms\Api\Data\BlockInterfaceFactory::class)
+        $blockDataFactory = $this->getMockBuilder(BlockInterfaceFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
         $blockSearchResultFactory = $this->getMockBuilder(
-            \Magento\Cms\Api\Data\BlockSearchResultsInterfaceFactory::class
+            BlockSearchResultsInterfaceFactory::class
         )
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
-        $collectionFactory = $this->getMockBuilder(\Magento\Cms\Model\ResourceModel\Block\CollectionFactory::class)
+        $collectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
-        $this->storeManager = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
+        $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $store = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
+        $store = $this->getMockBuilder(StoreInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $store->expects($this->any())->method('getId')->willReturn(0);
         $this->storeManager->expects($this->any())->method('getStore')->willReturn($store);
 
-        $this->block = $this->getMockBuilder(\Magento\Cms\Model\Block::class)->disableOriginalConstructor()->getMock();
-        $this->blockData = $this->getMockBuilder(\Magento\Cms\Api\Data\BlockInterface::class)
+        $this->block = $this->getMockBuilder(Block::class)->disableOriginalConstructor()->getMock();
+        $this->blockExtensible = $this->getMockBuilder(BlockExtensible::class)->disableOriginalConstructor()->getMock();
+        $this->blockData = $this->getMockBuilder(BlockInterface::class)
             ->getMock();
-        $this->blockSearchResult = $this->getMockBuilder(\Magento\Cms\Api\Data\BlockSearchResultsInterface::class)
+        $this->blockSearchResult = $this->getMockBuilder(BlockSearchResultsInterface::class)
             ->getMock();
-        $this->collection = $this->getMockBuilder(\Magento\Cms\Model\ResourceModel\Block\Collection::class)
+        $this->collection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->setMethods(['addFieldToFilter', 'getSize', 'setCurPage', 'setPageSize', 'load', 'addOrder'])
             ->getMock();
@@ -118,7 +144,7 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->block);
         $blockDataFactory->expects($this->any())
             ->method('create')
-            ->willReturn($this->blockData);
+            ->willReturn($this->blockExtensible);
         $blockSearchResultFactory->expects($this->any())
             ->method('create')
             ->willReturn($this->blockSearchResult);
@@ -126,13 +152,13 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($this->collection);
         /**
-         * @var \Magento\Cms\Model\BlockFactory $blockFactory
-         * @var \Magento\Cms\Api\Data\BlockInterfaceFactory $blockDataFactory
-         * @var \Magento\Cms\Api\Data\BlockSearchResultsInterfaceFactory $blockSearchResultFactory
-         * @var \Magento\Cms\Model\ResourceModel\Block\CollectionFactory $collectionFactory
+         * @var BlockFactory $blockFactory
+         * @var BlockInterfaceFactory $blockDataFactory
+         * @var BlockSearchResultsInterfaceFactory $blockSearchResultFactory
+         * @var CollectionFactory $collectionFactory
          */
 
-        $this->dataHelper = $this->getMockBuilder(\Magento\Framework\Api\DataObjectHelper::class)
+        $this->dataHelper = $this->getMockBuilder(DataObjectHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -159,9 +185,9 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
     {
         $this->blockResource->expects($this->once())
             ->method('save')
-            ->with($this->block)
+            ->with($this->blockExtensible)
             ->willReturnSelf();
-        $this->assertEquals($this->block, $this->repository->save($this->block));
+        $this->assertEquals($this->blockExtensible, $this->repository->save($this->blockExtensible));
     }
 
     /**
@@ -171,16 +197,16 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
     {
         $blockId = '123';
 
-        $this->block->expects($this->once())
+        $this->blockExtensible->expects($this->once())
             ->method('getId')
             ->willReturn(true);
         $this->blockResource->expects($this->once())
             ->method('load')
-            ->with($this->block, $blockId)
-            ->willReturn($this->block);
+            ->with($this->blockExtensible, $blockId)
+            ->willReturn($this->blockExtensible);
         $this->blockResource->expects($this->once())
             ->method('delete')
-            ->with($this->block)
+            ->with($this->blockExtensible)
             ->willReturnSelf();
 
         $this->assertTrue($this->repository->deleteById($blockId));
@@ -188,48 +214,45 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     *
-     * @expectedException \Magento\Framework\Exception\CouldNotSaveException
      */
     public function testSaveException()
     {
         $this->blockResource->expects($this->once())
             ->method('save')
-            ->with($this->block)
-            ->willThrowException(new \Exception());
-        $this->repository->save($this->block);
+            ->with($this->blockExtensible)
+            ->willThrowException(new Exception());
+        $this->expectException(CouldNotSaveException::class);
+        $this->repository->save($this->blockExtensible);
     }
 
     /**
      * @test
-     *
-     * @expectedException \Magento\Framework\Exception\CouldNotDeleteException
      */
     public function testDeleteException()
     {
         $this->blockResource->expects($this->once())
             ->method('delete')
-            ->with($this->block)
-            ->willThrowException(new \Exception());
-        $this->repository->delete($this->block);
+            ->with($this->blockExtensible)
+            ->willThrowException(new Exception());
+        $this->expectException(CouldNotDeleteException::class);
+        $this->repository->delete($this->blockExtensible);
     }
 
     /**
      * @test
-     *
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testGetByIdException()
     {
         $blockId = '123';
 
-        $this->block->expects($this->once())
+        $this->blockExtensible->expects($this->once())
             ->method('getId')
-            ->willReturn(false);
+            ->willReturn(null);
         $this->blockResource->expects($this->once())
             ->method('load')
-            ->with($this->block, $blockId)
-            ->willReturn($this->block);
+            ->with($this->blockExtensible, $blockId)
+            ->willReturn($this->blockExtensible);
+        $this->expectException(NoSuchEntityException::class);
         $this->repository->getById($blockId);
     }
 
@@ -240,10 +263,10 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
     {
         $total = 10;
 
-        /** @var \Magento\Framework\Api\SearchCriteriaInterface $criteria */
-        $criteria = $this->getMockBuilder(\Magento\Framework\Api\SearchCriteriaInterface::class)->getMock();
+        /** @var SearchCriteriaInterface $criteria */
+        $criteria = $this->getMockBuilder(SearchCriteriaInterface::class)->getMock();
 
-        $this->collection->addItem($this->block);
+        $this->collection->addItem($this->blockExtensible);
         $this->collection->expects($this->once())
             ->method('getSize')
             ->willReturn($total);
@@ -263,7 +286,7 @@ class BlockRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $this->blockSearchResult->expects($this->once())
             ->method('setItems')
-            ->with([$this->block])
+            ->with([$this->blockExtensible])
             ->willReturnSelf();
         $this->assertEquals($this->blockSearchResult, $this->repository->getList($criteria));
     }

--- a/app/code/Magento/Cms/Test/Unit/Model/PageExtensibleTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/PageExtensibleTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Cms\Test\Unit\Model;
+
+use Magento\Cms\Helper\Page;
+use Magento\Cms\Model\PageExtensible;
+use Magento\Cms\Model\ResourceModel\Page as PageResource;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * Class PageExtensibleTest
+ * @package Magento\Cms\Test\Unit\Model
+ */
+class PageExtensibleTest extends TestCase
+{
+    /**
+     * @var PageExtensible
+     */
+    protected $pageExtensible;
+
+    /**
+     * @var Context|MockObject
+     */
+    protected $contextMock;
+
+    /**
+     * @var ManagerInterface|MockObject
+     */
+    protected $eventManagerMock;
+
+    /**
+     * @var PageResource|MockObject
+     */
+    protected $resourcePageMock;
+
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    protected $scopeConfigMock;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->eventManagerMock = $this->getMockBuilder(ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->eventManagerMock = $this->getMockBuilder(ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->resourcePageMock = $this->getMockBuilder(PageResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIdFieldName', 'load', 'checkIdentifier'])
+            ->getMock();
+        $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
+            ->getMock();
+
+        $this->contextMock->expects($this->any())
+            ->method('getEventDispatcher')
+            ->willReturn($this->eventManagerMock);
+        /*$this->resourcePageMock->expects($this->any())
+            ->method('getResources')
+            ->willReturn($this->resourceMock);*/
+
+        $objectManager = new ObjectManager($this);
+
+        $this->pageExtensible = $objectManager->getObject(
+            PageExtensible::class,
+            [
+                'context' => $this->contextMock,
+                'resource' => $this->resourcePageMock,
+                'scopeConfig' => $this->scopeConfigMock
+            ]
+        );
+    }
+
+    /**
+     * Test getStores method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetStoresWhenDataIsStoredUnderStoresKey()
+    {
+        $stores = [1, 4, 9];
+        $this->pageExtensible->setData('stores', $stores);
+        $expected = $stores;
+        $actual = $this->pageExtensible->getStores();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getStores method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetStoresWhenDataIsStoreIdKey()
+    {
+        $stores = [1, 4, 9];
+        $this->pageExtensible->setData('store_id', $stores);
+        $expected = $stores;
+        $actual = $this->pageExtensible->getStores();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getStores method
+     *
+     * @test
+     *
+     * @return void
+     */
+    public function testGetStoresWhenThereIsNoStoreData()
+    {
+        $actual = $this->pageExtensible->getStores();
+        $this->assertSame([], $actual);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function testNoRoutePage(): void
+    {
+        $this->assertEquals($this->pageExtensible, $this->pageExtensible->noRoutePage());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    public function testCheckIdentifier(): void
+    {
+        $identifier = '1';
+        $storeId = 2;
+        $fetchOneResult = 'some result';
+
+        $this->resourcePageMock->expects($this->atLeastOnce())
+            ->method('checkIdentifier')
+            ->with($identifier, $storeId)
+            ->willReturn($fetchOneResult);
+
+        $this->assertInternalType('int', $this->pageExtensible->checkIdentifier($identifier, $storeId));
+    }
+
+    /**
+     * @test
+     * @expectedExceptionMessage This identifier is reserved for "CMS No Route Page" in configuration.
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    public function testBeforeSave404Identifier(): void
+    {
+        $this->pageExtensible->setId(1);
+        $this->pageExtensible->setOrigData('identifier', 'no-route');
+        $this->pageExtensible->setIdentifier('no-route2');
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('getValue')
+            ->willReturnMap(
+                [
+                    [
+                        Page::XML_PATH_NO_ROUTE_PAGE,
+                        ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+                        null,
+                        'no-route'
+                    ]
+                ]
+            );
+
+        $this->expectException(LocalizedException::class);
+        $this->pageExtensible->beforeSave();
+    }
+
+    /**
+     * @test
+     * @expectedExceptionMessage This identifier is reserved for "CMS Home Page" in configuration.
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    public function testBeforeSaveHomeIdentifier(): void
+    {
+        $this->pageExtensible->setId(1);
+        $this->pageExtensible->setOrigData('identifier', 'home');
+        $this->pageExtensible->setIdentifier('home2');
+
+        $this->scopeConfigMock->expects($this->atLeastOnce())
+            ->method('getValue')
+            ->willReturnMap(
+                [
+                    [
+                        Page::XML_PATH_HOME_PAGE,
+                        ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+                        null,
+                        'home'
+                    ]
+                ]
+            );
+
+        $this->expectException(LocalizedException::class);
+        $this->pageExtensible->beforeSave();
+    }
+
+    /**
+     * @test
+     * @expectedExceptionMessage This identifier is reserved for "CMS No Cookies Page" in configuration.
+     *
+     * @return void
+     */
+    public function testBeforeSaveNoCookiesIdentifier(): void
+    {
+        $this->pageExtensible->setId(1);
+        $this->pageExtensible->setOrigData('identifier', 'no-cookies');
+        $this->pageExtensible->setIdentifier('no-cookies2');
+
+        $this->scopeConfigMock->expects($this->atLeastOnce())
+            ->method('getValue')
+            ->willReturnMap(
+                [
+                    [
+                        Page::XML_PATH_NO_COOKIES_PAGE,
+                        ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+                        null,
+                        'no-cookies'
+                    ]
+                ]
+            );
+
+        $this->expectException(LocalizedException::class);
+        $this->pageExtensible->beforeSave();
+    }
+}

--- a/app/code/Magento/Cms/etc/di.xml
+++ b/app/code/Magento/Cms/etc/di.xml
@@ -12,8 +12,10 @@
                 type="Magento\Framework\Api\SearchResults" />
     <preference for="Magento\Cms\Api\GetBlockByIdentifierInterface" type="Magento\Cms\Model\GetBlockByIdentifier" />
     <preference for="Magento\Cms\Api\GetPageByIdentifierInterface" type="Magento\Cms\Model\GetPageByIdentifier" />
-    <preference for="Magento\Cms\Api\Data\PageInterface" type="Magento\Cms\Model\Page" />
-    <preference for="Magento\Cms\Api\Data\BlockInterface" type="Magento\Cms\Model\Block" />
+    <preference for="Magento\Cms\Api\Data\PageInterface" type="Magento\Cms\Model\PageExtensible" />
+    <preference for="Magento\Cms\Api\Data\BlockInterface" type="Magento\Cms\Model\BlockExtensible" />
+    <preference for="Magento\Cms\Api\Data\PageExtensibleInterface" type="Magento\Cms\Model\PageExtensible" />
+    <preference for="Magento\Cms\Api\Data\BlockExtensibleInterface" type="Magento\Cms\Model\BlockExtensible" />
     <preference for="Magento\Cms\Api\BlockRepositoryInterface" type="Magento\Cms\Model\BlockRepository" />
     <preference for="Magento\Cms\Api\PageRepositoryInterface" type="Magento\Cms\Model\PageRepository" />
     <preference for="Magento\Ui\Component\Wysiwyg\ConfigInterface" type="Magento\Cms\Model\Wysiwyg\Config"/>

--- a/app/code/Magento/Cms/etc/di.xml
+++ b/app/code/Magento/Cms/etc/di.xml
@@ -12,8 +12,10 @@
                 type="Magento\Cms\Model\BlockSearchResults" />
     <preference for="Magento\Cms\Api\GetBlockByIdentifierInterface" type="Magento\Cms\Model\GetBlockByIdentifier" />
     <preference for="Magento\Cms\Api\GetPageByIdentifierInterface" type="Magento\Cms\Model\GetPageByIdentifier" />
-    <preference for="Magento\Cms\Api\Data\PageInterface" type="Magento\Cms\Model\Page" />
-    <preference for="Magento\Cms\Api\Data\BlockInterface" type="Magento\Cms\Model\Block" />
+    <preference for="Magento\Cms\Api\Data\PageInterface" type="Magento\Cms\Model\PageExtensible" />
+    <preference for="Magento\Cms\Api\Data\BlockInterface" type="Magento\Cms\Model\BlockExtensible" />
+    <preference for="Magento\Cms\Api\Data\PageExtensibleInterface" type="Magento\Cms\Model\PageExtensible" />
+    <preference for="Magento\Cms\Api\Data\BlockExtensibleInterface" type="Magento\Cms\Model\BlockExtensible" />
     <preference for="Magento\Cms\Api\BlockRepositoryInterface" type="Magento\Cms\Model\BlockRepository" />
     <preference for="Magento\Cms\Api\PageRepositoryInterface" type="Magento\Cms\Model\PageRepository\ValidationComposite" />
     <preference for="Magento\Ui\Component\Wysiwyg\ConfigInterface" type="Magento\Cms\Model\Wysiwyg\Config"/>


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Until now, there was no possibility to extend page and block models using extension attributes. Model has been fixed to enabled this option. According to backward compatibility models implements new interface, no changes were made in existing ones.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/magento2/issues/17458

### Manual testing scenarios
1. Add custom extension attribute 
2. Try if you can save and get it.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
