### PR TITLE
Sales: add missing unit tests for model classes

### DIFF
--- a/app/code/Magento/Sales/Test/Unit/Model/ValidatorResultMergerTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ValidatorResultMergerTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Test\Unit\Model;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Sales\Model\ValidatorResultInterface;
+use Magento\Sales\Model\ValidatorResultInterfaceFactory;
+use Magento\Sales\Model\ValidatorResultMerger;
+
+/**
+ * @covers \Magento\Sales\Model\ValidatorResultMerger
+ */
+class ValidatorResultMergerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var ValidatorResultMerger
+     */
+    private $validatorResultMerger;
+
+    /**
+     * Object Manager
+     *
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var ValidatorResultInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $validatorResultFactoryMock;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->validatorResultFactoryMock = $this->getMockBuilder(ValidatorResultInterfaceFactory::class)
+        ->setMethods(['create'])->disableOriginalConstructor()->getMock();
+        $this->objectManager = new ObjectManager($this);
+        $this->validatorResultMerger = $this->objectManager->getObject(
+            ValidatorResultMerger::class,
+            [
+                'validatorResultInterfaceFactory' => $this->validatorResultFactoryMock,
+            ]
+        );
+    }
+
+    /**
+     * Test merge method
+     *
+     * @return void
+     */
+    public function testMerge()
+    {
+        $validatorResultMock = $this->createMock(ValidatorResultInterface::class);
+        $orderValidationResultMock = $this->createMock(ValidatorResultInterface::class);
+        $creditmemoValidationResultMock = $this->createMock(ValidatorResultInterface::class);
+        $itemsValidationMessages = [['test04', 'test05'], ['test06']];
+        $this->validatorResultFactoryMock->expects($this->once())->method('create')
+            ->willReturn($validatorResultMock);
+        $orderValidationResultMock->expects($this->once())->method('getMessages')->willReturn(['test01', 'test02']);
+        $creditmemoValidationResultMock->expects($this->once())->method('getMessages')->willReturn(['test03']);
+
+        $validatorResultMock->expects($this->at(0))->method('addMessage')->with('test01');
+        $validatorResultMock->expects($this->at(1))->method('addMessage')->with('test02');
+        $validatorResultMock->expects($this->at(2))->method('addMessage')->with('test03');
+        $validatorResultMock->expects($this->at(3))->method('addMessage')->with('test04');
+        $validatorResultMock->expects($this->at(4))->method('addMessage')->with('test05');
+        $validatorResultMock->expects($this->at(5))->method('addMessage')->with('test06');
+        $expected = $validatorResultMock;
+        $actual = $this->validatorResultMerger->merge(
+            $orderValidationResultMock,
+            $creditmemoValidationResultMock,
+            ...$itemsValidationMessages
+        );
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/app/code/Magento/Sales/Test/Unit/Model/ValidatorResultTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ValidatorResultTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Test\Unit\Model;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Sales\Model\ValidatorResult;
+
+/**
+ * @covers \Magento\Sales\Model\ValidatorResult
+ */
+class ValidatorResultTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var ValidatorResult
+     */
+    private $validatorResult;
+
+    /**
+     * Object Manager
+     *
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->validatorResult = $this->objectManager->getObject(ValidatorResult::class);
+    }
+
+    /**
+     * Test addMessage method
+     *
+     * @return void
+     */
+    public function testAddMessages()
+    {
+        $messageFirst = 'Sample message 01.';
+        $messageSecond = 'Sample messages 02.';
+        $messageThird = 'Sample messages 03.';
+        $expected = [$messageFirst, $messageSecond, $messageThird];
+        $this->validatorResult->addMessage($messageFirst);
+        $this->validatorResult->addMessage($messageSecond);
+        $this->validatorResult->addMessage($messageThird);
+        $actual = $this->validatorResult->getMessages();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test hasMessages method
+     *
+     * @return void
+     */
+    public function testHasMessages()
+    {
+        $this->assertFalse($this->validatorResult->hasMessages());
+        $messageFirst = 'Sample message 01.';
+        $messageSecond = 'Sample messages 02.';
+        $this->validatorResult->addMessage($messageFirst);
+        $this->validatorResult->addMessage($messageSecond);
+        $this->assertTrue($this->validatorResult->hasMessages());
+    }
+}


### PR DESCRIPTION
### Description
This PR adds missing unit tests for Sales model classes:
- `Magento\Sales\Model\ValidatorResult`
- `Magento\Sales\Model\ValidatorResultMerger`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
