### PR TITLE
[Forwardport] 9830 - Null order in Magento\Sales\Block\Order\PrintShipment.php

### DIFF
--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_print.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_print.xml
@@ -12,12 +12,12 @@
     <body>
         <attribute name="class" value="account"/>
         <referenceContainer name="page.main.title">
-            <block class="Magento\Sales\Block\Order\PrintShipment" name="order.status" template="Magento_Sales::order/order_status.phtml" />
+            <block class="Magento\Sales\Block\Order\PrintShipment" cacheable="false" name="order.status" template="Magento_Sales::order/order_status.phtml" />
             <block class="Magento\Sales\Block\Order\PrintShipment" name="order.date" template="Magento_Sales::order/order_date.phtml" />
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Order\PrintShipment" name="sales.order.print" template="Magento_Sales::order/view.phtml">
-                <block class="Magento\Sales\Block\Order\PrintShipment" name="order_items" template="Magento_Sales::order/items.phtml">
+                <block class="Magento\Sales\Block\Order\Items" name="order_items" template="Magento_Sales::order/items.phtml">
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.print.renderers" as="renderer.list" />
                     <block class="Magento\Sales\Block\Order\Totals" name="order_totals" template="Magento_Sales::order/totals.phtml">
                         <arguments>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17998

**DESCRIPTION**
When trying to print the order information from customer's account view the following error is placed in httpd logs:
`Fatal error: Call to a member function getRealOrderId() on null in /vendor/magento/module-sales/Block/Order/PrintShipment.php`
The cause of this was additional AJAX request taking place after closing the print prompt as discussed by @ihor-sviziev in #9830, trying to render print information one additional time, however without registry properly initialized, it results in the error. I've changed the block that was causing this issue to be uncachable, which seems to be fixing the problem. I've also added changes that were added to 2.1 from #10530 that were not present in 2.2.

**FIXED ISSUES**

 - https://github.com/magento/magento2/issues/9830 Null order in Magento\Sales\Block\Order\PrintShipment.php
- https://github.com/magento/magento2/issues/10530 Print order error on magento 2.1.8

**MANUAL TESTING SCENARIOS**

- create a new order as logged customer
- go to your account page
- go to order view
- click 'Print order' button
- check httpd logs whether or not the error described in the #9830 is visible