### PR TITLE
[Backport] Prevent XSS on checkout

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/details.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/details.html
@@ -8,7 +8,7 @@
     <text args="currentBillingAddress().prefix"/> <text args="currentBillingAddress().firstname"/> <text args="currentBillingAddress().middlename"/>
     <text args="currentBillingAddress().lastname"/> <text args="currentBillingAddress().suffix"/><br/>
     <text args="_.values(currentBillingAddress().street).join(', ')"/><br/>
-    <text args="currentBillingAddress().city "/>, <span html="currentBillingAddress().region"></span> <text args="currentBillingAddress().postcode"/><br/>
+    <text args="currentBillingAddress().city "/>, <span text="currentBillingAddress().region"></span> <text args="currentBillingAddress().postcode"/><br/>
     <text args="getCountryName(currentBillingAddress().countryId)"/><br/>
     <a if="currentBillingAddress().telephone" attr="'href': 'tel:' + currentBillingAddress().telephone" text="currentBillingAddress().telephone"></a><br/>
 

--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
@@ -8,7 +8,7 @@
     <text args="address().prefix"/> <text args="address().firstname"/> <text args="address().middlename"/>
     <text args="address().lastname"/> <text args="address().suffix"/><br/>
     <text args="_.values(address().street).join(', ')"/><br/>
-    <text args="address().city "/>, <span html="address().region"></span> <text args="address().postcode"/><br/>
+    <text args="address().city "/>, <span text="address().region"></span> <text args="address().postcode"/><br/>
     <text args="getCountryName(address().countryId)"/><br/>
     <a if="address().telephone" attr="'href': 'tel:' + address().telephone" text="address().telephone"></a><br/>
 

--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-information/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-information/address-renderer/default.html
@@ -8,7 +8,7 @@
     <text args="address().prefix"/> <text args="address().firstname"/> <text args="address().middlename"/>
     <text args="address().lastname"/> <text args="address().suffix"/><br/>
     <text args="_.values(address().street).join(', ')"/><br/>
-    <text args="address().city "/>, <span html="address().region"></span> <text args="address().postcode"/><br/>
+    <text args="address().city "/>, <span text="address().region"></span> <text args="address().postcode"/><br/>
     <text args="getCountryName(address().countryId)"/><br/>
     <a if="address().telephone" attr="'href': 'tel:' + address().telephone" text="address().telephone"></a><br/>
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18487
### Description
The State/Province field (when selecting a country like The Netherlands) gives the user an input field (in checkout/account address). When filling <script>alert('hello world')</script>, the user will experience self xss in the next step of the checkout.

### Fixed Issues (if relevant)
Bugcrowd reference cd8d0c3b57686f09cde51c4afaa2f0e70e51f9093121fb7140e3b7f26a89b7fd (which got marked as "won't fix")

### Manual testing scenarios
See description/ (bugcrowd for video)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
