### PR TITLE
[2.3] Admin Grid column ordering/positioning not working when single store mode set On

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/core/renderer/layout.js
+++ b/app/code/Magento/Ui/view/base/web/js/core/renderer/layout.js
@@ -224,7 +224,7 @@ define([
          */
         build: function (parent, node, name) {
             var defaults    = parent && parent.childDefaults || {},
-                children    = node.children,
+                children    = this.filterDisabledChildren(node.children),
                 type        = getNodeType(parent, node),
                 dataScope   = getDataScope(parent, node),
                 component,
@@ -292,6 +292,35 @@ define([
             }
 
             return node;
+        },
+
+        /**
+         * Filter out all disabled components.
+         *
+         * @param {Object} children
+         * @returns {*}
+         */
+        filterDisabledChildren: function (children) {
+            var cIds;
+
+            //cleanup children config.componentDisabled = true
+            if (children && typeof children === 'object') {
+                cIds = Object.keys(children);
+
+                if (cIds) {
+                    _.each(cIds, function (cId) {
+                        if (typeof children[cId] === 'object' &&
+                            children[cId].hasOwnProperty('config') &&
+                            typeof children[cId].config === 'object' &&
+                            children[cId].config.hasOwnProperty('componentDisabled') &&
+                            children[cId].config.componentDisabled === true) {
+                            delete children[cId];
+                        }
+                    });
+                }
+            }
+
+            return children;
         },
 
         /**


### PR DESCRIPTION
added component status based filtering

### Description
New functionality filters out all disabled UI components (based on internal logic some components are not applicable when the store has single store mode enabled) as it affects children length comparison and different useful UX behaviours.

### Fixed Issues
1. #12070 M2.2.0 Admin Grid column ordering/positioning not working when single store mode set On

### Manual testing scenarios
1. Install Magento
2. Ensure single store mode on
3. View sales order grid
4. Launch Browser development tools and monitor network traffic.
5. Move a column. If there is an AJAX call after each column move, then the fix has worked. Without the fix, there will be no AJAX calls for each column move.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
