### PR TITLE
Fixed issue with product copy outside of admin area

### DIFF
--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -38,26 +38,12 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">
-        <arguments>
-            <argument name="constructors" xsi:type="array">
-                <item name="crossSell" xsi:type="string">Magento\Catalog\Model\Product\CopyConstructor\CrossSell</item>
-                <item name="upSell" xsi:type="string">Magento\Catalog\Model\Product\CopyConstructor\UpSell</item>
-                <item name="related" xsi:type="string">Magento\Catalog\Model\Product\CopyConstructor\Related</item>
-            </argument>
-        </arguments>
-    </type>
     <type name="Magento\Catalog\Controller\Adminhtml\Product\Attribute\Validate">
         <arguments>
             <argument name="multipleAttributeList" xsi:type="array">
                 <item name="select" xsi:type="string">option</item>
                 <item name="multiselect" xsi:type="string">option</item>
             </argument>
-        </arguments>
-    </type>
-    <type name="Magento\Catalog\Model\Product\Copier">
-        <arguments>
-            <argument name="copyConstructor" xsi:type="object">Magento\Catalog\Model\Product\CopyConstructor\Composite</argument>
         </arguments>
     </type>
     <type name="Magento\Catalog\Model\Product\Option\UrlBuilder">

--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -1143,4 +1143,18 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">
+        <arguments>
+            <argument name="constructors" xsi:type="array">
+                <item name="crossSell" xsi:type="string">Magento\Catalog\Model\Product\CopyConstructor\CrossSell</item>
+                <item name="upSell" xsi:type="string">Magento\Catalog\Model\Product\CopyConstructor\UpSell</item>
+                <item name="related" xsi:type="string">Magento\Catalog\Model\Product\CopyConstructor\Related</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\Catalog\Model\Product\Copier">
+        <arguments>
+            <argument name="copyConstructor" xsi:type="object">Magento\Catalog\Model\Product\CopyConstructor\Composite</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/CatalogInventory/etc/adminhtml/di.xml
+++ b/app/code/Magento/CatalogInventory/etc/adminhtml/di.xml
@@ -7,13 +7,6 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\CatalogInventory\Model\Stock\Item" type="Magento\CatalogInventory\Model\Adminhtml\Stock\Item" />
-    <type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">
-        <arguments>
-            <argument name="constructors" xsi:type="array">
-                <item name="catalog_inventory" xsi:type="string">Magento\CatalogInventory\Model\Product\CopyConstructor\CatalogInventory</item>
-            </argument>
-        </arguments>
-    </type>
     <type name="Magento\CatalogInventory\Model\Spi\StockStateProviderInterface">
         <arguments>
             <argument name="qtyCheckApplicable" xsi:type="boolean">false</argument>

--- a/app/code/Magento/CatalogInventory/etc/di.xml
+++ b/app/code/Magento/CatalogInventory/etc/di.xml
@@ -136,4 +136,11 @@
     <type name="Magento\CatalogInventory\Model\ResourceModel\Stock\Item">
         <plugin name="priceIndexUpdater" type="Magento\CatalogInventory\Model\Plugin\PriceIndexUpdater" />
     </type>
+    <type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">
+        <arguments>
+            <argument name="constructors" xsi:type="array">
+                <item name="catalog_inventory" xsi:type="string">Magento\CatalogInventory\Model\Product\CopyConstructor\CatalogInventory</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Downloadable/etc/adminhtml/di.xml
+++ b/app/code/Magento/Downloadable/etc/adminhtml/di.xml
@@ -9,13 +9,6 @@
     <type name="Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper">
         <plugin name="Downloadable" type="Magento\Downloadable\Controller\Adminhtml\Product\Initialization\Helper\Plugin\Downloadable" sortOrder="70" />
     </type>
-    <type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">
-        <arguments>
-            <argument name="constructors" xsi:type="array">
-                <item name="downloadable" xsi:type="string">Magento\Downloadable\Model\Product\CopyConstructor\Downloadable</item>
-            </argument>
-        </arguments>
-    </type>
     <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
         <arguments>
             <argument name="modifiers" xsi:type="array">

--- a/app/code/Magento/Downloadable/etc/di.xml
+++ b/app/code/Magento/Downloadable/etc/di.xml
@@ -157,4 +157,11 @@
             <argument name="connectionName" xsi:type="string">indexer</argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">
+        <arguments>
+            <argument name="constructors" xsi:type="array">
+                <item name="downloadable" xsi:type="string">Magento\Downloadable\Model\Product\CopyConstructor\Downloadable</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Summary:
Error when using  `Magento\Catalog\Model\Product\Copier::copy() ` anywhere else than in admin area.

### Description
`<type name="Magento\Catalog\Model\Product\CopyConstructor\Composite">...</type>`
and 
`<type name="Magento\Catalog\Model\Product\Copier">...</type>`
definitions were defined only in adminhtml/di.xml in Catalog, Downloadable and CatalogInventory modules.
That caused error to be thrown in case `Magento\Catalog\Model\Product\Copier::copy() ` is used anywhere else (frontend/console) than admin area.
Error thrown is:
```( ! ) Fatal error: Uncaught Error: Cannot instantiate interface Magento\Catalog\Model\Product\CopyConstructorInterface in /var/www/html/lib/internal/Magento/Framework/ObjectManager/Factory/Dynamic/Developer.php on line 52```

Example is that one is not able to run custom controller like the following:

```
namespace Inchoo\Copy\Controller\Test;

use Magento\Framework\App\Action\Action;
use Magento\Framework\App\Action\Context;
use Magento\Catalog\Model\Product\Copier;
use Magento\Framework\Exception\NoSuchEntityException;

class Test extends Action
{
    public $copier;
    public $productRepository;
    const TEST_PRODUCT_ID = 1;

    public function __construct(
        Context $context,
        Copier $copier,
        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
    ) {
        $this->copier = $copier;
        $this->productRepository = $productRepository;

        parent::__construct($context);
    }

    public function execute()
    {
        try {
            $product = $this->productRepository->getById(self::TEST_PRODUCT_ID);
        } catch (NoSuchEntityException $e) {
            die($e->getMessage());
        }

        $copier = $this->copier;
        $copier->copy($product);
    }
}
```

### Fixed Issues (if relevant)
[https://github.com/magento/magento2/issues/7056](https://github.com/magento/magento2/issues/7056)

### Manual testing scenarios
1. To make sure that existing functionality still works, just try to use Save and Duplicate option on admin product page.
2. To make sure it now works on frontend, code mentioned in description should not throw mentioned errors. It should duplicate product instead.
