### PR TITLE
Fix of saving "clone_field" fields 

### DIFF
--- a/app/code/Magento/Config/Model/Config.php
+++ b/app/code/Magento/Config/Model/Config.php
@@ -237,13 +237,14 @@ class Config extends \Magento\Framework\DataObject
      * Get field path
      *
      * @param Field $field
+     * @param string $fieldId Need for support of clone_field feature
      * @param array &$oldConfig Need for compatibility with _processGroup()
      * @param array &$extraOldGroups Need for compatibility with _processGroup()
      * @return string
      */
-    private function getFieldPath(Field $field, array &$oldConfig, array &$extraOldGroups): string
+    private function getFieldPath(Field $field, string $fieldId, array &$oldConfig, array &$extraOldGroups): string
     {
-        $path = $field->getGroupPath() . '/' . $field->getId();
+        $path = $field->getGroupPath() . '/' . $fieldId;
 
         /**
          * Look for custom defined field path
@@ -303,7 +304,7 @@ class Config extends \Magento\Framework\DataObject
         if (isset($groupData['fields'])) {
             foreach ($groupData['fields'] as $fieldId => $fieldData) {
                 $field = $this->getField($sectionId, $groupId, $fieldId);
-                $path = $this->getFieldPath($field, $oldConfig, $extraOldGroups);
+                $path = $this->getFieldPath($field, $fieldId, $oldConfig, $extraOldGroups);
                 if ($this->isValueChanged($oldConfig, $path, $fieldData)) {
                     $changedPaths[] = $path;
                 }
@@ -398,7 +399,7 @@ class Config extends \Magento\Framework\DataObject
                 $backendModel->addData($data);
                 $this->_checkSingleStoreMode($field, $backendModel);
 
-                $path = $this->getFieldPath($field, $extraOldGroups, $oldConfig);
+                $path = $this->getFieldPath($field, $fieldId, $extraOldGroups, $oldConfig);
                 $backendModel->setPath($path)->setValue($fieldData['value']);
 
                 $inherit = !empty($fieldData['inherit']);


### PR DESCRIPTION
### Description
After the Config model's refactoring, which came with released version 2.2.6, there was an error in storing the fileds which were created using "clone_field" feature. When the values were stored, the path was wrong and the values were stored under the wrong key.

E.g. when saving Product Image Placeholders.
Instead of expected values `catalog/placeholder/image_placeholder`, `catalog/placeholder/ small_image_placeholder`, `catalog/placeholder/swatch_image_placeholder` and `catalog/placeholder/thumbnail_placeholder`, all fields were saved to the `catalog/placeholder/ placeholder`.
### Manual testing scenarios
1. Configuration -> Catalog -> Catalog
2. Open Product Image Placeholders tab
3. Upload an image
4. Save
5. "Saved" image is missing after page load.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
