### PR TITLE
Fix for removing the dirs while creating a TAR archive

### DIFF
--- a/lib/internal/Magento/Framework/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Archive/Tar.php
@@ -259,10 +259,7 @@ class Tar extends \Magento\Framework\Archive\AbstractArchive implements \Magento
                 );
             }
 
-            array_shift($dirFiles);
-            /* remove  './'*/
-            array_shift($dirFiles);
-            /* remove  '../'*/
+            $dirFiles = array_diff($dirFiles, ['..', '.']);
 
             foreach ($dirFiles as $item) {
                 $this->_setCurrentFile($file . $item)->_createTar();

--- a/lib/internal/Magento/Framework/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Archive/Tar.php
@@ -4,15 +4,15 @@
  * See COPYING.txt for license details.
  */
 
+namespace Magento\Framework\Archive;
+
+use Magento\Framework\Archive\Helper\File;
+
 /**
  * Class to work with tar archives
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-namespace Magento\Framework\Archive;
-
-use Magento\Framework\Archive\Helper\File;
-
 class Tar extends \Magento\Framework\Archive\AbstractArchive implements \Magento\Framework\Archive\ArchiveInterface
 {
     /**


### PR DESCRIPTION
# Description
The bug caused issues during the export of analytics data from advanced
reporting. The SCANDIR has a parameter where the sort can be determined, but
using UNSORTED gives you unwanted lists of files/dirs. Therefor deleting
the first 2 via array_shift, is not a proper way of dealing with this. With this PR, it doesn't matter how you sort the results of the SCANDIR function, you'll always remove in a proper way the "." and "..".

# Fixed Issues (if relevant)
No issues were found about this issue

# Manual testing scenarios
- [x] Running of "analytics_collect_data" cronjob and check if the "." and ".." were removed in the result of the scandir PHP function.

# Contribution checklist
- [x]  Pull request has a meaningful description of its purpose
- [x]  All commits are accompanied by meaningful commit messages
- [ ]  All new or changed code is covered with unit/integration tests (if applicable)
- [ ]  All automated tests passed successfully (all builds on Travis CI are green)