### PR TITLE
Replace intval() function by using direct type casting to (int) where no default value is needed

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -3857,13 +3857,13 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 
         switch ($last) {
             case 'k':
-                $size = intval($size) * 1024;
+                $size = (int)$size * 1024;
                 break;
             case 'm':
-                $size = intval($size) * 1024 * 1024;
+                $size = (int)$size * 1024 * 1024;
                 break;
             case 'g':
-                $size = intval($size) * 1024 * 1024 * 1024;
+                $size = (int)$size * 1024 * 1024 * 1024;
                 break;
         }
 
@@ -3874,7 +3874,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             return Table::MAX_TEXT_SIZE;
         }
 
-        return intval($size);
+        return (int)$size;
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Helper.php
+++ b/lib/internal/Magento/Framework/DB/Helper.php
@@ -153,12 +153,12 @@ class Helper extends \Magento\Framework\DB\Helper\AbstractHelper
     protected function _assembleLimit($query, $limitCount, $limitOffset, $columnList = [])
     {
         if ($limitCount !== null) {
-            $limitCount = intval($limitCount);
+            $limitCount = (int)$limitCount;
             if ($limitCount <= 0) {
                 //throw new \Exception("LIMIT argument count={$limitCount} is not valid");
             }
 
-            $limitOffset = intval($limitOffset);
+            $limitOffset = (int)$limitOffset;
             if ($limitOffset < 0) {
                 //throw new \Exception("LIMIT argument offset={$limitOffset} is not valid");
             }

--- a/lib/internal/Magento/Framework/DB/Query.php
+++ b/lib/internal/Magento/Framework/DB/Query.php
@@ -142,7 +142,7 @@ class Query implements QueryInterface
             $sql = $this->getSelectCountSql();
             $this->totalRecords = $this->getConnection()->fetchOne($sql, $this->bindParams);
         }
-        return intval($this->totalRecords);
+        return (int)$this->totalRecords;
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
@@ -165,7 +165,7 @@ class BatchIterator implements BatchIteratorInterface
         );
         $row = $this->connection->fetchRow($wrapperSelect);
         $this->minValue = $row['max'];
-        return intval($row['cnt']);
+        return (int)$row['cnt'];
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Query/BatchRangeIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchRangeIterator.php
@@ -201,7 +201,7 @@ class BatchRangeIterator implements BatchIteratorInterface
             );
             $row = $this->connection->fetchRow($wrapperSelect);
 
-            $this->totalItemCount = intval($row['cnt']);
+            $this->totalItemCount = (int)$row['cnt'];
         }
 
         $rangeField = is_array($this->rangeField) ? $this->rangeField : [$this->rangeField];

