### PR TITLE
[Forwardport] add error message in else condition

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -109,10 +109,8 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
                     'Sorry, but we can\'t deliver to the destination country with this shipping module.'
                 )
             );
-
             return $error;
-        }
-
+        } 
         return $result;
     }
 

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -98,6 +98,20 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
 
             $result->append($method);
         }
+        elseif ($this->getConfigData('showmethod'))
+        {
+            $error = $this->_rateErrorFactory->create();
+            $error->setCarrier($this->_code);
+            $error->setCarrierTitle($this->getConfigData('title'));
+            $errorMsg = $this->getConfigData('specificerrmsg');
+            $error->setErrorMessage(
+                $errorMsg ? $errorMsg : __(
+                    'Sorry, but we can\'t deliver to the destination country with this shipping module.'
+                )
+            );
+
+            return $error;
+        }
 
         return $result;
     }

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -97,9 +97,7 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
             $method->setCost('0.00');
 
             $result->append($method);
-        }
-        elseif ($this->getConfigData('showmethod'))
-        {
+        } elseif ($this->getConfigData('showmethod')) {
             $error = $this->_rateErrorFactory->create();
             $error->setCarrier($this->_code);
             $error->setCarrierTitle($this->getConfigData('title'));
@@ -110,7 +108,7 @@ class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
                 )
             );
             return $error;
-        } 
+        }
         return $result;
     }
 


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/17982

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
STORES > Settings > Configuration > Sales > Shipping Methods > Free Shipping > Enabled > select Yes > > Minimum Order Amount > Enter 50 > Show Method if Not Applicable > Select Yes > Save Config

By configuring above settings Free shipping method should show in frontend with the error message if it is not applicable.

But the shipping is only displayed when it is applicable no matter what the option "Show Method if Not Applicable" value is set to.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17977: Show Method if Not Applicable for Free Shipping doesn't work.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Show Method if Not Applicable > Select Yes in this case if free shipping not applied then it should show error message
2. Show Method if Not Applicable > Select No in this case if free shipping not applied then it shouldn't show free shipping method

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
