### PR TITLE
Add MAGE_RUN_TYPE+MAGE_RUN_CODE to FPC identifier

### DIFF
--- a/app/code/Magento/PageCache/Model/App/CacheIdentifierPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/CacheIdentifierPlugin.php
@@ -10,6 +10,7 @@ use Magento\Store\Model\StoreManager;
 
 /**
  * Class CachePlugin
+ *
  * Should add design exceptions o identifier for built-in cache
  */
 class CacheIdentifierPlugin

--- a/app/code/Magento/PageCache/Model/App/CacheIdentifierPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/CacheIdentifierPlugin.php
@@ -6,6 +6,8 @@
 
 namespace Magento\PageCache\Model\App;
 
+use Magento\Store\Model\StoreManager;
+
 /**
  * Class CachePlugin
  * Should add design exceptions o identifier for built-in cache
@@ -40,10 +42,23 @@ class CacheIdentifierPlugin
     public function afterGetValue(\Magento\Framework\App\PageCache\Identifier $identifier, $result)
     {
         if ($this->config->getType() == \Magento\PageCache\Model\Config::BUILT_IN && $this->config->isEnabled()) {
+            $identifierPrefix = '';
+
             $ruleDesignException = $this->designExceptions->getThemeByRequest($this->request);
             if ($ruleDesignException !== false) {
-                return $ruleDesignException . $result;
+                $identifierPrefix .= 'DESIGN' . '=' . $ruleDesignException . '|';
             }
+
+            if ($runType = $this->request->getServerValue(StoreManager::PARAM_RUN_TYPE)) {
+                $identifierPrefix .= StoreManager::PARAM_RUN_TYPE . '=' .  $runType . '|';
+            }
+
+            if ($runCode = $this->request->getServerValue(StoreManager::PARAM_RUN_CODE)) {
+                $identifierPrefix .= StoreManager::PARAM_RUN_CODE . '=' . $runCode . '|';
+            }
+
+            return $identifierPrefix . $result;
+
         }
         return $result;
     }

--- a/app/code/Magento/PageCache/Test/Unit/App/CacheIdentifierPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/App/CacheIdentifierPluginTest.php
@@ -11,6 +11,7 @@ use Magento\Store\Model\StoreManager;
 
 /**
  * Class CacheIdentifierPluginTest
+ *
  * Test for plugin to identifier to work with design exceptions
  */
 class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
@@ -97,7 +98,8 @@ class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
             'Built-in + PageCache enabled' => [Config::BUILT_IN, true, null, false, false],
             'Built-in, PageCache enabled, no user-agent exceptions' =>
                 [Config::BUILT_IN, true, 'aa123aa', false, 'aa123aa'],
-            'Built-in, PageCache enabled, with design exception' => [Config::BUILT_IN, true, 'aa123aa', '7', 'DESIGN=7|aa123aa']
+            'Built-in, PageCache enabled, with design exception' =>
+                [Config::BUILT_IN, true, 'aa123aa', '7', 'DESIGN=7|aa123aa']
         ];
     }
 

--- a/app/code/Magento/PageCache/Test/Unit/App/CacheIdentifierPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/App/CacheIdentifierPluginTest.php
@@ -6,7 +6,6 @@
 namespace Magento\PageCache\Test\Unit\App;
 
 use Magento\PageCache\Model\Config;
