### PR TITLE
Fix newsletter subscription multiple callings

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -75,13 +75,19 @@ class Save extends \Magento\Newsletter\Controller\Manage
             try {
                 $customer = $this->customerRepository->getById($customerId);
                 $storeId = $this->storeManager->getStore()->getId();
-                $customer->setStoreId($storeId);
+                $isNeedToSaveCustomer = false;
+                if($customer->getStoreId() !== $storeId) {
+                    $customer->setStoreId($storeId);
+                    $isNeedToSaveCustomer = true;
+                }
                 $isSubscribedState = $customer->getExtensionAttributes()
                     ->getIsSubscribed();
                 $isSubscribedParam = (boolean)$this->getRequest()
                     ->getParam('is_subscribed', false);
                 if ($isSubscribedParam !== $isSubscribedState) {
-                    $this->customerRepository->save($customer);
+                    if($isNeedToSaveCustomer) {
+                        $this->customerRepository->save($customer);
+                    }
                     if ($isSubscribedParam) {
                         $subscribeModel = $this->subscriberFactory->create()
                             ->subscribeCustomerById($customerId);

--- a/app/code/Magento/Newsletter/Model/Plugin/CustomerPlugin.php
+++ b/app/code/Magento/Newsletter/Model/Plugin/CustomerPlugin.php
@@ -71,7 +71,6 @@ class CustomerPlugin
         $resultId = $result->getId();
         /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
         $subscriber = $this->subscriberFactory->create();
-        $subscriber->updateSubscription($resultId);
         // update the result only if the original customer instance had different value.
         $initialExtensionAttributes = $result->getExtensionAttributes();
         if ($initialExtensionAttributes === null) {


### PR DESCRIPTION
### Description
When working with newsletter module I found when customers update their subscription, Magento did it two and even three times (I mean by counting calling the same method in Subscribe model). My PR fixes that, so it may improve performance and stability.

### Manual testing scenarios
#### 1. When customers manages his subscription status from private office
1.1. Login as customer
1.2. Go to private office and click Edit on Newsletters block
1.3. Update customer subscription (if customer was subscribed then unsubscribe, otherwise subscribe)

**Expected result:**
Subscription status will be updated 1 time

**Actual result:**
Subscriber method "_updateCustomerSubscription" was called 3 times:
* 2 times from customer plugin (because in newsletter manage controller there is a customer saving method) - _without any changes_
* 1 times actually from newsletter manage controller - _with changes, the way it should be_

#### 2. When admin manages subscriber status from backend
2.1. Go to Customers and edit customer
2.2. Update customer subscription (if customer was subscribed then unsubscribe, otherwise subscribe)

**Expected result:**
Subscription status will be updated 1 time

**Actual result:**
Subscriber method "_updateCustomerSubscription" was called 2 times:
* 2 times from customer plugin - _during first call it's just updating current status, without any changes, and the second call is with changes, the way it should be_


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
