### PR TITLE
[Backport] Make it possible to disable report bugs link

### DIFF
--- a/app/code/Magento/Theme/etc/config.xml
+++ b/app/code/Magento/Theme/etc/config.xml
@@ -46,6 +46,7 @@ Disallow: /*SID=
             </header>
             <footer translate="copyright">
                 <copyright>Copyright &#169; 2013-present Magento, Inc. All rights reserved.</copyright>
+                <report_bugs>1</report_bugs>
             </footer>
         </design>
         <theme>

--- a/app/code/Magento/Theme/etc/di.xml
+++ b/app/code/Magento/Theme/etc/di.xml
@@ -213,6 +213,10 @@
                     <item name="path" xsi:type="string">design/footer/absolute_footer</item>
                     <item name="fieldset" xsi:type="string">other_settings/footer</item>
                 </item>
+                <item name="footer_report_bugs" xsi:type="array">
+                    <item name="path" xsi:type="string">design/footer/report_bugs</item>
+                    <item name="fieldset" xsi:type="string">other_settings/footer</item>
+                </item>
                 <item name="default_robots" xsi:type="array">
                     <item name="path" xsi:type="string">design/search_engine_robots/default_robots</item>
                     <item name="fieldset" xsi:type="string">other_settings/search_engine_robots</item>

--- a/app/code/Magento/Theme/i18n/en_US.csv
+++ b/app/code/Magento/Theme/i18n/en_US.csv
@@ -185,3 +185,7 @@ Settings,Settings
 "2 columns with left bar","2 columns with left bar"
 "2 columns with right bar","2 columns with right bar"
 "3 columns","3 columns"
+ID,ID
+View,View
+Action,Action
+"Display Report Bugs Link","Display Report Bugs Link"

--- a/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
+++ b/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
@@ -234,6 +234,20 @@
                     <dataScope>footer_copyright</dataScope>
                 </settings>
             </field>
+            <field name="footer_report_bugs" formElement="select">
+                <settings>
+                    <dataType>text</dataType>
+                    <label translate="true">Display Report Bugs Link</label>
+                    <dataScope>footer_report_bugs</dataScope>
+                </settings>
+                <formElements>
+                    <select>
+                        <settings>
+                            <options class="Magento\Config\Model\Config\Source\Yesno"/>
+                        </settings>
+                    </select>
+                </formElements>
+            </field>
         </fieldset>
         <fieldset name="search_engine_robots" sortOrder="120">
             <settings>

--- a/app/code/Magento/Theme/view/frontend/layout/default.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default.xml
@@ -119,7 +119,7 @@
                     </arguments>
                 </block>
                 <block class="Magento\Theme\Block\Html\Footer" name="copyright" template="Magento_Theme::html/copyright.phtml"/>
-                <block class="Magento\Framework\View\Element\Template" name="report.bugs" template="Magento_Theme::html/bugreport.phtml" />
+                <block class="Magento\Framework\View\Element\Template" name="report.bugs" template="Magento_Theme::html/bugreport.phtml" ifconfig="design/footer/report_bugs"/>
             </container>
         </referenceContainer>
         <referenceContainer name="before.body.end">


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/17803

### Description
Make it possible to disable report bugs link.
    
As developer I have removed this link a lot of times with a layout  update (remove=true).

Since we most of the times do not want this by default it should be configurable whether to show this link or not.

A new setting is added under Design > Configuration > Edit > Other Settings > Footer. 
The new label for this is 'Display Report Bugs Link'.

The default value for this setting is 'Yes' to keep it backwards compatible.

### Manual testing scenarios
1. Default setup with blank theme
2. Go to frontend
3. See 'report bugs' link in footer
4. Go to backend > Design > Configuration > Edit > Other Settings > Footer
5. Set setting 'Display Report Bugs Link' to 'No'
6. Flush cache
7. Go to frontend again
8. See that 'report bugs' link is removed from footer

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
