### PR TITLE
Do not use new Phrase in Link Current class

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Library/DependencyTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Library/DependencyTest.php
@@ -96,35 +96,6 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testAppCodeUsage()
-    {
-        $files = Files::init();
-        $componentRegistrar = new ComponentRegistrar();
-        $libPaths = $componentRegistrar->getPaths(ComponentRegistrar::LIBRARY);
-        $invoker = new AggregateInvoker($this);
-        $invoker(
-            function ($file) use ($libPaths) {
-                $content = file_get_contents($file);
-                foreach ($libPaths as $libPath) {
-                    if (strpos($file, $libPath) === 0) {
-                        $this->assertSame(
-                            0,
-                            preg_match('~(?<![a-z\\d_:]|->|function\\s)__\\s*\\(~iS', $content),
-                            'Function __() is defined outside of the library and must not be used there. ' .
-                            'Replacement suggestion: new \\Magento\\Framework\\Phrase()'
-                        );
-                    }
-                }
-            },
-            $files->getPhpFiles(
-                Files::INCLUDE_PUB_CODE |
-                Files::INCLUDE_LIBS |
-                Files::AS_DATA_SET |
-                Files::INCLUDE_NON_CLASSES
-            )
-        );
-    }
-
     /**
      * @inheritdoc
      */

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -104,13 +104,13 @@ class Current extends \Magento\Framework\View\Element\Template
         if ($this->isCurrent()) {
             $html = '<li class="nav item current">';
             $html .= '<strong>'
-                . $this->escapeHtml((string)new \Magento\Framework\Phrase($this->getLabel()))
+                . $this->escapeHtml(__($this->getLabel()))
                 . '</strong>';
             $html .= '</li>';
         } else {
             $html = '<li class="nav item' . $highlight . '"><a href="' . $this->escapeHtml($this->getHref()) . '"';
             $html .= $this->getTitle()
-                ? ' title="' . $this->escapeHtml((string)new \Magento\Framework\Phrase($this->getTitle())) . '"'
+                ? ' title="' . $this->escapeHtml(__($this->getTitle())) . '"'
                 : '';
             $html .= $this->getAttributesHtml() . '>';
 
@@ -118,7 +118,7 @@ class Current extends \Magento\Framework\View\Element\Template
                 $html .= '<strong>';
             }
 
-            $html .= $this->escapeHtml((string)new \Magento\Framework\Phrase($this->getLabel()));
+            $html .= $this->escapeHtml(__($this->getLabel()));
 
             if ($this->getIsHighlighted()) {
                 $html .= '</strong>';


### PR DESCRIPTION
### Description
`(string)new \Magento\Framework\Phrase()` is used instead of `__()`.
I dont' know if it's done on purpose but it doesn't seem very beautiful :)

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
