### PR TITLE
issue-18263

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -331,6 +331,7 @@ class Save extends Attribute implements HttpPostActionInterface
             $serializedOptions = json_decode($data['serialized_options'], JSON_OBJECT_AS_ARRAY);
             foreach ($serializedOptions as $serializedOption) {
                 $option = [];
+                $serializedOption = str_replace('&', urlencode('&'), $serializedOption);
                 parse_str($serializedOption, $option);
                 $data = array_replace_recursive($data, $option);
             }


### PR DESCRIPTION
This pull request intension is to fix issue magento/magento2#18263 (url: https://github.com/magento/magento2/issues/18263 )
Problem details are fully described in this issue.

### Description
This request proposes to change method preprocessOptionsData, screening ampersand with a result of urlencode('&').
Basically only one following lline of code was added:
$serializedOption = str_replace('&', urlencode('&'), $serializedOption);

### Fixed Issues (if relevant)

1. magento/magento2#18263: 2.2.6 Product Attributes (dropdown/multi-select) issue with ampersands

### Manual testing scenarios
(copy from issue description)
Create a new product attribute with type Dropdown (or Multi-Select).
Add an option like "Fish & Chips"
Save the attribute.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
