### PR TITLE
Add checkout_cart_product_add_before event #17830

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -370,6 +370,10 @@ class Cart extends DataObject implements CartInterface
         }
 
         if ($productId) {
+            $this->_eventManager->dispatch(
+                'checkout_cart_product_add_before',
+                ['info' => $requestInfo, 'product' => $product]
+            );
             try {
                 $result = $this->getQuote()->addProduct($product, $request);
             } catch (\Magento\Framework\Exception\LocalizedException $e) {

--- a/app/code/Magento/Checkout/Test/Unit/Model/CartTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/CartTest.php
@@ -318,6 +318,12 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $this->productRepository->expects($this->any())
             ->method('getById')
             ->will($this->returnValue($product));
+
+        $this->eventManagerMock->expects($this->at(0))->method('dispatch')->with(
+            'checkout_cart_product_add_before',
+            ['info' => $requestInfo, 'product' => $product]
+        );
+
         $this->quoteMock->expects($this->once())
         ->method('addProduct')
         ->will($this->returnValue(1));
@@ -325,7 +331,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->method('getQuote')
             ->will($this->returnValue($this->quoteMock));
 
-        $this->eventManagerMock->expects($this->at(0))->method('dispatch')->with(
+        $this->eventManagerMock->expects($this->at(1))->method('dispatch')->with(
             'checkout_cart_product_add_after',
             ['quote_item' => 1, 'product' => $product]
         );
@@ -363,6 +369,10 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $this->productRepository->expects($this->any())
             ->method('getById')
             ->will($this->returnValue($product));
+        $this->eventManagerMock->expects($this->at(0))->method('dispatch')->with(
+            'checkout_cart_product_add_before',
+            ['info' => 4, 'product' => $product]
+        );
         $this->quoteMock->expects($this->once())
             ->method('addProduct')
             ->will($this->returnValue('error'));
@@ -398,6 +408,11 @@ class CartTest extends \PHPUnit\Framework\TestCase
         $this->productRepository->expects($this->any())
             ->method('getById')
             ->will($this->returnValue($product));
+
+        $this->eventManagerMock->expects($this->never())->method('dispatch')->with(
+            'checkout_cart_product_add_before',
+            ['info' => 'bad', 'product' => $product]
+        );
 
         $this->eventManagerMock->expects($this->never())->method('dispatch')->with(
             'checkout_cart_product_add_after',


### PR DESCRIPTION
Add checkout_cart_product_add_before event [#17830](https://github.com/magento/magento2/issues/17830)

### Description
Add dispatch event checkout_cart_product_add_before 

