### PR TITLE
Fix issue #18056 : CacheInvalidate : stop at first server not responding

### DIFF
--- a/app/code/Magento/CacheInvalidate/Model/PurgeCache.php
+++ b/app/code/Magento/CacheInvalidate/Model/PurgeCache.php
@@ -70,7 +70,7 @@ class PurgeCache
                 $socketAdapter->close();
             } catch (\Exception $e) {
                 $this->logger->critical($e->getMessage(), compact('server', 'tagsPattern'));
-                return false;
+                continue;
             }
         }
 


### PR DESCRIPTION
### Description
Don't stop on the first fail when trying to purge Varnish cache servers

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/18056

### Manual testing scenarios
1. Setup 2 Varnish servers (cache1 and cache2) in the http_cache_hosts section of "env.php"
2. Turn off the first one (cache1)
3. Try to flush the full_page by launching bin/magento cache:flush full_page

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
