### PR TITLE
Out of stock product variation not showing for configurable product when allow to display out of stock product option set to yes from backend configuration

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -114,6 +114,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $this->catalogProduct = $catalogProduct;
         $this->currentCustomer = $currentCustomer;
         $this->configurableAttributeData = $configurableAttributeData;
+		$this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
         $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
         $this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
         $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
@@ -232,6 +233,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             'priceFormat' => $this->localeFormat->getPriceFormat(),
             'prices' => $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo()),
             'productId' => $currentProduct->getId(),
+			'stockStatus'=> $this->getStockStatus(),
             'chooseText' => __('Choose an Option...'),
             'images' => $this->getOptionImages(),
             'index' => isset($options['index']) ? $options['index'] : [],
@@ -245,6 +247,22 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
 
         return $this->jsonEncoder->encode($config);
     }
+	
+	/**
+     * Get product stock status for configurable variations
+     *
+     * @return array
+     * @since 100.2.0
+     */
+	 protected function getStockStatus(){
+		$stockStatus = [];
+        foreach ($this->getAllowProducts() as $product) {
+            $productStockObject = $this->stockStatusData->getStockItem($product->getId());
+            $isInStock = $productStockObject['is_in_stock'];
+			$stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
+        }
+        return $stockStatus;
+	 }	
 
     /**
      * Get product images for configurable variations

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -21,344 +21,331 @@ use Magento\Framework\Pricing\PriceCurrencyInterface;
  * @api
  * @since 100.0.2
  */
-class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
-{
-    /**
-     * Catalog product
-     *
-     * @var \Magento\Catalog\Helper\Product
-     */
-    protected $catalogProduct = null;
+class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView {
+	/**
+	 * Catalog product
+	 *
+	 * @var \Magento\Catalog\Helper\Product
+	 */
+	protected $catalogProduct = null;
 
-    /**
-     * Current customer
-     *
-     * @deprecated 100.2.0, as unused property
-     * @var CurrentCustomer
-     */
-    protected $currentCustomer;
+	/**
+	 * Current customer
+	 *
+	 * @deprecated 100.2.0, as unused property
+	 * @var CurrentCustomer
+	 */
+	protected $currentCustomer;
 
-    /**
-     * Prices
-     *
-     * @var array
-     */
-    protected $_prices = [];
+	/**
+	 * Prices
+	 *
+	 * @var array
+	 */
+	protected $_prices = [];
 
-    /**
-     * @var \Magento\Framework\Json\EncoderInterface
-     */
-    protected $jsonEncoder;
+	/**
+	 * @var \Magento\Framework\Json\EncoderInterface
+	 */
+	protected $jsonEncoder;
 
-    /**
-     * @var \Magento\ConfigurableProduct\Helper\Data $imageHelper
-     */
-    protected $helper;
+	/**
+	 * @var \Magento\ConfigurableProduct\Helper\Data $imageHelper
+	 */
+	protected $helper;
 
-    /**
-     * @var PriceCurrencyInterface
-     */
-    protected $priceCurrency;
+	/**
+	 * @var PriceCurrencyInterface
+	 */
+	protected $priceCurrency;
 
-    /**
-     * @var ConfigurableAttributeData
-     */
-    protected $configurableAttributeData;
+	/**
+	 * @var ConfigurableAttributeData
+	 */
+	protected $configurableAttributeData;
 
-    /**
-     * @var Format
-     */
-    private $localeFormat;
+	/**
+	 * @var Format
+	 */
+	private $localeFormat;
 
-    /**
-     * @var Session
-     */
-    private $customerSession;
+	/**
+	 * @var Session
+	 */
+	private $customerSession;
 
-    /**
-     * @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices
-     */
-    private $variationPrices;
+	/**
+	 * @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices
+	 */
+	private $variationPrices;
 
-    /**
-     * @param \Magento\Catalog\Block\Product\Context $context
-     * @param \Magento\Framework\Stdlib\ArrayUtils $arrayUtils
-     * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
-     * @param \Magento\ConfigurableProduct\Helper\Data $helper
-     * @param \Magento\Catalog\Helper\Product $catalogProduct
-     * @param CurrentCustomer $currentCustomer
-     * @param PriceCurrencyInterface $priceCurrency
-     * @param ConfigurableAttributeData $configurableAttributeData
-     * @param array $data
-     * @param Format|null $localeFormat
-     * @param Session|null $customerSession
-     * @param \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices|null $variationPrices
-     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
-     */
-    public function __construct(
-        \Magento\Catalog\Block\Product\Context $context,
-        \Magento\Framework\Stdlib\ArrayUtils $arrayUtils,
-        \Magento\Framework\Json\EncoderInterface $jsonEncoder,
-        \Magento\ConfigurableProduct\Helper\Data $helper,
-        \Magento\Catalog\Helper\Product $catalogProduct,
-        CurrentCustomer $currentCustomer,
-        PriceCurrencyInterface $priceCurrency,
-        ConfigurableAttributeData $configurableAttributeData,
-        array $data = [],
-        Format $localeFormat = null,
-        Session $customerSession = null,
-        \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices $variationPrices = null
-    ) {
-        $this->priceCurrency = $priceCurrency;
-        $this->helper = $helper;
-        $this->jsonEncoder = $jsonEncoder;
-        $this->catalogProduct = $catalogProduct;
-        $this->currentCustomer = $currentCustomer;
-        $this->configurableAttributeData = $configurableAttributeData;
-        $this->stockStatusData = ObjectManager::getInstance()->get(StockRegistryInterface::class);
-        $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
-        $this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
-        $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
-            \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices::class
-        );
+	/**
+	 * @param \Magento\Catalog\Block\Product\Context $context
+	 * @param \Magento\Framework\Stdlib\ArrayUtils $arrayUtils
+	 * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
+	 * @param \Magento\ConfigurableProduct\Helper\Data $helper
+	 * @param \Magento\Catalog\Helper\Product $catalogProduct
+	 * @param CurrentCustomer $currentCustomer
+	 * @param PriceCurrencyInterface $priceCurrency
+	 * @param ConfigurableAttributeData $configurableAttributeData
+	 * @param array $data
+	 * @param Format|null $localeFormat
+	 * @param Session|null $customerSession
+	 * @param \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices|null $variationPrices
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+	 */
+	public function __construct(
+		\Magento\Catalog\Block\Product\Context $context,
+		\Magento\Framework\Stdlib\ArrayUtils $arrayUtils,
+		\Magento\Framework\Json\EncoderInterface $jsonEncoder,
+		\Magento\ConfigurableProduct\Helper\Data $helper,
+		\Magento\Catalog\Helper\Product $catalogProduct,
+		CurrentCustomer $currentCustomer,
+		PriceCurrencyInterface $priceCurrency,
+		ConfigurableAttributeData $configurableAttributeData,
+		array $data = [],
+		Format $localeFormat = null,
+		Session $customerSession = null,
+		\Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices $variationPrices = null
+	) {
+		$this->priceCurrency = $priceCurrency;
+		$this->helper = $helper;
+		$this->jsonEncoder = $jsonEncoder;
+		$this->catalogProduct = $catalogProduct;
+		$this->currentCustomer = $currentCustomer;
+		$this->configurableAttributeData = $configurableAttributeData;
+		$this->stockStatusData = ObjectManager::getInstance()->get(StockRegistryInterface::class);
+		$this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
+		$this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
+		$this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
+			\Magento\ConfigurableProduct\Model\Product\Type\Configurable\Variations\Prices::class
+		);
 
-        parent::__construct(
-            $context,
-            $arrayUtils,
-            $data
-        );
-    }
+		parent::__construct(
+			$context,
+			$arrayUtils,
+			$data
+		);
+	}
 
