### PR TITLE
Update colinmollenhour/cache-backend-redis from version 1.10.5 to 1.10.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "lib-libxml": "*",
         "braintree/braintree_php": "3.35.0",
         "colinmollenhour/cache-backend-file": "~1.4.1",
-        "colinmollenhour/cache-backend-redis": "1.10.5",
+        "colinmollenhour/cache-backend-redis": "1.10.6",
         "colinmollenhour/credis": "1.10.0",
         "colinmollenhour/php-redis-session-abstract": "~1.4.0",
         "composer/composer": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18982aa4d36bcfd22cf073dfb578efdb",
+    "content-hash": "dcecc6ef5197bb32c59c7ba1f5d136ac",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -88,16 +88,16 @@
         },
         {
             "name": "colinmollenhour/cache-backend-redis",
-            "version": "1.10.5",
+            "version": "1.10.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/Cm_Cache_Backend_Redis.git",
-                "reference": "91d949e28d939e607484a4bbf9307cff5afa689b"
+                "reference": "cc941a5f4cc017e11d3eab9061811ba9583ed6bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/Cm_Cache_Backend_Redis/zipball/91d949e28d939e607484a4bbf9307cff5afa689b",
-                "reference": "91d949e28d939e607484a4bbf9307cff5afa689b",
+                "url": "https://api.github.com/repos/colinmollenhour/Cm_Cache_Backend_Redis/zipball/cc941a5f4cc017e11d3eab9061811ba9583ed6bf",
+                "reference": "cc941a5f4cc017e11d3eab9061811ba9583ed6bf",
                 "shasum": ""
             },
             "require": {
@@ -120,7 +120,7 @@
             ],
             "description": "Zend_Cache backend using Redis with full support for tags.",
             "homepage": "https://github.com/colinmollenhour/Cm_Cache_Backend_Redis",
-            "time": "2018-05-15T16:02:25+00:00"
+            "time": "2018-09-24T16:02:07+00:00"
         },
         {
             "name": "colinmollenhour/credis",


### PR DESCRIPTION
### Description

This PR updates the `colinmollenhour/cache-backend-redis` library to bring in support for a new `retry_reads_on_master` option which is useful for minimizing the impact of cache stampedes on an asynchronously replicated Redis cache backend. When this options is enabled, reads are first sent to the slave per normal and if the slave doesn't have the value the read is replayed on the master. Only if the value does not exist on the slave nor on the master will the backend return a (nil) value. The importance of this is highlighted only when both asynchronous replication is used and specific production traffic patters (i.e. ones which do not show up in load testing) result in a constant flood of cache writes to the same keys piling up in the replication buffers and toppling the redis slaves. See colinmollenhour/Cm_Cache_Backend_Redis#134 for more details on this.

The new option is used in env.php cache configuration, for example:

```
 'cache' => 
  array (
    'frontend' => 
    array (
      'default' => 
      array (
        'backend' => 'Cm_Cache_Backend_Redis',
        'backend_options' => 
        array (
          'server' => '940365-masterdb',
          'port' => '6379',
          'load_from_slave' => 'tcp://127.0.0.1:6379',
          'retry_reads_on_master' => '1',
        ),
      ),
    ),
  ),
```

### Fixed Issues (if relevant)

1. Fixes the inability to scale beyond 1Gbps of object cache reads in a production environment and maintain stability.

### Manual testing scenarios

1. Install Magento. If it stills works, this didn't break anything.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)