### PR TITLE
[2.3] Fix Store Emails - Missing From Name

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Message.php
+++ b/lib/internal/Magento/Framework/Mail/Message.php
@@ -90,9 +90,9 @@ class Message implements MailMessageInterface
     /**
      * {@inheritdoc}
      */
-    public function setFrom($fromAddress)
+    public function setFrom($fromAddress, $fromname = null)
     {
-        $this->zendMessage->setFrom($fromAddress);
+        $this->zendMessage->setFrom($fromAddress, $fromname);
         return $this;
     }
 


### PR DESCRIPTION
The refactoring of the Framework/Mail/Message.php for Magento 2.3 does not implement the second parameter in the setFrom() function.

1st Parameter is email
2nd Parameter (missing) is from address

### Description
This PR adds the missing from name to the setFrom function

### Fixed Issues (if relevant)
1. magento/magento2#18470: Store emails have correct from address but do not have a from name

### Manual testing scenarios
1. Apply #18471 so emails work correctly in the first place
2. Set a valid from name and from email address for sales contact
3. Add test product
4. Purchase test product
5. Verify that confirmation email has the correct from address and name

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
