### PR TITLE
Update Collection.php

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View/Collection.php
+++ b/lib/internal/Magento/Framework/Mview/View/Collection.php
@@ -96,7 +96,7 @@ class Collection extends \Magento\Framework\Data\Collection implements Collectio
             $orderedViewIds[] = $indexer->load($indexerId)->getViewId();
         }
         $orderedViewIds = array_filter($orderedViewIds);
-        $orderedViewIds += array_diff(array_keys($this->config->getViews()), $orderedViewIds);
+        $orderedViewIds = array_merge($orderedViewIds, array_diff(array_keys($this->config->getViews()), $orderedViewIds));
 
         return $orderedViewIds;
     }


### PR DESCRIPTION
multiplying arrays with same keys issue, if  $orderedViewIds and result of array_diff has same keys, values from array_diff will not be added to  $orderedViewIds 

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
