### PR TITLE
Fix shipping discount failed to apply during place order

### DIFF
--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
@@ -164,9 +164,8 @@ class Tax extends CommonTaxCollector
         $total->setBaseShippingInclTax(0);
         $total->setShippingTaxAmount(0);
         $total->setBaseShippingTaxAmount(0);
-        $total->setShippingAmountForDiscount(0);
-        $total->setBaseShippingAmountForDiscount(0);
-        $total->setBaseShippingAmountForDiscount(0);
+        $total->setShippingAmountForDiscount(null);
+        $total->setBaseShippingAmountForDiscount(null);
         $total->setTotalAmount('extra_tax', 0);
         $total->setBaseTotalAmount('extra_tax', 0);
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Caused by https://github.com/magento/magento2/pull/13185, `\Magento\Tax\Model\Sales\Total\Quote\Tax::clearValues()` is called to unset the total before collecting total. `null` is expected (representing unset state) in below condition however `0` is set and failed the condition necessary to calculate correct shipping discount.

```diff
- expected
+ actual
// \Magento\SalesRule\Model\Validator::processShippingAmount
    public function processShippingAmount(Address $address)
    {
-        // $shippingAmount = null
+        // $shippingAmount = 0
        $shippingAmount = $address->getShippingAmountForDiscount();
        if ($shippingAmount !== null) {
            $baseShippingAmount = $address->getBaseShippingAmountForDiscount();
        } else {
            $shippingAmount = $address->getShippingAmount();
            $baseShippingAmount = $address->getBaseShippingAmount();
        }
        // ...
        $discountAmount = ($shippingAmount - $address->getShippingDiscountAmount()) * $rulePercent / 100;
        // ...
    }
```

Shipping discount fail to apply to an order, when:
- order is checking out with payment method which do not collect total after `savePaymentInformation()` (for example, credit card methods usually meet this criteria, while paypal methods not)
- order is applied with a promotional rule with shipping discount

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Can't found any related issue so far

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create coupon of 20%off discount and set it to applicable to shipping
2. Apply the coupon
3. Check out with Braintree
4. After placed the order, go to account page to view the order

Expected result: Order discount contains shipping amount

Actual result: Order discount does not contain shipping amount

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)