### PR TITLE
[MAGETWO-85227]:+ This commit fixes a incorrect fetch of column value…

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Extended.php
@@ -43,6 +43,13 @@ class Extended extends \Magento\Backend\Block\Widget\Grid implements \Magento\Ba
     protected $_collection;
 
     /**
+     * Collection object
+     *
+     * @var \Magento\Framework\Data\Collection
+     */
+    protected $_unloadedCollection;
+
+    /**
      * Export flag
      *
      * @var bool
@@ -477,6 +484,7 @@ class Extended extends \Magento\Backend\Block\Widget\Grid implements \Magento\Ba
             parent::_prepareCollection();
 
             if (!$this->_isExport) {
+                $this->_unloadedCollection = clone $this->getCollection();
                 $this->getCollection()->load();
                 $this->_afterLoadCollection();
             }
@@ -1250,6 +1258,16 @@ class Extended extends \Magento\Backend\Block\Widget\Grid implements \Magento\Ba
     public function getCollection()
     {
         return $this->_collection;
+    }
+
+    /**
+     * get collection object
+     *
+     * @return \Magento\Framework\Data\Collection
+     */
+    public function getUnloadedCollection()
+    {
+        return $this->_unloadedCollection;
     }
 
     /**

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -279,9 +279,13 @@ class Extended extends \Magento\Backend\Block\Widget
             $massActionIdField = $this->getParentBlock()->getMassactionIdField();
         }
 
-        $allIdsCollection->clear();
-        $allIdsCollection->setPageSize(0);
-        $gridIds = $allIdsCollection->getColumnValues($massActionIdField);
+
+        $gridIds = [];
+        if ($allIdsCollection) {
+            $allIdsCollection->clear();
+            $allIdsCollection->setPageSize(0);
+            $gridIds = $allIdsCollection->getColumnValues($massActionIdField);
+        }
 
         if (!empty($gridIds)) {
             return join(",", $gridIds);

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -279,7 +279,6 @@ class Extended extends \Magento\Backend\Block\Widget
             $massActionIdField = $this->getParentBlock()->getMassactionIdField();
         }
 
-
         $gridIds = [];
         if ($allIdsCollection) {
             $allIdsCollection->clear();

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -272,15 +272,16 @@ class Extended extends \Magento\Backend\Block\Widget
         }
 
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
-        $allIdsCollection = clone $this->getParentBlock()->getCollection();
-
+        $allIdsCollection = $this->getParentBlock()->getUnloadedCollection();
         if ($this->getMassactionIdField()) {
             $massActionIdField = $this->getMassactionIdField();
         } else {
             $massActionIdField = $this->getParentBlock()->getMassactionIdField();
         }
 
-        $gridIds = $allIdsCollection->setPageSize(0)->getColumnValues($massActionIdField);
+        $allIdsCollection->clear();
+        $allIdsCollection->setPageSize(0);
+        $gridIds = $allIdsCollection->getColumnValues($massActionIdField);
 
         if (!empty($gridIds)) {
             return join(",", $gridIds);

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -45,7 +45,7 @@ class ExtendedTest extends \PHPUnit\Framework\TestCase
     {
         $this->_gridMock = $this->createPartialMock(
             \Magento\Backend\Block\Widget\Grid::class,
-            ['getId', 'getCollection']
+            ['getId', 'getUnloadedCollection']
         );
         $this->_gridMock->expects($this->any())->method('getId')->will($this->returnValue('test_grid'));
 
@@ -137,7 +137,7 @@ class ExtendedTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->_gridMock->expects($this->once())
-            ->method('getCollection')
+            ->method('getUnloadedCollection')
             ->willReturn($collectionMock);
 
         $collectionMock->expects($this->once())


### PR DESCRIPTION
[MAGETWO-85227]:+ This commit fixes a incorrect fetch of column values on a loaded collection

### Description
Clones a unloaded collection for the grid to use.
Resets the collection limit to remove the limit of the collection

### Fixed Issues (if relevant)
1. magento/magento2#12594: Couldn't select all items on Review grid

### Manual testing scenarios
1. login Magento admin
2. from main menu, select MARKETING -> User Content -> Reviews
3. select Select All under Actions checkbox

**Expected Result**
All review items are selected.

1. login Magento admin
2. from main menu, select MARKETING -> User Content -> Reviews
3. select Select all visible under Actions checkbox

**Expected Result**
Only visible review items are selected.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
