### PR TITLE
Introducing a dedicated cron.log file for logging cron related info, …

### DIFF
--- a/app/code/Magento/Cron/etc/di.xml
+++ b/app/code/Magento/Cron/etc/di.xml
@@ -16,6 +16,18 @@
     <type name="Magento\Framework\App\Config\Initial\Converter">
         <plugin name="cron_system_config_initial_converter_plugin" type="Magento\Cron\Model\System\Config\Initial\Converter" />
     </type>
+    <virtualType name="Magento\Cron\Model\VirtualLoggerHandler" type="Magento\Framework\Logger\Handler\Base">
+        <arguments>
+            <argument name="fileName" xsi:type="string">/var/log/cron.log</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Magento\Cron\Model\VirtualLogger" type="Magento\Framework\Logger\Monolog">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">Magento\Cron\Model\VirtualLoggerHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
     <!-- @api -->
     <virtualType name="shellBackground" type="Magento\Framework\Shell">
         <arguments>
@@ -25,6 +37,7 @@
     <type name="Magento\Cron\Observer\ProcessCronQueueObserver">
         <arguments>
             <argument name="shell" xsi:type="object">shellBackground</argument>
+            <argument name="logger" xsi:type="object">Magento\Cron\Model\VirtualLogger</argument>
         </arguments>
     </type>
     <type name="Magento\Framework\Console\CommandListInterface">


### PR DESCRIPTION
…this reduces output in the system.log file.

### Description
Magento 2.2.5 introduced better handling of cron job locking, but also added some extra logging output. This happened in  https://github.com/magento/magento2/commit/f274f03a45f0fa230efd5c1b6ee8e37b03530e2e (file: `app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php`).
For example, following extra output is logged now:
- `Cron Job sales_send_order_emails is run`
- `Cron Job sales_send_order_emails is successfully finished. Statistics: {"sum":0.00037288665771484,"count":1,"realmem":0,"emalloc":752,"realmem_start":39845888,"emalloc_start":36019592}`
- ...

But all this gets logged in the `system.log` file, and it happens for every cron job. Some of them run every single minute, so this causes a lot of extra output in the `system.log` file, which makes it harder to find other non-cron related output in that file.

This PR introduces a new file `cron.log` where all cron related output gets logged.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/17190: system.log rapidly increasing after Magento CE 2.2.5 update (cron logs)

### Manual testing scenarios
1. Set up a clean Magento
2. Run `bin/magento cron:run`
3. Expect to see no cron related messages in `system.log`, but now in a dedicated `cron.log` file

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
