### PR TITLE
Fix wrong reference in google analytics module layout xml

### DIFF
--- a/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
@@ -7,8 +7,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="head.additional">
+        <referenceBlock name="head.additional">
             <block class="Magento\GoogleAnalytics\Block\Ga" name="google_analytics" as="google_analytics" template="Magento_GoogleAnalytics::ga.phtml"/>
-        </referenceContainer>
+        </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
### Description
Simple change of reference (referenceContainer to referenceBlock) for Google Analytics module.

### Fixed Issues (if relevant)
1. magento/magento2#16497 Magento 2.2.5: Google Analytics not added to head correctly

### Manual testing scenarios
* Observe "head.additional" is created as block app/code/Magento/Catalog/view/frontend/layout/default.xml
* Observe "google_analytics" block is added to storefront by "referenceContainer" in app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
