### PR TITLE
Customer Grid Assign Customer Group not working

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/grid/submenu.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/submenu.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<ul class="action-submenu" each="data: action.actions, as: 'action'" css="_active: action.visible">
+<ul class="action-submenu" each="data: action.actions, as: 'action'" css="_active: $parent.visible">
     <li css="_visible: $data.visible">
         <span class="action-menu-item" text="label" click="$parent.applyAction.bind($parent, type)"/>
         <render args="name: $parent.submenuTemplate, data: $parent" if="$data.actions"/>


### PR DESCRIPTION
### Description
Customer Grid Action --> Assign Customer Group not working 
**Steps to reproduce:**
1. Go to Customers --> Actions --> Edit  --> Click ok on the Modal
2. Click on Assign Customer Group

**Expected Result:**
Customer Group names should appear
**Actual Result:** 
Nothing happens.
**Fix ::**
Its  due to the submenu listens to its own visible instead it should listen parent's visible.
