### PR TITLE
[Forwardport] [CatalogUrlRewrite] Covering the CategoryProcessUrlRewriteMovingObserver by Unit Test

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Test\Unit\Observer;
+
+use Magento\Catalog\Model\Category;
+use Magento\CatalogUrlRewrite\Block\UrlKeyRenderer;
+use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
+use Magento\CatalogUrlRewrite\Model\Map\DatabaseMapPool;
+use Magento\CatalogUrlRewrite\Model\Map\DataCategoryUrlRewriteDatabaseMap;
+use Magento\CatalogUrlRewrite\Model\Map\DataProductUrlRewriteDatabaseMap;
+use Magento\CatalogUrlRewrite\Model\UrlRewriteBunchReplacer;
+use Magento\CatalogUrlRewrite\Observer\CategoryProcessUrlRewriteMovingObserver;
+use Magento\CatalogUrlRewrite\Observer\UrlRewriteHandler;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class CategoryProcessUrlRewriteMovingObserverTest
+ *
+ * @covers \Magento\CatalogUrlRewrite\Observer\CategoryProcessUrlRewriteMovingObserver
+ */
+class CategoryProcessUrlRewriteMovingObserverTest extends TestCase
+{
+    /**
+     * @var CategoryProcessUrlRewriteMovingObserver
+     */
+    private $observer;
+
+    /**
+     * @var CategoryUrlRewriteGenerator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $categoryUrlRewriteGeneratorMock;
+
+    /**
+     * @var UrlPersistInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $urlPersistMock;
+
+    /**
+     * @var ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $scopeConfigMock;
+
+    /**
+     * @var UrlRewriteHandler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $urlRewriteHandlerMock;
+
+    /**
+     * @var UrlRewriteBunchReplacer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $urlRewriteBunchReplacerMock;
+
+    /**
+     * @var DatabaseMapPool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $databaseMapPoolMock;
+
+    /**
+     * Set Up
+     */
+    protected function setUp()
+    {
+        $this->categoryUrlRewriteGeneratorMock = $this->createMock(CategoryUrlRewriteGenerator::class);
+        $this->urlPersistMock = $this->createMock(UrlPersistInterface::class);
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $this->urlRewriteHandlerMock = $this->createMock(UrlRewriteHandler::class);
+        $this->urlRewriteBunchReplacerMock = $this->createPartialMock(UrlRewriteBunchReplacer::class,
+            ['doBunchReplace']
+        );
+        $this->databaseMapPoolMock = $this->createMock(DatabaseMapPool::class);
+
+        $this->observer = new CategoryProcessUrlRewriteMovingObserver(
+            $this->categoryUrlRewriteGeneratorMock,
+            $this->urlPersistMock,
+            $this->scopeConfigMock,
+            $this->urlRewriteHandlerMock,
+            $this->urlRewriteBunchReplacerMock,
+            $this->databaseMapPoolMock,
+            [
+                DataCategoryUrlRewriteDatabaseMap::class,
+                DataProductUrlRewriteDatabaseMap::class
+            ]
+        );
+    }
+
+    /**
+     * Test category process rewrite url by changing the parent
+     *
+     * @return void
+     */
+    public function testCategoryProcessUrlRewriteAfterMovingWithChangedParentId()
+    {
+        /** @var Observer|\PHPUnit_Framework_MockObject_MockObject $observerMock */
+        $observerMock = $this->createMock(Observer::class);
+        $eventMock = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCategory'])
+            ->getMock();
+        $categoryMock = $this->createPartialMock(Category::class, [
+            'dataHasChangedFor',
+            'getEntityId',
+            'getStoreId',
+            'setData'
+        ]);
+
+        $categoryMock->expects($this->once())->method('dataHasChangedFor')->with('parent_id')
+            ->willReturn(true);
+        $eventMock->expects($this->once())->method('getCategory')->willReturn($categoryMock);
+        $observerMock->expects($this->once())->method('getEvent')->willReturn($eventMock);
+        $this->scopeConfigMock->expects($this->once())->method('isSetFlag')
+            ->with(UrlKeyRenderer::XML_PATH_SEO_SAVE_HISTORY)->willReturn(true);
+        $this->categoryUrlRewriteGeneratorMock->expects($this->once())->method('generate')
+            ->with($categoryMock, true)->willReturn(['category-url-rewrite']);
+        $this->urlRewriteHandlerMock->expects($this->once())->method('generateProductUrlRewrites')
+            ->with($categoryMock)->willReturn(['product-url-rewrite']);
+        $this->databaseMapPoolMock->expects($this->exactly(2))->method('resetMap')->willReturnSelf();
+
+        $this->observer->execute($observerMock);
+    }
+
+    /**
+     * Test category process rewrite url without changing the parent
+     *
+     * @return void
+     */
+    public function testCategoryProcessUrlRewriteAfterMovingWithinNotChangedParent()
+    {
+        /** @var Observer|\PHPUnit_Framework_MockObject_MockObject $observerMock */
+        $observerMock = $this->createMock(Observer::class);
+        $eventMock = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCategory'])
+            ->getMock();
+        $categoryMock = $this->createPartialMock(Category::class, ['dataHasChangedFor']);
+        $observerMock->expects($this->once())->method('getEvent')->willReturn($eventMock);
+        $eventMock->expects($this->once())->method('getCategory')->willReturn($categoryMock);
+        $categoryMock->expects($this->once())->method('dataHasChangedFor')->with('parent_id')
+            ->willReturn(false);
+
+        $this->observer->execute($observerMock);
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
@@ -67,11 +67,8 @@ class CategoryProcessUrlRewriteMovingObserverTest extends \PHPUnit\Framework\Tes
         $this->urlPersistMock = $this->createMock(UrlPersistInterface::class);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
         $this->urlRewriteHandlerMock = $this->createMock(UrlRewriteHandler::class);
-        /** @var UrlRewriteBunchReplacer|\PHPUnit_Framework_MockObject_MockObject $urlRewriteBunchReplacerMock */
-        $urlRewriteBunchReplacerMock = $this->createPartialMock(
-            UrlRewriteBunchReplacer::class,
-            ['doBunchReplace']
-        );
+        /** @var UrlRewriteBunchReplacer|\PHPUnit_Framework_MockObject_MockObject $urlRewriteMock */
+        $urlRewriteMock = $this->createMock(UrlRewriteBunchReplacer::class);
         $this->databaseMapPoolMock = $this->createMock(DatabaseMapPool::class);
 
         $this->observer = new CategoryProcessUrlRewriteMovingObserver(
@@ -79,7 +76,7 @@ class CategoryProcessUrlRewriteMovingObserverTest extends \PHPUnit\Framework\Tes
             $this->urlPersistMock,
             $this->scopeConfigMock,
             $this->urlRewriteHandlerMock,
-            $urlRewriteBunchReplacerMock,
+            $urlRewriteMock,
             $this->databaseMapPoolMock,
             [
                 DataCategoryUrlRewriteDatabaseMap::class,

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
@@ -20,14 +20,13 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Class CategoryProcessUrlRewriteMovingObserverTest
  *
  * @covers \Magento\CatalogUrlRewrite\Observer\CategoryProcessUrlRewriteMovingObserver
  */
-class CategoryProcessUrlRewriteMovingObserverTest extends TestCase
+class CategoryProcessUrlRewriteMovingObserverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var CategoryProcessUrlRewriteMovingObserver
@@ -55,11 +54,6 @@ class CategoryProcessUrlRewriteMovingObserverTest extends TestCase
     private $urlRewriteHandlerMock;
 
     /**
-     * @var UrlRewriteBunchReplacer|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $urlRewriteBunchReplacerMock;
-
-    /**
      * @var DatabaseMapPool|\PHPUnit_Framework_MockObject_MockObject
      */
     private $databaseMapPoolMock;
@@ -73,7 +67,8 @@ class CategoryProcessUrlRewriteMovingObserverTest extends TestCase
         $this->urlPersistMock = $this->createMock(UrlPersistInterface::class);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
         $this->urlRewriteHandlerMock = $this->createMock(UrlRewriteHandler::class);
-        $this->urlRewriteBunchReplacerMock = $this->createPartialMock(
+        /** @var UrlRewriteBunchReplacer|\PHPUnit_Framework_MockObject_MockObject $urlRewriteBunchReplacerMock */
+        $urlRewriteBunchReplacerMock = $this->createPartialMock(
             UrlRewriteBunchReplacer::class,
             ['doBunchReplace']
         );
@@ -84,7 +79,7 @@ class CategoryProcessUrlRewriteMovingObserverTest extends TestCase
             $this->urlPersistMock,
             $this->scopeConfigMock,
             $this->urlRewriteHandlerMock,
-            $this->urlRewriteBunchReplacerMock,
+            $urlRewriteBunchReplacerMock,
             $this->databaseMapPoolMock,
             [
                 DataCategoryUrlRewriteDatabaseMap::class,

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
@@ -73,7 +73,8 @@ class CategoryProcessUrlRewriteMovingObserverTest extends TestCase
         $this->urlPersistMock = $this->createMock(UrlPersistInterface::class);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
         $this->urlRewriteHandlerMock = $this->createMock(UrlRewriteHandler::class);
-        $this->urlRewriteBunchReplacerMock = $this->createPartialMock(UrlRewriteBunchReplacer::class,
+        $this->urlRewriteBunchReplacerMock = $this->createPartialMock(
+            UrlRewriteBunchReplacer::class,
             ['doBunchReplace']
         );
         $this->databaseMapPoolMock = $this->createMock(DatabaseMapPool::class);

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteMovingObserverTest.php
@@ -24,7 +24,7 @@ use Magento\UrlRewrite\Model\UrlPersistInterface;
 /**
  * Class CategoryProcessUrlRewriteMovingObserverTest
  *
- * @covers \Magento\CatalogUrlRewrite\Observer\CategoryProcessUrlRewriteMovingObserver
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class CategoryProcessUrlRewriteMovingObserverTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18004
### Description
This PR adds missing unit tests for CategoryProcessUrlRewriteMovingObserver class:
- `\Magento\CatalogUrlRewrite\Observer\CategoryProcessUrlRewriteMovingObserver`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
