### PR TITLE
Add MAGE_RUN_TYPE+MAGE_RUN_CODE to FPC identifier

### DIFF
--- a/lib/internal/Magento/Framework/App/PageCache/Identifier.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Identifier.php
@@ -53,6 +53,8 @@ class Identifier
         $data = [
             $this->request->isSecure(),
             $this->request->getUriString(),
+            $this->request->getServerValue(StoreManager::PARAM_RUN_TYPE),
+            $this->request->getServerValue(StoreManager::PARAM_RUN_CODE),
             $this->request->get(\Magento\Framework\App\Response\Http::COOKIE_VARY_STRING)
                 ?: $this->context->getVaryString()
         ];


### PR DESCRIPTION
### Description (*)

Currently Magento 2.2.6 full page cache does not work correctly, when using SetEnv or similar techniques on unchanged URLs

So the MAGE_RUN_TYPE and MAGE_RUN_CODE should be added to the FPC identifier to allow for such use cases.

A common case is Magento 2 behind a reverse NGINX proxy.

### Manual testing scenarios (*)

Steps to reproduce, without proxy setup:
1) In pub/.htaccess set

SetEnv MAGE_RUN_TYPE store SetEnv MAGE_RUN_CODE italy

2) Now open Frontend

3) Now set

SetEnv MAGE_RUN_TYPE store SetEnv MAGE_RUN_CODE english

4) Now Open frontend, same URL

-> Italian version is displayed

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ x All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
