### PR TITLE
[BACKPORT] type casted $qty to float in \Magento\Catalog\Model\Produc…

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -972,7 +972,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     public function setQty($qty)
     {
         if ($this->getData('qty') != $qty) {
-            $this->setData('qty', (float)$qty);
+            $this->setData('qty', $qty);
             $this->reloadPriceInfo();
         }
         return $this;

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -972,7 +972,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     public function setQty($qty)
     {
         if ($this->getData('qty') != $qty) {
-            $this->setData('qty', $qty);
+            $this->setData('qty', (float)$qty);
             $this->reloadPriceInfo();
         }
         return $this;
@@ -985,7 +985,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      */
     public function getQty()
     {
-        return $this->getData('qty');
+        return (float)$this->getData('qty');
     }
 
     /**


### PR DESCRIPTION
…t::setQty()

type casted $qty to float in \Magento\Catalog\Model\Product::setQty()

### Description
Backport PR #18149

 \Magento\Catalog\Model\Product::getQty() should return float/double now, as mentioned in it's Doc-block 

### Fixed Issues (if relevant)
1. magento/magento2#18094: Should getQty() return int/float or string?

### Manual testing scenarios

1. Observe any event like `checkout_cart_product_add_after`
2. In the Observer, get an instance of `\Magento\Catalog\Model\Product`
3. Calling the `getQty` method of the above-mentioned class would return a `float`/`double` instead of `string`, as expected

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

