### PR TITLE
[Forwardport] Added checks to see if the payment is available

### DIFF
--- a/app/code/Magento/Payment/Observer/SalesOrderBeforeSaveObserver.php
+++ b/app/code/Magento/Payment/Observer/SalesOrderBeforeSaveObserver.php
@@ -15,13 +15,20 @@ class SalesOrderBeforeSaveObserver implements ObserverInterface
      *
      * @param \Magento\Framework\Event\Observer $observer
      * @return $this
+     * @throws \Magento\Framework\Exception\LocalizedException in case order has no payment specified.
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         /** @var \Magento\Sales\Model\Order $order */
         $order = $observer->getEvent()->getOrder();
 
-        if ($order->getPayment() && $order->getPayment()->getMethodInstance()->getCode() != 'free') {
+        if (!$order->getPayment()) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('Please provide payment for the order.')
+            );
+        }
+
+        if ($order->getPayment()->getMethodInstance()->getCode() != 'free') {
             return $this;
         }
 

--- a/app/code/Magento/Payment/Observer/SalesOrderBeforeSaveObserver.php
+++ b/app/code/Magento/Payment/Observer/SalesOrderBeforeSaveObserver.php
@@ -21,7 +21,7 @@ class SalesOrderBeforeSaveObserver implements ObserverInterface
         /** @var \Magento\Sales\Model\Order $order */
         $order = $observer->getEvent()->getOrder();
 
-        if ($order->getPayment()->getMethodInstance()->getCode() != 'free') {
+        if ($order->getPayment() && $order->getPayment()->getMethodInstance()->getCode() != 'free') {
             return $this;
         }
 

--- a/app/code/Magento/Payment/Test/Unit/Observer/SalesOrderBeforeSaveObserverTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Observer/SalesOrderBeforeSaveObserverTest.php
@@ -61,7 +61,7 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
         $paymentMock = $this->getMockBuilder(
             \Magento\Sales\Model\Order\Payment::class
         )->disableOriginalConstructor()->setMethods([])->getMock();
-        $order->expects($this->once())->method('getPayment')->will($this->returnValue($paymentMock));
+        $order->method('getPayment')->will($this->returnValue($paymentMock));
         $methodInstance = $this->getMockBuilder(
             \Magento\Payment\Model\MethodInterface::class
         )->getMockForAbstractClass();
@@ -86,7 +86,7 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
         $paymentMock = $this->getMockBuilder(
             \Magento\Sales\Model\Order\Payment::class
         )->disableOriginalConstructor()->setMethods([])->getMock();
-        $order->expects($this->once())->method('getPayment')->will($this->returnValue($paymentMock));
+        $order->method('getPayment')->will($this->returnValue($paymentMock));
         $methodInstance = $this->getMockBuilder(
             \Magento\Payment\Model\MethodInterface::class
         )->getMockForAbstractClass();
@@ -114,7 +114,7 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
         $paymentMock = $this->getMockBuilder(
             \Magento\Sales\Model\Order\Payment::class
         )->disableOriginalConstructor()->setMethods([])->getMock();
-        $order->expects($this->once())->method('getPayment')->will($this->returnValue($paymentMock));
+        $order->method('getPayment')->will($this->returnValue($paymentMock));
         $methodInstance = $this->getMockBuilder(
             \Magento\Payment\Model\MethodInterface::class
         )->getMockForAbstractClass();
@@ -157,6 +157,26 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * The method should check that the payment is available, as this is not always the case.
+     */
+    public function testDoesNothingWhenNoPaymentIsAvailable()
+    {
+        $this->_prepareEventMockWithMethods(['getOrder']);
+
+        $order = $this->getMockBuilder(\Magento\Sales\Model\Order::class)->disableOriginalConstructor()->setMethods(
+            array_merge(['__wakeup', 'getPayment'])
+        )->getMock();
+
+        $this->eventMock->expects($this->once())->method('getOrder')->will(
+            $this->returnValue($order)
+        );
+
+        $order->expects($this->exactly(1))->method('getPayment')->willReturn(null);
+
+        $this->salesOrderBeforeSaveObserver->execute($this->observerMock);
+    }
+
+    /**
      * Prepares EventMock with set of methods
      *
      * @param $methodsList
@@ -184,7 +204,7 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
         $paymentMock = $this->getMockBuilder(
             \Magento\Sales\Model\Order\Payment::class
         )->disableOriginalConstructor()->setMethods([])->getMock();
-        $order->expects($this->once())->method('getPayment')->will($this->returnValue($paymentMock));
+        $order->method('getPayment')->will($this->returnValue($paymentMock));
         $methodInstance = $this->getMockBuilder(
             \Magento\Payment\Model\MethodInterface::class
         )->getMockForAbstractClass();

--- a/app/code/Magento/Payment/Test/Unit/Observer/SalesOrderBeforeSaveObserverTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Observer/SalesOrderBeforeSaveObserverTest.php
@@ -158,6 +158,9 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * The method should check that the payment is available, as this is not always the case.
+     *
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @exceptedExceptionMessage Please provide payment for the order.
      */
     public function testDoesNothingWhenNoPaymentIsAvailable()
     {

--- a/app/code/Magento/Paypal/Plugin/OrderCanInvoice.php
+++ b/app/code/Magento/Paypal/Plugin/OrderCanInvoice.php
@@ -40,6 +40,10 @@ class OrderCanInvoice
      */
     public function afterCanInvoice(Order $order, bool $result): bool
     {
+        if (!$order->getPayment()) {
+            return false;
+        }
+
         if ($this->express->isOrderAuthorizationAllowed($order->getPayment())) {
             return false;
         }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/15683

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fix an error while submitting an order without payment method.

### Description
When submitting an order using the rest api without an payment, you would get an exception/error report due to the fact there was not payment method.

### Fixed Issues (if relevant)
1. magento/magento2#15652: REST API create order POST /V1/orders

### Manual testing scenarios
1.  Send an POST request to the rest/V1/orders endpoint containing the following:
``
{ "entity": { "base_grand_total" : 100, "customer_email" : "user@domain.tld", "grand_total" : 100, "items" : [ { "sku" : "TESTSEB" } ] } }
``

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
