### PR TITLE
Resolved #18025 - Rounding problem on prices when adding tax to display prices

### DIFF
--- a/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
@@ -15,6 +15,8 @@ use Magento\Tax\Api\TaxClassManagementInterface;
 use Magento\Tax\Model\Calculation;
 
 /**
+ * Tax Calculator Abstract Model
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 abstract class AbstractCalculator
@@ -424,8 +426,7 @@ abstract class AbstractCalculator
     }
 
     /**
-     * Given a store price that includes tax at the store rate, this function will back out the store's tax, and add in
-     * the customer's tax.  Returns this new price which is the customer's price including tax.
+     * Given a store price that includes tax at the store rate, this function will back out the store's tax, and add in the customer's tax.  Returns this new price which is the customer's price including tax.
      *
      * @param float $storePriceInclTax
      * @param float $storeRate

--- a/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
@@ -408,14 +408,14 @@ abstract class AbstractCalculator
         if ($price) {
             $rate = (string)$rate;
             $type = $type . $direction;
-            // initialize the delta to a small number to avoid non-deterministic behavior with rounding of 0.5
-            $delta = isset($this->roundingDeltas[$type][$rate]) ?
-                $this->roundingDeltas[$type][$rate] :
-                0.000001;
-            $price += $delta;
             $roundPrice = $price;
             if ($round) {
-                $roundPrice = $this->calculationTool->round($roundPrice);
+                // initialize the delta to a small number to avoid non-deterministic behavior with rounding of 0.5
+                $delta = isset($this->roundingDeltas[$type][$rate]) ?
+                    $this->roundingDeltas[$type][$rate] :
+                    0.000001;
+                $price += $delta;
+                $roundPrice = $this->calculationTool->round($price);
             }
             $this->roundingDeltas[$type][$rate] = $price - $roundPrice;
             $price = $roundPrice;

--- a/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
@@ -426,7 +426,10 @@ abstract class AbstractCalculator
     }
 
     /**
-     * Given a store price that includes tax at the store rate, this function will back out the store's tax, and add in the customer's tax.  Returns this new price which is the customer's price including tax.
+     * Calculate price including tax.
+     *
+     * Given a store price that includes tax at the store rate, this function will back out the store's tax, and add in
+     * the customer's tax.  Returns this new price which is the customer's price including tax.
      *
      * @param float $storePriceInclTax
      * @param float $storeRate

--- a/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
@@ -408,16 +408,19 @@ abstract class AbstractCalculator
     protected function deltaRound($price, $rate, $direction, $type = self::KEY_REGULAR_DELTA_ROUNDING, $round = true)
     {
         if ($price) {
+            if (!$round) {
+                return $price;
+            }
             $rate = (string)$rate;
             $type = $type . $direction;
+            // initialize the delta to a small number to avoid non-deterministic behavior with rounding of 0.5
+            $delta = isset($this->roundingDeltas[$type][$rate]) ?
+                $this->roundingDeltas[$type][$rate] :
+                0.000001;
+            $price += $delta;
             $roundPrice = $price;
             if ($round) {
-                // initialize the delta to a small number to avoid non-deterministic behavior with rounding of 0.5
-                $delta = isset($this->roundingDeltas[$type][$rate]) ?
-                    $this->roundingDeltas[$type][$rate] :
-                    0.000001;
-                $price += $delta;
-                $roundPrice = $this->calculationTool->round($price);
+                $roundPrice = $this->calculationTool->round($roundPrice);
             }
             $this->roundingDeltas[$type][$rate] = $price - $roundPrice;
             $price = $roundPrice;

--- a/app/code/Magento/Tax/Test/Unit/Model/Calculation/UnitBaseCalculatorTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Calculation/UnitBaseCalculatorTest.php
@@ -21,7 +21,7 @@ class UnitBaseCalculatorTest extends \PHPUnit\Framework\TestCase
 
     const CODE = 'CODE';
     const TYPE = 'TYPE';
-    const ROW_TAX = 44.958682408681;
+    const ROW_TAX = 44.954135954136;
     const ROW_TAX_ROUNDED = 44.95;
     const PRICE_INCL_TAX = 495.4954954955;
     const PRICE_INCL_TAX_ROUNDED = 495.50;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Resolved rounding problem on prices when adding tax to display prices.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18025: Rounding problem on prices when adding tax to display prices

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Set _Configuration > Tax > Calculation Settings_ to following:
![tax_calculation_settings](https://user-images.githubusercontent.com/5977769/45406384-682dde00-b677-11e8-85ec-e1400d2bc6ec.png)
2. Set  _Configuration > Tax > Price Display Settings_ to _Including Tax_
3. Tax should be added to price set in product data when getting amount from classes extending Magento\Framework\Pricing\Price\AbstractPrice. Example Affirm Water Bottle with price of 7.00 with tax of 25 percent results final value of 8.75

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
