### PR TITLE
Issue: Plus char is replaced by space in product attribute dropdown value, Fixed

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Save.php
@@ -222,13 +222,13 @@ class Save extends Attribute
                 $data['backend_model'] = $this->productHelper->getAttributeBackendModelByInputType(
                     $data['frontend_input']
                 );
-
-                if ($model->getIsUserDefined() === null) {
-                    $data['backend_type'] = $model->getBackendTypeByInput($data['frontend_input']);
-                }
             }
 
             $data += ['is_filterable' => 0, 'is_filterable_in_search' => 0];
+
+            if ($model->getIsUserDefined() === null || $model->getIsUserDefined() != 0) {
+                $data['backend_type'] = $model->getBackendTypeByInput($data['frontend_input']);
+            }
 
             $defaultValueField = $model->getDefaultValueByInput($data['frontend_input']);
             if ($defaultValueField) {
@@ -327,8 +327,7 @@ class Save extends Attribute
             $serializedOptions = json_decode($data['serialized_options'], JSON_OBJECT_AS_ARRAY);
             foreach ($serializedOptions as $serializedOption) {
                 $option = [];
-                $serializedOptionWithParsedAmpersand = str_replace('&', '%26', $serializedOption);
-                parse_str($serializedOptionWithParsedAmpersand, $option);
+                parse_str($this->escapeSpecialChars($serializedOption), $option);
                 $data = array_replace_recursive($data, $option);
             }
         }
@@ -354,6 +353,18 @@ class Save extends Attribute
         }
 
         return $this->resultFactory->create(ResultFactory::TYPE_REDIRECT)->setPath($path, $params);
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    private function escapeSpecialChars($value)
+    {
+        $valueArray = explode("=", $value);
+        $valueArray[1] = isset($valueArray[1])? urlencode($valueArray[1]):'';
+        $finalValue = implode("=", $valueArray);
+        return $finalValue;
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Saving product attribute dropdown option value with "+" and  "&" character was replacing with Space,
this issue is fixed in this pull request. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18263 
2. #18493 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Created a Attribute type drop down and saved value contains '+' character, its not replacing
2. Created a Attribute type drop down and saved value contains '&' character, its not replacing

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
