### PR TITLE
[Forwardport] ConfigurableProduct show prices in select options

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -362,7 +362,6 @@ define([
                 i,
                 j,
                 basePrice = parseFloat(this.options.spConfig.prices.basePrice.amount),
-                optionPriceLabel,
                 optionFinalPrice,
                 optionPriceDiff,
                 optionPrices = this.options.spConfig.optionPrices;
@@ -379,7 +378,6 @@ define([
             if (options) {
                 for (i = 0; i < options.length; i++) {
                     allowedProducts = [];
-                    optionPriceLabel = '';
                     optionPriceDiff = 0;
 
                     /* eslint-disable max-depth */

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -360,7 +360,12 @@ define([
                 index = 1,
                 allowedProducts,
                 i,
-                j;
+                j,
+                basePrice = parseFloat(this.options.spConfig.prices.basePrice.amount),
+                optionPriceLabel,
+                optionFinalPrice,
+                optionPriceDiff,
+                optionPrices = this.options.spConfig.optionPrices;
 
             this._clearSelect(element);
             element.options[0] = new Option('', '');
@@ -374,6 +379,8 @@ define([
             if (options) {
                 for (i = 0; i < options.length; i++) {
                     allowedProducts = [];
+                    optionPriceLabel = '';
+                    optionPriceDiff = 0;
 
                     /* eslint-disable max-depth */
                     if (prevConfig) {
@@ -387,6 +394,19 @@ define([
                         }
                     } else {
                         allowedProducts = options[i].products.slice(0);
+                        if (typeof allowedProducts[0] !== "undefined"
+                            && typeof optionPrices[allowedProducts[0]] !== "undefined") {
+
+                            optionFinalPrice = parseFloat(optionPrices[allowedProducts[0]].finalPrice.amount);
+                            optionPriceDiff = optionFinalPrice - basePrice;
+
+                            if (optionPriceDiff !== 0) {
+                                options[i].label = options[i].label + ' ' + priceUtils.formatPrice(
+                                    optionPriceDiff,
+                                    this.options.priceFormat,
+                                    1);
+                            }
+                        }
                     }
 
                     if (allowedProducts.length > 0) {
@@ -394,7 +414,7 @@ define([
                         element.options[index] = new Option(this._getOptionLabel(options[i]), options[i].id);
 
                         if (typeof options[i].price !== 'undefined') {
-                            element.options[index].setAttribute('price', options[i].prices);
+                            element.options[index].setAttribute('price', options[i].price);
                         }
 
                         element.options[index].config = options[i];

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -404,7 +404,7 @@ define([
                                 options[i].label = options[i].label + ' ' + priceUtils.formatPrice(
                                     optionPriceDiff,
                                     this.options.priceFormat,
-                                    1);
+                                    true);
                             }
                         }
                     }

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -392,8 +392,9 @@ define([
                         }
                     } else {
                         allowedProducts = options[i].products.slice(0);
-                        if (typeof allowedProducts[0] !== "undefined"
-                            && typeof optionPrices[allowedProducts[0]] !== "undefined") {
+
+                        if (typeof allowedProducts[0] !== 'undefined'
+                            && typeof optionPrices[allowedProducts[0]] !== 'undefined') {
 
                             optionFinalPrice = parseFloat(optionPrices[allowedProducts[0]].finalPrice.amount);
                             optionPriceDiff = optionFinalPrice - basePrice;

--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -393,8 +393,8 @@ define([
                     } else {
                         allowedProducts = options[i].products.slice(0);
 
-                        if (typeof allowedProducts[0] !== 'undefined'
-                            && typeof optionPrices[allowedProducts[0]] !== 'undefined') {
+                        if (typeof allowedProducts[0] !== 'undefined' &&
+                            typeof optionPrices[allowedProducts[0]] !== 'undefined') {
 
                             optionFinalPrice = parseFloat(optionPrices[allowedProducts[0]].finalPrice.amount);
                             optionPriceDiff = optionFinalPrice - basePrice;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17695
### Description
In Magento2 by default we can't show configurable product prices in select options, as it was done in custom options. There only labels with product name there. My improvement fixes that problem. 

### Manual testing scenarios
1. Add some configurable products to product in backend. Some options should have different price than another.
2. Open product page and click on the select which contains allowed products

**Expected result:**
You can see labels with prices

**Actual result:**
You can see labels without prices, but when you choose some of label, product price is updating

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
