### PR TITLE
Update documentation for Order#getAppliedRuleIds

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -580,8 +580,8 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
 
     /**
      * Gets the applied rule IDs for the order.
-     * Rules are comma separated if there are more than one.
      *
+     * Rules are comma separated if there are more than one.
      * @return string|null Applied rule IDs.
      */
     public function getAppliedRuleIds();

--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -580,6 +580,7 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
 
     /**
      * Gets the applied rule IDs for the order.
+     * Rules are comma separated if there are more than one.
      *
      * @return string|null Applied rule IDs.
      */

--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -582,6 +582,7 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Gets the applied rule IDs for the order.
      *
      * Rules are comma separated if there are more than one.
+     *
      * @return string|null Applied rule IDs.
      */
     public function getAppliedRuleIds();

--- a/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
@@ -416,6 +416,7 @@ interface OrderItemInterface extends \Magento\Framework\Api\ExtensibleDataInterf
      * Gets the applied rule IDs for the order item.
      *
      * Rules are comma separated if there are more than one.
+     *
      * @return string|null Applied rule IDs.
      */
     public function getAppliedRuleIds();

--- a/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
@@ -414,6 +414,7 @@ interface OrderItemInterface extends \Magento\Framework\Api\ExtensibleDataInterf
 
     /**
      * Gets the applied rule IDs for the order item.
+     * Rules are comma separated if there are more than one.
      *
      * @return string|null Applied rule IDs.
      */

--- a/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
@@ -414,8 +414,8 @@ interface OrderItemInterface extends \Magento\Framework\Api\ExtensibleDataInterf
 
     /**
      * Gets the applied rule IDs for the order item.
-     * Rules are comma separated if there are more than one.
      *
+     * Rules are comma separated if there are more than one.
      * @return string|null Applied rule IDs.
      */
     public function getAppliedRuleIds();

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -2112,6 +2112,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
 
     /**
      * Returns applied_rule_ids
+     * Rules are comma separated if there are more than one.
      *
      * @return string|null
      */

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -2114,6 +2114,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Returns applied_rule_ids
      *
      * Rules are comma separated if there are more than one.
+     *
      * @return string|null
      */
     public function getAppliedRuleIds()

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -2112,8 +2112,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
 
     /**
      * Returns applied_rule_ids
-     * Rules are comma separated if there are more than one.
      *
+     * Rules are comma separated if there are more than one.
      * @return string|null
      */
     public function getAppliedRuleIds()

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -726,6 +726,7 @@ class Item extends AbstractModel implements OrderItemInterface
      * Returns applied_rule_ids
      *
      * Rules are comma separated if there are more than one.
+     *
      * @return string|null
      */
     public function getAppliedRuleIds()

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -724,6 +724,7 @@ class Item extends AbstractModel implements OrderItemInterface
 
     /**
      * Returns applied_rule_ids
+     * Rules are comma separated if there are more than one.
      *
      * @return string|null
      */

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -724,8 +724,8 @@ class Item extends AbstractModel implements OrderItemInterface
 
     /**
      * Returns applied_rule_ids
-     * Rules are comma separated if there are more than one.
      *
+     * Rules are comma separated if there are more than one.
      * @return string|null
      */
     public function getAppliedRuleIds()


### PR DESCRIPTION
### Description
Update the documentation for getAppliedRuleIds, as it is not immediately clear if this is a single number in a string, or several that are comma separated.

### Manual testing scenarios
- Attempt to getAppliedRuleIds on an OrderInterface object
- Consult the documentation, and see it contains a string
- Scratch your head because you're not sure if it can contain multiple IDs or not, and if so how they're separated 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
