### PR TITLE
Backport 2.2 - Don't set a source model on the attribute when it's no…

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
@@ -594,9 +594,11 @@ abstract class AbstractAttribute extends \Magento\Framework\Model\AbstractExtens
     {
         if (empty($this->_source)) {
             if (!$this->getSourceModel()) {
-                $this->setSourceModel($this->_getDefaultSourceModel());
+                $this->_source = $this->_getDefaultSourceModel();
+            } else {
+                $this->_source = $this->getSourceModel();
             }
-            $source = $this->_universalFactory->create($this->getSourceModel());
+            $source = $this->_universalFactory->create($this->_source);
             if (!$source) {
                 throw new LocalizedException(
                     __(


### PR DESCRIPTION
…t needed. This avoids accidentally persisting the source model to the database when using multiselect attributes.

(cherry picked from commit 477ca51d052464e862301d945c8bb3550b6fa829)

### Description
This is a backport of #18244 for Magento 2.2, see original PR for full description.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13156: Updating attribute option data through API will set unwanted source_model on the attribute

### Manual testing scenarios
See original PR

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
