### PR TITLE
Issue #18245: fixing bug with admin orders and qty >50% of stock

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/QuoteItemQtyList.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/QuoteItemQtyList.php
@@ -28,6 +28,9 @@ class QuoteItemQtyList
      */
     public function getQty($productId, $quoteItemId, $quoteId, $itemQty)
     {
+        if (empty($quoteItemId)) {
+            return;
+        }
         $qty = $itemQty;
         if (isset(
             $this->_checkedQuoteItems[$quoteId][$productId]['qty']


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fix for issue #18245 where the sales_quote_item_save_after event would trigger twice and cause issues with admin orders if the quantity selected was over 50%.

The code had been adding the quantity twice, and creating a false warning message after adding the product to an admin order.

I have added a check to ensure the function is not run before the quote item has been saved the first time.

I do not know if this affects frontend operation.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18245 : Unable to add >50% of available product qty to order in admin panel


### Manual testing scenarios
1. In the admin panel, select Sales > Orders > Create New Order.
2. Select the sample "Veronica Costello" customer.
3. Select "Add Products".
4. Locate the following sample product and fill in the quantity field:
- SKU: WSH12-32-Red
- Quantity: 51
5. Select "Add Selected Product(s) to order"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
