### PR TITLE
Fix catalog_product_entity_media_gallery not cleared when related products are being deleted

### DIFF
--- a/app/code/Magento/Catalog/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Catalog/Setup/UpgradeSchema.php
@@ -145,6 +145,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
         if (version_compare($context->getVersion(), '2.2.6', '<')) {
             $this->addStoreIdFieldForWebsiteIndexTable($setup);
             $this->removeIndexFromPriceIndexTable($setup);
+            $this->addMediaGalleryValueCascadeDeleteMediaGallery($setup);
         }
 
         $setup->endSetup();
@@ -840,5 +841,30 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $setup->getTable('catalog_product_index_price_tmp'),
             $setup->getIdxName('catalog_product_index_price_tmp', ['min_price'])
         );
+    }
+
+    /**
+     * Add constraint to remove 'catalog_product_entity_media_gallery` rows with
+     * corresponding product pictures' paths when the product is deleted.
+     * 
+     * @param SchemaSetupInterface $setup
+     * @return void
+     */
+    private function addMediaGalleryValueCascadeDeleteMediaGallery(SchemaSetupInterface $setup)
+    {
+        $setup->getConnection()
+            ->addForeignKey(
+                $setup->getFkName(
+                    Gallery::GALLERY_TABLE,
+                    'value_id',
+                    Gallery::GALLERY_VALUE_TABLE,
+                    'value_id'
+                ),
+                $setup->getTable(Gallery::GALLERY_TABLE),
+                'value_id',
+                $setup->getTable(Gallery::GALLERY_VALUE_TABLE),
+                'value_id',
+                Table::ACTION_CASCADE
+            );
     }
 }


### PR DESCRIPTION
### Description
Add constraint to remove `catalog_product_entity_media_gallery` rows with corresponding product pictures' paths when the product is deleted.

### Fixed Issues
1. magento/magento2#17727: `catalog_product_entity_media_gallery` not cleared when related products deleted.

### Manual testing scenarios

#### Before applying this fix
1. Add new product,
2. add pictures to the new product,
3. check `catalog_product_entity_media_gallery` - there should be a row for each of the product pictures,
4. delete the product,
5. check the database table again - there still are rows corresponding to the product.

#### After applying this fix
1. Do steps 1-4 from the list above,
2. check the database table again - there are no rows corresponding to the product now.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
