### PR TITLE
Removed disable field from catalog_product_entity_media_gallery table…

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -218,8 +218,7 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 'position_default' => 'default_value.position',
                 'disabled_default' => 'default_value.disabled'
             ])
-            ->where($mainTableAlias . '.attribute_id = ?', $attributeId)
-            ->where($mainTableAlias . '.disabled = 0');
+            ->where($mainTableAlias . '.attribute_id = ?', $attributeId);
 
         // filter entities by store
         if ($storeId > 0) {

--- a/app/code/Magento/Catalog/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Catalog/Setup/UpgradeSchema.php
@@ -147,6 +147,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->removeIndexFromPriceIndexTable($setup);
         }
 
+        if (version_compare($context->getVersion(), '2.2.7', '<')) {
+            $this->removeDisabledColumnMediaGalleryTable($setup);
+        }
+
         $setup->endSetup();
     }
 
@@ -841,4 +845,11 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $setup->getIdxName('catalog_product_index_price_tmp', ['min_price'])
         );
     }
+
+    private function removeDisabledColumnMediaGalleryTable(SchemaSetupInterface $setup)
+    {
+        $setup->getConnection()->dropColumn($setup->getTable('catalog_product_entity_media_gallery'), 'disabled');
+    }
+
 }
+

--- a/app/code/Magento/Catalog/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Catalog/Setup/UpgradeSchema.php
@@ -850,6 +850,4 @@ class UpgradeSchema implements UpgradeSchemaInterface
     {
         $setup->getConnection()->dropColumn($setup->getTable('catalog_product_entity_media_gallery'), 'disabled');
     }
-
 }
-

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
@@ -306,7 +306,6 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
                 'file' => '/d/o/download_7.jpg',
                 'label' => null,
                 'position' => '1',
-                'disabled' => '0',
                 'label_default' => null,
                 'position_default' => '1',
                 'disabled_default' => '0',
@@ -404,9 +403,6 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
                 [
                     'main.attribute_id = ?',
                     $attributeId
-                ],
-                [
-                    'main.disabled = 0'
                 ],
                 [
                     'value.store_id = ' . $storeId . ' OR default_value.store_id = 0'

--- a/app/code/Magento/Catalog/etc/module.xml
+++ b/app/code/Magento/Catalog/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Catalog" setup_version="2.2.6">
+    <module name="Magento_Catalog" setup_version="2.2.7">
         <sequence>
             <module name="Magento_Eav"/>
             <module name="Magento_Cms"/>

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_image.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_image.php
@@ -21,7 +21,6 @@ $product->setStoreId(0)
             'file' => '/m/a/magento_image.jpg',
             'position' => 1,
             'label' => 'Image Alt Text',
-            'disabled' => 0,
             'media_type' => 'image'
         ],
     ]])


### PR DESCRIPTION
### Description

Removed 'disabled' field from catalog_product_entity_media_gallery table because is not used.

### Fixed Issues (if relevant)
1. magento/magento2#17796: Seems that `catalog_product_entity_media_gallery` contains unused `disabled` field

### Manual testing scenarios

1. Create New Product;
2. Add an Image to your product; 
3. Save the product;
4. Check if the table catalog_product_entity_media_gallery not have the field 'disabled';

