### PR TITLE
Fotorama loader replaced with actual product photo to visually speedup loading

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -235,6 +235,8 @@ class Gallery extends AbstractView
     }
 
     /**
+     * Get main product image
+     *
      * @param string $size
      * @return string
      */

--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -235,17 +235,18 @@ class Gallery extends AbstractView
     }
 
     /**
-     * @param string $image
      * @return string
      */
-    public function getMainProductImage()
+    public function getMainProductImage($size = 'medium_image_url')
     {
-        $image = $this->getGalleryImages()->toArray()['items'][0]['medium_image_url'];
+        foreach ($this->getGalleryImages() as $image) {
+            $image = $image->getData($size);
 
-        if (!$image) {
-            return $this->_imageHelper->getDefaultPlaceholderUrl('image');
+            if (!$image) {
+                return $this->_imageHelper->getDefaultPlaceholderUrl('image');
+            }
+
+            return $image;
         }
-
-        return $image;
     }
 }

--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -235,6 +235,7 @@ class Gallery extends AbstractView
     }
 
     /**
+     * @param string $size
      * @return string
      */
     public function getMainProductImage($size = 'medium_image_url')

--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -233,4 +233,19 @@ class Gallery extends AbstractView
 
         return $this->getData('gallery_images_config');
     }
+
+    /**
+     * @param string $image
+     * @return string
+     */
+    public function getMainProductImage()
+    {
+        $image = $this->getGalleryImages()->toArray()['items'][0]['medium_image_url'];
+
+        if (!$image) {
+            return $this->_imageHelper->getDefaultPlaceholderUrl('image');
+        }
+
+        return $image;
+    }
 }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -13,12 +13,10 @@
  */
 ?>
 
-<?php $images = $block->getGalleryImages()->toArray()['items'] ?>
-
 <div class="gallery-placeholder _block-content-loading" data-gallery-role="gallery-placeholder">
     <img
         class="gallery-placeholder__image"
-        src="<?= $images[0]['medium_image_url'] ?>"
+        src="<?= /* @escapeNotVerified */ $block->getMainProductImage() ?>"
     />
 </div>
 

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -12,32 +12,16 @@
  * @var $block \Magento\Catalog\Block\Product\View\Gallery
  */
 ?>
+
+<?php $images = $block->getGalleryImages()->toArray()['items'] ?>
+
 <div class="gallery-placeholder _block-content-loading" data-gallery-role="gallery-placeholder">
-    <div data-role="loader" class="loading-mask">
-        <div class="loader">
-            <img src="<?= /* @escapeNotVerified */ $block->getViewFileUrl('images/loader-1.gif') ?>"
-                 alt="<?= /* @escapeNotVerified */ __('Loading...') ?>">
-        </div>
-    </div>
+    <img
+        class="gallery-placeholder__image"
+        src="<?= $images[0]['medium_image_url'] ?>"
+    />
 </div>
-<!--Fix for jumping content. Loader must be the same size as gallery.-->
-<script>
-    var config = {
-            "width": <?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'width') ?>,
-            "thumbheight": <?php /* @escapeNotVerified */ echo $block->getImageAttribute('product_page_image_small', 'height')
-                        ?: $block->getImageAttribute('product_page_image_small', 'width'); ?>,
-            "navtype": "<?= /* @escapeNotVerified */ $block->getVar("gallery/navtype") ?>",
-            "height": <?= /* @escapeNotVerified */ $block->getImageAttribute('product_page_image_medium', 'height') ?>
-        },
-        thumbBarHeight = 0,
-        loader = document.querySelectorAll('[data-gallery-role="gallery-placeholder"] [data-role="loader"]')[0];
 
-    if (config.navtype === 'horizontal') {
-        thumbBarHeight = config.thumbheight;
-    }
-
-    loader.style.paddingBottom = ( config.height / config.width * 100) + "%";
-</script>
 <script type="text/x-magento-init">
     {
         "[data-gallery-role=gallery-placeholder]": {

--- a/lib/web/mage/gallery/gallery.less
+++ b/lib/web/mage/gallery/gallery.less
@@ -976,12 +976,9 @@
 
 // While first time init
 .gallery-placeholder {
-    .loading-mask {
-        padding: 0 0 50%;
-        position: static;
-    }
-    .loader img {
-        position: absolute;
+    &__image {
+        display: block;
+        margin: auto;
     }
 }
 
@@ -1002,6 +999,7 @@
         display: block;
     }
 }
+
 .fotorama__product-video--loaded {
     .fotorama__img, .fotorama__img--full {
         display: none !important;


### PR DESCRIPTION
### Description
I replaced Fotorama gallery loader with actual product photo, so until the full gallery is loaded, the user doesn't have to watch spinner for 3-30 seconds.

### Possible problems
This temporary photo might have different proportions than the default square, so in this case, it might behave weird (there will be visible flash when the Fotorma kicks in)

### Related Issues 
https://github.com/magento/magento2/issues/14667#issuecomment-415813263

### Manual testing scenarios
1. Load any product page
2. First product photo should be loaded almost immediately
3. After a few seconds, Fotorama gallery should replace the previously loaded photo.
