### PR TITLE
[Forwardport] Fix type hint of customer-data updateSectionId parameters

### DIFF
--- a/app/code/Magento/Customer/Controller/Section/Load.php
+++ b/app/code/Magento/Customer/Controller/Section/Load.php
@@ -71,11 +71,11 @@ class Load extends \Magento\Framework\App\Action\Action implements HttpGetAction
             $sectionNames = $this->getRequest()->getParam('sections');
             $sectionNames = $sectionNames ? array_unique(\explode(',', $sectionNames)) : null;
 
-            $updateSectionId = $this->getRequest()->getParam('update_section_id');
-            if ('false' === $updateSectionId) {
-                $updateSectionId = false;
+            $forceNewSectionTimestamp = $this->getRequest()->getParam('force_new_section_timestamp');
+            if ('false' === $forceNewSectionTimestamp) {
+                $forceNewSectionTimestamp = false;
             }
-            $response = $this->sectionPool->getSectionsData($sectionNames, (bool)$updateSectionId);
+            $response = $this->sectionPool->getSectionsData($sectionNames, (bool)$forceNewSectionTimestamp);
         } catch (\Exception $e) {
             $resultJson->setStatusHeader(
                 \Zend\Http\Response::STATUS_CODE_400,

--- a/app/code/Magento/Customer/CustomerData/Section/Identifier.php
+++ b/app/code/Magento/Customer/CustomerData/Section/Identifier.php
@@ -43,12 +43,12 @@ class Identifier
     /**
      * Init mark(identifier) for sections
      *
-     * @param bool $forceUpdate
+     * @param bool $forceNewTimestamp
      * @return int
      */
-    public function initMark($forceUpdate)
+    public function initMark($forceNewTimestamp)
     {
-        if ($forceUpdate) {
+        if ($forceNewTimestamp) {
             $this->markId = time();
             return $this->markId;
         }
@@ -68,18 +68,18 @@ class Identifier
      *
      * @param array $sectionsData
      * @param null $sectionNames
-     * @param bool $updateIds
+     * @param bool $forceNewTimestamp
      * @return array
      */
-    public function markSections(array $sectionsData, $sectionNames = null, $updateIds = false)
+    public function markSections(array $sectionsData, $sectionNames = null, $forceNewTimestamp = false)
     {
         if (!$sectionNames) {
             $sectionNames = array_keys($sectionsData);
         }
-        $markId = $this->initMark($updateIds);
+        $markId = $this->initMark($forceNewTimestamp);
 
         foreach ($sectionNames as $name) {
-            if ($updateIds || !array_key_exists(self::SECTION_KEY, $sectionsData[$name])) {
+            if ($forceNewTimestamp || !array_key_exists(self::SECTION_KEY, $sectionsData[$name])) {
                 $sectionsData[$name][self::SECTION_KEY] = $markId;
             }
         }

--- a/app/code/Magento/Customer/CustomerData/SectionPool.php
+++ b/app/code/Magento/Customer/CustomerData/SectionPool.php
@@ -55,10 +55,10 @@ class SectionPool implements SectionPoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getSectionsData(array $sectionNames = null, $updateIds = false)
+    public function getSectionsData(array $sectionNames = null, $forceNewTimestamp = false)
     {
         $sectionsData = $sectionNames ? $this->getSectionDataByNames($sectionNames) : $this->getAllSectionData();
-        $sectionsData = $this->identifier->markSections($sectionsData, $sectionNames, $updateIds);
+        $sectionsData = $this->identifier->markSections($sectionsData, $sectionNames, $forceNewTimestamp);
         return $sectionsData;
     }
 

--- a/app/code/Magento/Customer/CustomerData/SectionPoolInterface.php
+++ b/app/code/Magento/Customer/CustomerData/SectionPoolInterface.php
@@ -14,8 +14,8 @@ interface SectionPoolInterface
      * Get section data by section names. If $sectionNames is null then return all sections data
      *
      * @param array $sectionNames
-     * @param bool $updateIds
+     * @param bool $forceNewTimestamp
      * @return array
      */
-    public function getSectionsData(array $sectionNames = null, $updateIds = false);
+    public function getSectionsData(array $sectionNames = null, $forceNewTimestamp = false);
 }

--- a/app/code/Magento/Customer/Test/Unit/Controller/Section/LoadTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Section/LoadTest.php
@@ -83,13 +83,13 @@ class LoadTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param $sectionNames
-     * @param $updateSectionID
-     * @param $sectionNamesAsArray
-     * @param $updateIds
+     * @param string $sectionNames
+     * @param bool $forceNewSectionTimestamp
+     * @param string[] $sectionNamesAsArray
+     * @param bool $forceNewTimestamp
      * @dataProvider executeDataProvider
      */
-    public function testExecute($sectionNames, $updateSectionID, $sectionNamesAsArray, $updateIds)
+    public function testExecute($sectionNames, $forceNewSectionTimestamp, $sectionNamesAsArray, $forceNewTimestamp)
     {
         $this->resultJsonFactoryMock->expects($this->once())
             ->method('create')
@@ -103,12 +103,12 @@ class LoadTest extends \PHPUnit\Framework\TestCase
 
         $this->httpRequestMock->expects($this->exactly(2))
             ->method('getParam')
-            ->withConsecutive(['sections'], ['update_section_id'])
-            ->willReturnOnConsecutiveCalls($sectionNames, $updateSectionID);
+            ->withConsecutive(['sections'], ['force_new_section_timestamp'])
+            ->willReturnOnConsecutiveCalls($sectionNames, $forceNewSectionTimestamp);
 
         $this->sectionPoolMock->expects($this->once())
             ->method('getSectionsData')
-            ->with($sectionNamesAsArray, $updateIds)
+            ->with($sectionNamesAsArray, $forceNewTimestamp)
             ->willReturn([
                 'message' => 'some message',
                 'someKey' => 'someValue'
@@ -133,15 +133,15 @@ class LoadTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 'sectionNames' => 'sectionName1,sectionName2,sectionName3',
-                'updateSectionID' => 'updateSectionID',
+                'forceNewSectionTimestamp' => 'forceNewSectionTimestamp',
                 'sectionNamesAsArray' => ['sectionName1', 'sectionName2', 'sectionName3'],
-                'updateIds' => true
+                'forceNewTimestamp' => true
             ],
             [
                 'sectionNames' => null,
-                'updateSectionID' => null,
+                'forceNewSectionTimestamp' => null,
                 'sectionNamesAsArray' => null,
-                'updateIds' => false
+                'forceNewTimestamp' => false
             ],
         ];
     }

--- a/app/code/Magento/Customer/Test/Unit/CustomerData/SectionPoolTest.php
+++ b/app/code/Magento/Customer/Test/Unit/CustomerData/SectionPoolTest.php
@@ -63,7 +63,7 @@ class SectionPoolTest extends \PHPUnit\Framework\TestCase
 
         $this->identifierMock->expects($this->once())
             ->method('markSections')
-            //check also default value for $updateIds = false
+            //check also default value for $forceTimestamp = false
             ->with($allSectionsData, $sectionNames, false)
             ->willReturn($identifierResult);
         $modelResult = $this->model->getSectionsData($sectionNames);

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -75,17 +75,17 @@ define([
 
         /**
          * @param {Object} sectionNames
-         * @param {Boolean} updateSectionId
+         * @param {Boolean} forceNewSectionTimestamp
          * @return {*}
          */
-        getFromServer: function (sectionNames, updateSectionId) {
+        getFromServer: function (sectionNames, forceNewSectionTimestamp) {
             var parameters;
 
             sectionNames = sectionConfig.filterClientSideSections(sectionNames);
             parameters = _.isArray(sectionNames) ? {
                 sections: sectionNames.join(',')
             } : [];
-            parameters['update_section_id'] = updateSectionId;
+            parameters['update_section_id'] = forceNewSectionTimestamp;
 
             return $.getJSON(options.sectionLoadUrl, parameters).fail(function (jqXHR) {
                 throw new Error(jqXHR);
@@ -326,11 +326,11 @@ define([
 
         /**
          * @param {Array} sectionNames
-         * @param {Boolean} updateSectionId
+         * @param {Boolean} forceNewSectionTimestamp
          * @return {*}
          */
-        reload: function (sectionNames, updateSectionId) {
-            return dataProvider.getFromServer(sectionNames, updateSectionId).done(function (sections) {
+        reload: function (sectionNames, forceNewSectionTimestamp) {
+            return dataProvider.getFromServer(sectionNames, forceNewSectionTimestamp).done(function (sections) {
                 $(document).trigger('customer-data-reload', [sectionNames]);
                 buffer.update(sections);
             });

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -85,7 +85,7 @@ define([
             parameters = _.isArray(sectionNames) ? {
                 sections: sectionNames.join(',')
             } : [];
-            parameters['update_section_id'] = forceNewSectionTimestamp;
+            parameters['force_new_section_timestamp'] = forceNewSectionTimestamp;
 
             return $.getJSON(options.sectionLoadUrl, parameters).fail(function (jqXHR) {
                 throw new Error(jqXHR);

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -75,7 +75,7 @@ define([
 
         /**
          * @param {Object} sectionNames
-         * @param {Number} updateSectionId
+         * @param {Boolean} updateSectionId
          * @return {*}
          */
         getFromServer: function (sectionNames, updateSectionId) {
@@ -326,7 +326,7 @@ define([
 
         /**
          * @param {Array} sectionNames
-         * @param {Number} updateSectionId
+         * @param {Boolean} updateSectionId
          * @return {*}
          */
         reload: function (sectionNames, updateSectionId) {

--- a/setup/performance-toolkit/benchmark.jmx
+++ b/setup/performance-toolkit/benchmark.jmx
@@ -2881,12 +2881,12 @@ vars.put("customer_email", customerUser);
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -4906,12 +4906,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -5272,12 +5272,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -5566,12 +5566,12 @@ vars.put("customer_email", customerUser);
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -5739,12 +5739,12 @@ vars.put("product_sku", product.get("sku"));
               <boolProp name="HTTPArgument.use_equals">true</boolProp>
               <stringProp name="Argument.name">sections</stringProp>
             </elementProp>
-            <elementProp name="update_section_id" elementType="HTTPArgument">
+            <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
               <boolProp name="HTTPArgument.always_encode">true</boolProp>
               <stringProp name="Argument.value">false</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
               <boolProp name="HTTPArgument.use_equals">true</boolProp>
-              <stringProp name="Argument.name">update_section_id</stringProp>
+              <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             </elementProp>
             <elementProp name="_" elementType="HTTPArgument">
               <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -6171,12 +6171,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -6349,12 +6349,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -6787,12 +6787,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -7153,12 +7153,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -7869,12 +7869,12 @@ vars.put("customer_email", customerUser);
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -8105,12 +8105,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -8471,12 +8471,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -9146,12 +9146,12 @@ vars.put("customer_email", customerUser);
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -9330,12 +9330,12 @@ vars.put("product_sku", product.get("sku"));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -9662,12 +9662,12 @@ vars.put("customer_email", customerUser);
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -9929,12 +9929,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -10295,12 +10295,12 @@ vars.put("totalProductsAdded", String.valueOf(productsAdded));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -10492,12 +10492,12 @@ vars.put("item_id", vars.get("cart_items_qty_inputs_" + id));
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
@@ -10813,12 +10813,12 @@ vars.put("customer_email", customerUser);
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">false</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>

--- a/setup/performance-toolkit/benchmark_2015.jmx
+++ b/setup/performance-toolkit/benchmark_2015.jmx
@@ -2981,12 +2981,12 @@ vars.put("loadType", "Guest");</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">false</boolProp>
@@ -3217,12 +3217,12 @@ vars.put("loadType", "Guest");</stringProp>
             <stringProp name="Argument.name">sections</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
@@ -3565,12 +3565,12 @@ vars.put("loadType", "Guest");</stringProp>
             <stringProp name="Argument.name">sections</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
@@ -4039,12 +4039,12 @@ vars.put("loadType", "Guest");</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">false</boolProp>
@@ -4275,12 +4275,12 @@ vars.put("loadType", "Guest");</stringProp>
             <stringProp name="Argument.name">sections</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
@@ -4623,12 +4623,12 @@ vars.put("loadType", "Guest");</stringProp>
             <stringProp name="Argument.name">sections</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
@@ -5637,12 +5637,12 @@ vars.put("loadType", "Customer");</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
             <stringProp name="Argument.name">sections</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">false</boolProp>
@@ -5873,12 +5873,12 @@ vars.put("loadType", "Customer");</stringProp>
             <stringProp name="Argument.name">sections</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">
@@ -6221,12 +6221,12 @@ vars.put("loadType", "Customer");</stringProp>
             <stringProp name="Argument.name">sections</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
-          <elementProp name="update_section_id" elementType="HTTPArgument">
+          <elementProp name="force_new_section_timestamp" elementType="HTTPArgument">
             <boolProp name="HTTPArgument.always_encode">true</boolProp>
             <stringProp name="Argument.value">true</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
             <boolProp name="HTTPArgument.use_equals">true</boolProp>
-            <stringProp name="Argument.name">update_section_id</stringProp>
+            <stringProp name="Argument.name">force_new_section_timestamp</stringProp>
             <stringProp name="Argument.desc">true</stringProp>
           </elementProp>
           <elementProp name="_" elementType="HTTPArgument">


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16115

### Description

The type hint wrongly indicates the parameter should be a number, where in fact it is a boolean.
It is passed through to the server side to the controller action
`\Magento\Customer\Controller\Section\Load::execute()`
where it is cast to a bool and passed as the `$updateIds` parameter to
`\Magento\Customer\CustomerData\SectionPool::getSectionsData()`,
and from there as the boolean parameter `$forceUpdate  to the
`\Magento\Customer\CustomerData\Section\Identifier::initMark()` method.

This PR introduces no backward incompatibilities, it only fixes the type
hint to make the code more readable and improve compatibility with static
code analysis tools.

### Fixed Issues (if relevant)

I didn't bother first opening an issue about this small change.

### Manual testing scenarios

None, since it's only a comment change.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)