### PR TITLE
Fix the issue: FPT cannot be removed from a product #18265

### DIFF
--- a/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Weee.php
+++ b/app/code/Magento/Weee/Ui/DataProvider/Product/Form/Modifier/Weee.php
@@ -155,6 +155,7 @@ class Weee extends AbstractModifier
                         'dndConfig' => [
                             'enabled' => false,
                         ],
+                        'required' => (bool)$attributeConfig['arguments']['data']['config']['required'],
                     ],
                 ],
             ],


### PR DESCRIPTION
### Description
Once a fixed product tax (FPT) is added to a product, it can no longer be removed in the admin.

### Fixed Issues 
1. magento/magento2#18265: Fixed product tax (FPT) cannot be removed from a product

### Manual testing scenarios
1. Enable FPT in the system configuration
2. Create a FTP attribute and assign it to the default attribute set
3. Create a product with a FPT
4. Re-open the product in the admin and remove the FTP by clicking on the trash icon
5. Save the product

### Expected result

The FPT should be deleted.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
