### PR TITLE
[#18269] If import product has missing categories, make a lookup for existing categories to keep the correct url rewrites

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -248,7 +248,13 @@ class AfterImportDataObserver implements ObserverInterface
             }
         }
 
-        $this->categoryCache[$rowData['entity_id']] = $this->import->getProductCategories($rowData['sku']);
+        // If no categories are provided get the actual categories for product to prevent loss of existing rewrites
+        $productCategoryCache = $this->import->getProductCategories($rowData['sku']);
+        if (!isset($rowData['categories']) && !$productCategoryCache) {
+            $productCategoryCache = $product->getCategoryIds();
+        }
+
+        $this->categoryCache[$rowData['entity_id']] = $productCategoryCache;
         $this->websiteCache[$rowData['entity_id']] = $this->import->getProductWebsites($rowData['sku']);
         foreach ($this->websiteCache[$rowData['entity_id']] as $websiteId) {
             if (!isset($this->websitesToStoreIds[$websiteId])) {

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/AfterImportDataObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/AfterImportDataObserverTest.php
@@ -315,12 +315,14 @@ class AfterImportDataObserverTest extends \PHPUnit\Framework\TestCase
             ->expects($this->exactly(1))
             ->method('getStoreIdByCode')
             ->will($this->returnValueMap($map));
+
         $product = $this->createPartialMock(\Magento\Catalog\Model\Product::class, [
                 'getId',
                 'setId',
                 'getSku',
                 'setStoreId',
                 'getStoreId',
+                'getCategoryIds'
             ]);
         $product
             ->expects($this->exactly($productsCount))
@@ -338,6 +340,10 @@ class AfterImportDataObserverTest extends \PHPUnit\Framework\TestCase
                 $newSku[1]['entity_id'],
                 $newSku[1]['entity_id']
             );
+        $product
+            ->expects($this->any())
+            ->method('getCategoryIds')
+            ->willReturn([]);
         $product
             ->expects($this->exactly($productsCount))
             ->method('getSku')


### PR DESCRIPTION
…existing categories to keep the correct url rewrites

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18269: Product Import -> Missing categories entry in importfile removes url rewrites

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Updated Unit Test

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
