### PR TITLE
changes-for-add-to-cart-button-text-translate-with-custom-theme

### DIFF
--- a/app/code/Magento/Translation/Model/Json/PreProcessor.php
+++ b/app/code/Magento/Translation/Model/Json/PreProcessor.php
@@ -93,6 +93,7 @@ class PreProcessor implements PreProcessorInterface
             }
 
             $area = $this->areaList->getArea($areaCode);
+            $area->load(\Magento\Framework\App\Area::PART_DESIGN);
             $area->load(\Magento\Framework\App\Area::PART_TRANSLATE);
 
             $this->translate->setLocale($context->getLocale())->loadData($areaCode, true);


### PR DESCRIPTION
Description

The "Add to Cart" Button text is not translating correctly for custom theme after the product added to the cart. 
When product page load, the translation for the "Add to Cart" is working as expected and button not getting translated into "Add to Basket".

Fixed Issues (if relevant)

magento/magento2#3423

Manual testing scenarios
1.Go to app\design\frontend\vendor\theme\i18n\en_US.csv
2.changes the text
"Add to Cart","Add to Basket"
"Adding...","Adding Basket"
"Added","Added Basket"
3.And run the following commands:
php bin/magento setup:upgrade
php bin/magento setup:static-content:deploy
4.On Product page goes through the process of being added to the cart as expected, 
when add to cart process is completed the "Add to Cart" button shows Add To Basket from the translation and this work.

Contribution checklist

Pull request has a meaningful description of its purpose
All commits are accompanied by meaningful commit messages
All new or changed code is covered with unit/integration tests (if applicable)
All automated tests passed successfully (all builds on Travis CI are green)
