### PR TITLE
fixed issue #18458 : Alert widget gets close when click anywhere on screen

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/modal-component.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal-component.js
@@ -93,7 +93,7 @@ define([
          * @returns {Object} Chainable.
          */
         initModalEvents: function () {
-            this.options.keyEventHandlers.escapeKey = this.options.outerClickHandler = this[this.onCancel].bind(this);
+            this.options.keyEventHandlers.escapeKey = this[this.onCancel].bind(this);
 
             return this;
         },

--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -428,7 +428,6 @@ define([
             }
             events = $._data(this.overlay.get(0), 'events');
             events ? this.prevOverlayHandler = events.click[0].handler : false;
-            this.options.clickableOverlay ? this.overlay.unbind().on('click', outerClickHandler) : false;
         },
 
         /**

--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -416,6 +416,7 @@ define([
          */
         _createOverlay: function () {
             var events;
+            
             this.overlay = $('.' + this.options.overlayClass);
 
             if (!this.overlay.length) {

--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -416,9 +416,9 @@ define([
          */
         _createOverlay: function () {
             var events;
-            
-            this.overlay = $('.' + this.options.overlayClass);
 
+            this.overlay = $('.' + this.options.overlayClass);
+            
             if (!this.overlay.length) {
                 $(this.options.appendTo).addClass(this.options.parentModalClass);
                 this.overlay = $('<div></div>')

--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -415,9 +415,7 @@ define([
          * Creates overlay, append it to wrapper, set previous click event on overlay.
          */
         _createOverlay: function () {
-            var events,
-                outerClickHandler = this.options.outerClickHandler || this.closeModal;
-
+            var events;
             this.overlay = $('.' + this.options.overlayClass);
 
             if (!this.overlay.length) {


### PR DESCRIPTION
Fixes the issue of Alert widget gets close when click anywhere on screen .

Description
In older version of magento 2.2.6 when we click delete button of minicart then alert widget display for confirm to delete item from cart.This popup was only close when click on "cancel", "ok" & "close" button.But earlier version of magento 2.2.6 it is closing click anywhere on screen.In this PR i have fixed this issue.

Fixed Issues
#18458: Magento version 2.2.6 Alert widget gets close when click anywhere on screen #18458

Manual testing scenarios
1 - Add product into cart.
2- Click on cart logo and delete item from cart.
3 - Now popup will open for confirm.
4 - Click anywhere on screen.Now popup will not close.