### PR TITLE
18057: Fix adding switch options via API

### DIFF
--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -198,10 +198,10 @@ class EavAttribute
         if (!empty($optionsArray) && is_array($optionsArray)) {
             $optionsArray = $this->prepareOptionIds($optionsArray);
 
-            $defaultStoreAttribute = clone $attribute;
-            $defaultStoreAttribute->setStoreId(0);
+            $adminStoreAttribute = clone $attribute;
+            $adminStoreAttribute->setStoreId(0);
             $sourceModel = $this->tableFactory->create();
-            $sourceModel->setAttribute($defaultStoreAttribute);
+            $sourceModel->setAttribute($adminStoreAttribute);
 
             $this->prepareOptionLinks($optionsArray, $sourceModel);
         }

--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -81,9 +81,9 @@ class EavAttribute
         \Magento\Swatches\Model\ResourceModel\Swatch\CollectionFactory $collectionFactory,
         \Magento\Swatches\Model\SwatchFactory $swatchFactory,
         \Magento\Swatches\Helper\Data $swatchHelper,
+        \Magento\Eav\Model\Entity\Attribute\Source\TableFactory $tableFactory,
         Json $serializer = null,
-        SwatchResource $swatchResource = null,
-        \Magento\Eav\Model\Entity\Attribute\Source\TableFactory $tableFactory
+        SwatchResource $swatchResource = null
     ) {
         $this->swatchCollectionFactory = $collectionFactory;
         $this->swatchFactory = $swatchFactory;

--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -391,9 +391,11 @@ class EavAttribute
                     return $this->dependencyArray[$optionId];
                 }
             }
+
+            return null;
         }
 
-        return null;
+        return $optionId;
     }
 
     /**


### PR DESCRIPTION
### Description
This change allows to create correct options in text swatch attribute via REST API or PHP. The idea is to copy data required by swatch from options (keep in mind, that in case of API or PHP we will not have full options list in $attribute->getData('option'), and $attribute->getData('swatchtext'); will always return null.

### Fixed Issues (if relevant)
1. magento/magento2#18057: Swatch Text attributes options not created correctly via api

### Manual testing scenarios
For steps to reproduce, please check bug report: https://github.com/magento/magento2/issues/18057

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### TODO
That change will require update for unit tests.
