### PR TITLE
Fix productlink collection provider missing items

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
@@ -58,15 +58,15 @@ class CollectionProvider
     }
 
     /**
-     * Compare item by key 'position'
+     * Compare item by key 'position'.
      *
-     * @param array $a
-     * @param array $b
-     * @return int It returns -1, 0 or 1 when $a['position'] is respectively less than,
-     * equal to, or greater than $a['position']
+     * @param array $itemA
+     * @param array $itemB
+     * @return int Return -1, 0 or 1 when $itemA['position'] is
+     * respectively less than, equal to, or greater than $itemB['position']
      */
-    public function comparePosition(array $a, array $b): int
+    public function comparePosition(array $itemA, array $itemB): int
     {
-        return (int)$a['position'] <=> (int)$b['position'];
+        return (int)$itemA['position'] <=> (int)$itemB['position'];
     }
 }

--- a/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
@@ -47,22 +47,26 @@ class CollectionProvider
 
         $products = $this->providers[$type]->getLinkedProducts($product);
         $converter = $this->converterPool->getConverter($type);
-        $output = [];
         $sorterItems = [];
         foreach ($products as $item) {
-            $output[$item->getId()] = $converter->convert($item);
+            $sorterItems[$item->getId()] = $converter->convert($item);
         }
 
-        foreach ($output as $item) {
-            $itemPosition = $item['position'];
-            if (!isset($sorterItems[$itemPosition])) {
-                $sorterItems[$itemPosition] = $item;
-            } else {
-                $newPosition = $itemPosition + 1;
-                $sorterItems[$newPosition] = $item;
-            }
-        }
-        ksort($sorterItems);
+        usort($sorterItems, [$this, 'comparePosition']);
+
         return $sorterItems;
+    }
+
+    /**
+     * Compare item by key 'position'
+     *
+     * @param array $a
+     * @param array $b
+     * @return int It returns -1, 0 or 1 when $a['position'] is respectively less than,
+     * equal to, or greater than $a['position']
+     */
+    public function comparePosition(array $a, array $b): int
+    {
+        return (int)$a['position'] <=> (int)$b['position'];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/CollectionProviderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CollectionProviderTest.php
@@ -57,10 +57,12 @@ class CollectionProviderTest extends \PHPUnit\Framework\TestCase
         $linkedProductOneMock = $this->createMock(Product::class);
         $linkedProductTwoMock = $this->createMock(Product::class);
         $linkedProductThreeMock = $this->createMock(Product::class);
+        $linkedProductFourMock = $this->createMock(Product::class);
 
         $linkedProductOneMock->expects($this->once())->method('getId')->willReturn(1);
         $linkedProductTwoMock->expects($this->once())->method('getId')->willReturn(2);
         $linkedProductThreeMock->expects($this->once())->method('getId')->willReturn(3);
+        $linkedProductFourMock->expects($this->once())->method('getId')->willReturn(4);
 
         $this->converterPoolMock->expects($this->once())
             ->method('getConverter')
@@ -71,9 +73,10 @@ class CollectionProviderTest extends \PHPUnit\Framework\TestCase
             [$linkedProductOneMock, ['name' => 'Product One', 'position' => 10]],
             [$linkedProductTwoMock, ['name' => 'Product Two', 'position' => 2]],
             [$linkedProductThreeMock, ['name' => 'Product Three', 'position' => 2]],
+            [$linkedProductFourMock, ['name' => 'Product Four', 'position' => 5]],
         ];
 
-        $this->converterMock->expects($this->exactly(3))->method('convert')->willReturnMap($map);
+        $this->converterMock->expects($this->exactly(4))->method('convert')->willReturnMap($map);
 
         $this->providerMock->expects($this->once())
             ->method('getLinkedProducts')
@@ -82,14 +85,16 @@ class CollectionProviderTest extends \PHPUnit\Framework\TestCase
                 [
                     $linkedProductOneMock,
                     $linkedProductTwoMock,
-                    $linkedProductThreeMock
+                    $linkedProductThreeMock,
+                    $linkedProductFourMock,
                 ]
             );
 
         $expectedResult = [
-            2 => ['name' => 'Product Two', 'position' => 2],
-            3 => ['name' => 'Product Three', 'position' => 2],
-            10 => ['name' => 'Product One', 'position' => 10],
+            0 => ['name' => 'Product Three', 'position' => 2],
+            1 => ['name' => 'Product Two', 'position' => 2],
+            2 => ['name' => 'Product Four', 'position' => 5],
+            3 => ['name' => 'Product One', 'position' => 10],
         ];
 
         $actualResult = $this->model->getCollection($this->productMock, 'crosssell');


### PR DESCRIPTION
Fix productlink collection provider missing items when some positions are null.

### Description
There were several issues with the productlink collection provider. 

When several items have the position value of null, the position will get converted to '0'. When sorting, the items get sorted by indexing the items by position value and sort them by a key sort. Multiple '0' values for position, means duplicate indexes. 

The same applies with every case where multiple items have the same position value.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create some configurable products
2. Add related products to one of them
3. Try sorting the related products

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
