### PR TITLE
MSI-1735 deprecate cataloginventory

### DIFF
--- a/app/code/Magento/CatalogInventory/Api/Data/StockCollectionInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockCollectionInterface.php
@@ -15,6 +15,9 @@ use Magento\Framework\Api\SearchResultsInterface;
  * Interface StockCollectionInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockCollectionInterface extends SearchResultsInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/Data/StockInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockInterface.php
@@ -11,6 +11,9 @@ use Magento\Framework\Api\ExtensibleDataInterface;
  * Interface Stock
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockInterface extends ExtensibleDataInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/Data/StockItemCollectionInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockItemCollectionInterface.php
@@ -15,6 +15,9 @@ use Magento\Framework\Api\SearchResultsInterface;
  * Interface StockItemCollectionInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockItemCollectionInterface extends SearchResultsInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/Data/StockItemInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockItemInterface.php
@@ -11,6 +11,9 @@ use Magento\Framework\Api\ExtensibleDataInterface;
  * Interface StockItem
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockItemInterface extends ExtensibleDataInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/Data/StockStatusCollectionInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockStatusCollectionInterface.php
@@ -11,6 +11,9 @@ use Magento\Framework\Api\SearchResultsInterface;
  * Stock Status collection interface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockStatusCollectionInterface extends SearchResultsInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/Data/StockStatusInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockStatusInterface.php
@@ -11,6 +11,9 @@ use Magento\Framework\Api\ExtensibleDataInterface;
  * Interface StockStatusInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockStatusInterface extends ExtensibleDataInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/RegisterProductSaleInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/RegisterProductSaleInterface.php
@@ -12,6 +12,9 @@ use Magento\Framework\Exception\LocalizedException;
 
 /**
  * @api
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface RegisterProductSaleInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/RevertProductSaleInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/RevertProductSaleInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
 
 /**
  * @api
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface RevertProductSaleInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockConfigurationInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockConfigurationInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockConfigurationInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockConfigurationInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockCriteriaInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockCriteriaInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockCriteriaInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockCriteriaInterface extends \Magento\Framework\Api\CriteriaInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockIndexInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockIndexInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockIndexInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockIndexInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockItemCriteriaInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockItemCriteriaInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockItemCriteriaInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockItemCriteriaInterface extends \Magento\Framework\Api\CriteriaInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockItemRepositoryInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockItemRepositoryInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockItemRepository
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockItemRepositoryInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockManagementInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockManagementInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockManagementInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockManagementInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockRegistryInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockRegistryInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockRegistryInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockRegistryInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockRepositoryInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockRepositoryInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockRepositoryInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockRepositoryInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockStateInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockStateInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockStateInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockStateInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockStatusCriteriaInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockStatusCriteriaInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockStatusCriteriaInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockStatusCriteriaInterface extends \Magento\Framework\Api\CriteriaInterface
 {

--- a/app/code/Magento/CatalogInventory/Api/StockStatusRepositoryInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/StockStatusRepositoryInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Api;
  * Interface StockStatusRepositoryInterface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockStatusRepositoryInterface
 {

--- a/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
@@ -10,6 +10,9 @@ namespace Magento\CatalogInventory\Block\Adminhtml\Form\Field;
  *
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Minsaleqty extends \Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray
 {

--- a/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Stock.php
+++ b/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Stock.php
@@ -14,6 +14,9 @@ use Magento\Framework\Data\Form;
 /**
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Stock extends \Magento\Framework\Data\Form\Element\Select
 {

--- a/app/code/Magento/CatalogInventory/Block/Qtyincrements.php
+++ b/app/code/Magento/CatalogInventory/Block/Qtyincrements.php
@@ -14,6 +14,9 @@ use Magento\Framework\View\Element\Template;
  *
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Qtyincrements extends Template implements IdentityInterface
 {

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
@@ -11,6 +11,9 @@ namespace Magento\CatalogInventory\Block\Stockqty;
  *
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class DefaultStockqty extends AbstractStockqty implements \Magento\Framework\DataObject\IdentityInterface
 {

--- a/app/code/Magento/CatalogInventory/Helper/Stock.php
+++ b/app/code/Magento/CatalogInventory/Helper/Stock.php
@@ -18,6 +18,9 @@ use Magento\Store\Model\StoreManagerInterface;
  * Class Stock
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @api
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Stock
 {

--- a/app/code/Magento/CatalogInventory/Model/Adminhtml/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Adminhtml/Stock/Item.php
@@ -20,6 +20,9 @@ use Magento\Catalog\Model\Product;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Item extends \Magento\CatalogInventory\Model\Stock\Item implements IdentityInterface
 {

--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator.php
@@ -25,6 +25,9 @@ use Magento\Quote\Model\Quote\Item;
  * @api
  * @since 100.0.2
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class QuantityValidator
 {

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
@@ -18,6 +18,9 @@ use Magento\Catalog\Model\Product\Attribute\Source\Status as ProductStatus;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class DefaultStock extends AbstractIndexer implements StockInterface
 {

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/QueryProcessorInterface.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/QueryProcessorInterface.php
@@ -11,6 +11,9 @@ use Magento\Framework\DB\Select;
 /**
  * @api
  * @since 100.1.0
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface QueryProcessorInterface
 {

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/StockInterface.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/StockInterface.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock;
  * CatalogInventory Stock Indexer Interface
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 interface StockInterface
 {

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/StockFactory.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/StockFactory.php
@@ -12,6 +12,9 @@ namespace Magento\CatalogInventory\Model\ResourceModel\Indexer;
 /**
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class StockFactory
 {

--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock/Status.php
@@ -13,6 +13,9 @@ use Magento\Framework\App\ObjectManager;
  * CatalogInventory Stock Status per website Resource Model
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @api
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {

--- a/app/code/Magento/CatalogInventory/Model/Source/Backorders.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Backorders.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogInventory\Model\Source;
  * Back orders source class
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Backorders implements \Magento\Framework\Option\ArrayInterface
 {

--- a/app/code/Magento/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Stock.php
@@ -11,6 +11,9 @@ use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
  * CatalogInventory Stock source model
  * @api
  * @since 100.0.2
+ *
+ * @deprecated CatalogInventory will be replaced by Multi-Source Inventory (MSI)
+ *             see https://github.com/magento-engcom/msi/wiki/Technical-Vision.-Catalog-Inventory
  */
 class Stock extends AbstractSource
 {

--- a/app/code/Magento/CatalogInventory/composer.json
+++ b/app/code/Magento/CatalogInventory/composer.json
@@ -27,5 +27,6 @@
         "psr-4": {
             "Magento\\CatalogInventory\\": ""
         }
-    }
+    },
+    "abandoned": "magento/inventory-composer-metapackage"
 }


### PR DESCRIPTION
This changes are based on the `2.3-develop` branch, since in `2.3.0-release` branch are additional changes - commit needs to be cherry-picked into 2.3.0 release.

### Description
Changes adds a deprecation notification to all API and SPI of CatalogInventory module. It also add an abandoned entry to the CatalogInventory composer.json

### Fixed Issues (if relevant)
1. magento-engcom/msi#1735: Deprecate CatalogInventory before 2.3.0 release

### Manual testing scenarios
There are no functional changes in this PR

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
