### PR TITLE
[Forwardport] Fix module uninstall shell command and composer removal w/out regression

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/RemoveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/RemoveTest.php
@@ -24,7 +24,7 @@ class RemoveTest extends \PHPUnit\Framework\TestCase
                 [
                     'command' => 'remove',
                     'packages' => ['magento/package-a', 'magento/package-b'],
-                    '--no-update' => true,
+                    '--no-update-with-dependencies' => true,
                 ]
             );
         $composerAppFactory->expects($this->once())

--- a/lib/internal/Magento/Framework/Composer/Remove.php
+++ b/lib/internal/Magento/Framework/Composer/Remove.php
@@ -46,7 +46,7 @@ class Remove
             [
                 'command' => 'remove',
                 'packages' => $packages,
-                '--no-update' => true,
+                '--no-update-with-dependencies' => true,
             ]
         );
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18002
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There is a discrepancy between `composer.lock` and `composer.json` when removing a module via `bin/magento module:uninstall` command. Also, the output is wrong and the guide says it should do otherwise.
The removal option in the code solved the previous issue magento/magento2#5797 , but caused the new issue. The new change solves both.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17780: Module uninstall does not work with composer

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install Magento with composer (2.2.x) and set it up
2. Install Sample Datas with `bin/magento sampledata:deploy`
3. Complete Sample Data installation: `bin/magento setup:upgrade`
4. Remove one package: `bin/magento module:uninstall Magento_CmsSampleData`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
