### PR TITLE
Provide i18n wrapper to be used in underscore templates for translation

### DIFF
--- a/lib/web/underscore.js
+++ b/lib/web/underscore.js
@@ -1522,6 +1522,11 @@
     return '' + this._wrapped;
   };
 
+  // Provide i18n wrapper to be used in underscore templates for translation
+  _.i18n = function (str) {
+    return jQuery.mage.__(str);
+  };
+
   // AMD registration happens at the end for compatibility with AMD loaders
   // that may not enforce next-turn semantics on modules. Even though general
   // practice for AMD registration is to be anonymous, underscore registers


### PR DESCRIPTION
### Description
Provide i18n wrapper to be used in underscore templates for translation (using jQuery global object)

### Fixed Issues (if relevant)
1. magento/magento2#18012: Can not add string to underscore template using knockout

### Manual testing scenarios
1. Create a custom theme based on Luma
2. Extend Magento_Theme/frontend/web/templates/breadcrumbs.html or create any new underscore template
3. Add a string to breadcrumbs.html using i18n method using `<%= _.i18n('I will be translated!') %>`
4. translation should work on the string