### PR TITLE
Added validation on maximum quantity allowed in shopping cart

### DIFF
--- a/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
@@ -288,7 +288,7 @@
                     <settings>
                         <scopeLabel>[GLOBAL]</scopeLabel>
                         <validation>
-                            <rule name="validate-number" xsi:type="boolean">true</rule>
+                            <rule name="validate-greater-than-zero" xsi:type="boolean">true</rule>
                         </validation>
                         <label translate="true">Maximum Qty Allowed in Shopping Cart</label>
                         <dataScope>max_sale_qty</dataScope>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fixed validation maximum allowed quantity in cart,
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18477: Set maximum Qty Allowed in Shopping Cart is 0 still allow adding to cart

### Manual testing scenarios
1. Click to edit simple product, then click "Advanced Inventory ", enter 0 in "maximum Qty Allowed in Shopping Cart" field
2. Don't allow to add 0 in input box

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
