### PR TITLE
Checkout - Fix JS error Cannot read property 'quoteData' of undefined

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
@@ -7,7 +7,8 @@
  */
 define([
     'ko',
-    'underscore'
+    'underscore',
+    'domReady!'
 ], function (ko, _) {
     'use strict';
 


### PR DESCRIPTION
### Description
Sometimes after going to checkout page we have infinite loading indicator that caused by JS error
`Cannot read property 'quoteData' of undefined.`

This issue happened because quote.js file using window.checkoutConfig, that inserted directly into page, but sometimes quote.js component initialization executes first.

https://github.com/magento/magento2/blob/f6ca94c701f9d0b874e1c590786d1a5222e0c1db/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js#L32-L36

This change adding waiting when dome ready and `window.checkoutConfig` is already available

### Fixed Issues (if relevant)
N/A

### Related issues
1. https://github.com/magento/magento2/issues/14412: Magento 2.2.3 TypeErrors Cannot read property 'quoteData' / 'storecode' / 'sectionLoadUrl' of undefined

### Manual testing scenarios
1. Add some product to the cart
2. Go to checkout page
3. See console errors

Note: This issue reproducing quote small amount of times

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
