### PR TITLE
Fix: Exception Error in Catalog Price Rule while Backend language is not English

### DIFF
--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 
 /**
  * Save action for catalog rule
+ * 
  * @package Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
  */
 class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog implements HttpPostActionInterface

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -15,8 +15,8 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 
 /**
  * Save action for catalog rule
- * 
- * @package Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog implements HttpPostActionInterface
 {

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -61,6 +61,17 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog imple
                     ['request' => $this->getRequest()]
                 );
                 $data = $this->getRequest()->getPostValue();
+
+                $filterValues = ['from_date' => $this->_dateFilter];
+                if ($this->getRequest()->getParam('to_date')) {
+                    $filterValues['to_date'] = $this->_dateFilter;
+                }
+                $inputFilter = new \Zend_Filter_Input(
+                    $filterValues,
+                    [],
+                    $data
+                );
+                $data = $inputFilter->getUnescaped();
                 $id = $this->getRequest()->getParam('rule_id');
                 if ($id) {
                     $model = $ruleRepository->get($id);

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Save.php
@@ -14,7 +14,8 @@ use Magento\Framework\Stdlib\DateTime\Filter\Date;
 use Magento\Framework\App\Request\DataPersistorInterface;
 
 /**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * Save action for catalog rule
+ * @package Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
  */
 class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog implements HttpPostActionInterface
 {
@@ -40,7 +41,9 @@ class Save extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog imple
     }
 
     /**
-     * @return void
+     * Execute save action from catalog rule
+     *
+     * @return \Magento\Framework\App\ResponseInterface|\Magento\Framework\Controller\ResultInterface|void
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function execute()


### PR DESCRIPTION
Fix for: #12399 cause it's not fixed in 2.3-develop

### Description
I took the fix from https://github.com/magento/magento2/issues/12399#issuecomment-372317340 cause it's almost identical code like 
app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php:30

### Fixed Issues (if relevant)
1. magento/magento2#12399 : Exception Error in Catalog Price Rule while Backend language is not English

### Manual testing scenarios
https://youtu.be/xBMxMfKHmuc
1. Go to: System -> All User -> [Choose your user]
2. Change *Interface Locale* to Italien or French or Portuguese 
3. Relogin with this user 
4. Go to: Marketing -> catalog price rule
5. Edit a record already created (or create a new)
6. Set date From and/or To for example 20 Mai 2019 (Portuguese like "20/02/2019")
7. Click on "Save and Apply"

PHP DateTime can not work with that format. Same problem in Promo/Quote/Save was fixed 2014 and 2016. Maybe forget to fix in Promo/Catalog/Save too.

### Contribution checklist
 - [X ] Pull request has a meaningful description of its purpose
 - [X ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
