### PR TITLE
Replace floatval() function by using direct type casting to (float)

### DIFF
--- a/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
@@ -53,7 +53,7 @@ abstract class AbstractAssertForm extends AbstractConstraint
             }
             $formValue = isset($formData[$key]) ? $formData[$key] : null;
             if (is_numeric($formValue)) {
-                $formValue = floatval($formValue);
+                $formValue = (float)$formValue;
             }
 
             if (null === $formValue) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/View/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/View/CustomOptions.php
@@ -231,7 +231,7 @@ class CustomOptions extends Form
         return [
             'options' => [
                 [
-                    'price' => floatval($price),
+                    'price' => (float)$price,
                     'max_characters' => $maxCharacters,
                 ],
             ]
@@ -262,7 +262,7 @@ class CustomOptions extends Form
         return [
             'options' => [
                 [
-                    'price' => floatval($price),
+                    'price' => (float)$price,
                     'file_extension' => $this->getOptionNotice($option, 1),
                     'image_size_x' => preg_replace('/[^0-9]/', '', $this->getOptionNotice($option, 2)),
                     'image_size_y' => preg_replace('/[^0-9]/', '', $this->getOptionNotice($option, 3)),
@@ -344,7 +344,7 @@ class CustomOptions extends Form
         return [
             'options' => [
                 [
-                    'price' => floatval($price),
+                    'price' => (float)$price,
                 ],
             ]
         ];

--- a/dev/tests/functional/tests/app/Magento/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogRule/Test/Constraint/AssertCatalogPriceRuleForm.php
@@ -42,10 +42,10 @@ class AssertCatalogPriceRuleForm extends AbstractConstraint
         $fixtureData = $catalogPriceRule->getData();
         //convert discount_amount to float to compare
         if (isset($formData['discount_amount'])) {
-            $formData['discount_amount'] = floatval($formData['discount_amount']);
+            $formData['discount_amount'] = (float)$formData['discount_amount'];
         }
         if (isset($fixtureData['discount_amount'])) {
-            $fixtureData['discount_amount'] = floatval($fixtureData['discount_amount']);
+            $fixtureData['discount_amount'] = (float)$fixtureData['discount_amount'];
         }
         $diff = $this->verifyData($formData, $fixtureData);
         \PHPUnit\Framework\Assert::assertTrue(

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Handler/DownloadableProduct/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Handler/DownloadableProduct/Webapi.php
@@ -148,7 +148,7 @@ class Webapi extends SimpleProductWebapi implements DownloadableProductInterface
             'title' => $link['title'],
             'sort_order' => isset($link['sort_order']) ? $link['sort_order'] : 0,
             'is_shareable' => $link['is_shareable'],
-            'price' => floatval($link['price']),
+            'price' => (float)$link['price'],
             'number_of_downloads' => isset($link['number_of_downloads']) ? $link['number_of_downloads'] : 0,
             'link_type' => $link['type'],
             'link_url' => isset($link['link_url']) ? $link['link_url'] : null,

--- a/dev/tests/functional/tests/app/Magento/Reports/Test/Constraint/AssertSalesReportIntervalResult.php
+++ b/dev/tests/functional/tests/app/Magento/Reports/Test/Constraint/AssertSalesReportIntervalResult.php
@@ -52,7 +52,7 @@ class AssertSalesReportIntervalResult extends AbstractAssertSalesReportResult
     {
         $data = [];
         foreach ($salesResult as $key => $result) {
-            $data[$key] = floatval($result);
+            $data[$key] = (float)$result;
         }
 
         return $data;

--- a/dev/tests/functional/tests/app/Magento/Reports/Test/Constraint/AssertSalesReportTotalResult.php
+++ b/dev/tests/functional/tests/app/Magento/Reports/Test/Constraint/AssertSalesReportTotalResult.php
@@ -52,7 +52,7 @@ class AssertSalesReportTotalResult extends AbstractAssertSalesReportResult
     {
         $data = [];
         foreach ($salesResult as $key => $result) {
-            $data[$key] = floatval($result);
+            $data[$key] = (float)$result;
         }
 
         return $data;

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
@@ -582,7 +582,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         ];
         foreach ($options as $option) {
             foreach ($option->getValues() as $value) {
-                $this->assertEquals($expectedValue[$value->getSku()], floatval($value->getPrice()));
+                $this->assertEquals($expectedValue[$value->getSku()], (float)$value->getPrice());
             }
         }
     }

--- a/lib/internal/Magento/Framework/Filter/Template/Tokenizer/Variable.php
+++ b/lib/internal/Magento/Framework/Filter/Template/Tokenizer/Variable.php
@@ -313,6 +313,6 @@ class Variable extends \Magento\Framework\Filter\Template\Tokenizer\AbstractToke
         if (!$this->isNumeric()) {
             $this->prev();
         }
-        return floatval($value);
+        return (float)$value;
     }
 }

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Real.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Real.php
@@ -63,7 +63,7 @@ class Real implements FactoryInterface
         }
 
         if (isset($data['default'])) {
-            $data['default'] = floatval($data['default']);
+            $data['default'] = (float)$data['default'];
         }
 
         return $this->objectManager->create($this->className, $data);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Direct type casting is **up to 6x faster** than using casting functions like` floatval()`. So this pull request replaces the `floatval()` functions by direct type casting to `(float)`.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16848: Replace floatval() function by using direct type casting to (float)

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
