### PR TITLE
Virtual-only quotes use default shipping address for estimation instead of default billing address #17744 fix

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -227,7 +227,7 @@ define([
 
                 return;
             }
-            shippingAddress = quote.shippingAddress();
+            shippingAddress = quote.billingAddress();
 
             if(quote.isVirtual()) {
                 isBillingAddressInitialized = addressList.some(function (addrs) {

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -218,7 +218,6 @@ define([
          * Apply resolved billing address to quote
          */
         applyBillingAddress: function () {
-            var addressData;
             var shippingAddress;
             var isBillingAddressInitialized;
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -218,7 +218,9 @@ define([
          * Apply resolved billing address to quote
          */
         applyBillingAddress: function () {
+            var addressData;
             var shippingAddress;
+            var isBillingAddressInitialized;
 
             if (quote.billingAddress()) {
                 selectBillingAddress(quote.billingAddress());
@@ -227,9 +229,21 @@ define([
             }
             shippingAddress = quote.shippingAddress();
 
-            if (shippingAddress &&
+            if(quote.isVirtual()) {
+                isBillingAddressInitialized = addressList.some(function (addrs) {
+                    if (addrs.isDefaultBilling()) {
+                        selectBillingAddress(addrs);
+                        return true;
+                    }
+
+                    return false;
+                });
+            }
+
+            if (!isBillingAddressInitialized &&
+                shippingAddress &&
                 shippingAddress.canUseForBilling() &&
-                (shippingAddress.isDefaultShipping() || !quote.isVirtual())
+                (shippingAddress.isDefaultBilling() || !quote.isVirtual())
             ) {
                 //set billing address same as shipping by default if it is not empty
                 selectBillingAddress(quote.shippingAddress());


### PR DESCRIPTION
      - For the replacement of virtual products
      - Virtual-only quotes use default shipping address for estimation instead of default billing address #17744
     - Enter a billing address
     - Register a shipping address
     - Add a vidual product to cart
     - The address shown in the summary must be the billing address

      Second senary

   - Enter a billing address
   - Register a shipping address 
   - Add a vidual product to cart
  -  Add a simple product
  - The address shown in the summary must be the delivery address

  -  The behavior is for the cart (View and Edit Cart)


### Description

    The selectBillingAddress was added when the product is virtual only


### Fixed Issues (if relevant)

   Was fixed only (Virtual-only quotes use default address for estimation instead of default billing address # 17744 fix)

1. magento/magento2#17744: Issue Virtual-only quotes use default shipping address for estimation instead of default billing address

### Manual testing scenarios

    - Enter a billing address
    - Register a shipping address
    - Add a vidual product to cart
    - The address shown in the summary must be the billing address

      Second senary

  - Enter a billing address
  - Register a shipping address 
  - Add a vidual product to cart
  -  Add a simple product
  - The address shown in the summary must be the delivery address

### Contribution checklist

 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
