### PR TITLE
[BUGFIX] - Timezone conversion fix for catalog module product option …

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Date.php
@@ -209,7 +209,7 @@ class Date extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
                     \IntlDateFormatter::MEDIUM,
                     \IntlDateFormatter::NONE,
                     null,
-                    'UTC'
+                    null
                 );
             } elseif ($this->getOption()->getType() == ProductCustomOptionInterface::OPTION_TYPE_DATE_TIME) {
                 $result = $this->_localeDate->formatDateTime(
@@ -217,7 +217,7 @@ class Date extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
                     \IntlDateFormatter::SHORT,
                     \IntlDateFormatter::SHORT,
                     null,
-                    'UTC'
+                    null
                 );
             } elseif ($this->getOption()->getType() == ProductCustomOptionInterface::OPTION_TYPE_TIME) {
                 $result = $this->_localeDate->formatDateTime(
@@ -225,7 +225,7 @@ class Date extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
                     \IntlDateFormatter::NONE,
                     \IntlDateFormatter::SHORT,
                     null,
-                    'UTC'
+                    null
                 );
             } else {
                 $result = $optionValue;


### PR DESCRIPTION
…type date model getFormattedOptionValue method

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Saved value in UTC is expected to be in local timezone on frontend.

For steps to reproduce the issue see https://github.com/magento/magento2/pull/18181#issuecomment-425810715

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
