### PR TITLE
Fixes #18348 - Defaults not persisted for swatches.

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/web/js/product-attributes.js
+++ b/app/code/Magento/Swatches/view/adminhtml/web/js/product-attributes.js
@@ -441,7 +441,13 @@ define([
                 activePanel
                     .find('table input')
                     .each(function () {
-                        swatchValues.push(this.name + '=' + $(this).val());
+                        if (this.type === 'checkbox' || this.type === 'radio') {
+                            if (this.checked) {
+                                swatchValues.push(this.name + '=' + $(this).val());
+                            }
+                        } else {
+                            swatchValues.push(this.name + '=' + $(this).val());
+                        }
                     });
 
                 $('<input>')


### PR DESCRIPTION
### Description
When saving an attribute of type swatchtext or swatchvisual the selected
default was ignored and the last option always selected. This was due to
the JS always submitting all radio fields.

The standard dropdown attribute which this is built on top of only
submitted radio / checkbox fields if they were checked, so I copied this
behaviour forward.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18348: [2.2.6] In admin, last swatch option set to default upon save

### Manual testing scenarios
1. Create a swatchtext or swatchvisual attribute with at least 2 options.
2. Select an option that is not the last / bottom one as default.
3. Save and continue.
4. Confirm the selected default is still selected.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
