### PR TITLE
FIX whitespaces possible in product sku

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -160,6 +160,7 @@ class Helper
 
         $productData = $this->normalize($productData);
         $productData = $this->convertSpecialFromDateStringToObject($productData);
+        $productData['sku'] = trim($productData['sku']);
 
         if (!empty($productData['is_downloadable'])) {
             $productData['product_has_weight'] = 0;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -160,7 +160,10 @@ class Helper
 
         $productData = $this->normalize($productData);
         $productData = $this->convertSpecialFromDateStringToObject($productData);
-        $productData['sku'] = trim($productData['sku']);
+
+        if(isset($productData['sku'])) {
+            $productData['sku'] = trim($productData['sku']);
+        }
 
         if (!empty($productData['is_downloadable'])) {
             $productData['product_has_weight'] = 0;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -161,7 +161,7 @@ class Helper
         $productData = $this->normalize($productData);
         $productData = $this->convertSpecialFromDateStringToObject($productData);
 
-        if(isset($productData['sku'])) {
+        if (isset($productData['sku'])) {
             $productData['sku'] = trim($productData['sku']);
         }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -128,7 +128,6 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
 
                 $originalSku = $product->getSku();
                 $canSaveCustomOptions = $product->getCanSaveCustomOptions();
-                $product->setSku(trim($data['product']['sku']));
                 $product->save();
                 $this->handleImageRemoveError($data, $product->getId());
                 $this->getCategoryLinkManagement()->assignProductToCategories(

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -128,6 +128,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
 
                 $originalSku = $product->getSku();
                 $canSaveCustomOptions = $product->getCanSaveCustomOptions();
+                $product->setSku(trim($data['product']['sku']));
                 $product->save();
                 $this->handleImageRemoveError($data, $product->getId());
                 $this->getCategoryLinkManagement()->assignProductToCategories(

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -2441,7 +2441,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      */
     public function setSku($sku)
     {
-        return $this->setData(self::SKU, $sku);
+        return $this->setData(self::SKU, trim($sku));
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Set trimmed sku (provided by post request) in Magento\Catalog\Controller\Adminhtml\Product\Save on line 131 to prevent whitespaces in sku like the autogenerate function does.

### Fixed Issues (if relevant)
1. magento/magento2#16572: Trim whitespace on SKU when saving product

### Manual testing scenarios
1. Added a product from Backend with a sku with whitespaces at beginning and end
2. Saved a product from Backend with a sku with whitespaces at beginning and end
3. ran "php bin/magento dev:tests:run" from Magento Root/Install dir

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
