### PR TITLE
Allow user defined dropdown attributes to be searchable with Elasticsearch

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/Adapter/FieldType.php
+++ b/app/code/Magento/Elasticsearch/Model/Adapter/FieldType.php
@@ -40,7 +40,6 @@ class FieldType
             $fieldType = self::ES_DATA_TYPE_DATE;
         } elseif ((in_array($backendType, ['int', 'smallint'], true)
             || (in_array($frontendInput, ['select', 'boolean'], true) && $backendType !== 'varchar'))
-            && !$attribute->getIsUserDefined()
         ) {
             $fieldType = self::ES_DATA_TYPE_INT;
         } elseif ($backendType === 'decimal') {


### PR DESCRIPTION
In elasticsearch currently we have index created for drop-down attribute
```
"brand_value": "Nivea",
"brand": "38156"
``` 
Magento is searching with this request
```
            {
               "match":{
                  "brand":{
                     "query":"Nivea",
                     "boost":10
                  }
               }
            }
```

instead of 
```
            {
               "match":{
                  "brand_value":{
                     "query":"Nivea",
                     "boost":10
                  }
               }
            }
```

If I update attribute to is_user_defined = 0, search request is correct. 