-    /**
-     * Get cache key informative items.
-     *
-     * @return array
-     * @since 100.2.0
-     */
-    public function getCacheKeyInfo()
-    {
-        $parentData = parent::getCacheKeyInfo();
-        $parentData[] = $this->priceCurrency->getCurrency()->getCode();
-        $parentData[] = $this->customerSession->getCustomerGroupId();
-        return $parentData;
-    }
+	/**
+	 * Get cache key informative items.
+	 *
+	 * @return array
+	 * @since 100.2.0
+	 */
+	public function getCacheKeyInfo() {
+		$parentData = parent::getCacheKeyInfo();
+		$parentData[] = $this->priceCurrency->getCurrency()->getCode();
+		$parentData[] = $this->customerSession->getCustomerGroupId();
+		return $parentData;
+	}
 
-    /**
-     * Get allowed attributes
-     *
-     * @return array
-     */
-    public function getAllowAttributes()
-    {
-        return $this->getProduct()->getTypeInstance()->getConfigurableAttributes($this->getProduct());
-    }
+	/**
+	 * Get allowed attributes
+	 *
+	 * @return array
+	 */
+	public function getAllowAttributes() {
+		return $this->getProduct()->getTypeInstance()->getConfigurableAttributes($this->getProduct());
+	}
 
