### PR TITLE
[Forwardport] Allow usage of config-global.php when running Integration Tests

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -564,11 +564,11 @@ class Application
      *
      * @return void
      */
-    private function copyGlobalConfigFile()
+    /*private function copyGlobalConfigFile()
     {
         $targetFile = $this->_configDir . '/config.php';
         copy($this->globalConfigFile, $targetFile);
-    }
+    }*/
 
     /**
      * Gets a list of CLI params for installation

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -566,7 +566,7 @@ class Application
      */
     private function copyGlobalConfigFile()
     {
-        $targetFile = $this->_configDir . '/config.php';
+        $targetFile = $this->_configDir . '/config.local.php';
         copy($this->globalConfigFile, $targetFile);
     }
 

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -498,7 +498,7 @@ class Application
         $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::VAR_DIR][DirectoryList::PATH]);
 
         $this->copyAppConfigFiles();
-        $this->copyGlobalConfigFile();
+        //$this->copyGlobalConfigFile();
 
         $installParams = $this->getInstallCliParams();
 

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -498,6 +498,7 @@ class Application
         $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::VAR_DIR][DirectoryList::PATH]);
 
         $this->copyAppConfigFiles();
+        $this->copyGlobalConfigFile();
 
         $installParams = $this->getInstallCliParams();
 
@@ -556,6 +557,17 @@ class Application
                 copy($file, $targetFile);
             }
         }
+    }
+    
+    /**
+     * Copies global configuration file from the tests folder (see TESTS_GLOBAL_CONFIG_FILE)
+     *
+     * @return void
+     */
+    private function copyGlobalConfigFile()
+    {
+        $targetFile = $this->_configDir . '/config.php';
+        copy($this->globalConfigFile, $targetFile);
     }
 
     /**

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -498,7 +498,7 @@ class Application
         $this->_ensureDirExists($this->_initParams[$dirs][DirectoryList::VAR_DIR][DirectoryList::PATH]);
 
         $this->copyAppConfigFiles();
-        //$this->copyGlobalConfigFile();
+        $this->copyGlobalConfigFile();
 
         $installParams = $this->getInstallCliParams();
 
@@ -564,11 +564,11 @@ class Application
      *
      * @return void
      */
-    /*private function copyGlobalConfigFile()
+    private function copyGlobalConfigFile()
     {
         $targetFile = $this->_configDir . '/config.php';
         copy($this->globalConfigFile, $targetFile);
-    }*/
+    }
 
     /**
      * Gets a list of CLI params for installation


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16361

When running Integration Tests (`bin/magento dev:tests:run integration`), you will need to customize a couple of files to properly setup the testing environment. Part of this procedure is customizing the `phpunit.xml` which also defines a file `TESTS_GLOBAL_CONFIG_FILE` (pointing to either `etc/config-global.php` or `etc/config-global.php.dist`). However, configuration files defined in this `TESTS_GLOBAL_CONFIG_FILE` never end up in the sandbox environment. This issue was also encountered in another issue https://github.com/magento/magento2/issues/15196

With this PR, the `TESTS_GLOBAL_CONFIG_FILE` is actually put to use. The `TESTS_GLOBAL_CONFIG_FILE` is picked up properly by the existing bootstrap and then passed on to the constructor of the testing application class. Next, the `install()` method of the application class is run. This is where the bug occurs. The internal variable `$this->globalConfigFile` is never used. This PR adds the actual usage of this variable.

### Fixed Issues
1. magento/magento2#15196: Magento 2 integration tests enables all modules

### Manual testing scenarios
1. First, setup integration tests without this PR. Once everything is properly running, a new sandbox environment is created under `dev/tests/integration/tmp/sandbox-*`. The `etc/config.php` file in this sandbox should include the entries from either `etc/config-global.php` or `etc/config-global.php.dist`. However, it does not.
2. Next, apply this patch and rerun the integration tests. The `etc/config.local.php` file in the sandbox now should include the entries from the `etc/config-global.php` file. And this is merged together with the `etc/config.php`, containing all of the modules added through the Magento setup procedure.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
