### PR TITLE
Change sort order for customer group options

### DIFF
--- a/app/code/Magento/Customer/Model/GroupManagement.php
+++ b/app/code/Magento/Customer/Model/GroupManagement.php
@@ -20,6 +20,8 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
+ * The class contains methods for getting information about a customer group
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
@@ -104,7 +106,7 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function isReadonly($groupId)
     {
@@ -118,7 +120,7 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getDefaultGroup($storeId = null)
     {
@@ -144,7 +146,7 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getNotLoggedInGroup()
     {
@@ -152,7 +154,7 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getLoggedInGroups()
     {
@@ -179,7 +181,7 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getAllCustomersGroup()
     {


### PR DESCRIPTION
### Description
Change sort order for customer group options. The customer groups will be listed alphabetically.

### Fixed Issues
1. magento/magento2#18101: Wrong sort order for customer groups in customer grid filter

### Manual testing scenarios
1. imagine you've 50 customer groups (not only 3 default)
2. go to admin customer grid and filter by group

### Expected result
1. customer groups are listed alphabetically

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
