### PR TITLE
[Forwardport] Fix setup wizard page logo

### DIFF
--- a/setup/view/magento/setup/navigation/side-menu.phtml
+++ b/setup/view/magento/setup/navigation/side-menu.phtml
@@ -20,12 +20,8 @@
     ng-show="<?= implode( '&&', $expressions) ?>"
     >
 <nav class="admin__menu" ng-controller="mainController">
-    <span
-        class="logo logo-static"
-        data-edition="Community Edition">
-        <img class="logo-img"
-             src="./pub/images/logo.svg"
-             alt="Magento Admin Panel">
+    <span class="logo logo-static" data-edition="Community Edition">
+        <img class="logo-img" src="<?= $this->basePath() ?>/pub/images/logo.svg" alt="Magento Admin Panel">
     </span>
     <ul id="nav" role="menubar">
         <li class="item-home level-0" ng-class="{_active: $state.current.name === 'root.home'}">


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/18403

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

The logo on the left menu is broke, and not using the `baseurl` pattern so I fixed it.

### Fixed Issues (if relevant)

**Before:**

<img width="1678" alt="screenshot 2018-10-05 11 20 43" src="https://user-images.githubusercontent.com/610598/46544773-72b44f80-c892-11e8-8b92-83a078123a15.png">

**After:**

<img width="1678" alt="screenshot 2018-10-05 11 21 14" src="https://user-images.githubusercontent.com/610598/46544797-8364c580-c892-11e8-830b-7968e7e3c607.png">

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
