### PR TITLE
fix wysiwyg editor not decoding base64 filenames special chars

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -461,9 +461,9 @@ define([
         decodeDirectives: function (content) {
             // escape special chars in directives url to use it in regular expression
             var url = this.makeDirectiveUrl('%directive%').replace(/([$^.?*!+:=()\[\]{}|\\])/g, '\\$1'),
-                reg = new RegExp(url.replace('%directive%', '([a-zA-Z0-9,_-]+)'));
+                reg = new RegExp(url.replace('%directive%', '([a-zA-Z0-9,_-]+)')),
+                uriReg = /___directive\/(.*)\/key\//g;
 
-            var uriReg = /___directive\/(.*)\/key\//g;
             content = content.replace(uriReg, function (match) {
                 return decodeURIComponent(match);
             });

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -463,6 +463,11 @@ define([
             var url = this.makeDirectiveUrl('%directive%').replace(/([$^.?*!+:=()\[\]{}|\\])/g, '\\$1'),
                 reg = new RegExp(url.replace('%directive%', '([a-zA-Z0-9,_-]+)'));
 
+            var uriReg = /___directive\/(.*)\/key\//g;
+            content = content.replace(uriReg, function (match) {
+                return decodeURIComponent(match);
+            });
+
             return content.gsub(reg, function (match) { //eslint-disable-line no-extra-bind
                 return Base64.mageDecode(match[1]);
             });


### PR DESCRIPTION
### Description

Properly decode base64 special chars in TinyMCE. Whole part of code was changed in 2.3, but it is not working in 2.2

### Fixed Issues (if relevant)

1. magento/magento2#18138: WYSIWYG editor fails to parse directives of files with special characters in URL (so random files)

### Manual testing scenarios

1. https://github.com/magento/magento2/issues/18138