--- a/lib/internal/Magento/Framework/DB/Sql/LimitExpression.php
+++ b/lib/internal/Magento/Framework/DB/Sql/LimitExpression.php
@@ -46,14 +46,14 @@ class LimitExpression extends Expression
     public function __toString()
     {
         $sql = $this->sql;
-        $count = intval($this->count);
+        $count = (int)$this->count;
         if ($count <= 0) {
             /** @see Zend_Db_Adapter_Exception */
             #require_once 'Zend/Db/Adapter/Exception.php';
             throw new \Zend_Db_Adapter_Exception("LIMIT argument count=$count is not valid");
         }
 
-        $offset = intval($this->offset);
+        $offset = (int)$this->offset;
         if ($offset < 0) {
             /** @see Zend_Db_Adapter_Exception */
             #require_once 'Zend/Db/Adapter/Exception.php';

--- a/lib/internal/Magento/Framework/Data/Argument/Interpreter/ArrayType.php
+++ b/lib/internal/Magento/Framework/Data/Argument/Interpreter/ArrayType.php
@@ -90,11 +90,11 @@ class ArrayType implements InterpreterInterface
         $firstValue = 0;
         $secondValue = 0;
         if (isset($firstItem['sortOrder'])) {
-            $firstValue = intval($firstItem['sortOrder']);
+            $firstValue = (int)$firstItem['sortOrder'];
         }
 
         if (isset($secondItem['sortOrder'])) {
-            $secondValue = intval($secondItem['sortOrder']);
+            $secondValue = (int)$secondItem['sortOrder'];
         }
 
         if ($firstValue == $secondValue) {

--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -285,7 +285,7 @@ class Collection implements \IteratorAggregate, \Countable, ArrayInterface, Coll
         if ($this->_totalRecords === null) {
             $this->_totalRecords = count($this->getItems());
         }
-        return intval($this->_totalRecords);
+        return (int)$this->_totalRecords;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Exception/LocalizedException.php
+++ b/lib/internal/Magento/Framework/Exception/LocalizedException.php
@@ -33,7 +33,7 @@ class LocalizedException extends \Exception
     public function __construct(Phrase $phrase, \Exception $cause = null, $code = 0)
     {
         $this->phrase = $phrase;
-        parent::__construct($phrase->render(), intval($code), $cause);
+        parent::__construct($phrase->render(), (int)$code, $cause);
     }
 
     /**

--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -435,7 +435,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
             if (count($line) != 3) {
                 $this->doError("Invalid response line returned from server: " . $data);
             }
-            $this->_responseStatus = intval($line[1]);
+            $this->_responseStatus = (int)$line[1];
         } else {
             $name = $value = '';
             $out = explode(": ", trim($data), 2);

--- a/lib/internal/Magento/Framework/HTTP/Client/Socket.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Socket.php
@@ -424,7 +424,7 @@ class Socket implements \Magento\Framework\HTTP\ClientInterface
         if (count($line) != 3) {
             return $this->doError("Invalid response line returned from server: " . $responseLine);
         }
-        $this->_responseStatus = intval($line[1]);
+        $this->_responseStatus = (int)$line[1];
         $this->processResponseHeaders();
 
         $this->processRedirect();

--- a/lib/internal/Magento/Framework/Image.php
+++ b/lib/internal/Magento/Framework/Image.php
@@ -262,7 +262,7 @@ class Image
     public function setImageBackgroundColor($color)
     {
         /** @noinspection PhpUndefinedFieldInspection */
-        $this->_adapter->imageBackgroundColor = intval($color);
+        $this->_adapter->imageBackgroundColor = (int)$color;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
@@ -120,12 +120,12 @@ class TransportBuilderTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('Email Subject'))
             ->willReturnSelf();
 
-        $this->messageMock->expects($this->exactly(intval($messageType == MessageInterface::TYPE_TEXT)))
+        $this->messageMock->expects($this->exactly((int)($messageType == MessageInterface::TYPE_TEXT)))
             ->method('setBodyText')
             ->with($this->equalTo($bodyText))
             ->willReturnSelf();
 
-        $this->messageMock->expects($this->exactly(intval($messageType == MessageInterface::TYPE_HTML)))
+        $this->messageMock->expects($this->exactly((int)($messageType == MessageInterface::TYPE_HTML)))
             ->method('setBodyHtml')
             ->with($this->equalTo($bodyText))
             ->willReturnSelf();

--- a/lib/internal/Magento/Framework/MessageQueue/Config/CompositeReader.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Config/CompositeReader.php
@@ -69,10 +69,10 @@ class CompositeReader implements ReaderInterface
                 $firstValue = 0;
                 $secondValue = 0;
                 if (isset($firstItem['sortOrder'])) {
-                    $firstValue = intval($firstItem['sortOrder']);
+                    $firstValue = (int)$firstItem['sortOrder'];
                 }
                 if (isset($secondItem['sortOrder'])) {
-                    $secondValue = intval($secondItem['sortOrder']);
+                    $secondValue = (int)$secondItem['sortOrder'];
                 }
                 return $firstValue <=> $secondValue;
             }

--- a/lib/internal/Magento/Framework/MessageQueue/Config/Reader/Xml/CompositeConverter.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Config/Reader/Xml/CompositeConverter.php
@@ -68,10 +68,10 @@ class CompositeConverter implements ConverterInterface
                 $firstValue = 0;
                 $secondValue = 0;
                 if (isset($firstItem['sortOrder'])) {
-                    $firstValue = intval($firstItem['sortOrder']);
+                    $firstValue = (int)$firstItem['sortOrder'];
                 }
                 if (isset($secondItem['sortOrder'])) {
-                    $secondValue = intval($secondItem['sortOrder']);
+                    $secondValue = (int)$secondItem['sortOrder'];
                 }
                 return $firstValue <=> $secondValue;
             }

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Columns/Integer.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Columns/Integer.php
@@ -89,7 +89,7 @@ class Integer implements DbDefinitionProcessorInterface
             $this->unsigned->toDefinition($column),
             $this->nullable->toDefinition($column),
             $column->getDefault() !== null ?
