### PR TITLE
[Forwardport] Admin Login Form > Aliging Label

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_extends.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_extends.less
@@ -54,8 +54,6 @@
         &._required {
             > .admin__field-label {
                 span {
-                    padding-left: 1.5rem;
-
                     &:after {
                         left: 0;
                         margin-left: @temp_gutter; // @todo ui: update after finalizing Form Grid mixing css/source/forms/_temp.less:10


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/18400

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

Aligning the form label used on admin login form.

### Fixed Issues (if relevant)

**before:**

<img width="556" alt="screenshot 2018-10-05 10 20 53" src="https://user-images.githubusercontent.com/610598/46541285-9d4dda80-c889-11e8-8c44-1f6f080879bb.png">

**after:**

<img width="555" alt="screenshot 2018-10-05 10 21 01" src="https://user-images.githubusercontent.com/610598/46541308-a6d74280-c889-11e8-8843-d3b0f156dd10.png">

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
