### PR TITLE
Fix the typo in PHPDoc comment

### DIFF
--- a/app/code/Magento/Backend/Model/Config/SessionLifetime/BackendModel.php
+++ b/app/code/Magento/Backend/Model/Config/SessionLifetime/BackendModel.php
@@ -16,14 +16,17 @@ use Magento\Framework\Exception\LocalizedException;
  */
 class BackendModel extends Value
 {
-    /** Maximum dmin session lifetime; 1 year*/
+    /** Maximum admin session lifetime; 1 year*/
     const MAX_LIFETIME = 31536000;
 
     /** Minimum admin session lifetime */
     const MIN_LIFETIME = 60;
 
     /**
+     * Processing object before save data
+     *
      * @since 100.1.0
+     * @throws LocalizedException
      */
     public function beforeSave()
     {


### PR DESCRIPTION
### Description
Fix the typo in PHPDoc comment for `MAX_LIFETIME` constant.

### Manual testing scenarios
N/A

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
