### PR TITLE
Add class into image builder

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/Image.php
+++ b/app/code/Magento/Catalog/Block/Product/Image.php
@@ -6,6 +6,8 @@
 namespace Magento\Catalog\Block\Product;
 
 /**
+ * Product image block
+ *
  * @api
  * @method string getImageUrl()
  * @method string getWidth()
@@ -13,6 +15,7 @@ namespace Magento\Catalog\Block\Product;
  * @method string getLabel()
  * @method float getRatio()
  * @method string getCustomAttributes()
+ * @method string getClass()
  * @since 100.0.2
  */
 class Image extends \Magento\Framework\View\Element\Template

--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -77,16 +77,29 @@ class ImageFactory
     {
         $result = [];
         foreach ($attributes as $name => $value) {
-            $result[] = $name . '="' . $value . '"';
+            if ($name != 'class') {
+                $result[] = $name . '="' . $value . '"';
+            }
         }
         return !empty($result) ? implode(' ', $result) : '';
     }
 
     /**
+     * Retrieve image class for HTML element
+     *
+     * @param array $attributes
+     * @return string
+     */
+    private function getClass(array $attributes): string
+    {
+        return $attributes['class'] ?? 'product-image-photo';
+    }
+
+    /**
      * Calculate image ratio
      *
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      * @return float
      */
     private function getRatio(int $width, int $height): float
@@ -98,8 +111,9 @@ class ImageFactory
     }
 
     /**
-     * @param Product $product
+     * Get image label
      *
+     * @param Product $product
      * @param string $imageType
      * @return string
      */
@@ -114,6 +128,7 @@ class ImageFactory
 
     /**
      * Create image block from product
+     *
      * @param Product $product
      * @param string $imageId
      * @param array|null $attributes
@@ -154,6 +169,7 @@ class ImageFactory
                 'label' => $this->getLabel($product, $imageMiscParams['image_type']),
                 'ratio' => $this->getRatio($imageMiscParams['image_width'], $imageMiscParams['image_height']),
                 'custom_attributes' => $this->getStringCustomAttributes($attributes),
+                'class' => $this->getClass($attributes),
                 'product_id' => $product->getId()
             ],
         ];

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageFactoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageFactoryTest.php
@@ -145,7 +145,8 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
                     'label' => 'test_image_label',
                     'ratio' => 1,
                     'custom_attributes' => '',
-                    'product_id' => null
+                    'product_id' => null,
+                    'class' => 'product-image-photo'
                 ],
             ],
         ];
@@ -190,6 +191,7 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
                 'custom_attributes' => [
                     'name_1' => 'value_1',
                     'name_2' => 'value_2',
+                    'class' => 'my-class'
                 ],
             ],
             'expected' => [
@@ -201,7 +203,8 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
                     'label' => 'test_product_name',
                     'ratio' => 0.5, // <==
                     'custom_attributes' => 'name_1="value_1" name_2="value_2"',
-                    'product_id' => null
+                    'product_id' => null,
+                    'class' => 'my-class'
                 ],
             ],
         ];

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -10,7 +10,7 @@
       style="width:<?= /* @escapeNotVerified */ $block->getWidth() ?>px;">
     <span class="product-image-wrapper"
           style="padding-bottom: <?= /* @escapeNotVerified */ ($block->getRatio() * 100) ?>%;">
-        <img class="product-image-photo"
+        <img class="<?= /* @escapeNotVerified */ $block->getClass() ?>"
             <?= /* @escapeNotVerified */ $block->getCustomAttributes() ?>
             src="<?= /* @escapeNotVerified */ $block->getImageUrl() ?>"
             max-width="<?= /* @escapeNotVerified */ $block->getWidth() ?>"


### PR DESCRIPTION
### Description
Currently, the product image has an hardcoded class `product-image-photo` which can't be overriden when using the `$attributes` parameter of the `imageBuilder->create()` function.

### Manual testing scenarios
1. Display a product image using 
```
$block->getImage($product, $image, ['class' => 'my-custom-class'])->toHtml();
```

=> The `img` tag has `my-custom-class` as class.

2. Display a product image using 
```
$block->getImage($product, $image)->toHtml();
```

=> The `img` tag has `product-image-photo` as class.

The aim here is to allow customization without breaking the default value.

I'm open to discussion about how to deal with this!

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
