### PR TITLE
fixes for requestShippingRates populates wrong store and website IDs …

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -999,17 +999,24 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
 
         $request->setFreeMethodWeight($item ? 0 : $this->getFreeMethodWeight());
 
+        
+         // =======================================================
+
         /**
-         * Store and website identifiers specified from StoreManager
+         * Store and website identifiers need specify from quote
          */
-        $request->setStoreId($this->storeManager->getStore()->getId());
-        $request->setWebsiteId($this->storeManager->getWebsite()->getId());
+        $request->setStoreId($this->getQuote()->getStore()->getId());
+        $request->setWebsiteId($this->getQuote()->getStore()->getWebsiteId());
         $request->setFreeShipping($this->getFreeShipping());
         /**
          * Currencies need to convert in free shipping
          */
-        $request->setBaseCurrency($this->storeManager->getStore()->getBaseCurrency());
-        $request->setPackageCurrency($this->storeManager->getStore()->getCurrentCurrency());
+        $request->setBaseCurrency($this->getQuote()->getStore()->getBaseCurrency());
+        $request->setPackageCurrency($this->getQuote()->getStore()->getCurrentCurrency());
+
+        // =======================================================
+        
+        
         $request->setLimitCarrier($this->getLimitCarrier());
         $baseSubtotalInclTax = $this->getBaseSubtotalTotalInclTax();
         $request->setBaseSubtotalInclTax($baseSubtotalInclTax);


### PR DESCRIPTION
### Description (*)
Fixes applied when creating a new order in the admin panel, clicking "Get shipping methods and rates" shipping methods returned for the chosen store.If the instance configured for multipile websites,all attributes which require website specific data like currency, this fixes will work.

### Fixed Issues (if relevant)

1. magento/magento2#15497: requestShippingRates populates wrong store and website IDs when retrieving shipping rates and methods in admin panel


### Manual testing scenarios (*)

1. Create two or more websites within the Magento install, and create each with their own store and store views.
2. Turn on some shipping methods for one store, and other shipping methods for the other store.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
