### PR TITLE
[Backport] fix(Webapi Xml Renderer - 18361): removed the not needed ampersand re…

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/Rest/Response/Renderer/Xml.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Response/Renderer/Xml.php
@@ -111,8 +111,7 @@ class Xml implements \Magento\Framework\Webapi\Rest\Response\RendererInterface
             /** Without the following transformation boolean values are rendered incorrectly */
             $value = $value ? 'true' : 'false';
         }
-        $replacementMap = ['&' => '&amp;'];
-        return str_replace(array_keys($replacementMap), array_values($replacementMap), $value);
+        return $value;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Webapi/Rest/Response/Renderer/Xml.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Response/Renderer/Xml.php
@@ -111,7 +111,7 @@ class Xml implements \Magento\Framework\Webapi\Rest\Response\RendererInterface
             /** Without the following transformation boolean values are rendered incorrectly */
             $value = $value ? 'true' : 'false';
         }
-        return $value;
+        return (string) $value;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Webapi/Rest/Response/Renderer/Xml.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Response/Renderer/Xml.php
@@ -7,6 +7,9 @@
  */
 namespace Magento\Framework\Webapi\Rest\Response\Renderer;
 
+/**
+ * Renders response data in Xml format.
+ */
 class Xml implements \Magento\Framework\Webapi\Rest\Response\RendererInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Response/Renderer/XmlTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Response/Renderer/XmlTest.php
@@ -77,6 +77,11 @@ class XmlTest extends \PHPUnit\Framework\TestCase
                 'Invalid XML render with numeric symbol in data index.'
             ],
             [
+                ['key' => 'test & foo'],
+                '<?xml version="1.0"?><response><key>test &amp; foo</key></response>',
+                'Invalid XML render with ampersand symbol in data index.'
+            ],
+            [
                 ['.key' => 'value'],
                 '<?xml version="1.0"?><response><item_key>value</item_key></response>',
                 'Invalid XML render with "." symbol in data index.'


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

Fixes #18361 (ampersand xml serialisation issue)


### Description

As described in https://github.com/magento/magento2/issues/18361, the issue is about having the ampersand in any customer text field, and when using the WebApi, it causes an issue of doubling the encoding. I.e `&amp;amp;`, which is not the case in the XML format, so it should be resolved.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18361: Customer last name is encoded twice in the XML interface #18361

### Manual testing scenarios

1.  Create a customer via Backend with the last name "Foo & Bar Corp"
2. Create an order (via frontend is fine)
3. Export the order via XML interfcae

```
curl -XPOST -H 'Content-Type: application/json' http://hostname/rest/V1/integration/admin/token -d '{ "username": "admin_username", "password": "admin_password" }'
export B=code received above
 curl -X GET --header "Accept: application/xml" --header "Authorization: Bearer $B" "http://hostname/rest/english/V1/orders/1"
```
The `customer_lastname` tag should contain `Foo &amp; Bar Corp`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/18380