### PR TITLE
requestShippingRates: set quote ID as given by the store manager

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1002,7 +1002,7 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
         /**
          * Store and website identifiers specified from StoreManager
          */
-        $request->setQuoteStoreId($this->getQuote()->getStoreId());
+        $request->setQuoteStoreId($this->storeManager->getWebsite()->getId());
         $request->setStoreId($this->storeManager->getStore()->getId());
         $request->setWebsiteId($this->storeManager->getWebsite()->getId());
         $request->setFreeShipping($this->getFreeShipping());


### PR DESCRIPTION
requestShippingRates: set quote ID as given by the store manager and not as given by the order itself

### Description

Because of the issue https://github.com/magento/magento2/issues/12889 this particalur line was added as a "fix", setting the store id for the quote as given by the quote object itself.
This lead to the standard shipping method's name shown in the cart view totals and shipping rate listing in the checkout to be shown as given by the store view, where the last product was added.

### Fixed Issues (if relevant)
This change should still solve the problem described in the issue https://github.com/magento/magento2/issues/12889 and don't mess up the labeling of the shipping rates shown in checkout for websites with multilanguage store views.

### Manual testing scenarios
Can be reproduce, if at least two store views, each with a different language and language specific naming of shipping rates, for one website are given. Add a product in one store view, switch to another language and go the checkout/cart view page.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
