### PR TITLE
#14530 Removing destroy current customer session command on reset password

### DIFF
--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -954,6 +954,8 @@ class AccountManagement implements AccountManagementInterface
     }
 
     /**
+     * Get an instance of eav validator
+     *
      * @return Backend
      */
     private function getEavValidator()
@@ -1152,6 +1154,8 @@ class AccountManagement implements AccountManagementInterface
     }
 
     /**
+     * Get email templates paths for new account handles
+     *
      * @return array
      * @deprecated 100.1.0
      */

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -625,7 +625,6 @@ class AccountManagement implements AccountManagementInterface
         $customerSecure->setRpTokenCreatedAt(null);
         $customerSecure->setPasswordHash($this->createPasswordHash($newPassword));
         $this->getAuthentication()->unlock($customer->getId());
-        $this->sessionManager->destroy();
         $this->destroyCustomerSessions($customer->getId());
         $this->customerRepository->save($customer);
 

--- a/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
@@ -1547,7 +1547,6 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
         $this->customerSecure->expects($this->once())->method('setRpTokenCreatedAt')->with(null);
         $this->customerSecure->expects($this->any())->method('setPasswordHash')->willReturn(null);
 
-        $this->sessionManager->expects($this->atLeastOnce())->method('destroy');
         $this->sessionManager->expects($this->atLeastOnce())->method('getSessionId');
         $visitor = $this->getMockBuilder(\Magento\Customer\Model\Visitor::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
### Description
Removing the destroy current session command on reset password method. This was the [commit](https://github.com/magento/magento2/commit/772acf1f53036b313225300fe5e48e7f3af1c6a0#diff-5cd5a61664bf74a46f1e1bf261e3fdca) that has added this line, we don't necessarialy need to remove the current guest session, just the logged customer sessions to force the re-login on other computers.

### Fixed Issues (if relevant)
1. magento/magento2#14530: Shopping cart is emptied after reset password procedure

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Keep as a guest user (Without log in)
2. Add any product in the cart.
3. Proceed to reset the password.
4. Click on the email's URL to change your password.
5. Set a new password.
6. You will be redirected to the login page. At this moment the cart needs to keep the products that you have added.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
