### PR TITLE
Backend: add missing unit test for ModuleService class

### DIFF
--- a/app/code/Magento/Backend/Test/Unit/Service/V1/ModuleServiceTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Service/V1/ModuleServiceTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\Backend\Test\Unit\Model;
+namespace Magento\Backend\Test\Unit\Service\V1;
 
 use Magento\Backend\Service\V1\ModuleService;
 use Magento\Framework\Module\ModuleListInterface;

--- a/app/code/Magento/Backend/Test/Unit/Service/V1/ModuleServiceTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Service/V1/ModuleServiceTest.php
@@ -16,7 +16,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
  *
  * Covers \Magento\Sales\Model\ValidatorResultMerger
  */
-class ValidatorResultMergerTest extends \PHPUnit\Framework\TestCase
+class ModuleServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Testable Object

--- a/app/code/Magento/Backend/Test/Unit/Service/V1/ModuleServiceTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Service/V1/ModuleServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Backend\Test\Unit\Model;
+
+use Magento\Backend\Service\V1\ModuleService;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * Module List Service Test
+ *
+ * Covers \Magento\Sales\Model\ValidatorResultMerger
+ */
+class ValidatorResultMergerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var ModuleService
+     */
+    private $moduleService;
+
+    /**
+     * @var ModuleListInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $moduleListMock;
+
+    /**
+     * Object Manager
+     *
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->moduleListMock = $this->createMock(ModuleListInterface::class);
+        $this->objectManager = new ObjectManager($this);
+        $this->moduleService = $this->objectManager->getObject(
+            ModuleService::class,
+            [
+                'moduleList' => $this->moduleListMock,
+            ]
+        );
+    }
+
+    /**
+     * Test getModules method
+     *
+     * @return void
+     */
+    public function testGetModules()
+    {
+        $moduleNames = ['Magento_Backend', 'Magento_Catalog', 'Magento_Customer'];
+        $this->moduleListMock->expects($this->once())->method('getNames')->willReturn($moduleNames);
+
+        $expected = $moduleNames;
+        $actual = $this->moduleService->getModules();
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
### Description
This PR adds missing unit tests for Module List Service class:
- `\Magento\Backend\Service\V1\ModuleService`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
