### PR TITLE
Fixes variables in configuration fields not being replaced with actual value…

### DIFF
--- a/app/code/Magento/Config/Block/System/Config/Form.php
+++ b/app/code/Magento/Config/Block/System/Config/Form.php
@@ -424,6 +424,10 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 $backendModel = $field->getBackendModel();
                 // Backend models which implement ProcessorInterface are processed by ScopeConfigInterface
                 if (!$backendModel instanceof ProcessorInterface) {
+                    if (array_key_exists($path, $this->_configData)) {
+                        $data = $this->_configData[$path];
+                    }
+
                     $backendModel->setPath($path)
                         ->setValue($data)
                         ->setWebsite($this->getWebsiteCode())


### PR DESCRIPTION
…s in the backend form fields.

### Description
See https://github.com/magento/magento2/issues/15972 for a full description

**Watch out**: I feel very unsecure about these changes, these should best be reviewed by someone with deep knowledge about how the configuration system works in Magento I think.
The behavior described below worked fine in Magento 2.2.0 but broke since 2.2.1, by: https://github.com/magento/magento2/commit/86d46ce0bdeca61ade5c1063edcb70367f17b2a5 & https://github.com/magento/magento2/commit/6c9a8b258446950e2bd8b41844c529a7be67f335
Maybe @viktym would be an appropriate reviewer here, since he seems to have deep knowledge about that part in the code.

It would also be awesome if tests could get added to prevent this bug from re-appearing in the future. I already attempted creating a unit test for this, but failed horribly. Any help would be appreciated!

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/15972: Since Magento 2.2.1, certain variables in the configuration get resolved to their actual value

### Manual testing scenarios
1. Setup a clean Magento
2. In the backend configuration go to: General > Web > Base URLs & Base URLs (Secure)
3. Enter `{{unsecure_base_url}}media/` in "Base URL for User Media Files" and `{{secure_base_url}}media/` in "Secure Base URL for User Media Files"
4. Save Config
5. Look at those two fields you just edited, they should remain unchanged

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