-                sprintf('DEFAULT %s', (string) intval($column->getDefault())) : '',
+                sprintf('DEFAULT %s', (string) (int)$column->getDefault()) : '',
             $this->identity->toDefinition($column),
             $this->comment->toDefinition($column)
         );

--- a/lib/internal/Magento/Framework/Setup/SchemaListenerDefinition/TextBlobDefinition.php
+++ b/lib/internal/Magento/Framework/Setup/SchemaListenerDefinition/TextBlobDefinition.php
@@ -27,13 +27,13 @@ class TextBlobDefinition implements DefinitionConverterInterface
 
         switch ($last) {
             case 'k':
-                $size = intval($size) * 1024;
+                $size = (int)$size * 1024;
                 break;
             case 'm':
-                $size = intval($size) * 1024 * 1024;
+                $size = (int)$size * 1024 * 1024;
                 break;
             case 'g':
-                $size = intval($size) * 1024 * 1024 * 1024;
+                $size = (int)$size * 1024 * 1024 * 1024;
                 break;
         }
 
@@ -44,7 +44,7 @@ class TextBlobDefinition implements DefinitionConverterInterface
             return Table::MAX_TEXT_SIZE;
         }
 
-        return intval($size);
+        return (int)$size;
     }
 
     /**

--- a/lib/internal/Magento/Framework/System/Ftp.php
+++ b/lib/internal/Magento/Framework/System/Ftp.php
@@ -127,7 +127,7 @@ class Ftp
     public function connect($string, $timeout = 900)
     {
         $params = $this->validateConnectionString($string);
-        $port = isset($params['port']) ? intval($params['port']) : 21;
+        $port = isset($params['port']) ? (int)$params['port'] : 21;
 
         $this->_conn = ftp_connect($params['host'], $port, $timeout);
 
@@ -188,7 +188,7 @@ class Ftp
         if (empty($data[1])) {
             return false;
         }
-        if (intval($data[0]) != 257) {
+        if ((int)$data[0] != 257) {
             return false;
         }
         $out = trim($data[1], '"');

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
@@ -297,8 +297,8 @@ class Context implements ContextInterface
      */
     public function sortButtons(array $itemA, array $itemB)
     {
-        $sortOrderA = isset($itemA['sort_order']) ? intval($itemA['sort_order']) : 0;
-        $sortOrderB = isset($itemB['sort_order']) ? intval($itemB['sort_order']) : 0;
+        $sortOrderA = isset($itemA['sort_order']) ? (int)$itemA['sort_order'] : 0;
+        $sortOrderB = isset($itemB['sort_order']) ? (int)$itemB['sort_order'] : 0;
 
         return $sortOrderA - $sortOrderB;
     }

--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -317,7 +317,7 @@ class ErrorProcessor
     protected function _saveFatalErrorReport($reportData)
     {
         $this->directoryWrite->create('report/api');
-        $reportId = abs(intval(microtime(true) * random_int(100, 1000)));
+        $reportId = abs((int)(microtime(true) * random_int(100, 1000)));
         $this->directoryWrite->writeFile('report/api/' . $reportId, $this->serializer->serialize($reportData));
         return $reportId;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Direct type casting is **up to 6x faster** than using casting functions like` intval()`. So this pull request replaces the `intval()` functions by direct type casting to `(int)` where no default value is needed.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18035: [2.3] Changed intval($val) to (int) $val, since it is faster:

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
