### PR TITLE
[Forwardport] Fixed issue with lib-line-height mixin failing when value of 'normal'…

### DIFF
--- a/lib/web/css/source/lib/_typography.less
+++ b/lib/web/css/source/lib/_typography.less
@@ -37,12 +37,16 @@
 }
 
 //  Rem line height
-.lib-line-height(@heightValue) when not (@heightValue = false) and not (ispercentage(@heightValue)) {
+.lib-line-height(@heightValue) when not (@heightValue = false) and not (@heightValue = normal) and not (ispercentage(@heightValue)) {
     .lib-font-size-value(@heightValue);
     .lib-css(line-height, @fontValue);
 }
 
 .lib-line-height(@heightValue) when (ispercentage(@heightValue)) and not (@heightValue = false) {
+    .lib-css(line-height, @heightValue);
+}
+
+.lib-line-height(@heightValue) when (@heightValue = normal) {
     .lib-css(line-height, @heightValue);
 }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18168


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

This fixes an issue with the lib-line-height LESS mixin that results in an error during compilation if a value of "normal" is passed in.

### Issue Reproduction Steps

1. Introduce any LESS, in a theme or module file, that uses the mixin .lib-line-height with a value of "normal."
2. Compile LESS, whether with Grunt, with browser compilation in developer mode, or via a setup:static-content:deploy.
3. The following error is thrown during LESS compilation:  "SyntaxError: Operation on an invalid type in …"

### Alternate Reproduction Steps

A common scenario that will cause this is if the mixin .lib-inline-block-space-item is used without parameters, as "normal" is passed in as the default value for @_line-height, which is then passed to .lib-line-height.

### Additional Information

This issue became more prominent/likely in 2.2.6, because previously the definition of .lib-inline-block-space-item used a simple "line-height: @_line-height" declaration, whereas now it calls .lib-line-height with the value.

The first definition of .lib-line-height - with the guard "when not (@heightValue = false) and not (ispercentage(@heightValue)" - is the one that is matched if "normal" is passed in.  This definition uses the mixin .lib-font-size-value, which does mathematical calculations on the value that are not valid for a value of "normal."

### Fix

Placed additional guards on the first definition of .lib-line-height so that it does not match the value of "normal," and added a new definition that matches this value, avoiding the .lib-font-size-value call.