### PR TITLE
[Forwardport] fix: reset search mini-form when we have no data / an empty response

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -306,12 +306,13 @@ define([
                             dropdown.append(html);
                         });
 
+                        this._resetResponseList(true);
+
                         this.responseList.indexList = this.autoComplete.html(dropdown)
                             .css(clonePosition)
                             .show()
                             .find(this.options.responseFieldElements + ':visible');
 
-                        this._resetResponseList(false);
                         this.element.removeAttr('aria-activedescendant');
 
                         if (this.responseList.indexList.length) {
@@ -338,6 +339,11 @@ define([
                                     this._resetResponseList(false);
                                 }
                             }.bind(this));
+                    } else {
+                        this._resetResponseList(true);
+                        this.autoComplete.hide();
+                        this._updateAriaHasPopup(false);
+                        this.element.removeAttr('aria-activedescendant');
                     }
                 }, this));
             } else {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18055

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Currently the search form does not reset the results when we have no result / data.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to http://mag2opensource.basecom.de/catalogsearch/result/?q=pullover
2. write `pullover` in the search
3. autocomplete with result number appears
4. now append `en` so we have `pulloveren`
5. autocomplete still shows the results

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
