### PR TITLE
Fix the issue with customer inline edit when password is expired 

### DIFF
--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/InlineEdit.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/InlineEdit.php
@@ -6,14 +6,16 @@
 namespace Magento\Customer\Controller\Adminhtml\Index;
 
 use Magento\Backend\App\Action;
-use Magento\Customer\Model\EmailNotificationInterface;
-use Magento\Customer\Test\Block\Form\Login;
-use Magento\Customer\Ui\Component\Listing\AttributeRepository;
-use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\EmailNotificationInterface;
+use Magento\Customer\Ui\Component\Listing\AttributeRepository;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Message\MessageInterface;
 
 /**
+ * Customer inline edit action
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class InlineEdit extends \Magento\Backend\App\Action implements HttpPostActionInterface
@@ -102,7 +104,11 @@ class InlineEdit extends \Magento\Backend\App\Action implements HttpPostActionIn
     }
 
     /**
+     * Inline edit action execute
+     *
      * @return \Magento\Framework\Controller\Result\Json
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function execute()
     {
@@ -250,7 +256,7 @@ class InlineEdit extends \Magento\Backend\App\Action implements HttpPostActionIn
     protected function getErrorMessages()
     {
         $messages = [];
-        foreach ($this->getMessageManager()->getMessages()->getItems() as $error) {
+        foreach ($this->getMessageManager()->getMessages()->getErrors() as $error) {
             $messages[] = $error->getText();
         }
         return $messages;
@@ -263,7 +269,7 @@ class InlineEdit extends \Magento\Backend\App\Action implements HttpPostActionIn
      */
     protected function isErrorExists()
     {
-        return (bool)$this->getMessageManager()->getMessages(true)->getCount();
+        return (bool)$this->getMessageManager()->getMessages(true)->getCountByType(MessageInterface::TYPE_ERROR);
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Customer\Test\Unit\Controller\Adminhtml\Index;
 
 use Magento\Customer\Model\EmailNotificationInterface;
+use Magento\Framework\Message\MessageInterface;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -242,10 +243,11 @@ class InlineEditTest extends \PHPUnit\Framework\TestCase
             ->method('getMessages')
             ->willReturn($this->messageCollection);
         $this->messageCollection->expects($this->once())
-            ->method('getItems')
+            ->method('getErrors')
             ->willReturn([$this->message]);
         $this->messageCollection->expects($this->once())
-            ->method('getCount')
+            ->method('getCountByType')
+            ->with(MessageInterface::TYPE_ERROR)
             ->willReturn(1);
         $this->message->expects($this->once())
             ->method('getText')


### PR DESCRIPTION
### Description
The issue appeared because of the success, notice and warning messages considered as error ones.

### Fixed Issues (if relevant)
1. magento/magento2#18162: Cannot edit customer using inline edit if password is expired

### Manual testing scenarios
1. Set `admin/security/password_is_forced` to `0` (_Recommended_).
2. Make sure Password Lifetime is past so the message `It's time to change your password.` is shown.
3. Open customer grid and try to edit and save using inline editor.

### Expected result
1. Customer is saved.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