-    /**
-     * Check if allowed attributes have options
-     *
-     * @return bool
-     */
-    public function hasOptions()
-    {
-        $attributes = $this->getAllowAttributes();
-        if (count($attributes)) {
-            foreach ($attributes as $attribute) {
-                /** @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute $attribute */
-                if ($attribute->getData('options')) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+	/**
+	 * Check if allowed attributes have options
+	 *
+	 * @return bool
+	 */
+	public function hasOptions() {
+		$attributes = $this->getAllowAttributes();
+		if (count($attributes)) {
+			foreach ($attributes as $attribute) {
+				/** @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute $attribute */
+				if ($attribute->getData('options')) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
-    /**
-     * Get Allowed Products
-     *
-     * @return \Magento\Catalog\Model\Product[]
-     */
-    public function getAllowProducts()
-    {
-        if (!$this->hasAllowProducts()) {
-            $products = [];
-            $skipSaleableCheck = $this->catalogProduct->getSkipSaleableCheck();
-            $allProducts = $this->getProduct()->getTypeInstance()->getUsedProducts($this->getProduct(), null);
-            foreach ($allProducts as $product) {
-                if ($product->isSaleable() || $skipSaleableCheck) {
-                    $products[] = $product;
-                }
-            }
-            $this->setAllowProducts($products);
-        }
-        return $this->getData('allow_products');
-    }
+	/**
+	 * Get Allowed Products
+	 *
+	 * @return \Magento\Catalog\Model\Product[]
+	 */
+	public function getAllowProducts() {
+		if (!$this->hasAllowProducts()) {
+			$products = [];
+			$skipSaleableCheck = $this->catalogProduct->getSkipSaleableCheck();
+			$allProducts = $this->getProduct()->getTypeInstance()->getUsedProducts($this->getProduct(), null);
+			foreach ($allProducts as $product) {
+				if ($product->isSaleable() || $skipSaleableCheck) {
+					$products[] = $product;
+				}
+			}
+			$this->setAllowProducts($products);
+		}
+		return $this->getData('allow_products');
+	}
 
-    /**
-     * Retrieve current store
-     *
-     * @return \Magento\Store\Model\Store
-     */
-    public function getCurrentStore()
-    {
-        return $this->_storeManager->getStore();
-    }
+	/**
+	 * Retrieve current store
+	 *
+	 * @return \Magento\Store\Model\Store
+	 */
+	public function getCurrentStore() {
+		return $this->_storeManager->getStore();
+	}
 
-    /**
-     * Returns additional values for js config, con be overridden by descendants
-     *
-     * @return array
-     */
-    protected function _getAdditionalConfig()
-    {
-        return [];
-    }
+	/**
+	 * Returns additional values for js config, con be overridden by descendants
+	 *
+	 * @return array
+	 */
+	protected function _getAdditionalConfig() {
+		return [];
+	}
 
-    /**
-     * Composes configuration for js
-     *
-     * @return string
-     */
-    public function getJsonConfig()
-    {
-        $store = $this->getCurrentStore();
-        $currentProduct = $this->getProduct();
+	/**
+	 * Composes configuration for js
+	 *
+	 * @return string
+	 */
+	public function getJsonConfig() {
+		$store = $this->getCurrentStore();
+		$currentProduct = $this->getProduct();
 
-        $options = $this->helper->getOptions($currentProduct, $this->getAllowProducts());
-        $attributesData = $this->configurableAttributeData->getAttributesData($currentProduct, $options);
+		$options = $this->helper->getOptions($currentProduct, $this->getAllowProducts());
+		$attributesData = $this->configurableAttributeData->getAttributesData($currentProduct, $options);
 
-        $config = [
-            'attributes' => $attributesData['attributes'],
-            'template' => str_replace('%s', '<%- data.price %>', $store->getCurrentCurrency()->getOutputFormat()),
-            'currencyFormat' => $store->getCurrentCurrency()->getOutputFormat(),
-            'optionPrices' => $this->getOptionPrices(),
-            'priceFormat' => $this->localeFormat->getPriceFormat(),
-            'prices' => $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo()),
-            'productId' => $currentProduct->getId(),
-            'stockStatus' => $this->getStockStatus(),
-            'chooseText' => __('Choose an Option...'),
-            'images' => $this->getOptionImages(),
-            'index' => isset($options['index']) ? $options['index'] : [],
-        ];
+		$config = [
+			'attributes' => $attributesData['attributes'],
+			'template' => str_replace('%s', '<%- data.price %>', $store->getCurrentCurrency()->getOutputFormat()),
+			'currencyFormat' => $store->getCurrentCurrency()->getOutputFormat(),
+			'optionPrices' => $this->getOptionPrices(),
+			'priceFormat' => $this->localeFormat->getPriceFormat(),
+			'prices' => $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo()),
+			'productId' => $currentProduct->getId(),
+			'stockStatus' => $this->getStockStatus(),
+			'chooseText' => __('Choose an Option...'),
+			'images' => $this->getOptionImages(),
+			'index' => isset($options['index']) ? $options['index'] : [],
+		];
 
-        if ($currentProduct->hasPreconfiguredValues() && !empty($attributesData['defaultValues'])) {
-            $config['defaultValues'] = $attributesData['defaultValues'];
-        }
+		if ($currentProduct->hasPreconfiguredValues() && !empty($attributesData['defaultValues'])) {
+			$config['defaultValues'] = $attributesData['defaultValues'];
+		}
 
-        $config = array_merge($config, $this->_getAdditionalConfig());
+		$config = array_merge($config, $this->_getAdditionalConfig());
 
-        return $this->jsonEncoder->encode($config);
-    }
+		return $this->jsonEncoder->encode($config);
+	}
 
-    /**
-     * Get product stock status for configurable variations
-     *
-     * @return array
-     * @since 100.2.0
-     */
-    public function getStockStatus()
-    {
-        $stockStatus = [];
-        foreach ($this->getAllowProducts() as $product) {
-            $productStockObject = $this->stockStatusData->getStockItem($product->getId());
-            $isInStock = $productStockObject['is_in_stock'];
-            $stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
-        }
-        return $stockStatus;
-    }
+	/**
+	 * Get product stock status for configurable variations
+	 *
+	 * @return array
+	 * @since 100.2.0
+	 */
+	public function getStockStatus() {
+		$stockStatus = [];
+		foreach ($this->getAllowProducts() as $product) {
+			$productStockObject = $this->stockStatusData->getStockItem($product->getId());
+			$isInStock = $productStockObject['is_in_stock'];
+			$stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
+		}
+		return $stockStatus;
+	}
 
-    /**
-     * Get product images for configurable variations
-     *
-     * @return array
-     * @since 100.2.0
-     */
-    protected function getOptionImages()
-    {
-        $images = [];
-        foreach ($this->getAllowProducts() as $product) {
-            $productImages = $this->helper->getGalleryImages($product) ?: [];
-            foreach ($productImages as $image) {
-                $images[$product->getId()][] =
-                    [
-                    'thumb' => $image->getData('small_image_url'),
-                    'img' => $image->getData('medium_image_url'),
-                    'full' => $image->getData('large_image_url'),
-                    'caption' => $image->getLabel(),
-                    'position' => $image->getPosition(),
-                    'isMain' => $image->getFile() == $product->getImage(),
-                    'type' => str_replace('external-', '', $image->getMediaType()),
-                    'videoUrl' => $image->getVideoUrl(),
-                ];
-            }
-        }
+	/**
+	 * Get product images for configurable variations
+	 *
+	 * @return array
+	 * @since 100.2.0
+	 */
+	protected function getOptionImages() {
+		$images = [];
+		foreach ($this->getAllowProducts() as $product) {
+			$productImages = $this->helper->getGalleryImages($product) ?: [];
+			foreach ($productImages as $image) {
+				$images[$product->getId()][] =
+				[
+					'thumb' => $image->getData('small_image_url'),
+					'img' => $image->getData('medium_image_url'),
+					'full' => $image->getData('large_image_url'),
+					'caption' => $image->getLabel(),
+					'position' => $image->getPosition(),
+					'isMain' => $image->getFile() == $product->getImage(),
+					'type' => str_replace('external-', '', $image->getMediaType()),
+					'videoUrl' => $image->getVideoUrl(),
+				];
+			}
+		}
 
-        return $images;
-    }
+		return $images;
+	}
 
-    /**
-     * @return array
-     */
-    protected function getOptionPrices()
-    {
-        $prices = [];
-        foreach ($this->getAllowProducts() as $product) {
-            $tierPrices = [];
-            $priceInfo = $product->getPriceInfo();
-            $tierPriceModel = $priceInfo->getPrice('tier_price');
-            $tierPricesList = $tierPriceModel->getTierPriceList();
-            foreach ($tierPricesList as $tierPrice) {
-                $tierPrices[] = [
-                    'qty' => $this->localeFormat->getNumber($tierPrice['price_qty']),
-                    'price' => $this->localeFormat->getNumber($tierPrice['price']->getValue()),
-                    'percentage' => $this->localeFormat->getNumber(
-                        $tierPriceModel->getSavePercent($tierPrice['price'])
-                    ),
-                ];
-            }
+	/**
+	 * @return array
+	 */
+	protected function getOptionPrices() {
+		$prices = [];
+		foreach ($this->getAllowProducts() as $product) {
+			$tierPrices = [];
+			$priceInfo = $product->getPriceInfo();
+			$tierPriceModel = $priceInfo->getPrice('tier_price');
+			$tierPricesList = $tierPriceModel->getTierPriceList();
+			foreach ($tierPricesList as $tierPrice) {
+				$tierPrices[] = [
+					'qty' => $this->localeFormat->getNumber($tierPrice['price_qty']),
+					'price' => $this->localeFormat->getNumber($tierPrice['price']->getValue()),
+					'percentage' => $this->localeFormat->getNumber(
+						$tierPriceModel->getSavePercent($tierPrice['price'])
+					),
+				];
+			}
 
-            $prices[$product->getId()] =
-                [
-                'oldPrice' => [
-                    'amount' => $this->localeFormat->getNumber(
-                        $priceInfo->getPrice('regular_price')->getAmount()->getValue()
-                    ),
-                ],
-                'basePrice' => [
-                    'amount' => $this->localeFormat->getNumber(
-                        $priceInfo->getPrice('final_price')->getAmount()->getBaseAmount()
-                    ),
-                ],
-                'finalPrice' => [
-                    'amount' => $this->localeFormat->getNumber(
-                        $priceInfo->getPrice('final_price')->getAmount()->getValue()
-                    ),
-                ],
-                'tierPrices' => $tierPrices,
-            ];
-        }
-        return $prices;
-    }
+			$prices[$product->getId()] =
+			[
+				'oldPrice' => [
+					'amount' => $this->localeFormat->getNumber(
+						$priceInfo->getPrice('regular_price')->getAmount()->getValue()
+					),
+				],
+				'basePrice' => [
+					'amount' => $this->localeFormat->getNumber(
+						$priceInfo->getPrice('final_price')->getAmount()->getBaseAmount()
+					),
+				],
+				'finalPrice' => [
+					'amount' => $this->localeFormat->getNumber(
+						$priceInfo->getPrice('final_price')->getAmount()->getValue()
+					),
+				],
+				'tierPrices' => $tierPrices,
+			];
+		}
+		return $prices;
+	}
 
-    /**
-     * Replace ',' on '.' for js
-     *
-     * @deprecated 100.2.0 Will be removed in major release
-     * @param float $price
-     * @return string
-     */
-    protected function _registerJsPrice($price)
-    {
-        return str_replace(',', '.', $price);
-    }
+	/**
+	 * Replace ',' on '.' for js
+	 *
+	 * @deprecated 100.2.0 Will be removed in major release
+	 * @param float $price
+	 * @return string
+	 */
+	protected function _registerJsPrice($price) {
+		return str_replace(',', '.', $price);
+	}
 
-    /**
-     * Should we generate "As low as" block or not
-     *
-     * @return bool
-     * @since 100.2.0
-     */
-    public function showMinimalPrice()
-    {
-        return true;
-    }
+	/**
+	 * Should we generate "As low as" block or not
+	 *
+	 * @return bool
+	 * @since 100.2.0
+	 */
+	public function showMinimalPrice() {
+		return true;
+	}
 }

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -114,7 +114,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $this->catalogProduct = $catalogProduct;
         $this->currentCustomer = $currentCustomer;
         $this->configurableAttributeData = $configurableAttributeData;
-	$this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
+	  $this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
         $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
         $this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
         $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
@@ -233,7 +233,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             'priceFormat' => $this->localeFormat->getPriceFormat(),
             'prices' => $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo()),
             'productId' => $currentProduct->getId(),
-	    'stockStatus'=> $this->getStockStatus(),
+	      'stockStatus'=> $this->getStockStatus(),
             'chooseText' => __('Choose an Option...'),
             'images' => $this->getOptionImages(),
             'index' => isset($options['index']) ? $options['index'] : [],

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -114,7 +114,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $this->catalogProduct = $catalogProduct;
         $this->currentCustomer = $currentCustomer;
         $this->configurableAttributeData = $configurableAttributeData;
-	  $this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
+        $this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
         $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
         $this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
         $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
@@ -233,7 +233,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             'priceFormat' => $this->localeFormat->getPriceFormat(),
             'prices' => $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo()),
             'productId' => $currentProduct->getId(),
-	      'stockStatus'=> $this->getStockStatus(),
+            'stockStatus' => $this->getStockStatus(),
             'chooseText' => __('Choose an Option...'),
             'images' => $this->getOptionImages(),
             'index' => isset($options['index']) ? $options['index'] : [],
@@ -247,7 +247,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
 
         return $this->jsonEncoder->encode($config);
     }
