### PR TITLE
Added possiblity to remove breadcrumbs and add them after/before others

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -129,6 +129,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
     {
         if (!isset($this->_crumbs[$before])) {
             $this->addCrumb($crumbName, $crumbInfo);
+            return $this;
         }
 
         $keys = array_keys($this->_crumbs);

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -35,7 +35,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      *
      * @var array
      */
-    protected $_crumbs;
+    protected $_crumbs = [];
 
     /**
      * Cache key info
@@ -67,8 +67,8 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
     /**
      * Add crumb
      *
-     * @param string $crumbName
-     * @param array $crumbInfo
+     * @param string $crumbName Name of the crumb
+     * @param array $crumbInfo Crumb data
      * @return $this
      */
     public function addCrumb($crumbName, $crumbInfo)
@@ -84,6 +84,90 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
         }
 
         return $this;
+    }
+
+    /**
+     * Add crumb after another
+     *
+     * @param string $crumbName Name of the crumb
+     * @param array $crumbInfo Crumb data
+     * @param string $after Name of the crumb to insert after
+     * @return $this
+     */
+    public function addCrumbAfter($crumbName, $crumbInfo, $after)
+    {
+        foreach ($this->_properties as $key) {
+            if (!isset($crumbInfo[$key])) {
+                $crumbInfo[$key] = null;
+            }
+        }
+
+        if ((!isset($this->_crumbs[$crumbName])) || (!$this->_crumbs[$crumbName]['readonly'])) {
+            if (isset($this->_crumbs[$after])) {
+                $offset = array_search($after, array_keys($this->_crumbs)) + 1;
+                $crumbsBefore = array_slice($this->_crumbs, 0, $offset, true);
+                $crumbsAfter = array_slice($this->_crumbs, $offset, null, true);
+                $this->_crumbs = $crumbsBefore + array($crumbName => $crumbInfo) + $crumbsAfter;
+            } else {
+                $this->_crumbs[$crumbName] = $crumbInfo;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add crumb before another
+     *
+     * @param string $crumbName Name of the crumb
+     * @param array $crumbInfo Crumb data
+     * @param string $before ame of the crumb to insert before
+     * @return $this
+     */
+    public function addCrumbBefore($crumbName, $crumbInfo, $before)
+    {
+        if (isset($this->_crumbs[$before])) {
+            $keys = array_keys($this->_crumbs);
+            $offset = array_search($before, $keys);
+            # add before first
+            if (!$offset) {
+                foreach ($this->_properties as $key) {
+                    if (!isset($crumbInfo[$key])) {
+                        $crumbInfo[$key] = null;
+                    }
+                }
+                $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
+            } else {
+                $this->addCrumbAfter($crumbName, $crumbInfo, $keys[$offset-1]);
+            }
+        } else {
+            $this->addCrumb($crumbName, $crumbInfo);
+        }
+        return $this;
+    }
+
+    /**
+     * Remove crumb
+     *
+     * @param string $crumbName Name of the crumb
+     * @return $this
+     */
+    public function removeCrumb($crumbName)
+    {
+        if (isset($this->_crumbs[$crumbName])) {
+            unset($this->_crumbs[$crumbName]);
+        }
+        return $this;
+    }
+
+    /**
+     * Get all crumbs
+
+     * @return array
+     */
+    public function getCrumbs()
+    {
+        return $this->_crumbs;
     }
 
     /**

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -103,14 +103,15 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
         }
 
         if ((!isset($this->_crumbs[$crumbName])) || (!$this->_crumbs[$crumbName]['readonly'])) {
-            if (isset($this->_crumbs[$after])) {
-                $offset = array_search($after, array_keys($this->_crumbs)) + 1;
-                $crumbsBefore = array_slice($this->_crumbs, 0, $offset, true);
-                $crumbsAfter = array_slice($this->_crumbs, $offset, null, true);
-                $this->_crumbs = $crumbsBefore + array($crumbName => $crumbInfo) + $crumbsAfter;
-            } else {
-                $this->_crumbs[$crumbName] = $crumbInfo;
+            if (!isset($this->_crumbs[$after])) {
+                $this->addCrumb($crumbName, $crumbInfo);
+                return $this;
             }
+
+            $offset = array_search($after, array_keys($this->_crumbs)) + 1;
+            $crumbsBefore = array_slice($this->_crumbs, 0, $offset, true);
+            $crumbsAfter = array_slice($this->_crumbs, $offset, null, true);
+            $this->_crumbs = $crumbsBefore + array($crumbName => $crumbInfo) + $crumbsAfter;
         }
 
         return $this;
@@ -126,23 +127,26 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      */
     public function addCrumbBefore($crumbName, $crumbInfo, $before)
     {
-        if (isset($this->_crumbs[$before])) {
-            $keys = array_keys($this->_crumbs);
-            $offset = array_search($before, $keys);
-            # add before first
-            if (!$offset) {
-                foreach ($this->_properties as $key) {
-                    if (!isset($crumbInfo[$key])) {
-                        $crumbInfo[$key] = null;
-                    }
-                }
-                $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
-            } else {
-                $this->addCrumbAfter($crumbName, $crumbInfo, $keys[$offset-1]);
-            }
-        } else {
+        if (!isset($this->_crumbs[$before])) {
             $this->addCrumb($crumbName, $crumbInfo);
         }
+
+        $keys = array_keys($this->_crumbs);
+        $offset = array_search($before, $keys);
+
+        # add before first
+        if ($offset) {
+            $this->addCrumbAfter($crumbName, $crumbInfo, $keys[$offset - 1]);
+            return $this;
+        }
+
+        foreach ($this->_properties as $key) {
+            if (!isset($crumbInfo[$key])) {
+                $crumbInfo[$key] = null;
+            }
+        }
+        $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
+
         return $this;
     }
 

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -111,7 +111,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
             $offset = array_search($after, array_keys($this->_crumbs)) + 1;
             $crumbsBefore = array_slice($this->_crumbs, 0, $offset, true);
             $crumbsAfter = array_slice($this->_crumbs, $offset, null, true);
-            $this->_crumbs = $crumbsBefore + array($crumbName => $crumbInfo) + $crumbsAfter;
+            $this->_crumbs = $crumbsBefore + [$crumbName => $crumbInfo] + $crumbsAfter;
         }
 
         return $this;
@@ -146,7 +146,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
             }
         }
 
-        $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
+        $this->_crumbs = [$crumbName => $crumbInfo] + $this->_crumbs;
 
         return $this;
     }

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -135,7 +135,6 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
         $keys = array_keys($this->_crumbs);
         $offset = array_search($before, $keys);
 
