### PR TITLE
Empty option label should always be a space even if attribute is required

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -9,6 +9,8 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
+ * Eav attribute default source when values are coming from another table
+ *
  * @api
  * @since 100.0.2
  */
@@ -127,12 +129,14 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     }
 
     /**
+     * Add an empty option to the array
+     *
      * @param array $options
      * @return array
      */
     private function addEmptyOption(array $options)
     {
-        array_unshift($options, ['label' => $this->getAttribute()->getIsRequired() ? '' : ' ', 'value' => '']);
+        array_unshift($options, ['label' => ' ', 'value' => '']);
         return $options;
     }
 


### PR DESCRIPTION
### Description
When adding an empty option, Magento checks if the attribute is required or not. If it's not required, it adds an empty option with a space label (` `), but if it's required it adds an empty option without label.

The issue is when an attribute is required, the empty option is not selected by default, it's the first option. It causes some issues because if the admin does not pay attention, he/she will save the product with the first option. That's not what is expected, we want an error message telling this attribute is required.

### Manual testing scenarios
#### Before this PR
1. Create a dropdown attribute with some options - let's say `Option 1`, `Option 2`, `Option 3`
2. Set it required
3. Create a new product without touching this attribute
4. The product is created with `Option 1` as value for this attribute

#### After this PR
1. Create a dropdown attribute with some options - let's say `Option 1`, `Option 2`, `Option 3`
2. Set it required
3. Create a new product without touching this attribute
4. The product is not created, an error message tells this attribute is required

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
