### PR TITLE
Module Catalog: fix issue with custom option price conversion for different base currency on website level

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Option/Value.php
@@ -160,19 +160,22 @@ class Value extends AbstractDb
             && isset($objectPrice)
             && $object->getStoreId() != Store::DEFAULT_STORE_ID
         ) {
-            $baseCurrency = $this->_config->getValue(
+            $website  = $this->_storeManager->getStore($object->getStoreId())->getWebsite();
+
+            $websiteBaseCurrency = $this->_config->getValue(
                 Currency::XML_PATH_CURRENCY_BASE,
-                'default'
+                ScopeInterface::SCOPE_WEBSITE,
+                $website
             );
 
-            $storeIds = $this->_storeManager->getStore($object->getStoreId())->getWebsite()->getStoreIds();
+            $storeIds = $website->getStoreIds();
             if (is_array($storeIds)) {
                 foreach ($storeIds as $storeId) {
                     if ($priceType == 'fixed') {
                         $storeCurrency = $this->_storeManager->getStore($storeId)->getBaseCurrencyCode();
                         /** @var $currencyModel Currency */
                         $currencyModel = $this->_currencyFactory->create();
-                        $currencyModel->load($baseCurrency);
+                        $currencyModel->load($websiteBaseCurrency);
                         $rate = $currencyModel->getRate($storeCurrency);
                         if (!$rate) {
                             $rate = 1;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Issue is connected to the custom option price conversion based on base currency configured on default level, but not on website level (Magento allows to configure different base currency on website level according to [documentation](https://docs.magento.com/m2/ce/user_guide/stores/currency-configuration.html)).

_It's reproduced on the following Magento setup with multi-currency configuration:_
1. There are 2 websites configured: US and CA (or another one).
2. Base Currency is configured in the next way: default level - USD; CA - CAD.
3. And if you try to update product with custom options (with non zero price) on CA website level, for example, you need just to change product price, every time you save the product, custom options price will be converted according to USD/CAD currency rate.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No related issues found.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Steps to reproduce**
1. Create 2 websites on Magento: US website and CA website.
2. Set up Base Currency to USD (or any other) on default scope.
3. Set up Base Currency to CAD on CA website scope.
4. Create product with custom options and set up non zero price for option value.
5. Save the product.
6. Change configuration scope on CA website.
7. Save product.

**Expected result**
Custom option value price is not changed, because no actual changes were done.

**Actual result**
Custom option value price is updated according to USD/CAD currency rate.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
