### PR TITLE
throw exception InvalidArgumentException during validate scheme

### DIFF
--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -121,7 +121,7 @@ class Validator
      * @param string $typeName
      * @return $this
      * @throws \Exception In case when type is invalid
-     * @throws \InvalidArgumentException
+`     * @throws \InvalidArgumentException if methods don't have annotation
      */
     protected function validateType($typeName)
     {

--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -46,6 +46,8 @@ class Validator
     {
         try {
             $this->validateType($responseSchema);
+        } catch (\InvalidArgumentException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new \LogicException(
                 sprintf(
@@ -67,6 +69,8 @@ class Validator
     {
         try {
             $this->validateType($requestSchema);
+        } catch (\InvalidArgumentException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new \LogicException(
                 sprintf(
@@ -90,6 +94,8 @@ class Validator
     {
         try {
             $this->methodsMap->getMethodParams($serviceName, $methodName);
+        } catch (\InvalidArgumentException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new \LogicException(
                 sprintf(

--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -48,7 +48,7 @@ class Validator
             $this->validateType($responseSchema);
         } catch (\InvalidArgumentException $e) {
             throw new \LogicException(
-                'Response schema definition has wrong annotations',
+                'Response schema definition has service class with wrong annotated methods',
                 $e->getCode(),
                 $e
             );
@@ -75,7 +75,7 @@ class Validator
             $this->validateType($requestSchema);
         } catch (\InvalidArgumentException $e) {
             throw new \LogicException(
-                'Response schema definition has wrong annotations',
+                'Request schema definition has service class with wrong annotated methods',
                 $e->getCode(),
                 $e
             );

--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -13,6 +13,7 @@ use Magento\Framework\Reflection\MethodsMap;
  */
 class Validator
 {
+    const INVALID_ANNOTATIONS = 123;
     /**
      * @var TypeProcessor
      */
@@ -47,7 +48,11 @@ class Validator
         try {
             $this->validateType($responseSchema);
         } catch (\InvalidArgumentException $e) {
-            throw $e;
+            throw new \LogicException(
+                'Response schema definition has wrong annotations',
+                self::INVALID_ANNOTATIONS,
+                $e
+            );
         } catch (\Exception $e) {
             throw new \LogicException(
                 sprintf(
@@ -70,7 +75,11 @@ class Validator
         try {
             $this->validateType($requestSchema);
         } catch (\InvalidArgumentException $e) {
-            throw $e;
+            throw new \LogicException(
+                'Response schema definition has wrong annotations',
+                self::INVALID_ANNOTATIONS,
+                $e
+            );
         } catch (\Exception $e) {
             throw new \LogicException(
                 sprintf(
@@ -94,8 +103,6 @@ class Validator
     {
         try {
             $this->methodsMap->getMethodParams($serviceName, $methodName);
-        } catch (\InvalidArgumentException $e) {
-            throw $e;
         } catch (\Exception $e) {
             throw new \LogicException(
                 sprintf(
@@ -115,6 +122,7 @@ class Validator
      * @param string $typeName
      * @return $this
      * @throws \Exception In case when type is invalid
+     * @throws \InvalidArgumentException
      */
     protected function validateType($typeName)
     {

--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -38,6 +38,8 @@ class Validator
     }
 
     /**
+     * Validate response schema definition for topic
+     *
      * @param string $responseSchema
      * @param string $topicName
      * @return void
@@ -65,6 +67,8 @@ class Validator
     }
 
     /**
+     * Validate request schema definition for topic
+     *
      * @param string $requestSchema
      * @param string $topicName
      * @return void
@@ -92,6 +96,8 @@ class Validator
     }
 
     /**
+     * Validate service method specified in the definition of handler
+     *
      * @param string $serviceName
      * @param string $methodName
      * @param string $handlerName

--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -127,7 +127,7 @@ class Validator
      * @param string $typeName
      * @return $this
      * @throws \Exception In case when type is invalid
-`     * @throws \InvalidArgumentException if methods don't have annotation
+     * @throws \InvalidArgumentException if methods don't have annotation
      */
     protected function validateType($typeName)
     {

--- a/lib/internal/Magento/Framework/Communication/Config/Validator.php
+++ b/lib/internal/Magento/Framework/Communication/Config/Validator.php
@@ -13,7 +13,6 @@ use Magento\Framework\Reflection\MethodsMap;
  */
 class Validator
 {
-    const INVALID_ANNOTATIONS = 123;
     /**
      * @var TypeProcessor
      */
@@ -50,7 +49,7 @@ class Validator
         } catch (\InvalidArgumentException $e) {
             throw new \LogicException(
                 'Response schema definition has wrong annotations',
-                self::INVALID_ANNOTATIONS,
+                $e->getCode(),
                 $e
             );
         } catch (\Exception $e) {
@@ -77,7 +76,7 @@ class Validator
         } catch (\InvalidArgumentException $e) {
             throw new \LogicException(
                 'Response schema definition has wrong annotations',
-                self::INVALID_ANNOTATIONS,
+                $e->getCode(),
                 $e
             );
         } catch (\Exception $e) {

--- a/lib/internal/Magento/Framework/Reflection/MethodsMap.php
+++ b/lib/internal/Magento/Framework/Reflection/MethodsMap.php
@@ -94,6 +94,8 @@ class MethodsMap
      *  'validatePassword' => 'boolean'
      * ]
      * </pre>
+     * @throws \InvalidArgumentException
+     * @throws \ReflectionException
      */
     public function getMethodsMap($interfaceName)
     {
@@ -148,6 +150,8 @@ class MethodsMap
      *
      * @param string $interfaceName
      * @return array
+     * @throws \ReflectionException
+     * @throws \InvalidArgumentException
      */
     private function getMethodMapViaReflection($interfaceName)
     {

--- a/lib/internal/Magento/Framework/Reflection/MethodsMap.php
+++ b/lib/internal/Magento/Framework/Reflection/MethodsMap.php
@@ -94,8 +94,8 @@ class MethodsMap
      *  'validatePassword' => 'boolean'
      * ]
      * </pre>
-     * @throws \InvalidArgumentException
-     * @throws \ReflectionException
+     * @throws \InvalidArgumentException if methods don't have annotation
+     * @throws \ReflectionException for missing DocBock or invalid reflection class
      */
     public function getMethodsMap($interfaceName)
     {
@@ -150,8 +150,8 @@ class MethodsMap
      *
      * @param string $interfaceName
      * @return array
-     * @throws \ReflectionException
-     * @throws \InvalidArgumentException
+     * @throws \ReflectionException for missing DocBock or invalid reflection class
+     * @throws \InvalidArgumentException if methods don't have annotation
      */
     private function getMethodMapViaReflection($interfaceName)
     {

--- a/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.

--- a/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
@@ -17,7 +17,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
 
         $this->methodsMap->expects(static::any())
             ->method('getMethodsMap')
-            ->will($this->throwException(new \InvalidArgumentException()));
+            ->will($this->throwException(new \InvalidArgumentException('message', 333)));
 
 
         $this->typeProcessor = $this->createMock(TypeProcessor::class);
@@ -32,7 +32,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException  \LogicException
-     * @expectedExceptionCode 123
+     * @expectedExceptionCode 333
      */
     public function testValidateResponseSchemaType()
     {
@@ -43,7 +43,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException  \LogicException
-     * @expectedExceptionCode 123
+     * @expectedExceptionCode 333
      */
     public function testValidateRequestSchemaType()
     {

--- a/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * m2git
+ */
+
+namespace Magento\Framework\Test\Unit\Communication\Config;
+
+
+use Magento\Framework\Communication\Config\Validator;
+use Magento\Framework\Reflection\MethodsMap;
+use Magento\Framework\Reflection\TypeProcessor;
+
+class ValidatorTest extends \PHPUnit\Framework\TestCase
+{
+    protected $typeProcessor;
+    protected $methodsMap;
+
+    public function setUp()
+    {
+        $this->methodsMap = $this->createMock(MethodsMap::class);
+
+        $this->methodsMap->expects(static::any())
+            ->method('getMethodsMap')
+            ->will($this->throwException(new \InvalidArgumentException()));
+
+
+        $this->typeProcessor = $this->createMock(TypeProcessor::class);
+        $this->typeProcessor->expects(static::any())
+            ->method('isTypeSimple')
+            ->willReturn(false);
+
+        $this->typeProcessor->expects(static::any())
+            ->method('isTypeSimple')
+            ->willReturn(false);
+    }
+
+    /**
+     * @expectedException  \LogicException
+     * @expectedExceptionCode 123
+     */
+    public function testValidateResponseSchemaType()
+    {
+        /** @var Validator $validator */
+        $validator = new Validator($this->typeProcessor, $this->methodsMap);
+        $validator->validateResponseSchemaType('123', '123');
+    }
+
+    /**
+     * @expectedException  \LogicException
+     * @expectedExceptionCode 123
+     */
+    public function testValidateRequestSchemaType()
+    {
+        /** @var Validator $validator */
+        $validator = new Validator($this->typeProcessor, $this->methodsMap);
+        $validator->validateRequestSchemaType('123', '123');
+    }
+}

--- a/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * m2git
- */
-
 namespace Magento\Framework\Test\Unit\Communication\Config;
 
 

--- a/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
@@ -1,14 +1,27 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 namespace Magento\Framework\Test\Unit\Communication\Config;
-
 
 use Magento\Framework\Communication\Config\Validator;
 use Magento\Framework\Reflection\MethodsMap;
 use Magento\Framework\Reflection\TypeProcessor;
 
+/**
+ * Unit test for \Magento\Framework\Communication\Config\Validator class
+ */
 class ValidatorTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var TypeProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $typeProcessor;
+
+    /**
+     * @var MethodsMap|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $methodsMap;
 
     public function setUp()
@@ -18,7 +31,6 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $this->methodsMap->expects(static::any())
             ->method('getMethodsMap')
             ->will($this->throwException(new \InvalidArgumentException('message', 333)));
-
 
         $this->typeProcessor = $this->createMock(TypeProcessor::class);
         $this->typeProcessor->expects(static::any())
@@ -33,6 +45,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * @expectedException  \LogicException
      * @expectedExceptionCode 333
+     * @expectedExceptionMessage Response schema definition has service class with wrong annotated methods
      */
     public function testValidateResponseSchemaType()
     {
@@ -44,6 +57,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * @expectedException  \LogicException
      * @expectedExceptionCode 333
+     * @expectedExceptionMessage Request schema definition has service class with wrong annotated methods
      */
     public function testValidateRequestSchemaType()
     {

--- a/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/Communication/Config/ValidatorTest.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Test\Unit\Communication\Config;
 
 use Magento\Framework\Communication\Config\Validator;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14555

### Manual testing scenarios
A schema class:
class Dummy {
    private $foo;

    public function getFoo() { return $this->foo; }
    public function setFoo($foo) { $this->foo = $foo; }
}
Communication configuration (communication.xml):
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
    <topic name="foo_topic" request="Dummy" />
</config>
Run validation for communication configuration. It can be done either automatically if you're using Magento EE, or can be done manually by calling into Magento\Framework\Communication\Config->getTopic("foo_topic")

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
