### PR TITLE
Fix table rate failing for zip+4 address #17770

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/RateQuery.php
+++ b/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/RateQuery.php
@@ -42,6 +42,7 @@ class RateQuery
             ') OR (',
             [
                 "dest_country_id = :country_id AND dest_region_id = :region_id AND dest_zip = :postcode",
+                "dest_country_id = :country_id AND dest_region_id = :region_id AND dest_zip = :postcode_prefix",
                 "dest_country_id = :country_id AND dest_region_id = :region_id AND dest_zip = ''",
 
                 // Handle asterisk in dest_zip field
@@ -51,7 +52,7 @@ class RateQuery
                 "dest_country_id = '0' AND dest_region_id = 0 AND dest_zip = '*'",
                 "dest_country_id = :country_id AND dest_region_id = 0 AND dest_zip = ''",
                 "dest_country_id = :country_id AND dest_region_id = 0 AND dest_zip = :postcode",
-                "dest_country_id = :country_id AND dest_region_id = 0 AND dest_zip = '*'"
+                "dest_country_id = :country_id AND dest_region_id = 0 AND dest_zip = :postcode_prefix"
             ]
         ) . ')';
         $select->where($orWhere);
@@ -85,6 +86,7 @@ class RateQuery
             ':country_id' => $this->request->getDestCountryId(),
             ':region_id' => (int)$this->request->getDestRegionId(),
             ':postcode' => $this->request->getDestPostcode(),
+            ':postcode_prefix' => $this->getDestPostcodePrefix()
         ];
 
         // Render condition by condition name
@@ -111,5 +113,19 @@ class RateQuery
     public function getRequest()
     {
         return $this->request;
+    }
+
+    /**
+     * Returns the entire postcode if it contains no dash
+     * or the part of it prior to the dash in the other case
+     * @return string
+     */
+    private function getDestPostcodePrefix()
+    {
+        if (!preg_match("/^(.+)-(.+)$/", $this->request->getDestPostcode(), $zipParts)) {
+            return $this->request->getDestPostcode();
+        }
+
+        return $zipParts[1];
     }
 }


### PR DESCRIPTION
### Description
Currently when a customer uses an American ZIP+4 postcode, the table rate shipping method fails to return a quote.

### Fixed Issues (if relevant)
1. magento/magento2#17770

### Manual testing scenarios
1. Create a Product with weight >= 1.
2. Enable the Table shipping rate 
3. Import the rate CSV file:
`Country,Region/State,Zip/Postal Code,Weight (and above),Shipping Price`
`USA,*,12345,1,2`
4. Create a customer on the frontend with a zip code in the format ZIP+4 (ex: 12345-1234).
5. Add Product to your cart
6. Go to checkout

### Expected result
<!--- Tell us what should happen -->
1. The table rate shipping method should ignore the extension and  appear with a 2$ shipping fee.

### Actual result
<!--- Tell us what happens instead -->
1. The table rate shipping is not present.

The issue is now fixed. If the customer uses a ZIP+4 code (ex: 12345-1234) in case a rate for an exact match (12345-1234) is not found in the table there will be a fallback check for 12345.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
