### PR TITLE
18615 updates structure for last_trans_id to match structures for amazon and klarna.

### DIFF
--- a/app/code/Magento/Sales/etc/db_schema.xml
+++ b/app/code/Magento/Sales/etc/db_schema.xml
@@ -663,7 +663,7 @@
         <column xsi:type="varchar" name="cc_ss_start_month" nullable="true" length="128" comment="Cc Ss Start Month"/>
         <column xsi:type="varchar" name="echeck_account_type" nullable="true" length="255"
                 comment="Echeck Account Type"/>
-        <column xsi:type="varchar" name="last_trans_id" nullable="true" length="32" comment="Last Trans Id"/>
+        <column xsi:type="varchar" name="last_trans_id" nullable="true" length="255" comment="Last Trans Id"/>
         <column xsi:type="varchar" name="cc_cid_status" nullable="true" length="32" comment="Cc Cid Status"/>
         <column xsi:type="varchar" name="cc_owner" nullable="true" length="128" comment="Cc Owner"/>
         <column xsi:type="varchar" name="cc_type" nullable="true" length="32" comment="Cc Type"/>


### PR DESCRIPTION
### Description (*)

- Resolves 18615 
- Klarna orders are not being stored correctly in 'sales_order_payment'.'last_trans_id' due to the structure of the field having a limit of 32 characters where as the klarna reference is currently 36 characters.
- The structure for last_trans_id has been updated from Varchar 32 to Varchar 255
- This is inline with the structures for:
    - klarna_core_order order_id
    -  amazon_sales_order amazon_order_reference_id
- This should provide greater compatibility with 3rd party payments.

### Fixed Issues (if relevant)
1. magento/magento2#18615: Field restriction incompatibilities between klarna_core_order and sales_order_payment last_trans_id

### Manual testing scenarios (*)
1. Configure klarna payment gateway in sandbox mode https://playground.eu.portal.klarna.com
2. Place test order using Klarna 
3. Observe the 'sales_order_payment'.'last_trans_id' and record reference
4. Compare this reference with the value stored in 'klarna_core_order'.'klarna_order_id'
5. Configure amazon payment gateway in sandbox mode
6. Place test order using Amazon 
7. Observe the 'sales_order_payment'.'last_trans_id' and record reference
8. Compare this reference with the value stored in 'amzon_sales_order'.'amazon_order_reference_id'

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds on Travis CI are green)
