### PR TITLE
[Forwardport] Update shipment collection to unserialize `packages` attribute after load

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Shipment/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Shipment/Collection.php
@@ -57,14 +57,16 @@ class Collection extends AbstractCollection implements ShipmentSearchResultInter
     }
 
     /**
-     * Used to emulate after load functionality for each item without loading them
+     * Unserialize packages in each item
      *
      * @return $this
      */
     protected function _afterLoad()
     {
-        $this->walk('afterLoad');
+        foreach ($this->_items as $item) {
+            $this->getResource()->unserializeFields($item);
+        }
 
-        return $this;
+        return parent::_afterLoad();
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17679

### Description
The column `packages` in `sales_shipment` is in its resource model `\Magento\Sales\Model\ResourceModel\Order\Shipment` characterized as a serializable field. But `packages` doesn't get unserialized when shipments are loaded with a collection. This pull request fixes the issue by unserializing the field after the collection is loaded.

### Manual testing scenarios
1. Create a shipment through the backend. `packages` is in my case set to `[]`.
2. Load this shipment with a collection. The attribute `packages` is a string, but should be an array.

```php
class Shipment
{
    /**
     * @var \Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory
     */
    protected $shipmentCollectionFactory;

    /**
     * @var \Magento\Sales\Api\ShipmentRepositoryInterface
     */
    protected $shipmentRepository;

    public function __construct(
        \Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory $shipmentCollectionFactory,
        \Magento\Sales\Api\ShipmentRepositoryInterface $shipmentRepository
    ) {
        $this->shipmentCollectionFactory = $shipmentCollectionFactory;
        $this->shipmentRepository = $shipmentRepository;
    }

    public function execute()
    {
        /** @var \Magento\Sales\Model\Order\Shipment $shipment */
        $shipment = $this->shipmentRepository->get(1);
        echo gettype($shipment->getPackages()) . "\n";

        /** @var \Magento\Sales\Model\ResourceModel\Order\Shipment\Collection $shipmentCollection */
        $shipmentCollection = $this->shipmentCollectionFactory->create();
        $shipment = $shipmentCollection->addAttributeToFilter('entity_id', 1)
            ->getFirstItem();

        echo gettype($shipment->getPackages());
    }
}
```
In this example the same shipment is loaded with 1.) the shipment repository and 2.) the shipment collection. The output is:
```
array
string
```

This consequently causes further problems if the shipment loaded with the shipment collection is being updated, because `packages` gets saved as `"[]"` (the quotation marks are now a part of the string). `packages` now can't get unserialized when it's loaded with any method. Also an error is shown if this shipment is opened in the backend because an array is expected but a string is given:
```
Exception #0 (Exception): Warning: Invalid argument supplied for foreach() in /path/to/magento2/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/packed.phtml on line 12
```


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