-        # add before first
         if ($offset) {
             $this->addCrumbAfter($crumbName, $crumbInfo, $keys[$offset - 1]);
             return $this;
@@ -146,6 +145,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
                 $crumbInfo[$key] = null;
             }
         }
+
         $this->_crumbs = array($crumbName => $crumbInfo) + $this->_crumbs;
 
         return $this;

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -3,8 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\Theme\Block\Html;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\View\Element\Template;
 
@@ -14,7 +18,7 @@ use Magento\Framework\View\Element\Template;
  * @api
  * @since 100.0.2
  */
-class Breadcrumbs extends \Magento\Framework\View\Element\Template
+class Breadcrumbs extends Template
 {
     /**
      * Current template name
@@ -60,8 +64,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
         Json $serializer = null
     ) {
         parent::__construct($context, $data);
-        $this->serializer =
-            $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()->get(Json::class);
+        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
     }
 
     /**
@@ -71,7 +74,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      * @param array $crumbInfo Crumb data
      * @return $this
      */
-    public function addCrumb($crumbName, $crumbInfo)
+    public function addCrumb(string $crumbName, array $crumbInfo): self
     {
         foreach ($this->_properties as $key) {
             if (!isset($crumbInfo[$key])) {
@@ -94,7 +97,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      * @param string $after Name of the crumb to insert after
      * @return $this
      */
-    public function addCrumbAfter($crumbName, $crumbInfo, $after)
+    public function addCrumbAfter(string $crumbName, array $crumbInfo, string $after): self
     {
         foreach ($this->_properties as $key) {
             if (!isset($crumbInfo[$key])) {
@@ -125,7 +128,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      * @param string $before ame of the crumb to insert before
      * @return $this
      */
-    public function addCrumbBefore($crumbName, $crumbInfo, $before)
+    public function addCrumbBefore(string $crumbName, array $crumbInfo, string $before): self
     {
         if (!isset($this->_crumbs[$before])) {
             $this->addCrumb($crumbName, $crumbInfo);
@@ -157,7 +160,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      * @param string $crumbName Name of the crumb
      * @return $this
      */
-    public function removeCrumb($crumbName)
+    public function removeCrumb(string $crumbName): self
     {
         if (isset($this->_crumbs[$crumbName])) {
             unset($this->_crumbs[$crumbName]);
@@ -170,7 +173,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
 
      * @return array
      */
-    public function getCrumbs()
+    public function getCrumbs(): array
     {
         return $this->_crumbs;
     }
@@ -182,7 +185,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      *
      * @return array
      */
-    public function getCacheKeyInfo()
+    public function getCacheKeyInfo(): array
     {
         if ($this->_cacheKeyInfo === null) {
             $this->_cacheKeyInfo = parent::getCacheKeyInfo() + [
@@ -198,7 +201,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      *
      * @return string
      */
-    protected function _toHtml()
+    protected function _toHtml(): string
     {
         if (is_array($this->_crumbs)) {
             reset($this->_crumbs);

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
@@ -55,64 +55,96 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
     public function testAddCrumbAfterExisting()
     {
         $this->assertEmpty($this->block->toHtml());
-        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
-        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
-        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
-        $this->block->addCrumb('test1', $info1);
-        $this->block->addCrumb('test2', $info2);
-        $this->block->addCrumbAfter('test3', $info3, 'test1');
+
+        $crumbs = [];
+        $crumbs['test1'] = ['label' => '1', 'title' => '1', 'link' => '1'];
+        $crumbs['test2'] = ['label' => '2', 'title' => '2', 'link' => '2'];
+        $crumbs['test3'] = ['label' => '3', 'title' => '3', 'link' => '3'];
+
+        foreach ($crumbs as &$crumb) {
+            $crumb += ['first' => null, 'last' => null, 'readonly' => null];
+        }
+
+        $this->block->addCrumb('test1', $crumbs['test1']);
+        $this->block->addCrumb('test2', $crumbs['test2']);
+        $this->block->addCrumbAfter('test3', $crumbs['test3'], 'test1');
+
         $result = [];
-        $result['test1'] = $info1;
-        $result['test3'] = $info3;
-        $result['test2'] = $info2;
+        $result['test1'] = $crumbs['test1'];
+        $result['test3'] = $crumbs['test3'];
+        $result['test2'] = $crumbs['test2'];
         $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testAddCrumbAfterNonExisting()
     {
         $this->assertEmpty($this->block->toHtml());
-        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
-        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
-        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
-        $this->block->addCrumb('test1', $info1);
-        $this->block->addCrumb('test2', $info2);
-        $this->block->addCrumbAfter('test3', $info3, 'na');
+
+        $crumbs = [];
+        $crumbs['test1'] = ['label' => '1', 'title' => '1', 'link' => '1'];
+        $crumbs['test2'] = ['label' => '2', 'title' => '2', 'link' => '2'];
+        $crumbs['test3'] = ['label' => '3', 'title' => '3', 'link' => '3'];
+
+        foreach ($crumbs as &$crumb) {
+            $crumb += ['first' => null, 'last' => null, 'readonly' => null];
+        }
+
+        $this->block->addCrumb('test1', $crumbs['test1']);
+        $this->block->addCrumb('test2', $crumbs['test2']);
+        $this->block->addCrumbAfter('test3', $crumbs['test3'], 'na');
+
         $result = [];
-        $result['test1'] = $info1;
-        $result['test2'] = $info2;
-        $result['test3'] = $info3;
+        $result['test1'] = $crumbs['test1'];
+        $result['test2'] = $crumbs['test2'];
+        $result['test3'] = $crumbs['test3'];
         $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testAddCrumbBeforeExisting()
     {
         $this->assertEmpty($this->block->toHtml());
-        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
-        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
-        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
-        $this->block->addCrumb('test1', $info1);
-        $this->block->addCrumb('test2', $info2);
-        $this->block->addCrumbBefore('test3', $info3, 'test2');
+
+        $crumbs = [];
+        $crumbs['test1'] = ['label' => '1', 'title' => '1', 'link' => '1'];
+        $crumbs['test2'] = ['label' => '2', 'title' => '2', 'link' => '2'];
+        $crumbs['test3'] = ['label' => '3', 'title' => '3', 'link' => '3'];
+
+        foreach ($crumbs as &$crumb) {
+            $crumb += ['first' => null, 'last' => null, 'readonly' => null];
+        }
+
+        $this->block->addCrumb('test1', $crumbs['test1']);
+        $this->block->addCrumb('test2', $crumbs['test2']);
+        $this->block->addCrumbBefore('test3', $crumbs['test3'], 'test2');
+
         $result = [];
-        $result['test1'] = $info1;
-        $result['test3'] = $info3;
-        $result['test2'] = $info2;
+        $result['test1'] = $crumbs['test1'];
+        $result['test3'] = $crumbs['test3'];
+        $result['test2'] = $crumbs['test2'];
         $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testAddCrumbBeforeNonExisting()
     {
         $this->assertEmpty($this->block->toHtml());
-        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
-        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
-        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
-        $this->block->addCrumb('test1', $info1);
-        $this->block->addCrumb('test2', $info2);
-        $this->block->addCrumbBefore('test3', $info3, 'na');
+
+        $crumbs = [];
+        $crumbs['test1'] = ['label' => '1', 'title' => '1', 'link' => '1'];
+        $crumbs['test2'] = ['label' => '2', 'title' => '2', 'link' => '2'];
+        $crumbs['test3'] = ['label' => '3', 'title' => '3', 'link' => '3'];
+
+        foreach ($crumbs as &$crumb) {
+            $crumb += ['first' => null, 'last' => null, 'readonly' => null];
+        }
+
+        $this->block->addCrumb('test1', $crumbs['test1']);
+        $this->block->addCrumb('test2', $crumbs['test2']);
+        $this->block->addCrumbBefore('test3', $crumbs['test3'], 'na');
+
         $result = [];
-        $result['test1'] = $info1;
-        $result['test2'] = $info2;
-        $result['test3'] = $info3;
+        $result['test1'] = $crumbs['test1'];
+        $result['test2'] = $crumbs['test2'];
+        $result['test3'] = $crumbs['test3'];
         $this->assertEquals($this->block->getCrumbs(), $result);
     }
 

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
@@ -49,7 +49,6 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($this->block->getCrumbs(), []);
         $info = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
         $this->block->addCrumb('test', $info);
-        $html = $this->block->toHtml();
         $this->assertEquals($this->block->getCrumbs(), $info);
     }
 
@@ -62,7 +61,6 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbAfter('test3', $info3, 'test1');
-        $html = $this->block->toHtml();
         $this->assertEquals($this->block->getCrumbs(), $info1 + $info3 + $info2);
     }
 
@@ -75,7 +73,6 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbAfter('test3', $info3, 'na');
-        $html = $this->block->toHtml();
         $this->assertEquals($this->block->getCrumbs(), $info1 + $info2 + $info3);
     }
 
@@ -88,7 +85,6 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbBefore('test3', $info3, 'test2');
-        $html = $this->block->toHtml();
         $this->assertEquals($this->block->getCrumbs(), $info1 + $info3 + $info1);
     }
 
@@ -101,7 +97,6 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbBefore('test3', $info3, 'na');
-        $html = $this->block->toHtml();
         $this->assertEquals($this->block->getCrumbs(), $info1 + $info2 + $info3);
     }
 
@@ -110,7 +105,6 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($this->block->toHtml());
         $info = ['label' => 'test label', 'title' => 'test title', 'link' => 'test link'];
         $this->block->addCrumb('test', $info);
-        $html = $this->block->toHtml();
         $this->block->removeCrumb('test');
         $this->assertEmpty($this->block->toHtml());
     }

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
@@ -61,7 +61,11 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbAfter('test3', $info3, 'test1');
-        $this->assertEquals($this->block->getCrumbs(), $info1 + $info3 + $info2);
+        $result = [];
+        $result['test1'] = $info1;
+        $result['test3'] = $info3;
+        $result['test2'] = $info2;
+        $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testAddCrumbAfterNonExisting()
@@ -73,7 +77,11 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbAfter('test3', $info3, 'na');
-        $this->assertEquals($this->block->getCrumbs(), $info1 + $info2 + $info3);
+        $result = [];
+        $result['test1'] = $info1;
+        $result['test2'] = $info2;
+        $result['test3'] = $info3;
+        $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testAddCrumbBeforeExisting()
@@ -85,7 +93,11 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbBefore('test3', $info3, 'test2');
-        $this->assertEquals($this->block->getCrumbs(), $info1 + $info3 + $info1);
+        $result = [];
+        $result['test1'] = $info1;
+        $result['test3'] = $info3;
+        $result['test2'] = $info2;
+        $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testAddCrumbBeforeNonExisting()
@@ -97,7 +109,11 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $info1);
         $this->block->addCrumb('test2', $info2);
         $this->block->addCrumbBefore('test3', $info3, 'na');
-        $this->assertEquals($this->block->getCrumbs(), $info1 + $info2 + $info3);
+        $result = [];
+        $result['test1'] = $info1;
+        $result['test2'] = $info2;
+        $result['test3'] = $info3;
+        $this->assertEquals($this->block->getCrumbs(), $result);
     }
 
     public function testRemoveCrumb()
@@ -107,6 +123,7 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test', $info);
         $this->block->removeCrumb('test');
         $this->assertEmpty($this->block->toHtml());
+        $this->assertEquals($this->block->getCrumbs(), []);
     }
 
     public function testGetCacheKeyInfo()

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
@@ -43,6 +43,78 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('test link', $html);
     }
 
+    public function testGetCrumb()
+    {
+        $this->assertEmpty($this->block->toHtml());
+        $this->assertEquals($this->block->getCrumbs(), []);
+        $info = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
+        $this->block->addCrumb('test', $info);
+        $html = $this->block->toHtml();
+        $this->assertEquals($this->block->getCrumbs(), $info);
+    }
+
+    public function testAddCrumbAfterExisting()
+    {
+        $this->assertEmpty($this->block->toHtml());
+        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
+        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
+        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
+        $this->block->addCrumb('test1', $info1);
+        $this->block->addCrumb('test2', $info2);
+        $this->block->addCrumbAfter('test3', $info3, 'test1');
+        $html = $this->block->toHtml();
+        $this->assertEquals($this->block->getCrumbs(), $info1 + $info3 + $info2);
+    }
+
+    public function testAddCrumbAfterNonExisting()
+    {
+        $this->assertEmpty($this->block->toHtml());
+        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
+        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
+        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
+        $this->block->addCrumb('test1', $info1);
+        $this->block->addCrumb('test2', $info2);
+        $this->block->addCrumbAfter('test3', $info3, 'na');
+        $html = $this->block->toHtml();
+        $this->assertEquals($this->block->getCrumbs(), $info1 + $info2 + $info3);
+    }
+
+    public function testAddCrumbBeforeExisting()
+    {
+        $this->assertEmpty($this->block->toHtml());
+        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
+        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
+        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
+        $this->block->addCrumb('test1', $info1);
+        $this->block->addCrumb('test2', $info2);
+        $this->block->addCrumbBefore('test3', $info3, 'test2');
+        $html = $this->block->toHtml();
+        $this->assertEquals($this->block->getCrumbs(), $info1 + $info3 + $info1);
+    }
+
+    public function testAddCrumbBeforeNonExisting()
+    {
+        $this->assertEmpty($this->block->toHtml());
+        $info1 = ['label' => '1', 'title' => '1', 'link' => '1', 'first' => null, 'last' => null, 'readonly' => null];
+        $info2 = ['label' => '2', 'title' => '2', 'link' => '2', 'first' => null, 'last' => null, 'readonly' => null];
+        $info3 = ['label' => '3', 'title' => '3', 'link' => '3', 'first' => null, 'last' => null, 'readonly' => null];
+        $this->block->addCrumb('test1', $info1);
+        $this->block->addCrumb('test2', $info2);
+        $this->block->addCrumbBefore('test3', $info3, 'na');
+        $html = $this->block->toHtml();
+        $this->assertEquals($this->block->getCrumbs(), $info1 + $info2 + $info3);
+    }
+
+    public function testRemoveCrumb()
+    {
+        $this->assertEmpty($this->block->toHtml());
+        $info = ['label' => 'test label', 'title' => 'test title', 'link' => 'test link'];
+        $this->block->addCrumb('test', $info);
+        $html = $this->block->toHtml();
+        $this->block->removeCrumb('test');
+        $this->assertEmpty($this->block->toHtml());
+    }
+
     public function testGetCacheKeyInfo()
     {
         $crumbs = ['test' => ['label' => 'test label', 'title' => 'test title', 'link' => 'test link']];

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
@@ -92,12 +92,7 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $crumbs['test1']);
         $this->block->addCrumb('test2', $crumbs['test2']);
         $this->block->addCrumbAfter('test3', $crumbs['test3'], 'na');
-
-        $result = [];
-        $result['test1'] = $crumbs['test1'];
-        $result['test2'] = $crumbs['test2'];
-        $result['test3'] = $crumbs['test3'];
-        $this->assertEquals($this->block->getCrumbs(), $result);
+        $this->assertEquals($this->block->getCrumbs(), $crumbs);
     }
 
     public function testAddCrumbBeforeExisting()
@@ -140,12 +135,7 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->block->addCrumb('test1', $crumbs['test1']);
         $this->block->addCrumb('test2', $crumbs['test2']);
         $this->block->addCrumbBefore('test3', $crumbs['test3'], 'na');
-
-        $result = [];
-        $result['test1'] = $crumbs['test1'];
-        $result['test2'] = $crumbs['test2'];
-        $result['test3'] = $crumbs['test3'];
-        $this->assertEquals($this->block->getCrumbs(), $result);
+        $this->assertEquals($this->block->getCrumbs(), $crumbs);
     }
 
     public function testRemoveCrumb()

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Html/BreadcrumbsTest.php
@@ -5,8 +5,11 @@
  */
 namespace Magento\Theme\Block\Html;
 
+use Magento\Framework\App\State;
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\View\LayoutInterface;
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Theme\Block\Html\Breadcrumbs;
 
 /**
  * @magentoAppArea frontend
@@ -14,7 +17,7 @@ use Magento\TestFramework\Helper\Bootstrap;
 class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Theme\Block\Html\Breadcrumbs
+     * @var Breadcrumbs
      */
     private $block;
 
@@ -25,10 +28,10 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        Bootstrap::getObjectManager()->get(\Magento\Framework\App\State::class)->setAreaCode('frontend');
+        Bootstrap::getObjectManager()->get(State::class)->setAreaCode('frontend');
         $this->block = Bootstrap::getObjectManager()
-            ->get(\Magento\Framework\View\LayoutInterface::class)
-            ->createBlock(\Magento\Theme\Block\Html\Breadcrumbs::class);
+            ->get(LayoutInterface::class)
+            ->createBlock(Breadcrumbs::class);
         $this->serializer = Bootstrap::getObjectManager()->get(SerializerInterface::class);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

In M1 `addCrumb($crumbName, $crumbInfo, $after = false)`  had a 3rd parameter that wasn't used. In M2 `$after` has been removed instead of adding functionality.

This PR adds 4 methods:

- `addCrumbAfter($crumbName, $crumbInfo, $after)`
- `addCrumbBefore($crumbName, $crumbInfo, $before)`
- `removeCrumb($crumbName)`
- `getCrumbs()`

(last one was mainly for UnitTests)

"Forward-Port":

1. OpenMage/magento-lts#336
2. netz98/N98_LayoutHelper#10

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. n/a

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. add XML layout updates to products to add/remove crumbs (e.g. after/before `home`-crumb)
2. programatically ...

```
 $block->addCrumbAfter(
     'my_crumb',
     ['label' => label, 'title' => title],
     'home'
);
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
