### PR TITLE
Don't set a source model on the attribute when it's not needed. This …

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
@@ -608,9 +608,11 @@ abstract class AbstractAttribute extends \Magento\Framework\Model\AbstractExtens
     {
         if (empty($this->_source)) {
             if (!$this->getSourceModel()) {
-                $this->setSourceModel($this->_getDefaultSourceModel());
+                $this->_source = $this->_getDefaultSourceModel();
+            } else {
+                $this->_source = $this->getSourceModel();
             }
-            $source = $this->_universalFactory->create($this->getSourceModel());
+            $source = $this->_universalFactory->create($this->_source);
             if (!$source) {
                 throw new LocalizedException(
                     __(


### PR DESCRIPTION
…avoids accidentally persisting the source model to the database when using multiselect attributes.

### Description
This removes calling a setter (`setSourceModel`) inside a getter (`getSource `) which is considered bad practice, since it changes state of an object, and a getter shouldn't change the state of an object.

This is not some theoretical case, please see the manual testing scenario or https://github.com/magento/magento2/issues/13156 to have an example where this can be seen in practice.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13156: Updating attribute option data through API will set unwanted source_model on the attribute

### Manual testing scenarios
1. Setup a clean Magento installation
2. Create an Integration with full access rights & activate it, I'm assuming the access token is `abcd` (see step 6)
3. Using the adminhtml, create a new `multiselect` product attribute, use attribute code: `test_multi`
4. Take a look in the database, in the table: `eav_attribute`, notice that the `source_model` is `NULL`
5. Using the adminhtml, add some options to the attribute and verify that the `source_model` is still `NULL` in the database
6. Now add an option through a REST call (make sure to use a new option):
```bash
curl -k -X POST "https://domain.tld/rest/all/V1/products/attributes/test_multi/options" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer abcd" -d "{ \"option\": { \"label\": \"whatever\" }}"
```
7. Take a look at the database again, expected is that `source_model` stays `NULL`, but it doesn't, it changes to `Magento\Eav\Model\Entity\Attribute\Source\Table`

This PR fixes this.

### Further
The reason why this only happens with `multiselect` attributes and not with `select` attributes, is because of this piece of code: https://github.com/magento/magento2/blob/f36db11/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php#L383-L392
I don't know if `multiselect` should be added as well next to the condition on the `select` in that piece of code. I didn't try to figure it out anymore, since it was already complex enough to figure out all what was going on :)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
