### PR TITLE
#17744 Adding logic to get default billing address used on Cart and Checkout

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -227,7 +227,7 @@ define([
                 return;
             }
 
-            if(quote.isVirtual()) {
+            if (quote.isVirtual()) {
                 isBillingAddressInitialized = addressList.some(function (addrs) {
                     if (addrs.isDefaultBilling()) {
                         selectBillingAddress(addrs);

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -231,13 +231,16 @@ define([
                 isBillingAddressInitialized = addressList.some(function (addrs) {
                     if (addrs.isDefaultBilling()) {
                         selectBillingAddress(addrs);
+
                         return true;
                     }
+
                     return false;
                 });
             }
 
             shippingAddress = quote.shippingAddress();
+
             if (!isBillingAddressInitialized &&
                 shippingAddress &&
                 shippingAddress.canUseForBilling() &&

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -219,15 +219,26 @@ define([
          */
         applyBillingAddress: function () {
             var shippingAddress;
+            var isBillingAddressInitialized;
 
             if (quote.billingAddress()) {
                 selectBillingAddress(quote.billingAddress());
 
                 return;
             }
-            shippingAddress = quote.shippingAddress();
+            shippingAddress = quote.billingAddress();
+            if(quote.isVirtual()) {
+                isBillingAddressInitialized = addressList.some(function (addrs) {
+                    if (addrs.isDefaultBilling()) {
+                        selectBillingAddress(addrs);
+                        return true;
+                    }
+                    return false;
+                });
+            }
 
-            if (shippingAddress &&
+            if (!isBillingAddressInitialized &&
+                shippingAddress &&
                 shippingAddress.canUseForBilling() &&
                 (shippingAddress.isDefaultShipping() || !quote.isVirtual())
             ) {

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -218,8 +218,8 @@ define([
          * Apply resolved billing address to quote
          */
         applyBillingAddress: function () {
-            var shippingAddress;
-            var isBillingAddressInitialized;
+            var shippingAddress,
+                isBillingAddressInitialized;
 
             if (quote.billingAddress()) {
                 selectBillingAddress(quote.billingAddress());

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -226,7 +226,7 @@ define([
 
                 return;
             }
-            shippingAddress = quote.billingAddress();
+
             if(quote.isVirtual()) {
                 isBillingAddressInitialized = addressList.some(function (addrs) {
                     if (addrs.isDefaultBilling()) {
@@ -237,6 +237,7 @@ define([
                 });
             }
 
+            shippingAddress = quote.shippingAddress();
             if (!isBillingAddressInitialized &&
                 shippingAddress &&
                 shippingAddress.canUseForBilling() &&

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/cc-form.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/cc-form.test.js
@@ -19,7 +19,12 @@ define([
                     billingAddress: ko.observable(),
                     shippingAddress: ko.observable(),
                     paymentMethod: ko.observable(),
-                    totals: ko.observable({})
+                    totals: ko.observable({}),
+
+                    /** Stub */
+                    isVirtual: function () {
+                        return false;
+                    }
                 },
                 'Magento_Braintree/js/view/payment/validator-handler': jasmine.createSpyObj(
                     'validator-handler',

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/paypal.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/paypal.test.js
@@ -25,6 +25,8 @@ define([
                     totals: ko.observable({
                         'base_grand_total': 0
                     }),
+
+                    /** Stub */
                     isVirtual: function () {
                         return false;
                     }

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/paypal.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Braintree/frontend/js/view/payment/method-renderer/paypal.test.js
@@ -24,7 +24,10 @@ define([
                     paymentMethod: ko.observable(),
                     totals: ko.observable({
                         'base_grand_total': 0
-                    })
+                    }),
+                    isVirtual: function () {
+                        return false;
+                    }
                 },
                 'Magento_Braintree/js/view/payment/adapter': {
                     config: {},

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Paypal/frontend/js/view/payment/method-renderer/paypal-express-abstract.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Paypal/frontend/js/view/payment/method-renderer/paypal-express-abstract.test.js
@@ -28,8 +28,12 @@ define([
                     billingAddress: ko.observable(),
                     shippingAddress: ko.observable(),
                     paymentMethod: ko.observable(),
-                    totals: ko.observable({})
+                    totals: ko.observable({}),
 
+                    /** Stub */
+                    isVirtual: function () {
+                        return false;
+                    }
                 },
                 'Magento_Checkout/js/action/set-payment-information': setPaymentMock,
                 'Magento_Checkout/js/model/payment/additional-validators': {


### PR DESCRIPTION
### Description
Fixing the bug when the cart is virtual and the estimate was getting the shipping address instead billing address.

### Fixed Issues
1. magento/magento2#17744: Virtual-only quotes use default shipping address for estimation instead of default billing address

### Manual testing scenarios

#### First scenario
1. Register a billing and a shipping address (Diferents)
2. Add a virtual product to cart
3. The address used in the estimation must be the billing address

#### Second scenario
1. Register a billing and a shipping address (Diferents)
2. Add a virtual product to cart
3. Add a simple product
4. The address used in the estimation must be the shipping address

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
