### PR TITLE
move hardcoded MIME types from class private to DI configuration.

### DIFF
--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -82,6 +82,7 @@ class ImageUploader
      * @param string $baseTmpPath
      * @param string $basePath
      * @param string[] $allowedExtensions
+     * @param string[] $allowedMimeTypes
      */
     public function __construct(
         \Magento\MediaStorage\Helper\File\Storage\Database $coreFileStorageDatabase,

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -93,7 +93,7 @@ class ImageUploader
         $baseTmpPath,
         $basePath,
         $allowedExtensions,
-        $allowedMimeTypes
+        $allowedMimeTypes = []
     ) {
         $this->coreFileStorageDatabase = $coreFileStorageDatabase;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA);

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -67,14 +67,9 @@ class ImageUploader
     /**
      * List of allowed image mime types
      *
-     * @var array
+     * @var string[]
      */
-    private $allowedMimeTypes = [
-        'image/jpg',
-        'image/jpeg',
-        'image/gif',
-        'image/png',
-    ];
+    protected $allowedMimeTypes;
 
     /**
      * ImageUploader constructor
@@ -96,7 +91,8 @@ class ImageUploader
         \Psr\Log\LoggerInterface $logger,
         $baseTmpPath,
         $basePath,
-        $allowedExtensions
+        $allowedExtensions,
+        $allowedMimeTypes
     ) {
         $this->coreFileStorageDatabase = $coreFileStorageDatabase;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA);
@@ -106,6 +102,7 @@ class ImageUploader
         $this->baseTmpPath = $baseTmpPath;
         $this->basePath = $basePath;
         $this->allowedExtensions = $allowedExtensions;
+        $this->allowedMimeTypes = $allowedMimeTypes;
     }
 
     /**
@@ -175,6 +172,14 @@ class ImageUploader
     }
 
     /**
+     * @return string[]
+     */
+    public function getAllowedMimeTypes()
+    {
+        return $this->allowedMimeTypes;
+    }
+
+    /**
      * Retrieve path
      *
      * @param string $path
@@ -239,7 +244,7 @@ class ImageUploader
         $uploader = $this->uploaderFactory->create(['fileId' => $fileId]);
         $uploader->setAllowedExtensions($this->getAllowedExtensions());
         $uploader->setAllowRenameFiles(true);
-        if (!$uploader->checkMimeType($this->allowedMimeTypes)) {
+        if (!$uploader->checkMimeType($this->getAllowedMimeTypes())) {
             throw new \Magento\Framework\Exception\LocalizedException(__('File validation failed.'));
         }
         $result = $uploader->save($this->mediaDirectory->getAbsolutePath($baseTmpPath));

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -69,7 +69,7 @@ class ImageUploader
      *
      * @var string[]
      */
-    protected $allowedMimeTypes;
+    private $allowedMimeTypes;
 
     /**
      * ImageUploader constructor
@@ -173,16 +173,6 @@ class ImageUploader
     }
 
     /**
-     * Retrieve allowed mime types
-     *
-     * @return string[]
-     */
-    public function getAllowedMimeTypes()
-    {
-        return $this->allowedMimeTypes;
-    }
-
-    /**
      * Retrieve path
      *
      * @param string $path
@@ -247,7 +237,7 @@ class ImageUploader
         $uploader = $this->uploaderFactory->create(['fileId' => $fileId]);
         $uploader->setAllowedExtensions($this->getAllowedExtensions());
         $uploader->setAllowRenameFiles(true);
-        if (!$uploader->checkMimeType($this->getAllowedMimeTypes())) {
+        if (!$uploader->checkMimeType($this->allowedMimeTypes)) {
             throw new \Magento\Framework\Exception\LocalizedException(__('File validation failed.'));
         }
         $result = $uploader->save($this->mediaDirectory->getAbsolutePath($baseTmpPath));

--- a/app/code/Magento/Catalog/Model/ImageUploader.php
+++ b/app/code/Magento/Catalog/Model/ImageUploader.php
@@ -163,7 +163,7 @@ class ImageUploader
     }
 
     /**
-     * Retrieve base path
+     * Retrieve allowed extensions
      *
      * @return string[]
      */
@@ -173,6 +173,8 @@ class ImageUploader
     }
 
     /**
+     * Retrieve allowed mime types
+     *
      * @return string[]
      */
     public function getAllowedMimeTypes()

--- a/app/code/Magento/Catalog/Test/Unit/Model/ImageUploaderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ImageUploaderTest.php
@@ -104,7 +104,7 @@ class ImageUploaderTest extends \PHPUnit\Framework\TestCase
         $this->baseTmpPath = 'base/tmp/';
         $this->basePath =  'base/real/';
         $this->allowedExtensions = ['.jpg'];
-        $this->allowedMimeTypes = ['image/jpg'];
+        $this->allowedMimeTypes = ['image/jpg', 'image/jpeg', 'image/gif', 'image/png'];
 
         $this->imageUploader =
             new \Magento\Catalog\Model\ImageUploader(

--- a/app/code/Magento/Catalog/Test/Unit/Model/ImageUploaderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ImageUploaderTest.php
@@ -69,9 +69,16 @@ class ImageUploaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Allowed extensions
      *
-     * @var string
+     * @var array
      */
     private $allowedExtensions;
+
+    /**
+     * Allowed mime types
+     *
+     * @var array
+     */
+    private $allowedMimeTypes;
 
     protected function setUp()
     {
@@ -97,6 +104,7 @@ class ImageUploaderTest extends \PHPUnit\Framework\TestCase
         $this->baseTmpPath = 'base/tmp/';
         $this->basePath =  'base/real/';
         $this->allowedExtensions = ['.jpg'];
+        $this->allowedMimeTypes = ['image/jpg'];
 
         $this->imageUploader =
             new \Magento\Catalog\Model\ImageUploader(
@@ -107,7 +115,8 @@ class ImageUploaderTest extends \PHPUnit\Framework\TestCase
                 $this->loggerMock,
                 $this->baseTmpPath,
                 $this->basePath,
-                $this->allowedExtensions
+                $this->allowedExtensions,
+                $this->allowedMimeTypes
             );
     }
 

--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -220,6 +220,12 @@
                 <item name="gif" xsi:type="string">gif</item>
                 <item name="png" xsi:type="string">png</item>
             </argument>
+            <argument name="allowedMimeTypes" xsi:type="array">
+                <item name="jpg" xsi:type="string">image/jpg</item>
+                <item name="jpeg" xsi:type="string">image/jpeg</item>
+                <item name="gif" xsi:type="string">image/gif</item>
+                <item name="png" xsi:type="string">image/png</item>
+            </argument>
         </arguments>
     </virtualType>
     <type name="Magento\Catalog\Controller\Adminhtml\Category\Image\Upload">

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ImageUploaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ImageUploaderTest.php
@@ -50,6 +50,7 @@ class ImageUploaderTest extends \PHPUnit\Framework\TestCase
                 'baseTmpPath' => $this->mediaDirectory->getRelativePath('tmp'),
                 'basePath' => __DIR__,
                 'allowedExtensions' => ['jpg', 'jpeg', 'gif', 'png'],
+                'allowedMimeTypes' => ['image/jpg', 'image/jpeg', 'image/gif', 'image/png']
             ]
         );
     }


### PR DESCRIPTION
### Description
With this fix, developers can add custom catalog image types like SVG from di.xml configuration.
In Catalog ImageUploader allowed extensions can be customized, but allowed mime types are hardcoded in the class into a private property. (with no getter method). This PR solves this limitation.

