### PR TITLE
Issue #17508 - Change response redirect method to reference the corre…

### DIFF
--- a/app/code/Magento/Braintree/Test/Unit/Controller/Paypal/SaveShippingMethodTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Controller/Paypal/SaveShippingMethodTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Braintree\Test\Unit\Controller\Paypal;
 
+use Magento\Framework\App\Response\HttpInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Framework\View\Layout;
 use Magento\Checkout\Model\Session;
@@ -13,7 +14,6 @@ use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Result\Page;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\App\Response\RedirectInterface;
@@ -52,7 +52,7 @@ class SaveShippingMethodTest extends \PHPUnit\Framework\TestCase
     private $requestMock;
 
     /**
-     * @var ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var HttpInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $responseMock;
 
@@ -93,7 +93,7 @@ class SaveShippingMethodTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
         $this->urlMock = $this->getMockBuilder(UrlInterface::class)
             ->getMockForAbstractClass();
-        $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
+        $this->responseMock = $this->getMockBuilder(HttpInterface::class)
             ->setMethods(['setBody'])
             ->getMockForAbstractClass();
         $this->resultFactoryMock = $this->getMockBuilder(ResultFactory::class)

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
@@ -24,7 +24,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
     protected $request;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\App\ResponseInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\App\Response\HttpInterface
      */
     protected $response;
 
@@ -88,13 +88,20 @@ class LinkTest extends \PHPUnit\Framework\TestCase
         $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
             ->disableOriginalConstructor()->getMock();
         $this->response = $this->createPartialMock(
-            \Magento\Framework\App\ResponseInterface::class,
+            \Magento\Framework\App\Response\HttpInterface::class,
             [
                 'setHttpResponseCode',
+                'getHttpResponseCode',
                 'clearBody',
                 'sendHeaders',
                 'sendResponse',
-                'setHeader'
+                'setHeader',
+                'getHeader',
+                'clearHeader',
+                'setStatusHeader',
+                'appendBody',
+                'setBody',
+                'setRedirect'
             ]
         );
         $this->session = $this->createPartialMock(\Magento\Customer\Model\Session::class, [

--- a/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/Address/ShippingSavedTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/Address/ShippingSavedTest.php
@@ -63,7 +63,7 @@ class ShippingSavedTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->checkoutMock);
         $this->contextMock = $this->createMock(\Magento\Framework\App\Action\Context::class);
         $requestMock = $this->createMock(\Magento\Framework\App\RequestInterface::class);
-        $responseMock = $this->createMock(\Magento\Framework\App\ResponseInterface::class);
+        $responseMock = $this->createMock(\Magento\Framework\App\Response\HttpInterface::class);
         $this->redirectMock = $this->createMock(\Magento\Framework\App\Response\RedirectInterface::class);
         $this->contextMock->expects($this->any())->method('getObjectManager')->willReturn($this->objectManagerMock);
         $this->contextMock->expects($this->any())->method('getRequest')->willReturn($requestMock);

--- a/app/code/Magento/Newsletter/Test/Unit/Controller/Manage/SaveTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Controller/Manage/SaveTest.php
@@ -24,7 +24,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     private $requestMock;
 
     /**
-     * @var \Magento\Framework\App\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Response\HttpInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $responseMock;
 
@@ -58,7 +58,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
         $this->requestMock = $this->getMockBuilder(\Magento\Framework\App\RequestInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\ResponseInterface::class)
+        $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\HttpInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->messageManagerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Billing/Agreement/CancelTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Billing/Agreement/CancelTest.php
@@ -75,7 +75,7 @@ class CancelTest extends \PHPUnit\Framework\TestCase
         $this->_request = $this->createMock(\Magento\Framework\App\RequestInterface::class);
         $this->_request->expects($this->once())->method('getParam')->with('agreement')->will($this->returnValue(15));
 
-        $response = $this->createMock(\Magento\Framework\App\ResponseInterface::class);
+        $response = $this->createMock(\Magento\Framework\App\Response\HttpInterface::class);
 
         $redirect = $this->createMock(\Magento\Framework\App\Response\RedirectInterface::class);
 

--- a/app/code/Magento/Store/App/Response/Redirect.php
+++ b/app/code/Magento/Store/App/Response/Redirect.php
@@ -177,12 +177,12 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
     /**
      * Set redirect into response
      *
-     * @param \Magento\Framework\App\ResponseInterface $response
+     * @param \Magento\Framework\App\Response\HttpInterface $response
      * @param string $path
      * @param array $arguments
      * @return void
      */
-    public function redirect(\Magento\Framework\App\ResponseInterface $response, $path, $arguments = [])
+    public function redirect(\Magento\Framework\App\Response\HttpInterface $response, $path, $arguments = [])
     {
         $arguments = $this->updatePathParams($arguments);
         $response->setRedirect($this->_urlBuilder->getUrl($path, $arguments));

--- a/lib/internal/Magento/Framework/App/Response/RedirectInterface.php
+++ b/lib/internal/Magento/Framework/App/Response/RedirectInterface.php
@@ -61,10 +61,10 @@ interface RedirectInterface
     /**
      * Set redirect into response
      *
-     * @param \Magento\Framework\App\ResponseInterface $response
+     * @param \Magento\Framework\App\Response\HttpInterface $response
      * @param string $path
      * @param array $arguments
      * @return void
      */
-    public function redirect(\Magento\Framework\App\ResponseInterface $response, $path, $arguments = []);
+    public function redirect(\Magento\Framework\App\Response\HttpInterface $response, $path, $arguments = []);
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Action/ActionTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Action/ActionTest.php
@@ -24,7 +24,7 @@ class ActionTest extends \PHPUnit\Framework\TestCase
     protected $_requestMock;
 
     /**
-     * @var \Magento\Framework\App\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Response\HttpInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $_responseMock;
 
@@ -87,7 +87,7 @@ class ActionTest extends \PHPUnit\Framework\TestCase
         $this->_redirectMock = $this->createMock(\Magento\Framework\App\Response\RedirectInterface::class);
         $this->_requestMock = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
             ->disableOriginalConstructor()->getMock();
-        $this->_responseMock = $this->createMock(\Magento\Framework\App\ResponseInterface::class);
+        $this->_responseMock = $this->createMock(\Magento\Framework\App\Response\HttpInterface::class);
 
         $this->pageConfigMock = $this->createPartialMock(\Magento\Framework\View\Page\Config::class, ['getConfig']);
         $this->viewMock = $this->createMock(\Magento\Framework\App\ViewInterface::class);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Magento\Store\App\Response\Redirect::redirect method has the wrong interface declared for the response argument. The problem is that the 'setRedirect()' is not specified in \Magento\Framework\App\ResponseInterface but is instead not available until the next level of inheritance Magento\Framework\App\Response\HttpInterface.

Changed Magento\Store\App\Response\Redirect::redirect method so the $response argument is the type of \Magento\Framework\App\Response\HttpInterface. This fixes fixes the issue with the 'setRedirect()' not existing. Changed the unit tests.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17508: Response/Redirect referring to wrong interface layer

### Manual testing scenarios
1. Tested that redirects are still working.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
