### PR TITLE
Avoid static methods in \Magento\Catalog\Model\Product\Visibility

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -14,6 +14,7 @@ use Magento\Framework\DB\Query\Generator as QueryGenerator;
 use Magento\Framework\DB\Select;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Store\Model\Store;
+use Magento\Catalog\Model\Product\Visibility;
 
 /**
  * Class AbstractAction
@@ -113,6 +114,11 @@ abstract class AbstractAction
     protected $tableMaintainer;
 
     /**
+     * @var Visibility
+     */
+    protected $productVisibility;
+
+    /**
      * @var string
      * @since 101.0.0
      */
@@ -130,6 +136,7 @@ abstract class AbstractAction
      * @param QueryGenerator $queryGenerator
      * @param MetadataPool|null $metadataPool
      * @param TableMaintainer|null $tableMaintainer
+     * @param Visibility|null $productVisibility
      */
     public function __construct(
         \Magento\Framework\App\ResourceConnection $resource,
@@ -137,7 +144,8 @@ abstract class AbstractAction
         \Magento\Catalog\Model\Config $config,
         QueryGenerator $queryGenerator = null,
         MetadataPool $metadataPool = null,
-        TableMaintainer $tableMaintainer = null
+        TableMaintainer $tableMaintainer = null,
+        Visibility $productVisibility = null
     ) {
         $this->resource = $resource;
         $this->connection = $resource->getConnection();
@@ -146,6 +154,7 @@ abstract class AbstractAction
         $this->queryGenerator = $queryGenerator ?: ObjectManager::getInstance()->get(QueryGenerator::class);
         $this->metadataPool = $metadataPool ?: ObjectManager::getInstance()->get(MetadataPool::class);
         $this->tableMaintainer = $tableMaintainer ?: ObjectManager::getInstance()->get(TableMaintainer::class);
+        $this->productVisibility = $productVisibility ?: ObjectManager::getInstance()->get(Visibility::class);
     }
 
     /**
@@ -316,11 +325,7 @@ abstract class AbstractAction
                 \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
             )->where(
                 $this->connection->getIfNullSql('cpvs.value', 'cpvd.value') . ' IN (?)',
-                [
-                    \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_CATALOG,
-                    \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_SEARCH,
-                    \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH
-                ]
+                $this->productVisibility->getVisibleInSiteIds()
             )->columns(
                 [
                     'category_id' => 'cc.entity_id',
@@ -559,11 +564,7 @@ abstract class AbstractAction
             \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
         )->where(
             $this->connection->getIfNullSql('cpvs.value', 'cpvd.value') . ' IN (?)',
-            [
-                \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_CATALOG,
-                \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_SEARCH,
-                \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH
-            ]
+            $this->productVisibility->getVisibleInSiteIds()
         )->where(
             $this->connection->getIfNullSql('ccas.value', 'ccad.value') . ' = ?',
             1
@@ -780,11 +781,7 @@ abstract class AbstractAction
                 \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
             )->where(
                 $this->connection->getIfNullSql('cpvs.value', 'cpvd.value') . ' IN (?)',
-                [
-                    \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_CATALOG,
-                    \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_SEARCH,
-                    \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH
-                ]
+                $this->productVisibility->getVisibleInSiteIds()
             )->group(
                 'cp.entity_id'
             )->columns(

--- a/app/code/Magento/Catalog/Model/Product/Visibility.php
+++ b/app/code/Magento/Catalog/Model/Product/Visibility.php
@@ -83,11 +83,21 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
     }
 
     /**
+     * Retrieve not visible in site ids array
+     *
+     * @return string[]
+     */
+    public function getNotVisibleInSiteIds()
+    {
+        return [self::VISIBILITY_NOT_VISIBLE];
+    }
+
+    /**
      * Retrieve option array
      *
      * @return array
      */
