### PR TITLE
[fix] to cancel an order, we first have to cancel invoice

### DIFF
--- a/app/code/Magento/Paypal/Model/Ipn.php
+++ b/app/code/Magento/Paypal/Model/Ipn.php
@@ -341,6 +341,10 @@ class Ipn extends \Magento\Paypal\Model\AbstractIpn implements IpnInterface
     protected function _registerPaymentFailure()
     {
         $this->_importPaymentInformation();
+        /** @var \Magento\Sales\Model\Order\Invoice $invoice */
+        foreach ($this->_order->getInvoiceCollection() as $invoice) {
+            $invoice->cancel()->save();
+        }
         $this->_order->registerCancellation($this->_createIpnComment(''))->save();
     }
 


### PR DESCRIPTION
Paypal failed payment can't cancelled order if invoice was generated.

### Description
See issue: https://github.com/magento/magento2/issues/10603

### Fixed Issues (if relevant)
1. magento/magento2#10603 : PayPal failed eCheck change order status to Validated instead of Canceled

### Manual testing scenarios
1. Make a paypal payment with wire transfert
2. Cancel order from customer side
3. Order should be cancelled

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
