### PR TITLE
Fix issue 17152 - prevent email being marked as not sent if email cop…

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender.php
@@ -65,6 +65,8 @@ abstract class Sender
     }
 
     /**
+     * Send order email if it is enabled in configuration.
+     * 
      * @param Order $order
      * @return bool
      */
@@ -94,6 +96,8 @@ abstract class Sender
     }
 
     /**
+     * Populate order email template with customer information.
+     *
      * @param Order $order
      * @return void
      */
@@ -115,6 +119,8 @@ abstract class Sender
     }
 
     /**
+     * Create Sender object using appropriate template and identity.
+     *
      * @return Sender
      */
     protected function getSender()
@@ -128,6 +134,8 @@ abstract class Sender
     }
 
     /**
+     * Get template options.
+     *
      * @return array
      */
     protected function getTemplateOptions()
@@ -139,6 +147,8 @@ abstract class Sender
     }
 
     /**
+     * Render shipping address into html.
+     *
      * @param Order $order
      * @return string|null
      */
@@ -150,6 +160,8 @@ abstract class Sender
     }
 
     /**
+     * Render billing address into html.
+     *
      * @param Order $order
      * @return string|null
      */

--- a/app/code/Magento/Sales/Model/Order/Email/Sender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender.php
@@ -81,13 +81,15 @@ abstract class Sender
 
         try {
             $sender->send();
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            return false;
+        }
+        try {
             $sender->sendCopyTo();
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
-
-            return false;
         }
-
         return true;
     }
 

--- a/app/code/Magento/Sales/Model/Order/Email/Sender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender.php
@@ -66,7 +66,7 @@ abstract class Sender
 
     /**
      * Send order email if it is enabled in configuration.
-     * 
+     *
      * @param Order $order
      * @return bool
      */


### PR DESCRIPTION
### Description
Prevent email being marked as not sent if email copy fails due to exception.

### Fixed Issues (if relevant)
1. magento/magento2#17152 Failure of "Send Order Email Copy" spams customers, every minute, forever.

### Manual testing scenarios
Provided inside reported issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
