### PR TITLE
[#16017]:+ removed an empty div class from the name widget

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/widget/name.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/name.phtml
@@ -33,7 +33,6 @@ $suffix = $block->showSuffix();
     </label>
     <div class="control">
         <fieldset class="fieldset fieldset-fullname">
-        <div class="fields">
 <?php endif; ?>
 
     <?php if ($prefix): ?>


### PR DESCRIPTION
Removed an empty div class from the name widget. This class had no purpose. 

### Description
The issue [#16017] was open for this fix. The div class was rendered, but useless. Therefore I removed it. 

### Fixed Issues (if relevant)
1. magento/magento2#16017: empty div.fields in .fieldset-fullname

### Manual testing scenarios
1. Go to the registration page
2. Check the generated HTML
3. The div class fields should be removed from the fieldset-fullname

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
