### PR TITLE
add more CDATA-related tests for `Magento\Framework\Config\Dom::merge` and fix failing ones

### DIFF
--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -192,18 +192,18 @@ class Dom
                 /* skip the case when the matched node has children, otherwise they get overridden */
                 if (!$matchedNode->hasChildNodes()
                     || $this->_isTextNode($matchedNode)
-                    || $this->_isCdataNode($matchedNode)
+                    || $this->isCdataNode($matchedNode)
                 ) {
                     $matchedNode->nodeValue = $node->childNodes->item(0)->nodeValue;
                 }
-            } elseif ($this->_isCdataNode($node) && $this->_isTextNode($matchedNode)) {
+            } elseif ($this->isCdataNode($node) && $this->_isTextNode($matchedNode)) {
                 /* Replace text node with CDATA section */
-                if ($this->_findCdataSection($node)) {
-                    $matchedNode->nodeValue = $this->_findCdataSection($node)->nodeValue;
+                if ($this->findCdataSection($node)) {
+                    $matchedNode->nodeValue = $this->findCdataSection($node)->nodeValue;
                 }
-            } elseif ($this->_isCdataNode($node) && $this->_isCdataNode($matchedNode)) {
+            } elseif ($this->isCdataNode($node) && $this->isCdataNode($matchedNode)) {
                 /* Replace CDATA with new one */
-                $this->_replaceCdataNode($matchedNode, $node);
+                $this->replaceCdataNode($matchedNode, $node);
             } else {
                 /* recursive merge for all child nodes */
                 foreach ($node->childNodes as $childNode) {
@@ -237,7 +237,7 @@ class Dom
      * @param \DOMNode $node
      * @return bool
      */
-    protected function _isCdataNode($node)
+    private function isCdataNode($node)
     {
         // If every child node of current is NOT \DOMElement
         // It is arbitrary combination of text nodes and CDATA sections.
@@ -256,7 +256,7 @@ class Dom
      * @param \DOMNode $node
      * @return \DOMCdataSection|null
      */
-    protected function _findCdataSection($node)
+    private function findCdataSection($node)
     {
         foreach ($node->childNodes as $childNode) {
             if ($childNode instanceof \DOMCdataSection) {
@@ -271,10 +271,10 @@ class Dom
      * @param \DOMNode $oldNode
      * @param \DOMNode $newNode
      */
-    protected function _replaceCdataNode($oldNode, $newNode)
+    private function replaceCdataNode($oldNode, $newNode)
     {
-        $oldCdata = $this->_findCdataSection($oldNode);
-        $newCdata = $this->_findCdataSection($newNode);
+        $oldCdata = $this->findCdataSection($oldNode);
+        $newCdata = $this->findCdataSection($newNode);
 
         if ($oldCdata && $newCdata) {
             $oldCdata->nodeValue = $newCdata->nodeValue;

--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -190,12 +190,17 @@ class Dom
             /* override node value */
             if ($this->_isTextNode($node)) {
                 /* skip the case when the matched node has children, otherwise they get overridden */
-                if (!$matchedNode->hasChildNodes() || $this->_isTextNode($matchedNode) || $this->_isCdataNode($matchedNode)) {
+                if (!$matchedNode->hasChildNodes()
+                    || $this->_isTextNode($matchedNode)
+                    || $this->_isCdataNode($matchedNode)
+                ) {
                     $matchedNode->nodeValue = $node->childNodes->item(0)->nodeValue;
                 }
-            } elseif ($this->_isCdataNode($node) && $this->_isTextNode($matchedNode) && $this->_findCdataSection($node)) {
+            } elseif ($this->_isCdataNode($node) && $this->_isTextNode($matchedNode)) {
                 /* Replace text node with CDATA section */
-                $matchedNode->nodeValue = $this->_findCdataSection($node)->nodeValue;
+                if ($this->_findCdataSection($node)) {
+                    $matchedNode->nodeValue = $this->_findCdataSection($node)->nodeValue;
+                }
             } elseif ($this->_isCdataNode($node) && $this->_isCdataNode($matchedNode)) {
                 /* Replace CDATA with new one */
                 $this->_replaceCdataNode($matchedNode, $node);
@@ -227,8 +232,9 @@ class Dom
     }
 
     /**
-     * Check if the node content is CDATA (probably surrounded with text nodes)
-     * @param $node
+     * Check if the node content is CDATA (probably surrounded with text nodes) or just text node
+     *
+     * @param \DOMNode $node
      * @return bool
      */
     protected function _isCdataNode($node)
@@ -246,7 +252,8 @@ class Dom
 
     /**
      * Finds CDATA section from given node children
-     * @param $node
+     *
+     * @param \DOMNode $node
      * @return \DOMCdataSection|null
      */
     protected function _findCdataSection($node)
@@ -260,8 +267,9 @@ class Dom
 
     /**
      * Replaces CDATA section in $oldNode with $newNode's
-     * @param $oldNode
-     * @param $newNode
+     *
+     * @param \DOMNode $oldNode
+     * @param \DOMNode $newNode
      */
     protected function _replaceCdataNode($oldNode, $newNode)
     {

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Framework\Config\Test\Unit;
 
+/**
+ * Test for \Magento\Framework\Config\Dom class.
+ */
 class DomTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
@@ -62,13 +62,37 @@ class DomTest extends \PHPUnit\Framework\TestCase
             ['override_node.xml', 'override_node_new.xml', [], null, 'override_node_merged.xml'],
             ['override_node_new.xml', 'override_node.xml', [], null, 'override_node_merged.xml'],
             ['text_node.xml', 'text_node_new.xml', [], null, 'text_node_merged.xml'],
-            'text node replaced with cdata' => ['text_node_cdata.xml', 'text_node_cdata_new.xml', [], null, 'text_node_cdata_merged.xml'],
+            'text node replaced with cdata' => [
+                'text_node_cdata.xml',
+                'text_node_cdata_new.xml',
+                [],
+                null,
+                'text_node_cdata_merged.xml'
+            ],
             'cdata' => ['cdata.xml', 'cdata_new.xml', [], null, 'cdata_merged.xml'],
             'cdata with html' => ['cdata_html.xml', 'cdata_html_new.xml', [], null, 'cdata_html_merged.xml'],
-            'cdata replaced with text node' => ['cdata_text.xml', 'cdata_text_new.xml', [], null, 'cdata_text_merged.xml'],
+            'cdata replaced with text node' => [
+                'cdata_text.xml',
+                'cdata_text_new.xml',
+                [],
+                null,
+                'cdata_text_merged.xml'
+            ],
             'big cdata' => ['big_cdata.xml', 'big_cdata_new.xml', [], null, 'big_cdata_merged.xml'],
-            'big cdata with attribute' => ['big_cdata_attribute.xml', 'big_cdata_attribute_new.xml', [], null, 'big_cdata_attribute_merged.xml'],
-            'big cdata replaced with text' => ['big_cdata_text.xml', 'big_cdata_text_new.xml', [], null, 'big_cdata_text_merged.xml'],
+            'big cdata with attribute' => [
+                'big_cdata_attribute.xml',
+                'big_cdata_attribute_new.xml',
+                [],
+                null,
+                'big_cdata_attribute_merged.xml'
+            ],
+            'big cdata replaced with text' => [
+                'big_cdata_text.xml',
+                'big_cdata_text_new.xml',
+                [],
+                null,
+                'big_cdata_text_merged.xml'
+            ],
             [
                 'recursive.xml',
                 'recursive_new.xml',

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php
@@ -62,6 +62,13 @@ class DomTest extends \PHPUnit\Framework\TestCase
             ['override_node.xml', 'override_node_new.xml', [], null, 'override_node_merged.xml'],
             ['override_node_new.xml', 'override_node.xml', [], null, 'override_node_merged.xml'],
             ['text_node.xml', 'text_node_new.xml', [], null, 'text_node_merged.xml'],
+            'text node replaced with cdata' => ['text_node_cdata.xml', 'text_node_cdata_new.xml', [], null, 'text_node_cdata_merged.xml'],
+            'cdata' => ['cdata.xml', 'cdata_new.xml', [], null, 'cdata_merged.xml'],
+            'cdata with html' => ['cdata_html.xml', 'cdata_html_new.xml', [], null, 'cdata_html_merged.xml'],
+            'cdata replaced with text node' => ['cdata_text.xml', 'cdata_text_new.xml', [], null, 'cdata_text_merged.xml'],
+            'big cdata' => ['big_cdata.xml', 'big_cdata_new.xml', [], null, 'big_cdata_merged.xml'],
+            'big cdata with attribute' => ['big_cdata_attribute.xml', 'big_cdata_attribute_new.xml', [], null, 'big_cdata_attribute_merged.xml'],
+            'big cdata replaced with text' => ['big_cdata_text.xml', 'big_cdata_text_new.xml', [], null, 'big_cdata_text_merged.xml'],
             [
                 'recursive.xml',
                 'recursive_new.xml',

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode attr="text">
+            <![CDATA[Some Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_merged.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_merged.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode attr="text">
+            <![CDATA[Some Other Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_new.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_attribute_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Other Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_merged.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_merged.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Other Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_new.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Other Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_merged.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>Some Other Phrase</subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_merged.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>Some Other Phrase</subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/big_cdata_text_new.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some <br /> Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_merged.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_merged.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some <br /> Other <br /> Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_new.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_html_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some <br /> Other <br /> Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_merged.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_merged.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some Other Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_new.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some Other Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode><![CDATA[Some Phrase]]></subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_merged.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>Some Other Phrase</subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_merged.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (c) Vaimo Group. All rights reserved.
+ See LICENSE_VAIMO.txt for license details.
+-->
+<root>
+    <node>
+        <subnode>Some Other Phrase</subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/cdata_text_new.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) Vaimo Group. All rights reserved.
- See LICENSE_VAIMO.txt for license details.
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 -->
 <root>
     <node>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/text_node_cdata.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/text_node_cdata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<root>
+    <node>
+        <subnode>Some Phrase</subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/text_node_cdata_merged.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/text_node_cdata_merged.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Other Phrase]]>
+        </subnode>
+    </node>
+</root>

--- a/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/text_node_cdata_new.xml
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/_files/dom/text_node_cdata_new.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<root>
+    <node>
+        <subnode>
+            <![CDATA[Some Other Phrase]]>
+        </subnode>
+    </node>
+</root>


### PR DESCRIPTION
### Description

This PR fixes several issues I found trying to update field comment of another module in Magento 2 Admin:

```xml
<comment>
    <![CDATA[
        "Redirect" redirects the client directly to the target store. <br />
        "Countries Popup" shows the Countries Popup to select target store. <br />
        "Auto" does detect when it's needed to use "Redirect" or "Countries Popup" depending on current request. <br />
    ]]>
</comment>
```
If I create another `system.xml` file updating such a comment it will never be replaced because `$this->_isTextNode($matchingNode)` will always return `false`: this `<comment>` node contains three childNodes, none of them is `\DomElement` (empty text node, cdata section, empty text node).

During investigation of this, I created a bunch of new test cases for `Magento\Framework\Config\Dom::merge` and fixed failing ones.

### Manual testing scenarios (*)
Detailed steps described in [THIS comment](https://github.com/magento/magento2/pull/18336#issuecomment-471598656)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
