### PR TITLE
Remove unused mixin code

### DIFF
--- a/lib/web/css/source/lib/_layout.less
+++ b/lib/web/css/source/lib/_layout.less
@@ -8,33 +8,6 @@
 //  _____________________________________________
 
 //  Page Width mixin
-.lib-layout-width(
-    @_layout__min-width: @layout__min-width,
-    @_layout__max-width: @layout__max-width,
-    @_layout__indent: @layout-indent__width
-) when not (@responsive = true) {
-    ._lib-layout-width(@_layout__min-width, @_layout__max-width);
-    .lib-css(padding-left, @layout-indent__width);
-    .lib-css(padding-right, @layout-indent__width);
-    margin: 0 auto;
-}
-
-._lib-layout-width(
-        @_layout__min-width: @layout__min-width,
-        @_layout__max-width: @layout__max-width
-    ) when (@_layout__min-width = @_layout__max-width) {
-    .lib-css(width, @_layout__min-width);
-}
-
-._lib-layout-width(
-        @_layout__min-width: @layout__min-width,
-        @_layout__max-width: @layout__max-width
-    ) when not (@_layout__min-width = @_layout__max-width) {
-    .lib-css(max-width, @_layout__max-width);
-    .lib-css(min-width, @_layout__min-width);
-    width: auto;
-}
-
 #lib-layout-columns() {
     & when (@use-flex = true) {
         .lib-vendor-prefix-display(flex);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removed unused mixin code from core file(lib).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #15060: .lib-layout-width mixin not available?


### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
