### PR TITLE
[Backport] Fix empty cart button

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -24,7 +24,7 @@
         <?php endif ?>
         <table id="shopping-cart-table"
                class="cart items data table"
-               data-mage-init='{"shoppingCart":{"emptyCartButton": "action.clear",
+               data-mage-init='{"shoppingCart":{"emptyCartButton": ".action.clear",
                "updateCartActionContainer": "#update_cart_action_container"}}'>
             <caption role="heading" aria-level="2" class="table-caption"><?= /* @escapeNotVerified */ __('Shopping Cart Items') ?></caption>
             <thead>


### PR DESCRIPTION
### Description (*)
This commit fixes the empty cart button on the cart page. It was not working because of the selector in 'app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js:17':

```
$(this.options.emptyCartButton).on('click', $.proxy(function () {
                $(this.options.emptyCartButton).attr('name', 'update_cart_action_temp');
                $(this.options.updateCartActionContainer)
                    .attr('name', 'update_cart_action').attr('value', 'empty_cart');
            }, this));
```

`this.options.emptyCartButton` is set in `app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml:27`:

```
data-mage-init='{"shoppingCart":{"emptyCartButton": "action.clear",
```

That selector should be .action.clear instead of action.clear to be able to select the empty-cart-button

### Fixed Issues (if relevant)
magento/magento2#18589: Empty cart button does not work

### Manual testing scenarios (*)
1. Add a product to your cart
2. Go to the cart page
3. In the developer-console of your browser run `jQuery('.action.clear').show();` to show the default "empty cart button"
4. Click the button "Clear shopping Cart"
5. The cart should now be cleared

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Original PR 
https://github.com/magento/magento2/pull/18596