-	
+
     /**
      * Get product stock status for configurable variations
      *
@@ -256,14 +256,14 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
      */
     protected function getStockStatus()
     {
-	$stockStatus = [];
+        $stockStatus = [];
         foreach ($this->getAllowProducts() as $product) {
             $productStockObject = $this->stockStatusData->getStockItem($product->getId());
             $isInStock = $productStockObject['is_in_stock'];
-	    $stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
+            $stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
         }
         return $stockStatus;
-    }	
+    }
 
     /**
      * Get product images for configurable variations
@@ -279,15 +279,15 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             foreach ($productImages as $image) {
                 $images[$product->getId()][] =
                     [
-                        'thumb' => $image->getData('small_image_url'),
-                        'img' => $image->getData('medium_image_url'),
-                        'full' => $image->getData('large_image_url'),
-                        'caption' => $image->getLabel(),
-                        'position' => $image->getPosition(),
-                        'isMain' => $image->getFile() == $product->getImage(),
-                        'type' => str_replace('external-', '', $image->getMediaType()),
-                        'videoUrl' => $image->getVideoUrl(),
-                    ];
+                    'thumb' => $image->getData('small_image_url'),
+                    'img' => $image->getData('medium_image_url'),
+                    'full' => $image->getData('large_image_url'),
+                    'caption' => $image->getLabel(),
+                    'position' => $image->getPosition(),
+                    'isMain' => $image->getFile() == $product->getImage(),
+                    'type' => str_replace('external-', '', $image->getMediaType()),
+                    'videoUrl' => $image->getVideoUrl(),
+                ];
             }
         }
 
@@ -303,7 +303,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         foreach ($this->getAllowProducts() as $product) {
             $tierPrices = [];
             $priceInfo = $product->getPriceInfo();
-            $tierPriceModel =  $priceInfo->getPrice('tier_price');
+            $tierPriceModel = $priceInfo->getPrice('tier_price');
             $tierPricesList = $tierPriceModel->getTierPriceList();
             foreach ($tierPricesList as $tierPrice) {
                 $tierPrices[] = [
@@ -317,23 +317,23 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
 
             $prices[$product->getId()] =
                 [
-                    'oldPrice' => [
-                        'amount' => $this->localeFormat->getNumber(
-                            $priceInfo->getPrice('regular_price')->getAmount()->getValue()
-                        ),
-                    ],
-                    'basePrice' => [
-                        'amount' => $this->localeFormat->getNumber(
-                            $priceInfo->getPrice('final_price')->getAmount()->getBaseAmount()
-                        ),
-                    ],
-                    'finalPrice' => [
-                        'amount' => $this->localeFormat->getNumber(
-                            $priceInfo->getPrice('final_price')->getAmount()->getValue()
-                        ),
-                    ],
-                    'tierPrices' => $tierPrices,
-                 ];
+                'oldPrice' => [
+                    'amount' => $this->localeFormat->getNumber(
+                        $priceInfo->getPrice('regular_price')->getAmount()->getValue()
+                    ),
+                ],
+                'basePrice' => [
+                    'amount' => $this->localeFormat->getNumber(
+                        $priceInfo->getPrice('final_price')->getAmount()->getBaseAmount()
+                    ),
+                ],
+                'finalPrice' => [
+                    'amount' => $this->localeFormat->getNumber(
+                        $priceInfo->getPrice('final_price')->getAmount()->getValue()
+                    ),
+                ],
+                'tierPrices' => $tierPrices,
+            ];
         }
         return $prices;
     }

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -114,7 +114,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $this->catalogProduct = $catalogProduct;
         $this->currentCustomer = $currentCustomer;
         $this->configurableAttributeData = $configurableAttributeData;
-		$this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
+	$this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
         $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
         $this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
         $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
@@ -233,7 +233,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             'priceFormat' => $this->localeFormat->getPriceFormat(),
             'prices' => $this->variationPrices->getFormattedPrices($this->getProduct()->getPriceInfo()),
             'productId' => $currentProduct->getId(),
-			'stockStatus'=> $this->getStockStatus(),
+	    'stockStatus'=> $this->getStockStatus(),
             'chooseText' => __('Choose an Option...'),
             'images' => $this->getOptionImages(),
             'index' => isset($options['index']) ? $options['index'] : [],
@@ -254,15 +254,15 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
      * @return array
      * @since 100.2.0
      */
