### PR TITLE
Use version_compare to compare version strings correctly

### DIFF
--- a/lib/internal/Magento/Framework/Module/Plugin/DbStatusValidator.php
+++ b/lib/internal/Magento/Framework/Module/Plugin/DbStatusValidator.php
@@ -121,7 +121,7 @@ class DbStatusValidator
             (array)$allDbVersionErrors,
             function ($carry, $item) {
                 if ($item[DbVersionInfo::KEY_CURRENT] === 'none'
-                    || $item[DbVersionInfo::KEY_CURRENT] < $item[DbVersionInfo::KEY_REQUIRED]
+                    || version_compare($item[DbVersionInfo::KEY_CURRENT], $item[DbVersionInfo::KEY_REQUIRED], '<')
                 ) {
                     $carry['version_too_low'][] = $item;
                 } else {

--- a/lib/internal/Magento/Framework/Test/Unit/Module/Plugin/DbStatusValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Module/Plugin/DbStatusValidatorTest.php
@@ -157,29 +157,29 @@ class DbStatusValidatorTest extends \PHPUnit\Framework\TestCase
                     [
                         DbVersionInfo::KEY_MODULE => 'Magento_Module4',
                         DbVersionInfo::KEY_TYPE => 'data',
-                        DbVersionInfo::KEY_CURRENT => '1.0.1',
-                        DbVersionInfo::KEY_REQUIRED => '1.0.0'
+                        DbVersionInfo::KEY_CURRENT => '1.0.10',
+                        DbVersionInfo::KEY_REQUIRED => '1.0.9'
                     ],
                 ],
                 'expectedMessage' => "Please update your modules: "
                     . "Run \"composer install\" from the Magento root directory.\n"
                     . "The following modules are outdated:\n"
                     . "Magento_Module3 schema: code version - 1.0.0, database version - 2.0.0\n"
-                    . "Magento_Module4 data: code version - 1.0.0, database version - 1.0.1",
+                    . "Magento_Module4 data: code version - 1.0.9, database version - 1.0.10",
             ],
             'some versions too high, some too low' => [
                 'errors' => [
+                    [
+                        DbVersionInfo::KEY_MODULE => 'Magento_Module2',
+                        DbVersionInfo::KEY_TYPE => 'schema',
+                        DbVersionInfo::KEY_CURRENT => '1.9.0',
+                        DbVersionInfo::KEY_REQUIRED => '1.12.0'
+                    ],
                     [
                         DbVersionInfo::KEY_MODULE => 'Magento_Module1',
                         DbVersionInfo::KEY_TYPE => 'schema',
                         DbVersionInfo::KEY_CURRENT => '2.0.0',
                         DbVersionInfo::KEY_REQUIRED => '1.0.0'
-                    ],
-                    [
-                        DbVersionInfo::KEY_MODULE => 'Magento_Module2',
-                        DbVersionInfo::KEY_TYPE => 'schema',
-                        DbVersionInfo::KEY_CURRENT => '1.0.0',
-                        DbVersionInfo::KEY_REQUIRED => '2.0.0'
                     ],
                 ],
                 'expectedMessage' => "Please update your modules: "


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Version numbers were compared with regular alphanumeric string comparison `<`, which results in `1.10 < 1.9`. Instead, `version_compare` should be used

### Manual testing scenarios
1. Update a module from version 1.9.0 to 1.10.0 and open the shop in the browser
2. Expected message: "run setup:upgrade", not "run composer install"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