-    public static function getOptionArray()
+    public function getOptionArray()
     {
         return [
             self::VISIBILITY_NOT_VISIBLE => __('Not Visible Individually'),
@@ -102,9 +112,9 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
      *
      * @return array
      */
-    public static function getAllOption()
+    public function getAllOption()
     {
-        $options = self::getOptionArray();
+        $options = $this->getOptionArray();
         array_unshift($options, ['value' => '', 'label' => '']);
         return $options;
     }
@@ -114,10 +124,10 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
      *
      * @return array
      */
-    public static function getAllOptions()
+    public function getAllOptions()
     {
         $res = [];
-        foreach (self::getOptionArray() as $index => $value) {
+        foreach ($this->getOptionArray() as $index => $value) {
             $res[] = ['value' => $index, 'label' => $value];
         }
         return $res;
@@ -129,9 +139,9 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
      * @param int $optionId
      * @return string
      */
-    public static function getOptionText($optionId)
+    public function getOptionText($optionId)
     {
-        $options = self::getOptionArray();
+        $options = $this->getOptionArray();
         return isset($options[$optionId]) ? $options[$optionId] : null;
     }
 

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product.php
@@ -8,6 +8,7 @@ namespace Magento\Catalog\Model\ResourceModel;
 use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductWebsiteLink;
 use Magento\Framework\App\ObjectManager;
 use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
+use Magento\Catalog\Model\Product\Visibility;
 
 /**
  * Product entity resource model
@@ -90,6 +91,11 @@ class Product extends AbstractResource
     private $tableMaintainer;
 
     /**
+     * @var Visibility
+     */
+    private $productVisibility;
+
+    /**
      * @param \Magento\Eav\Model\Entity\Context $context
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Catalog\Model\Factory $modelFactory
@@ -101,6 +107,7 @@ class Product extends AbstractResource
      * @param \Magento\Catalog\Model\Product\Attribute\DefaultAttributes $defaultAttributes
      * @param array $data
      * @param TableMaintainer|null $tableMaintainer
+     * @param Visibility|null $productVisibility
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -115,7 +122,8 @@ class Product extends AbstractResource
         \Magento\Eav\Model\Entity\TypeFactory $typeFactory,
         \Magento\Catalog\Model\Product\Attribute\DefaultAttributes $defaultAttributes,
         $data = [],
-        TableMaintainer $tableMaintainer = null
+        TableMaintainer $tableMaintainer = null,
+        Visibility $productVisibility = null
     ) {
         $this->_categoryCollectionFactory = $categoryCollectionFactory;
         $this->_catalogCategory = $catalogCategory;
@@ -131,6 +139,7 @@ class Product extends AbstractResource
         );
         $this->connectionName  = 'catalog';
         $this->tableMaintainer = $tableMaintainer ?: ObjectManager::getInstance()->get(TableMaintainer::class);
+        $this->productVisibility = $productVisibility ?: ObjectManager::getInstance()->get(Visibility::class);
     }
 
     /**
@@ -406,8 +415,8 @@ class Product extends AbstractResource
             'product_id = ? AND is_parent = 1',
             $entityId
         )->where(
-            'visibility != ?',
-            \Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE
+            'visibility NOT IN (?)',
+            $this->productVisibility->getNotVisibleInSiteIds()
         );
     }
 

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
@@ -6,6 +6,7 @@
 namespace Magento\Catalog\Model\ResourceModel\Product\Indexer\Eav;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
 use Magento\Framework\App\ObjectManager;
 
 /**
@@ -24,23 +25,30 @@ abstract class AbstractEav extends \Magento\Catalog\Model\ResourceModel\Product\
     protected $_eventManager = null;
 
     /**
+     * @var \Magento\Catalog\Model\Product\Visibility
+     */
+    private $productVisibility;
+
+    /**
      * AbstractEav constructor.
      * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
      * @param \Magento\Framework\Indexer\Table\StrategyInterface $tableStrategy
      * @param \Magento\Eav\Model\Config $eavConfig
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param null $connectionName
-     * @param \Magento\Indexer\Model\Indexer\StateFactory|null $stateFactory
+     * @param \Magento\Catalog\Model\Product\Visibility|null $productVisibility
      */
     public function __construct(
         \Magento\Framework\Model\ResourceModel\Db\Context $context,
         \Magento\Framework\Indexer\Table\StrategyInterface $tableStrategy,
         \Magento\Eav\Model\Config $eavConfig,
         \Magento\Framework\Event\ManagerInterface $eventManager,
-        $connectionName = null
+        $connectionName = null,
+        Visibility $productVisibility = null
     ) {
         $this->_eventManager = $eventManager;
         parent::__construct($context, $tableStrategy, $eavConfig, $connectionName);
+        $this->productVisibility = $productVisibility ?: ObjectManager::getInstance()->get(Visibility::class);
     }
 
     /**
@@ -139,7 +147,7 @@ abstract class AbstractEav extends \Magento\Catalog\Model\ResourceModel\Product\
             []
         );
         $linkField = $this->getMetadataPool()->getMetadata(ProductInterface::class)->getLinkField();
-        $condition = $connection->quoteInto('=?', \Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE);
+        $condition = $connection->quoteInto('NOT IN (?)', $this->productVisibility->getNotVisibleInSiteIds());
         $this->_addAttributeToSelect(
             $select,
             'visibility',

--- a/app/code/Magento/CatalogUrlRewrite/Model/CategoryBasedProductRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/CategoryBasedProductRewriteGenerator.php
@@ -8,6 +8,7 @@ namespace Magento\CatalogUrlRewrite\Model;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Class ProductUrlRewriteGenerator
@@ -22,12 +23,20 @@ class CategoryBasedProductRewriteGenerator
     private $productScopeRewriteGenerator;
 
     /**
+     * @var Visibility
+     */
+    private $productVisibility;
+
+    /**
      * @param ProductScopeRewriteGenerator $productScopeRewriteGenerator
+     * @param Visibility|null $productVisibility
      */
     public function __construct(
-        ProductScopeRewriteGenerator $productScopeRewriteGenerator
+        ProductScopeRewriteGenerator $productScopeRewriteGenerator,
+        Visibility $productVisibility = null
     ) {
         $this->productScopeRewriteGenerator = $productScopeRewriteGenerator;
+        $this->productVisibility = $productVisibility ?: ObjectManager::getInstance()->get(Visibility::class);
     }
 
     /**
@@ -40,7 +49,7 @@ class CategoryBasedProductRewriteGenerator
      */
     public function generate(Product $product, Category $category, $rootCategoryId = null)
     {
-        if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
+        if (in_array($product->getVisibility(), $this->productVisibility->getNotVisibleInSiteIds())) {
             return [];
         }
 

--- a/app/code/Magento/CatalogUrlRewrite/Model/CategoryProductUrlPathGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/CategoryProductUrlPathGenerator.php
@@ -7,6 +7,7 @@ namespace Magento\CatalogUrlRewrite\Model;
 
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Class ProductUrlRewriteGenerator
@@ -20,12 +21,20 @@ class CategoryProductUrlPathGenerator
     private $productScopeRewriteGenerator;
 
     /**
+     * @var Visibility
+     */
+    private $productVisibility;
+
+    /**
      * @param ProductScopeRewriteGenerator $productScopeRewriteGenerator
+     * @param Visibility|null $productVisibility
      */
     public function __construct(
-        ProductScopeRewriteGenerator $productScopeRewriteGenerator
+        ProductScopeRewriteGenerator $productScopeRewriteGenerator,
+        Visibility $productVisibility = null
     ) {
         $this->productScopeRewriteGenerator = $productScopeRewriteGenerator;
+        $this->productVisibility = $productVisibility ?: ObjectManager::getInstance()->get(Visibility::class);
     }
 
     /**
@@ -37,7 +46,7 @@ class CategoryProductUrlPathGenerator
      */
     public function generate(Product $product, $rootCategoryId = null)
     {
-        if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
+        if (in_array($product->getVisibility(), $this->productVisibility->getNotVisibleInSiteIds())) {
             return [];
         }
 

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
@@ -79,12 +79,18 @@ class ProductUrlRewriteGenerator
     private $productScopeRewriteGenerator;
 
     /**
+     * @var Visibility
+     */
+    private $productVisibility;
+
+    /**
      * @param \Magento\CatalogUrlRewrite\Model\Product\CanonicalUrlRewriteGenerator $canonicalUrlRewriteGenerator
      * @param \Magento\CatalogUrlRewrite\Model\Product\CurrentUrlRewritesRegenerator $currentUrlRewritesRegenerator
      * @param \Magento\CatalogUrlRewrite\Model\Product\CategoriesUrlRewriteGenerator $categoriesUrlRewriteGenerator
      * @param \Magento\CatalogUrlRewrite\Model\ObjectRegistryFactory $objectRegistryFactory
      * @param \Magento\CatalogUrlRewrite\Service\V1\StoreViewService $storeViewService
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Catalog\Model\Product\Visibility|null $productVisibility
      */
     public function __construct(
         CanonicalUrlRewriteGenerator $canonicalUrlRewriteGenerator,
@@ -92,7 +98,8 @@ class ProductUrlRewriteGenerator
         CategoriesUrlRewriteGenerator $categoriesUrlRewriteGenerator,
         ObjectRegistryFactory $objectRegistryFactory,
         StoreViewService $storeViewService,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        Visibility $productVisibility = null
     ) {
         $this->canonicalUrlRewriteGenerator = $canonicalUrlRewriteGenerator;
         $this->currentUrlRewritesRegenerator = $currentUrlRewritesRegenerator;
@@ -100,6 +107,7 @@ class ProductUrlRewriteGenerator
         $this->objectRegistryFactory = $objectRegistryFactory;
         $this->storeViewService = $storeViewService;
         $this->storeManager = $storeManager;
+        $this->productVisibility = $productVisibility ?: ObjectManager::getInstance()->get(Visibility::class);
     }
 
     /**
@@ -127,7 +135,7 @@ class ProductUrlRewriteGenerator
      */
     public function generate(Product $product, $rootCategoryId = null)
     {
-        if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
+        if (in_array($product->getVisibility(), $this->productVisibility->getNotVisibleInSiteIds())) {
             return [];
         }
 

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Pricing/Price/SpecialPriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Pricing/Price/SpecialPriceTest.php
@@ -26,10 +26,16 @@ class SpecialPriceTest extends \PHPUnit\Framework\TestCase
      */
     private $productCollectionFactory;
 
+    /**
+     * @var Visibility
+     */
+    private $productVisibility;
+
     protected function setUp()
     {
         $this->productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
         $this->productCollectionFactory = Bootstrap::getObjectManager()->get(CollectionFactory::class);
+        $this->productVisibility = Bootstrap::getObjectManager()->get(Visibility::class);
     }
 
     /**
@@ -72,7 +78,7 @@ class SpecialPriceTest extends \PHPUnit\Framework\TestCase
         /** @var ProductCollection $collection */
         $collection = $this->productCollectionFactory->create();
         $collection
-            ->setVisibility([Visibility::VISIBILITY_IN_CATALOG, Visibility::VISIBILITY_BOTH])
+            ->setVisibility($this->productVisibility->getVisibleInCatalogIds())
             ->setOrder(ProductInterface::PRICE, Collection::SORT_ORDER_DESC);
 
         /** @var Product[] $items */
@@ -104,7 +110,7 @@ class SpecialPriceTest extends \PHPUnit\Framework\TestCase
         /** @var ProductCollection $collection */
         $collection = $this->productCollectionFactory->create();
         $collection
-            ->setVisibility([Visibility::VISIBILITY_IN_CATALOG, Visibility::VISIBILITY_BOTH])
+            ->setVisibility($this->productVisibility->getVisibleInCatalogIds())
             ->setOrder(ProductInterface::PRICE, Collection::SORT_ORDER_DESC);
 
         /** @var Product[] $items */

--- a/dev/tests/integration/testsuite/Magento/Framework/Search/Adapter/Mysql/AdapterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Search/Adapter/Mysql/AdapterTest.php
@@ -11,6 +11,7 @@ use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\Collection;
 use Magento\Framework\Search\EngineResolverInterface;
 use Magento\Search\Model\EngineResolver;
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Catalog\Model\Product\Visibility;
 
 /**
  * Class AdapterTest
@@ -42,6 +43,11 @@ class AdapterTest extends \PHPUnit\Framework\TestCase
      */
     protected $searchEngine = EngineResolver::CATALOG_SEARCH_MYSQL_ENGINE;
 
+    /**
+     * @var Visibility
+     */
+    private $productVisibility;
+
     protected function setUp()
     {
         $this->objectManager = Bootstrap::getObjectManager();
@@ -63,6 +69,8 @@ class AdapterTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->adapter = $this->createAdapter();
+
+        $this->productVisibility = Bootstrap::getObjectManager()->get(Visibility::class);
 
         $indexer = $this->objectManager->create(\Magento\Indexer\Model\Indexer::class);
         $indexer->load('catalogsearch_fulltext');
@@ -535,10 +543,7 @@ class AdapterTest extends \PHPUnit\Framework\TestCase
             ->create(Collection::class)
             ->setAttributeFilter($attribute->getId());
 
-        $visibility = [
-            \Magento\Catalog\Model\Product\Visibility::VISIBILITY_IN_SEARCH,
-            \Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH,
-        ];
+        $visibility = $this->productVisibility->getVisibleInSearchIds();
 
         $firstOption = $selectOptions->getFirstItem();
         $firstOptionId = $firstOption->getId();


### PR DESCRIPTION
### Description
This pr will avoid [static methods](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Product/Visibility.php#L90) in `\Magento\Catalog\Model\Product\Visibility`. 

It looks like this code is simply [ported without refactoring]( https://github.com/OpenMage/magento-lts/blob/1.9.3.x/app/code/core/Mage/Catalog/Model/Product/Visibility.php#L136)

In m2 these methods must be non-static public methods. Thus, we can replace this model via DI or create a plugin for it. But for now, we can't create a plugin for `getAllOption` method and put new options to all the places where magento uses this source model.

Even though this class is marked as an [@api ](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Product/Visibility.php#L14)

The second oddity: this model has special visibility getters
[getVisibleInCatalogIds](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Product/Visibility.php#L60)
[getVisibleInSearchIds](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Product/Visibility.php#L70)
[getVisibleInSiteIds](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Product/Visibility.php#L80)

But in some places modules[ use constants directly](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php#L319-L323)

And these getters are only for visible values, but we need not visible values in [some places](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/ResourceModel/Product.php#L408-L411)

### Fixed Issues (if relevant)
No issues were found about this issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)