### PR TITLE
Customer Name Prefix shows white space when extra separator is addes.…

### DIFF
--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -9,6 +9,10 @@ use Magento\Config\Model\Config\Source\Nooptreq as NooptreqSource;
 use Magento\Customer\Helper\Address as AddressHelper;
 use Magento\Framework\Escaper;
 
+/**
+ * Class Options
+ * @package Magento\Customer\Model
+ */
 class Options
 {
     /**
@@ -38,7 +42,7 @@ class Options
     /**
      * Retrieve name prefix dropdown options
      *
-     * @param null $store
+     * @param $store
      * @return array|bool
      */
     public function getNamePrefixOptions($store = null)
@@ -52,7 +56,7 @@ class Options
     /**
      * Retrieve name suffix dropdown options
      *
-     * @param null $store
+     * @param $store
      * @return array|bool
      */
     public function getNameSuffixOptions($store = null)
@@ -64,6 +68,8 @@ class Options
     }
 
     /**
+     * Prepare Name Suffix Options
+     *
      * @param $options
      * @param bool $isOptional
      * @return array|bool
@@ -78,6 +84,7 @@ class Options
 
     /**
      * Unserialize and clear name prefix or suffix options
+     *
      * If field is optional, add an empty first option.
      *
      * @param string $options
@@ -95,9 +102,7 @@ class Options
         foreach ($options as $value) {
             $value = $this->escaper->escapeHtml(trim($value));
             $result[$value] = $value;
-            $result = array_filter($result);
         }
-
         if ($isOptional && trim(current($options))) {
             $result = array_merge([' ' => ' '], $result);
         }

--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -102,6 +102,7 @@ class Options
         foreach ($options as $value) {
             $value = $this->escaper->escapeHtml(trim($value));
             $result[$value] = $value;
+            $result = array_filter($result);
         }
         if ($isOptional && trim(current($options))) {
             $result = array_merge([' ' => ' '], $result);

--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -11,6 +11,7 @@ use Magento\Framework\Escaper;
 
 /**
  * Class Options
+ *
  * @package Magento\Customer\Model
  */
 class Options
@@ -42,7 +43,7 @@ class Options
     /**
      * Retrieve name prefix dropdown options
      *
-     * @param $store
+     * @param string|null $store
      * @return array|bool
      */
     public function getNamePrefixOptions($store = null)
@@ -56,7 +57,7 @@ class Options
     /**
      * Retrieve name suffix dropdown options
      *
-     * @param $store
+     * @param string|null $store
      * @return array|bool
      */
     public function getNameSuffixOptions($store = null)
@@ -70,7 +71,7 @@ class Options
     /**
      * Prepare Name Suffix Options
      *
-     * @param $options
+     * @param string|null $options
      * @param bool $isOptional
      * @return array|bool
      *

--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -95,7 +95,9 @@ class Options
         foreach ($options as $value) {
             $value = $this->escaper->escapeHtml(trim($value));
             $result[$value] = $value;
+            $result = array_filter($result);
         }
+
         if ($isOptional && trim(current($options))) {
             $result = array_merge([' ' => ' '], $result);
         }


### PR DESCRIPTION
… #17861

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
When we configure the Customer Name Prefix and leave at the end of the field the separator ";" Magento renders a white field. When we set the option with required is impossible leave the white field so I filter the values and clean the white option to have only the prefix defined

Honestly I believe that is not a bug but only a way to work with Magento. If you simple not ends the options with the separator the problem will not happens but once some users are not familiar with this logic I believe is better filter the options and remove the white spaces

### Fixed Issues (if relevant)
1. magento/magento2#17861: Customer Name Prefix shows white space when extra separator is addes.
2. Issue fixed: https://github.com/magento/magento2/issues/17861

### Manual testing scenarios
1. Enable the customer name prefix on Store>Configuration>Customer>Customer Configuration.
2. Go to Name and Address Option
3. Select in Show Prefix the option Required
4. Insert the prefixes desired in Prefix Dropdown Options using the separator ; and leave the ; at the end like (Mr;Ms;Mrs;)
5. Go to the frontend page and create a new user to see that the white option will not appear

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