-use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManager;
 
 /**
@@ -96,10 +95,18 @@ class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
             'Varnish + PageCache enabled' => [Config::VARNISH, true, null, false, false],
             'Built-in + PageCache disabled' => [Config::BUILT_IN, false, null, false, false],
             'Built-in + PageCache enabled' => [Config::BUILT_IN, true, null, false, false],
-            'Built-in, PageCache enabled, no user-agent exceptions' =>
-                [Config::BUILT_IN, true, 'aa123aa', false, 'aa123aa'],
-            'Built-in, PageCache enabled, with design exception' =>
-                [Config::BUILT_IN, true, 'aa123aa', '7', 'DESIGN=7|aa123aa']
+            'Built-in, PageCache enabled, no user-agent exceptions' => [Config::BUILT_IN,
+                true,
+                'aa123aa',
+                false,
+                'aa123aa'
+            ],
+            'Built-in, PageCache enabled, with design exception' => [Config::BUILT_IN,
+                true,
+                'aa123aa',
+                '7',
+                'DESIGN=7|aa123aa'
+            ]
         ];
     }
 
@@ -121,14 +128,16 @@ class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
         $defaultRequestMock = clone $this->requestMock;
         $defaultRequestMock->expects($this->any())
             ->method('getServerValue')
-            ->willReturnCallback(function ($param) {
-                if ($param == StoreManager::PARAM_RUN_TYPE) {
-                    return 'store';
+            ->willReturnCallback(
+                function ($param) {
+                    if ($param == StoreManager::PARAM_RUN_TYPE) {
+                        return 'store';
+                    }
+                    if ($param == StoreManager::PARAM_RUN_CODE) {
+                        return 'default';
+                    }
                 }
-                if ($param == StoreManager::PARAM_RUN_CODE) {
-                    return 'default';
-                }
-            });
+            );
 
         $nullSha1 = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
 
@@ -143,14 +152,16 @@ class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
         $otherRequestMock = clone $this->requestMock;
         $otherRequestMock->expects($this->any())
             ->method('getServerValue')
-            ->willReturnCallback(function ($param) {
-                if ($param == StoreManager::PARAM_RUN_TYPE) {
-                    return 'store';
+            ->willReturnCallback(
+                function ($param) {
+                    if ($param == StoreManager::PARAM_RUN_TYPE) {
+                        return 'store';
+                    }
+                    if ($param == StoreManager::PARAM_RUN_CODE) {
+                        return 'klingon';
+                    }
                 }
-                if ($param == StoreManager::PARAM_RUN_CODE) {
-                    return 'klingon';
-                }
-            });
+            );
 
         $otherPlugin = new \Magento\PageCache\Model\App\CacheIdentifierPlugin(
             $this->designExceptionsMock,

--- a/app/code/Magento/PageCache/Test/Unit/App/CacheIdentifierPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/App/CacheIdentifierPluginTest.php
@@ -6,6 +6,8 @@
 namespace Magento\PageCache\Test\Unit\App;
 
 use Magento\PageCache\Model\Config;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManager;
 
 /**
  * Class CacheIdentifierPluginTest
@@ -56,7 +58,7 @@ class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test of adding design exceptions to the kay of cache hash
+     * Test of adding design exceptions + run code to the key of cache hash
      *
      * @param string $cacheType
      * @param bool $isPageCacheEnabled
@@ -95,7 +97,68 @@ class CacheIdentifierPluginTest extends \PHPUnit\Framework\TestCase
             'Built-in + PageCache enabled' => [Config::BUILT_IN, true, null, false, false],
             'Built-in, PageCache enabled, no user-agent exceptions' =>
                 [Config::BUILT_IN, true, 'aa123aa', false, 'aa123aa'],
-            'Built-in, PageCache enabled, with design exception' => [Config::BUILT_IN, true, 'aa123aa', '7', '7aa123aa']
+            'Built-in, PageCache enabled, with design exception' => [Config::BUILT_IN, true, 'aa123aa', '7', 'DESIGN=7|aa123aa']
         ];
+    }
+
+    /**
+     * Tests that different stores cause different identifiers
+     * (property based testing approach)
+     */
+    public function testAfterGetValueRunParamsCauseDifferentIdentifiers()
+    {
+        $identifierMock = $this->createMock(\Magento\Framework\App\PageCache\Identifier::class);
+
+        $this->pageCacheConfigMock->expects($this->any())
+            ->method('getType')
+            ->willReturn(Config::BUILT_IN);
+        $this->pageCacheConfigMock->expects($this->any())
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $defaultRequestMock = clone $this->requestMock;
+        $defaultRequestMock->expects($this->any())
+            ->method('getServerValue')
+            ->willReturnCallback(function ($param) {
+                if ($param == StoreManager::PARAM_RUN_TYPE) {
+                    return 'store';
+                }
+                if ($param == StoreManager::PARAM_RUN_CODE) {
+                    return 'default';
+                }
+            });
+
+        $nullSha1 = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
+
+        $defaultPlugin = new \Magento\PageCache\Model\App\CacheIdentifierPlugin(
+            $this->designExceptionsMock,
+            $defaultRequestMock,
+            $this->pageCacheConfigMock
+        );
+
+        $defaultStoreResult = $defaultPlugin->afterGetValue($identifierMock, $nullSha1);
+
+        $otherRequestMock = clone $this->requestMock;
+        $otherRequestMock->expects($this->any())
+            ->method('getServerValue')
+            ->willReturnCallback(function ($param) {
+                if ($param == StoreManager::PARAM_RUN_TYPE) {
+                    return 'store';
+                }
+                if ($param == StoreManager::PARAM_RUN_CODE) {
+                    return 'klingon';
+                }
+            });
+
+        $otherPlugin = new \Magento\PageCache\Model\App\CacheIdentifierPlugin(
+            $this->designExceptionsMock,
+            $otherRequestMock,
+            $this->pageCacheConfigMock
+        );
+        $otherStoreResult = $otherPlugin->afterGetValue($identifierMock, $nullSha1);
+
+        $this->assertNotEquals($nullSha1, $defaultStoreResult);
+        $this->assertNotEquals($nullSha1, $otherStoreResult);
+        $this->assertNotEquals($defaultStoreResult, $otherStoreResult);
     }
 }

--- a/lib/internal/Magento/Framework/App/PageCache/Identifier.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Identifier.php
@@ -56,6 +56,7 @@ class Identifier
             $this->request->get(\Magento\Framework\App\Response\Http::COOKIE_VARY_STRING)
                 ?: $this->context->getVaryString()
         ];
+
         return sha1($this->serializer->serialize($data));
     }
 }


### PR DESCRIPTION
### Description

Currently Magento 2.2.6 full page cache does not work correctly, when using SetEnv or similar techniques on unchanged URLs

So the MAGE_RUN_TYPE and MAGE_RUN_CODE should be added to the FPC identifier to allow for such use cases.

A common case is Magento 2 behind a reverse NGINX proxy.

### Manual testing scenarios

Steps to reproduce, without proxy setup:
1) In pub/.htaccess set

SetEnv MAGE_RUN_TYPE store SetEnv MAGE_RUN_CODE italy

2) Now open Frontend

3) Now set

SetEnv MAGE_RUN_TYPE store SetEnv MAGE_RUN_CODE english

4) Now Open frontend, same URL

-> Italian version is displayed

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
