### PR TITLE
[Backport] [Sales] Covering the AssignOrderToCustomerObserver by Unit Test

### DIFF
--- a/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
@@ -72,7 +72,7 @@ class AssignOrderToCustomerObserverTest extends \PHPUnit\Framework\TestCase
         $this->orderRepositoryMock->expects($this->once())->method('get')->with($orderId)
             ->willReturn($orderMock);
 
-        if (is_null($customerId)) {
+        if (!$customerId) {
             $this->orderRepositoryMock->expects($this->once())->method('save')->with($orderMock);
         } else {
             $this->orderRepositoryMock->expects($this->never())->method('save')->with($orderMock);

--- a/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Test\Unit\Observer;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Observer\AssignOrderToCustomerObserver;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * Class AssignOrderToCustomerObserverTest
+ */
+class AssignOrderToCustomerObserverTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var AssignOrderToCustomerObserver */
+    protected $sut;
+
+    /** @var OrderRepositoryInterface|PHPUnit_Framework_MockObject_MockObject */
+    protected $orderRepositoryMock;
+
+    /**
+     * Set Up
+     */
+    protected function setUp()
+    {
+        $this->orderRepositoryMock = $this->getMockBuilder(OrderRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->sut = new AssignOrderToCustomerObserver($this->orderRepositoryMock);
+    }
+
+    /**
+     * Test assigning order to customer after issuing guest order
+     *
+     * @dataProvider getCustomerIds
+     * @param null|int $customerId
+     * @return void
+     */
+    public function testAssignOrderToCustomerAfterGuestOrder($customerId)
+    {
+        $orderId = 1;
+
+        /** @var Observer|PHPUnit_Framework_MockObject_MockObject $observerMock */
+        $observerMock = $this->createMock(Observer::class);
+        /** @var Event|PHPUnit_Framework_MockObject_MockObject $eventMock */
+        $eventMock = $this->getMockBuilder(Event::class)->disableOriginalConstructor()
+            ->setMethods(['getData'])
+            ->getMock();
+        /** @var CustomerInterface|PHPUnit_Framework_MockObject_MockObject $customerMock */
+        $customerMock = $this->createMock(CustomerInterface::class);
+        /** @var OrderInterface|PHPUnit_Framework_MockObject_MockObject $orderMock */
+        $orderMock = $this->getMockBuilder(OrderInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $observerMock->expects($this->once())->method('getEvent')->willReturn($eventMock);
+        $eventMock->expects($this->any())->method('getData')
+            ->willReturnMap([
+                ['delegate_data', null, ['__sales_assign_order_id' => $orderId]],
+                ['customer_data_object', null, $customerMock]
+            ]);
+        $orderMock->expects($this->once())->method('getCustomerId')->willReturn($customerId);
+        $this->orderRepositoryMock->expects($this->once())->method('get')->with($orderId)
+            ->willReturn($orderMock);
+
+        if (is_null($customerId)) {
+            $this->orderRepositoryMock->expects($this->once())->method('save')->with($orderMock);
+        } else {
+            $this->orderRepositoryMock->expects($this->never())->method('save')->with($orderMock);
+        }
+
+        $this->sut->execute($observerMock);
+    }
+
+    /**
+     * Customer id assigned to order
+     *
+     * @return array
+     */
+    public function getCustomerIds()
+    {
+        return [[null, 1]];
+    }
+}

--- a/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
@@ -74,10 +74,11 @@ class AssignOrderToCustomerObserverTest extends \PHPUnit\Framework\TestCase
 
         if (!$customerId) {
             $this->orderRepositoryMock->expects($this->once())->method('save')->with($orderMock);
-        } else {
-            $this->orderRepositoryMock->expects($this->never())->method('save')->with($orderMock);
+            $this->sut->execute($observerMock);
+            return ;
         }
 
+        $this->orderRepositoryMock->expects($this->never())->method('save')->with($orderMock);
         $this->sut->execute($observerMock);
     }
 


### PR DESCRIPTION
Original PR #18490

### Description
This PR adds missing unit tests for AssignOrderToCustomerObserver class:
- `\Magento\Sales\Observer\AssignOrderToCustomerObserver`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
