### PR TITLE
Resolve typo despatch event

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -317,8 +317,8 @@ class DataProvider
             $attributes = $productAttributes->getItems();
 
             /**
-             * Event argument `catelogsearch_searchable_attributes_load_after` is @deprecated. Use
-             * `catalogsearch_searchable_attributes_load_after` instead.
+             * @deprecated Event argument catelogsearch_searchable_attributes_load_after.
+             * @see catalogsearch_searchable_attributes_load_after instead.
              */
             $this->eventManager->dispatch(
                 'catelogsearch_searchable_attributes_load_after',

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -316,6 +316,10 @@ class DataProvider
             /** @var \Magento\Eav\Model\Entity\Attribute[] $attributes */
             $attributes = $productAttributes->getItems();
 
+            /**
+             * Event argument `catelogsearch_searchable_attributes_load_after` is @deprecated 100.2.5. Use
+             * `catalogsearch_searchable_attributes_load_after` instead.
+             */
             $this->eventManager->dispatch(
                 'catalogsearch_searchable_attributes_load_after',
                 ['engine' => $this->engine, 'attributes' => $attributes]

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -317,7 +317,7 @@ class DataProvider
             $attributes = $productAttributes->getItems();
 
             $this->eventManager->dispatch(
-                'catelogsearch_searchable_attributes_load_after',
+                'catalogsearch_searchable_attributes_load_after',
                 ['engine' => $this->engine, 'attributes' => $attributes]
             );
 

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -317,9 +317,14 @@ class DataProvider
             $attributes = $productAttributes->getItems();
 
             /**
-             * Event argument `catelogsearch_searchable_attributes_load_after` is @deprecated 100.2.5. Use
+             * Event argument `catelogsearch_searchable_attributes_load_after` is @deprecated. Use
              * `catalogsearch_searchable_attributes_load_after` instead.
              */
+            $this->eventManager->dispatch(
+                'catelogsearch_searchable_attributes_load_after',
+                ['engine' => $this->engine, 'attributes' => $attributes]
+            );
+
             $this->eventManager->dispatch(
                 'catalogsearch_searchable_attributes_load_after',
                 ['engine' => $this->engine, 'attributes' => $attributes]


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->


### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18355: Typo in dispatched event name

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  method Magento\CatalogSearch\Model\Indexer\Fulltext\Action\DataProvider::getSearchableAttributes dispatches event with typo in its name
2. catelogsearch_searchable_attributes_load_after
instead of
catalogsearch_searchable_attributes_load_after

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
