### PR TITLE
#17784 [CatalogImportExport][export] - added website store views to export

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -1195,12 +1195,12 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             $this->updateDataWithCategoryColumns($dataRow, $multiRawData['rowCategories'], $productId);
             if (!empty($multiRawData['rowWebsites'][$productId])) {
                 $websiteCodes = [];
-                $websiteStoreViewCodes = [];
+                $storeViewCodes = [];
                 foreach ($multiRawData['rowWebsites'][$productId] as $productWebsite) {
                     $websiteCodes[] = $this->_websiteIdToCode[$productWebsite];
                     if (isset($this->_websiteStoreViews[$productWebsite])) {
-                        $websiteStoreViewCodes = array_merge(
-                            $websiteStoreViewCodes,
+                        $storeViewCodes = array_merge(
+                            $storeViewCodes,
                             $this->_websiteStoreViews[$productWebsite]
                         );
                     }
@@ -1208,7 +1208,7 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
                 $dataRow[self::COL_PRODUCT_WEBSITES] =
                     implode(Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR, $websiteCodes);
                 $dataRow[self::COL_STORE] =
-                    implode(IMPORT::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR, $websiteStoreViewCodes);
+                    implode(IMPORT::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR, $storeViewCodes);
                 $multiRawData['rowWebsites'][$productId] = [];
             }
             if (!empty($multiRawData['mediaGalery'][$productLinkId])) {


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
I've added preloading of website store views, which are used to fill exported CSV file in column "store_view_code", which was empty.

### Fixed Issues (if relevant)
1. [magento/magento2#17784](https://github.com/magento/magento2/issues/17784): store_view_code column has empty values in csv


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create few websites, stores, and store views
2. Create few products, assign them to websites
3. Export data to CSV