### PR TITLE
[Backport] Checkout - Fix "Cannot read property 'code' on undefined" issue

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/progress-bar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/progress-bar.js
@@ -24,16 +24,16 @@ define([
 
         /** @inheritdoc */
         initialize: function () {
-            var steps;
+            var stepsValue;
 
             this._super();
             $(window).hashchange(_.bind(stepNavigator.handleHash, stepNavigator));
 
             if (!window.location.hash) {
-                steps = stepNavigator.steps();
+                stepsValue = stepNavigator.steps();
 
-                if (steps.length) {
-                    stepNavigator.setHash(steps.sort(stepNavigator.sortItems)[0].code);
+                if (stepsValue.length) {
+                    stepNavigator.setHash(stepsValue.sort(stepNavigator.sortItems)[0].code);
                 }
             }
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/progress-bar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/progress-bar.js
@@ -24,11 +24,17 @@ define([
 
         /** @inheritdoc */
         initialize: function () {
+            var steps;
+
             this._super();
             $(window).hashchange(_.bind(stepNavigator.handleHash, stepNavigator));
 
             if (!window.location.hash) {
-                stepNavigator.setHash(stepNavigator.steps().sort(stepNavigator.sortItems)[0].code);
+                steps = stepNavigator.steps();
+
+                if (steps.length) {
+                    stepNavigator.setHash(steps.sort(stepNavigator.sortItems)[0].code);
+                }
             }
 
             stepNavigator.handleHash();


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18494

### Description
After upgrading from 2.2.5 to 2.2.6 with module One Step Checkout module we started getting js error "Cannot read property 'code' of undefined". 
Reason - this module removes all checkout "steps", but in Magento code there is no check that we have at least one step.

### Fixed Issues (if relevant)
1. magento/magento2#18164: Checkout - Cannot read property 'code' of undefined
2. https://github.com/mageplaza/m2-one-step-checkout-releases/issues/3: Cannot read property 'code' of undefined

### Manual testing scenarios
1. Add to checkout page js component that will require 'Magento_Checkout/js/model/step-navigator'
2. Add in it `stepNavigator.steps.removeAll();` to remove all steps
3. Go to checkout, look in console

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
