### PR TITLE
[Forwardport] Fix for parsing attribute options labels, when & used.

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -331,8 +331,8 @@ class Save extends Attribute implements HttpPostActionInterface
             $serializedOptions = json_decode($data['serialized_options'], JSON_OBJECT_AS_ARRAY);
             foreach ($serializedOptions as $serializedOption) {
                 $option = [];
-                $serializedOptionWithParsedAmpersand = str_replace('&', '%26', $serializedOption);
-                parse_str($serializedOptionWithParsedAmpersand, $option);
+                $serializedValue = str_replace('&', '%26', $serializedOption);
+                parse_str($serializedValue, $option);
                 $data = array_replace_recursive($data, $option);
             }
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -331,7 +331,8 @@ class Save extends Attribute implements HttpPostActionInterface
             $serializedOptions = json_decode($data['serialized_options'], JSON_OBJECT_AS_ARRAY);
             foreach ($serializedOptions as $serializedOption) {
                 $option = [];
-                parse_str($serializedOption, $option);
+                $serializedOptionWithParsedAmpersand = str_replace('&', '%26', $serializedOption);
+                parse_str($serializedOptionWithParsedAmpersand, $option);
                 $data = array_replace_recursive($data, $option);
             }
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18354
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
After updating Magento to 2.2.6 when attribute is saved, and option label contains & label is cut before &. It is caused by usage of function `parse_str()` which is confused by `&`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add attribute option with label containing char `&`
2. Save attribute
3. Check if label wa correctly saved.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
