### PR TITLE
Braintree Paypal Review: check if variable is array when validating request data

### DIFF
--- a/app/code/Magento/Braintree/Controller/Paypal/Review.php
+++ b/app/code/Magento/Braintree/Controller/Paypal/Review.php
@@ -60,7 +60,7 @@ class Review extends AbstractAction
         try {
             $this->validateQuote($quote);
 
-            if ($this->validateRequestData($requestData)) {
+            if ($requestData && $this->validateRequestData($requestData)) {
                 $this->quoteUpdater->execute(
                     $requestData['nonce'],
                     $requestData['details'],
@@ -91,14 +91,11 @@ class Review extends AbstractAction
     }
 
     /**
-     * @param $requestData
-     * @return bool
+     * @param array $requestData
+     * @return boolean
      */
-    private function validateRequestData($requestData)
+    private function validateRequestData(array $requestData)
     {
-        if (is_array($requestData)) {
-            return !empty($requestData['nonce']) && !empty($requestData['details']);
-        }
-        return false;
+        return !empty($requestData['nonce']) && !empty($requestData['details']);
     }
 }

--- a/app/code/Magento/Braintree/Controller/Paypal/Review.php
+++ b/app/code/Magento/Braintree/Controller/Paypal/Review.php
@@ -91,11 +91,15 @@ class Review extends AbstractAction
     }
 
     /**
-     * @param array $requestData
-     * @return boolean
+     * @param $requestData
+     * @return bool
      */
-    private function validateRequestData(array $requestData)
+    private function validateRequestData($requestData)
     {
-        return !empty($requestData['nonce']) && !empty($requestData['details']);
+        if (is_array($requestData)) {
+            return !empty($requestData['nonce']) && !empty($requestData['details']);
+        } else {
+            return false;
+        }
     }
 }

--- a/app/code/Magento/Braintree/Controller/Paypal/Review.php
+++ b/app/code/Magento/Braintree/Controller/Paypal/Review.php
@@ -98,8 +98,7 @@ class Review extends AbstractAction
     {
         if (is_array($requestData)) {
             return !empty($requestData['nonce']) && !empty($requestData['details']);
-        } else {
-            return false;
         }
+        return false;
     }
 }


### PR DESCRIPTION
### Description (*)
In some cases when the Magento/Braintree/Paypal/Review.php class gets executed, the `$requestData = json_decode(
            $this->getRequest()->getPostValue('result', '{}'),
            true
        );` does not get declared as an array as the requested post value returns a `null`, causing the `validateRequestData($requestData)` function call to produce the `TypeError: Uncaught exception` as the function expects the passed variable  `$requestData` to be an array.

This pull request introduces changes that ensure there are no exceptions when a `null` value is passed to the `validateRequestData($requestData)` function.

### Fixed Issues (if relevant)
1. n/a

### Manual testing scenarios (*)
1. n/a

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
