### PR TITLE
Backport 2.2 - Fix issue 17152 - prevent email being marked as not se…

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender.php
@@ -65,6 +65,8 @@ abstract class Sender
     }
 
     /**
+     * Send order email if it is enabled in configuration.
+     *
      * @param Order $order
      * @return bool
      */
@@ -81,17 +83,21 @@ abstract class Sender
 
         try {
             $sender->send();
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            return false;
+        }
+        try {
             $sender->sendCopyTo();
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
-
-            return false;
         }
-
         return true;
     }
 
     /**
+     * Populate order email template with customer information.
+     *
      * @param Order $order
      * @return void
      */
@@ -113,6 +119,8 @@ abstract class Sender
     }
 
     /**
+     * Create Sender object using appropriate template and identity.
+     *
      * @return Sender
      */
     protected function getSender()
@@ -126,6 +134,8 @@ abstract class Sender
     }
 
     /**
+     * Get template options.
+     *
      * @return array
      */
     protected function getTemplateOptions()
@@ -137,6 +147,8 @@ abstract class Sender
     }
 
     /**
+     * Render shipping address into html.
+     *
      * @param Order $order
      * @return string|null
      */
@@ -148,6 +160,8 @@ abstract class Sender
     }
 
     /**
+     * Render billing address into html.
+     *
      * @param Order $order
      * @return string|null
      */


### PR DESCRIPTION
…nt if email copy fails due to exception

### Description
Prevent email being marked as not sent if email copy fails due to exception.

---> Backport of https://github.com/magento/magento2/pull/18288

### Fixed Issues (if relevant)
1. magento/magento2#17152 Failure of "Send Order Email Copy" spams customers, every minute, forever.

### Manual testing scenarios
Provided inside reported issue

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
