### PR TITLE
Fix issue 6208 - join 'websites' field for product_listing UI component

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/AddWebsitesFieldToCollection.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/AddWebsitesFieldToCollection.php
@@ -21,6 +21,40 @@ class AddWebsitesFieldToCollection implements AddFieldToCollectionInterface
      */
     public function addField(Collection $collection, $field, $alias = null)
     {
+        /** @var \Magento\Eav\Model\Entity\Collection\AbstractCollection $collection */
+
+        //Field added to select properly, but order uses entire expression instead of alias
+        $collection->joinField(
+            'websites',
+            'catalog_product_website',
+            new \Zend_Db_Expr("GROUP_CONCAT(at_websites.website_id SEPARATOR ',')"),
+            'product_id=entity_id',
+             null,
+            'left'
+        );
+        $collection->getSelect()->group('entity_id');
+
+        //Field added to select, but only takes one "website_id" value, we need group_concat to have this work properly
+//        $collection->joinField(
+//            'websites',
+//            'catalog_product_website',
+//            'website_id',
+//            'product_id=entity_id',
+//             null,
+//            'left'
+//        );
+//        $collection->getSelect()->group('entity_id');
+
+        //Field added to select properly, but filter isn't working
+        //app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php:L414 doesn't contain "websites" field, as we aren't using "joinField" method on collection
+//        $websiteExpr = "GROUP_CONCAT(websites_table.website_id SEPARATOR ',')";
+//        $collection->getSelect()->joinLeft(
+//            ['websites_table' => $collection->getTable('catalog_product_website')],
+//            'websites_table.product_id=entity_id',
+//            [$field => new \Zend_Db_Expr($websiteExpr)]
+//        );
+//        $collection->getSelect()->group('entity_id');
+
         /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
         $collection->addWebsiteNamesToResult();
     }


### PR DESCRIPTION
### Description
The root cause for the issue is that "websites" column isn't joined in initial collection, but website data is added after product collection is already loaded. See app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php:L793 and L805

I tried implementing the sorting properly (see changes). However, i'm unable to complete this pull request due to issues I faced.

I added new join inside `app/code/Magento/Catalog/Ui/DataProvider/Product/AddWebsitesFieldToCollection.php`. As product can be in multiple websites at once, we need to concatenate website IDs and use that as "websites" field. However, if I use "joinField" or "joinLeft" methods on collection, the group_concat is uses as alias for sorting later on.

What I need is to join a field, but when admin sorts the grid, the field's alias should be used for sorting.

Might be clearer if I show the SQL queries during sorting:

this is the query that's being run during sorting
```
SELECT `e`.*, GROUP_CONCAT(at_websites.website_id SEPARATOR ',') AS `websites`, `at_qty`.`qty` FROM `catalog_product_entity` AS `e`
 LEFT JOIN `catalog_product_website` AS `at_websites` ON (at_websites.`product_id`=e.entity_id)
 LEFT JOIN `cataloginventory_stock_item` AS `at_qty` ON (at_qty.`product_id`=e.entity_id) AND (at_qty.stock_id=1) GROUP BY `entity_id` ORDER BY `at_websites`.`GROUP_CONCAT(at_websites`.`website_id SEPARATOR ',')` ASC
 ;
```

but I need this query to run:
```
SELECT `e`.*, GROUP_CONCAT(at_websites.website_id SEPARATOR ',') AS `websites`, `at_qty`.`qty` FROM `catalog_product_entity` AS `e`
 LEFT JOIN `catalog_product_website` AS `at_websites` ON (at_websites.`product_id`=e.entity_id)
 LEFT JOIN `cataloginventory_stock_item` AS `at_qty` ON (at_qty.`product_id`=e.entity_id) AND (at_qty.stock_id=1) GROUP BY `entity_id` ORDER BY websites ASC
 ;
```

If I use "joinField" method from collection to add "websites" column, that field is properly added to "joinFields" variable, and available for sorting. app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php:L797

However, this also means that, during sorting, alias is mapped back to "GROUP_CONCAT" which causes the error: 
`Unknown column 'at_websites.GROUP_CONCAT(at_websites.website_id SEPARATOR ',')' in 'order clause'`

Any guidance would be appreciated. 

### Fixed Issues (if relevant)
1. magento/magento2#6208

### Manual testing scenarios
Open product grid in admin.
Try sorting products by websites
Sorting doesn't work

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
