### PR TITLE
Fix: If have no show Captcha on login page, still get message "Incorrect CAPTCHA" after post.

### DIFF
--- a/app/code/Magento/Captcha/Model/DefaultModel.php
+++ b/app/code/Magento/Captcha/Model/DefaultModel.php
@@ -314,7 +314,7 @@ class DefaultModel extends \Zend\Captcha\Image implements \Magento\Captcha\Model
         $storedWord = $this->getWord();
         $this->clearWord();
 
-        if (!$word || !$storedWord) {
+        if ($word != $storedWord) {
             return false;
         }
 

--- a/app/code/Magento/Captcha/Model/DefaultModel.php
+++ b/app/code/Magento/Captcha/Model/DefaultModel.php
@@ -314,8 +314,8 @@ class DefaultModel extends \Zend\Captcha\Image implements \Magento\Captcha\Model
         $storedWord = $this->getWord();
         $this->clearWord();
 
-        if ($word != $storedWord) {
-            return false;
+        if ($storedWord === null && !$word) {
+            return true;
         }
 
         if (!$this->isCaseSensitive()) {

--- a/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
@@ -135,7 +135,7 @@ class CheckUserLoginObserver implements ObserverInterface
             : null;
         if ($captchaModel->isRequired($login)) {
             $word = $this->captchaStringResolver->resolve($controller->getRequest(), $formId);
-            if ($word && !$captchaModel->isCorrect($word)) {
+            if (!$captchaModel->isCorrect($word)) {
                 try {
                     $customer = $this->getCustomerRepository()->get($login);
                     $this->getAuthentication()->processAuthenticationFailure($customer->getId());

--- a/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
+++ b/app/code/Magento/Captcha/Observer/CheckUserLoginObserver.php
@@ -135,7 +135,7 @@ class CheckUserLoginObserver implements ObserverInterface
             : null;
         if ($captchaModel->isRequired($login)) {
             $word = $this->captchaStringResolver->resolve($controller->getRequest(), $formId);
-            if (!$captchaModel->isCorrect($word)) {
+            if ($word && !$captchaModel->isCorrect($word)) {
                 try {
                     $customer = $this->getCustomerRepository()->get($login);
                     $this->getAuthentication()->processAuthenticationFailure($customer->getId());


### PR DESCRIPTION
### Description
<!---
 -->
  If have no show Captcha on login page, still get message "Incorrect CAPTCHA" after post.

### Manual testing scenarios
<!---
-->
   1. This problem happened when I try to login, if that captcha word and input area are not show on page (when you turned on Captcha)
it will still get the message "Incorrect CAPTCHA" after post.
In other word, captcha CheckUserLoginObserver always check captcha even have no show captcha on login page.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
