### PR TITLE
Fix issue with unexpected changing of subscription status after customer saving

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -613,16 +613,17 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
 
         $this->setStatus($status);
 
+        $storeId = $customerData->getStoreId();
+        if ((int)$customerData->getStoreId() === 0) {
+            $storeId = $this->_storeManager->getWebsite($customerData->getWebsiteId())->getDefaultStore()->getId();
+        }
+
         if (!$this->getId()) {
-            $storeId = $customerData->getStoreId();
-            if ($customerData->getStoreId() == 0) {
-                $storeId = $this->_storeManager->getWebsite($customerData->getWebsiteId())->getDefaultStore()->getId();
-            }
             $this->setStoreId($storeId)
                 ->setCustomerId($customerData->getId())
                 ->setEmail($customerData->getEmail());
         } else {
-            $this->setStoreId($customerData->getStoreId())
+            $this->setStoreId($storeId)
                 ->setEmail($customerData->getEmail());
         }
 

--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
@@ -213,6 +213,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateSubscription()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -234,7 +235,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('getConfirmationStatus')
             ->with($customerId)
             ->willReturn('account_confirmation_required');
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
 
         $storeModel = $this->getMockBuilder(\Magento\Store\Model\Store::class)
@@ -248,6 +249,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testUnsubscribeCustomerById()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -265,7 +267,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
 
@@ -274,6 +276,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testSubscribeCustomerById()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -291,7 +294,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
 
@@ -300,6 +303,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testSubscribeCustomerById1()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -317,7 +321,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
         $this->customerAccountManagement->expects($this->once())
@@ -331,6 +335,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testSubscribeCustomerByIdAfterConfirmation()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -348,7 +353,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
         $this->customerAccountManagement->expects($this->never())->method('getConfirmationStatus');

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/Plugin/PluginTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/Plugin/PluginTest.php
@@ -167,4 +167,42 @@ class PluginTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, (int)$subscriber->getId());
         return $subscriber;
     }
+
+    /**
+     * @magentoAppArea adminhtml
+     * @magentoDbIsolation enabled
+     */
+    public function testCustomerWithZeroStoreIdIsSubscribed()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+
+        $currentStore = $objectManager->get(
+            \Magento\Store\Model\StoreManagerInterface::class
+        )->getStore()->getId();
+
+        $subscriber = $objectManager->create(\Magento\Newsletter\Model\Subscriber::class);
+        /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
+        $subscriber->setStoreId($currentStore)
+            ->setCustomerId(0)
+            ->setSubscriberEmail('customer@example.com')
+            ->setSubscriberStatus(\Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED)
+            ->save();
+
+        /** @var \Magento\Customer\Api\Data\CustomerInterfaceFactory $customerFactory */
+        $customerFactory = $objectManager->get(\Magento\Customer\Api\Data\CustomerInterfaceFactory::class);
+        $customerDataObject = $customerFactory->create()
+            ->setFirstname('Firstname')
+            ->setLastname('Lastname')
+            ->setStoreId(0)
+            ->setEmail('customer@example.com');
+        /** @var \Magento\Customer\Api\Data\CustomerInterface $customer */
+        $customer = $this->accountManagement->createAccount($customerDataObject);
+
+        $this->customerRepository->save($customer);
+
+        $subscriber->loadByEmail('customer@example.com');
+
+        $this->assertEquals($customer->getId(), (int)$subscriber->getCustomerId());
+        $this->assertEquals($currentStore, (int)$subscriber->getStoreId());
+    }
 }


### PR DESCRIPTION
### Description
If in some cases (for example: after migration data from M1) customer will have store_id = 0 and there are subscriber that related to this customer, after re-saving customer data, it might cause unexpected "unsubscribe" letter which would confuse customer experience. 

My changes solves this problem because of adding additional checking storeId and if it's 0, getting it directly from the website.

### Manual testing scenarios
1. Create new customer 
1. Create customer
2. Go to MySQL and set store_id = 0 in customer_entity table for this customer
3. Go to MySQL and create record in newsletter_subscriber for this customer but with correct store_id and subscribe_status = 1.
4. Go to backend -> Customers and open it for edit
5. Change some customer data (for example, name) and save user

**Expected result:**
Nothing, except saving customer data, will happen

**Actual result:**
Customer will receive unsubscription letter.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
