### PR TITLE
Support of error pages behind a load balancer that serves HTTPS 

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -265,7 +265,7 @@ class Processor
             $host = 'localhost';
         }
 
-        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off')
+        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] !== 'off')
             || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -265,7 +265,8 @@ class Processor
             $host = 'localhost';
         }
 
-        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off');
+        // HTTP_X_FORWARDED_PROTO to check whether a webserver using HTTP is behind a load balancer serving HTTPS
+        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off') || $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https';
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 
         if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 443])

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -265,7 +265,6 @@ class Processor
             $host = 'localhost';
         }
 
-        // HTTP_X_FORWARDED_PROTO to check whether a webserver using HTTP is behind a load balancer serving HTTPS
         $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off') || $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https';
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -265,7 +265,8 @@ class Processor
             $host = 'localhost';
         }
 
-        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off') || $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https';
+        $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off')
+            || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 
         if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 443])


### PR DESCRIPTION
Support of error pages behind a load balancer that serves HTTPS but accesses the webserver on HTTP. Without this css is loaded on HTTP from a document loaded over HTTPS

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If you run magento on webservers serving on HTTP while the loadbalancer serves on HTTPS then base is set to a URL using HTTP which the page is HTTPS. The css is then blocked by browsers.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