-	 protected function getStockStatus(){
-		$stockStatus = [];
+     protected function getStockStatus(){
+	$stockStatus = [];
         foreach ($this->getAllowProducts() as $product) {
             $productStockObject = $this->stockStatusData->getStockItem($product->getId());
             $isInStock = $productStockObject['is_in_stock'];
 			$stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
         }
         return $stockStatus;
-	 }	
+     }	
 
     /**
      * Get product images for configurable variations

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -7,6 +7,7 @@
  */
 namespace Magento\ConfigurableProduct\Block\Product\View\Type;
 
+use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\ConfigurableProduct\Model\ConfigurableAttributeData;
 use Magento\Customer\Helper\Session\CurrentCustomer;
 use Magento\Customer\Model\Session;
@@ -114,7 +115,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         $this->catalogProduct = $catalogProduct;
         $this->currentCustomer = $currentCustomer;
         $this->configurableAttributeData = $configurableAttributeData;
-        $this->stockStatusData = ObjectManager::getInstance()->get('Magento\CatalogInventory\Api\StockRegistryInterface');
+        $this->stockStatusData = ObjectManager::getInstance()->get(StockRegistryInterface::class);
         $this->localeFormat = $localeFormat ?: ObjectManager::getInstance()->get(Format::class);
         $this->customerSession = $customerSession ?: ObjectManager::getInstance()->get(Session::class);
         $this->variationPrices = $variationPrices ?: ObjectManager::getInstance()->get(
@@ -254,7 +255,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
      * @return array
      * @since 100.2.0
      */
-    protected function getStockStatus()
+    public function getStockStatus()
     {
         $stockStatus = [];
         foreach ($this->getAllowProducts() as $product) {

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -2,7 +2,7 @@
 /**
  * Catalog super product configurable part block
  *
- * Copyright Â© Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\ConfigurableProduct\Block\Product\View\Type;
@@ -248,21 +248,22 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
         return $this->jsonEncoder->encode($config);
     }
 	
-	/**
+    /**
      * Get product stock status for configurable variations
      *
      * @return array
      * @since 100.2.0
      */
-     protected function getStockStatus(){
+    protected function getStockStatus()
+    {
 	$stockStatus = [];
         foreach ($this->getAllowProducts() as $product) {
             $productStockObject = $this->stockStatusData->getStockItem($product->getId());
             $isInStock = $productStockObject['is_in_stock'];
-			$stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
+	    $stockStatus[$product->getId()] = [$this->localeFormat->getNumber($isInStock)];
         }
         return $stockStatus;
-     }	
+    }	
 
     /**
      * Get product images for configurable variations

--- a/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\ConfigurableProduct\Plugin\Model\ResourceModel\Attribute;
 
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\CatalogInventory\Model\ResourceModel\Stock\Status;
 use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionSelectBuilderInterface;
 use Magento\Framework\DB\Select;
@@ -21,12 +22,19 @@ class InStockOptionSelectBuilder
      */
     private $stockStatusResource;
     
+	/**
+     *
+     * @var Configuration
+     */
+    private $stockConfiguration;
+	
     /**
      * @param Status $stockStatusResource
      */
-    public function __construct(Status $stockStatusResource)
+    public function __construct(Status $stockStatusResource, StockConfigurationInterface $stockConfiguration)
     {
         $this->stockStatusResource = $stockStatusResource;
+		$this->stockConfiguration = $stockConfiguration;
     }
 
     /**
@@ -40,14 +48,16 @@ class InStockOptionSelectBuilder
      */
     public function afterGetSelect(OptionSelectBuilderInterface $subject, Select $select)
     {
-        $select->joinInner(
-            ['stock' => $this->stockStatusResource->getMainTable()],
-            'stock.product_id = entity.entity_id',
-            []
-        )->where(
-            'stock.stock_status = ?',
-            \Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
-        );
+		if (!$this->stockConfiguration->isShowOutOfStock()) {
+			$select->joinInner(
+				['stock' => $this->stockStatusResource->getMainTable()],
+				'stock.product_id = entity.entity_id',
+				[]
+			)->where(
+				'stock.stock_status = ?',
+				\Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
+			);
+		}
         
         return $select;
     }

--- a/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
@@ -30,6 +30,7 @@ class InStockOptionSelectBuilder
 
     /**
      * @param Status $stockStatusResource
+     * @param StockConfigurationInterface $stockConfiguration
      */
     public function __construct(
         Status $stockStatusResource,

--- a/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
@@ -21,13 +21,13 @@ class InStockOptionSelectBuilder
      * @var Status
      */
     private $stockStatusResource;
-    
-	/**
+
+    /**
      *
      * @var Configuration
      */
     private $stockConfiguration;
-	
+
     /**
      * @param Status $stockStatusResource
      */
@@ -36,7 +36,7 @@ class InStockOptionSelectBuilder
         StockConfigurationInterface $stockConfiguration
     ) {
         $this->stockStatusResource = $stockStatusResource;
-	  $this->stockConfiguration = $stockConfiguration;
+        $this->stockConfiguration = $stockConfiguration;
     }
 
     /**
@@ -48,13 +48,13 @@ class InStockOptionSelectBuilder
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterGetSelect(OptionSelectBuilderInterface $subject, Select $select) 
+    public function afterGetSelect(OptionSelectBuilderInterface $subject, Select $select)
     {
         if (!$this->stockConfiguration->isShowOutOfStock()) {
             $select->joinInner(
-                    ['stock' => $this->stockStatusResource->getMainTable()], 'stock.product_id = entity.entity_id', []
+                ['stock' => $this->stockStatusResource->getMainTable()], 'stock.product_id = entity.entity_id', []
             )->where(
-                    'stock.stock_status = ?', \Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
+                'stock.stock_status = ?', \Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
             );
         }
         return $select;

--- a/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright Â© Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\ConfigurableProduct\Plugin\Model\ResourceModel\Attribute;
@@ -31,10 +31,12 @@ class InStockOptionSelectBuilder
     /**
      * @param Status $stockStatusResource
      */
-    public function __construct(Status $stockStatusResource, StockConfigurationInterface $stockConfiguration)
-    {
+    public function __construct(
+        Status $stockStatusResource,
+        StockConfigurationInterface $stockConfiguration
+    ) {
         $this->stockStatusResource = $stockStatusResource;
-		$this->stockConfiguration = $stockConfiguration;
+	$this->stockConfiguration = $stockConfiguration;
     }
 
     /**
@@ -46,19 +48,16 @@ class InStockOptionSelectBuilder
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterGetSelect(OptionSelectBuilderInterface $subject, Select $select)
+    public function afterGetSelect(OptionSelectBuilderInterface $subject, Select $select) 
     {
-		if (!$this->stockConfiguration->isShowOutOfStock()) {
-			$select->joinInner(
-				['stock' => $this->stockStatusResource->getMainTable()],
-				'stock.product_id = entity.entity_id',
-				[]
-			)->where(
-				'stock.stock_status = ?',
-				\Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
-			);
-		}
-        
+        if (!$this->stockConfiguration->isShowOutOfStock()) {
+            $select->joinInner(
+                    ['stock' => $this->stockStatusResource->getMainTable()], 'stock.product_id = entity.entity_id', []
+            )->where(
+                    'stock.stock_status = ?', \Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
+            );
+        }
         return $select;
     }
+
 }

--- a/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Attribute/InStockOptionSelectBuilder.php
@@ -36,7 +36,7 @@ class InStockOptionSelectBuilder
         StockConfigurationInterface $stockConfiguration
     ) {
         $this->stockStatusResource = $stockStatusResource;
-	$this->stockConfiguration = $stockConfiguration;
+	  $this->stockConfiguration = $stockConfiguration;
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -394,6 +394,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'productId' => $productId,
+			'stockStatus' => [],
             'chooseText' => __('Choose an Option...'),
             'images' => [],
             'index' => [],

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -394,7 +394,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'productId' => $productId,
-	    'stockStatus' => [],
+	      'stockStatus' => [],
             'chooseText' => __('Choose an Option...'),
             'images' => [],
             'index' => [],

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -336,7 +336,12 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $expectedArray = $this->getExpectedArray($productId, $amount, $priceQty, $percentage);
+        $stockStatus = $productTypeMock->expects($this->once())
+            ->method('getStockStatus')
+            ->with($productMock)
+            ->willReturn([]);
+
+        $expectedArray = $this->getExpectedArray($productId, $amount, $priceQty, $percentage, $stockStatus);
         $expectedJson = json_encode($expectedArray);
 
         $this->jsonEncoder->expects($this->once())->method('encode')->with($expectedArray)->willReturn($expectedJson);
@@ -355,7 +360,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
      * @param int $percentage
      * @return array
      */
-    private function getExpectedArray($productId, $amount, $priceQty, $percentage): array
+    private function getExpectedArray($productId, $amount, $priceQty, $percentage, $stockStatus): array
     {
         $expectedArray = [
             'attributes' => [],
@@ -394,7 +399,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'productId' => $productId,
-            'stockStatus' => [],
+            'stockStatus' => $stockStatus,
             'chooseText' => __('Choose an Option...'),
             'images' => [],
             'index' => [],

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -394,7 +394,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'productId' => $productId,
-			'stockStatus' => [],
+	    'stockStatus' => [],
             'chooseText' => __('Choose an Option...'),
             'images' => [],
             'index' => [],

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -336,10 +336,8 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $stockStatus = $productTypeMock->expects($this->once())
-            ->method('getStockStatus')
-            ->with($productMock)
-            ->willReturn([]);
+        $this->block->setData('product', $productMock);
+        $stockStatus = $this->block->getStockStatus();
 
         $expectedArray = $this->getExpectedArray($productId, $amount, $priceQty, $percentage, $stockStatus);
         $expectedJson = json_encode($expectedArray);

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -219,7 +219,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'USD',
                 null,
-            ]
+            ],
         ];
     }
 
@@ -394,7 +394,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'productId' => $productId,
-	      'stockStatus' => [],
+            'stockStatus' => [],
             'chooseText' => __('Choose an Option...'),
             'images' => [],
             'index' => [],

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -309,12 +309,34 @@ define([
                 this._sortAttributes();
                 this._RenderControls();
                 this._setPreSelectedGallery();
+				this._setStockStatus();
                 $(this.element).trigger('swatch.initialized');
             } else {
                 console.log('SwatchRenderer: No input data received');
             }
             this.options.tierPriceTemplate = $(this.options.tierPriceTemplateSelector).html();
         },
+		
+		/**
+         * @private
+         */
+		 _setStockStatus: function () {
+            var $widget = this, result,i;
+			result = $widget.options.jsonConfig.stockStatus;
+			for(var i = 0; i<this.options.jsonConfig.attributes[0].options.length;i++){
+				var productId = this.options.jsonConfig.attributes[0].options[i].products[0];
+				if(result[productId] == 0){
+					var optionId = this.options.jsonConfig.attributes[0].options[i].id;
+					$('.swatch-attribute').find('[option-id]').each(function () {
+						var $element = $(this),
+						option = $element.attr('option-id');
+						if(option == optionId){
+							$element.addClass('disabled');	
+						}
+					});
+				}
+			}
+         },
 
         /**
          * @private
@@ -732,6 +754,7 @@ define([
 
             $widget._loadMedia();
             $input.trigger('change');
+			$widget._setStockStatus();
         },
 
         /**

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright Â© Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -309,7 +309,7 @@ define([
                 this._sortAttributes();
                 this._RenderControls();
                 this._setPreSelectedGallery();
-	        this._setStockStatus();
+	          this._setStockStatus();
                 $(this.element).trigger('swatch.initialized');
             } else {
                 console.log('SwatchRenderer: No input data received');
@@ -754,7 +754,7 @@ define([
 
             $widget._loadMedia();
             $input.trigger('change');
-	    $widget._setStockStatus();
+	      $widget._setStockStatus();
         },
 
         /**

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright Â© Magento, Inc. All rights reserved.
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -309,7 +309,7 @@ define([
                 this._sortAttributes();
                 this._RenderControls();
                 this._setPreSelectedGallery();
-				this._setStockStatus();
+	        this._setStockStatus();
                 $(this.element).trigger('swatch.initialized');
             } else {
                 console.log('SwatchRenderer: No input data received');
@@ -317,26 +317,26 @@ define([
             this.options.tierPriceTemplate = $(this.options.tierPriceTemplateSelector).html();
         },
 		
-		/**
+	/**
          * @private
          */
-		 _setStockStatus: function () {
-            var $widget = this, result,i;
-			result = $widget.options.jsonConfig.stockStatus;
-			for(var i = 0; i<this.options.jsonConfig.attributes[0].options.length;i++){
-				var productId = this.options.jsonConfig.attributes[0].options[i].products[0];
-				if(result[productId] == 0){
-					var optionId = this.options.jsonConfig.attributes[0].options[i].id;
-					$('.swatch-attribute').find('[option-id]').each(function () {
-						var $element = $(this),
-						option = $element.attr('option-id');
-						if(option == optionId){
-							$element.addClass('disabled');	
-						}
-					});
-				}
-			}
-         },
+	_setStockStatus: function () {
+            var $widget = this, result, i;
+            result = $widget.options.jsonConfig.stockStatus;
+            for (var i = 0; i < this.options.jsonConfig.attributes[0].options.length; i++) {
+                var productId = this.options.jsonConfig.attributes[0].options[i].products[0];
+                if (result[productId] == 0) {
+                    var optionId = this.options.jsonConfig.attributes[0].options[i].id;
+                    $('.swatch-attribute').find('[option-id]').each(function () {
+                        var $element = $(this),
+                                option = $element.attr('option-id');
+                        if (option == optionId) {
+                            $element.addClass('disabled');
+                        }
+                    });
+                }
+            }
+        },
 
         /**
          * @private
@@ -754,7 +754,7 @@ define([
 
             $widget._loadMedia();
             $input.trigger('change');
-			$widget._setStockStatus();
+	    $widget._setStockStatus();
         },
 
         /**

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -309,18 +309,18 @@ define([
                 this._sortAttributes();
                 this._RenderControls();
                 this._setPreSelectedGallery();
-	          this._setStockStatus();
+                this._setStockStatus();
                 $(this.element).trigger('swatch.initialized');
             } else {
                 console.log('SwatchRenderer: No input data received');
             }
             this.options.tierPriceTemplate = $(this.options.tierPriceTemplateSelector).html();
         },
-		
-	/**
+        
+	    /**
          * @private
          */
-	_setStockStatus: function () {
+         _setStockStatus: function () {
             var $widget = this, result, i;
             result = $widget.options.jsonConfig.stockStatus;
             for (var i = 0; i < this.options.jsonConfig.attributes[0].options.length; i++) {
@@ -329,7 +329,7 @@ define([
                     var optionId = this.options.jsonConfig.attributes[0].options[i].id;
                     $('.swatch-attribute').find('[option-id]').each(function () {
                         var $element = $(this),
-                                option = $element.attr('option-id');
+                        option = $element.attr('option-id');
                         if (option == optionId) {
                             $element.addClass('disabled');
                         }
@@ -754,7 +754,7 @@ define([
 
             $widget._loadMedia();
             $input.trigger('change');
-	      $widget._setStockStatus();
+            $widget._setStockStatus();
         },
 
         /**


### PR DESCRIPTION
### Description
When display out of stock product set to YES from the backend configuration,  Configurable product variation not showing.
I found this problem when configurable product have only one option like color
![screenshot](https://user-images.githubusercontent.com/23476956/45893206-1825e880-bde8-11e8-8660-3d16e6ec8ad9.png)
![screenshot 1](https://user-images.githubusercontent.com/23476956/45893211-1b20d900-bde8-11e8-8aae-45c5cb15fb0f.png)

### Fixed Issues (if relevant)
1. magento/magento2#10454 : Attributes - Display Out of Stock Products

### Manual testing scenarios
For steps to reproduce, please check bug report : #10454 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
