### PR TITLE
[Forwardport] Fix type hint of @message declaration as the "setWidgetParameters" method allows arrays too

### DIFF
--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -15,7 +15,7 @@ use Magento\Framework\Serialize\Serializer\Json;
  * @method string getTitle()
  * @method \Magento\Widget\Model\Widget\Instance setTitle(string $value)
  * @method \Magento\Widget\Model\Widget\Instance setStoreIds(string $value)
- * @method \Magento\Widget\Model\Widget\Instance setWidgetParameters(string $value)
+ * @method \Magento\Widget\Model\Widget\Instance setWidgetParameters(string|array $value)
  * @method int getSortOrder()
  * @method \Magento\Widget\Model\Widget\Instance setSortOrder(int $value)
  * @method \Magento\Widget\Model\Widget\Instance setThemeId(int $value)


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18155

### Description
The magic `setWidgetParameters` method of the `\Magento\Widget\Model\Widget\Instance` class accepts not only strings as its parameter, but also arrays. If it's an array, it gets transformed to a string automatically before saving. This PR adds the corresponding type hint.

### Fixed Issues (if relevant)
The IDE shows a warning if you use an array as a parameter:

![grafik](https://user-images.githubusercontent.com/662059/45811888-9b531b80-bcce-11e8-932c-241d41d0e4d7.png)

This is especially annoying as the `getWidgetParameters` returns an array. It should be possible to use the same data type for getter and setter of one field.

### Manual testing scenarios
Insert the following code into your IDE:

```
 /** @var WidgetInstance $widget */
$widgetParameters = $widget->getWidgetParameters();
$widget->setWidgetParameters($widgetParameters);
```

It shouldn't show a warning as displayed in the screenshot above.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
