### PR TITLE
Fixes saving product in single-store mode if website_id <> 1

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -809,7 +809,9 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         if (!$this->hasStoreIds()) {
             $storeIds = [];
             if ($websiteIds = $this->getWebsiteIds()) {
-                $websiteIds = array_keys($websiteIds);
+                if ($this->_storeManager->isSingleStoreMode()) {
+                    $websiteIds = array_keys($websiteIds);
+                }
                 foreach ($websiteIds as $websiteId) {
                     $websiteStores = $this->_storeManager->getWebsite($websiteId)->getStoreIds();
                     $storeIds = array_merge($storeIds, $websiteStores);

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -809,7 +809,8 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         if (!$this->hasStoreIds()) {
             $storeIds = [];
             if ($websiteIds = $this->getWebsiteIds()) {
-                foreach ($websiteIds as $websiteId => $selectedId) {
+                $websiteIds = array_keys($websiteIds);
+                foreach ($websiteIds as $websiteId) {
                     $websiteStores = $this->_storeManager->getWebsite($websiteId)->getStoreIds();
                     $storeIds = array_merge($storeIds, $websiteStores);
                 }

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -809,7 +809,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         if (!$this->hasStoreIds()) {
             $storeIds = [];
             if ($websiteIds = $this->getWebsiteIds()) {
-                foreach ($websiteIds as $websiteId) {
+                foreach ($websiteIds as $websiteId => $selectedId) {
                     $websiteStores = $this->_storeManager->getWebsite($websiteId)->getStoreIds();
                     $storeIds = array_merge($storeIds, $websiteStores);
                 }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
This PR fixes the saving product in a single store mode, where the default website was removed, and a new one it is used instead.

### Fixed Issues (if relevant)
1. magento/magento2#13405: No such entity error when saving product in single-store mode if website_id <> 1

### Manual testing scenarios
1. Install a clean version of Magento version 2.2.2
2. Add a new website, store and store view, and make this the default
3. Delete the preinstalled website, store and store view
4. Add a new product and save it
5. Change the configurations to single-store mode
6. Open the product and save it again


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
