### PR TITLE
Fixes #18357 - SQL error when table prefix used.

### DIFF
--- a/app/code/Magento/CheckoutAgreements/Model/ResourceModel/Agreement/Grid/Collection.php
+++ b/app/code/Magento/CheckoutAgreements/Model/ResourceModel/Agreement/Grid/Collection.php
@@ -64,7 +64,7 @@ class Collection extends \Magento\CheckoutAgreements\Model\ResourceModel\Agreeme
 
         if (!empty($agreementId)) {
             $select = $this->getConnection()->select()->from(
-                ['agreement_store' => 'checkout_agreement_store']
+                ['agreement_store' => $this->getResource()->getTable('checkout_agreement_store')]
             )->where(
                 'agreement_store.agreement_id IN (?)',
                 $agreementId


### PR DESCRIPTION
### Description
Hard-coded table names cause errors if a table prefix, passing the table name to getTable resolves this.

### Fixed Issues (if relevant)
1. magento/magento2#18357

### Manual testing scenarios
1. Create a store using table prefixes
2. Navigate to Store > Terms and Conditions in the admin backend
3. Without the patch, errors are generated

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
