### PR TITLE
Remove wrong test expectation

### DIFF
--- a/app/code/Magento/ProductVideo/Test/Unit/Controller/Adminhtml/Product/Gallery/RetrieveImageTest.php
+++ b/app/code/Magento/ProductVideo/Test/Unit/Controller/Adminhtml/Product/Gallery/RetrieveImageTest.php
@@ -146,7 +146,6 @@ class RetrieveImageTest extends \PHPUnit\Framework\TestCase
         $readInterface->expects($this->any())->method('getAbsolutePath')->willReturn('');
         $this->abstractAdapter->expects($this->any())->method('validateUploadFile')->willReturn('true');
         $this->validatorMock->expects($this->once())->method('isValid')->with('jpg')->willReturn('true');
-        $this->filesystemMock->expects($this->once())->method('getDirectoryWrite')->willReturn($writeInterface);
         $this->curlMock->expects($this->once())->method('read')->willReturn('testimage');
 
         $this->image->execute();


### PR DESCRIPTION
### Description (*)
Removing wrong test expectation which fails unit tests

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/12419

### Manual testing scenarios (*)
1. Run `bin/magento dev:tests:run unit`, which fails with:

```
There was 1 failure:

1) Magento\ProductVideo\Test\Unit\Controller\Adminhtml\Product\Gallery\RetrieveImageTest::testExecute
Expectation failed for method name is equal to <string:getDirectoryWrite> when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.
```

### Contribution checklist (*)
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x ] All automated tests passed successfully (all builds on Travis CI are green)
