### PR TITLE
[Backport] Add required fields to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,11 +5,12 @@
      - Information on your environment,
      - Steps to reproduce,
      - Expected and actual results,
+	Fields marked with (*) are required. Please don't remove the template.
 
     Please also have a look at our guidelines article before adding a new issue https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
 -->
 
-### Preconditions
+### Preconditions (*)
 <!---
     Please provide as detailed information about your environment as possible.
     For example Magento version, tag, HEAD, PHP & MySQL version, etc..
@@ -17,7 +18,7 @@
 1. 
 2. 
 
-### Steps to reproduce
+### Steps to reproduce (*)
 <!---
     It is important to provide a set of clear steps to reproduce this bug.
     If relevant please include code samples
@@ -26,10 +27,10 @@
 2. 
 3. 
 
-### Expected result
+### Expected result (*)
 <!--- Tell us what should happen -->
 1. [Screenshots, logs or description]
 
-### Actual result
+### Actual result (*)
 <!--- Tell us what happens instead -->
 1. [Screenshots, logs or description]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
      - Information on your environment,
      - Steps to reproduce,
      - Expected and actual results,
-	Fields marked with (*) are required. Please don't remove the template.
+    Fields marked with (*) are required. Please don't remove the template.
 
     Please also have a look at our guidelines article before adding a new issue https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,28 +6,29 @@ about: Technical issue with the Magento 2 core components
 
 <!---
 Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
+Fields marked with (*) are required. Please don't remove the template.
 -->
 
-### Preconditions
+### Preconditions (*)
 <!---
 Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
 -->
 1.
 2.
 
-### Steps to reproduce
+### Steps to reproduce (*)
 <!---
 Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
 -->
 1.
 2.
 
-### Expected result
+### Expected result (*)
 <!--- Tell us what do you expect to happen. -->
 1. [Screenshots, logs or description]
 2.
 
-### Actual result
+### Actual result (*)
 <!--- Tell us what happened instead. Include error messages and issues. -->
 1. [Screenshots, logs or description]
 2.

--- a/.github/ISSUE_TEMPLATE/developer-experience-issue.md
+++ b/.github/ISSUE_TEMPLATE/developer-experience-issue.md
@@ -6,12 +6,13 @@ about: Issues related to customization, extensibility, modularity
 
 <!---
 Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
+Fields marked with (*) are required. Please don't remove the template.
 -->
 
-### Summary
+### Summary (*)
 <!--- Describe the issue you are experiencing. Include general information, error messages, environments, and so on. -->
 
-### Examples
+### Examples (*)
 <!--- Provide code examples or a patch with a test (recommended) to clearly indicate the problem. -->
 
 ### Proposed solution

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,12 +6,13 @@ about: Please consider reporting directly to https://github.com/magento/communit
 
 <!---
 Important: This repository is intended only for Magento 2 Technical Issues. Enter Feature Requests at https://github.com/magento/community-features. Project stakeholders monitor and manage requests. Feature requests entered using this form may be moved to the forum.
+Fields marked with (*) are required. Please don't remove the template.
 -->
 
-### Description
+### Description (*)
 <!--- Describe the feature you would like to add. -->
 
-### Expected behavior
+### Expected behavior (*)
 <!--- What is the expected behavior of this feature? How is it going to work? -->
 
 ### Benefits

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,8 +5,7 @@ about: Please consider reporting directly to https://github.com/magento/communit
 ---
 
 <!---
-Important: This repository is intended only for Magento 2 Technical Issues. Enter Feature Requests at https://github.com/magento/community-features. Project stakeholders monitor and manage requests. Feature requests entered using this form may be moved to the forum.
-Fields marked with (*) are required. Please don't remove the template.
+Important: This repository is intended only for Magento 2 Technical Issues. Enter Feature Requests at https://github.com/magento/community-features. Project stakeholders monitor and manage requests. Feature requests entered using this form may be moved to the forum. Fields marked with (*) are required. Please don't remove the template.
 -->
 
 ### Description (*)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,12 +3,13 @@
     To help us process this pull request we recommend that you add the following information:
      - Summary of the pull request,
      - Issue(s) related to the changes made,
-     - Manual testing scenarios,
+     - Manual testing scenarios
+    Fields marked with (*) are required. Please don't remove the template.
 -->
 
 <!--- Please provide a general summary of the Pull Request in the Title above -->
 
-### Description
+### Description (*)
 <!---
     Please provide a description of the changes proposed in the pull request.
     Letting us know what has changed and why it needed changing will help us validate this pull request.
@@ -22,7 +23,7 @@
 1. magento/magento2#<issue_number>: Issue title
 2. ...
 
-### Manual testing scenarios
+### Manual testing scenarios (*)
 <!---
     Please provide a set of unambiguous steps to test the proposed code change.
     Giving us manual testing scenarios will help with the processing and validation process.
@@ -30,7 +31,7 @@
 1. ...
 2. ...
 
-### Contribution checklist
+### Contribution checklist (*)
  - [ ] Pull request has a meaningful description of its purpose
  - [ ] All commits are accompanied by meaningful commit messages
  - [ ] All new or changed code is covered with unit/integration tests (if applicable)


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Developers submit PRs and issues without the template. This PR adds required fields.
Original PR https://github.com/magento/magento2/pull/18343
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Not relevant

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a PR or issue
2. New text reads "Fields marked with (*) are required. Please don't remove the template."

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x]  All automated tests passed successfully (all builds on Travis CI are green)
