### PR TITLE
[Forwardport] Fix category tree in cart price rule #17493

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/js/category-checkbox-tree.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/category-checkbox-tree.js
@@ -225,6 +225,7 @@ define([
 
             categoryLoader.on('beforeload', function (treeLoader, node) {
                 treeLoader.baseParams.id = node.attributes.id;
+                treeLoader.baseParams.selected = options.jsFormObject.updateElement.value;
             });
 
             categoryLoader.on('load', function () {

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Widget/CategoriesJson.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Widget/CategoriesJson.php
@@ -77,10 +77,11 @@ class CategoriesJson extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Wid
             if (!($category = $this->_initCategory())) {
                 return;
             }
+            $selected = $this->getRequest()->getPost('selected', '');
             $block = $this->_view->getLayout()->createBlock(
                 \Magento\Catalog\Block\Adminhtml\Category\Checkboxes\Tree::class
             )->setCategoryIds(
-                [$categoryId]
+                explode(',', $selected)
             );
             $this->getResponse()->representJson(
                 $block->getTreeJson($category)


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18175

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Currently if you try to create a catalog price rule based on categories with nesting level 4 or higher (1 being the Default Category), these categories (despite being correctly saved in the condition) won't have their corresponding checkboxes checked when you open the Category Chooser again.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17493

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open form for creating a new Catalog Rule 
2. Under Condition select Product Attribute -> Category
3. Open Category Chooser
4. Select one Category with level = 1, 2 or 3
5. Select at least one Category with level > 3 (4, 5, ...)
6. Click ok & close Category Chooser
5. Open again Category Chooser and see
   that only categories with level <= 3 are selected
   and category with level > 3 without selection

Point 5 is now fixed. All the previously chosen categories have their corresponding checkboxes checked after reopening Category Chooser.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
