### PR TITLE
Fixed incorrect datepicker icon position in admin panel

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_calendar-temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_calendar-temp.less
@@ -43,7 +43,7 @@
         height: @action__height;
         margin-left: -@action__height;
         overflow: hidden;
-        position: relative;
+        position: absolute;
         vertical-align: top;
         z-index: 1;
 


### PR DESCRIPTION
### Description (*)

The datepicker icons position in the admin panel is incorrect after porting a fix that is not actual for Magento 2.2+ (https://github.com/magento/magento2/pull/16776).

As result, we have the following position instead of the correct one:

![image](https://user-images.githubusercontent.com/2148959/46961144-65703f80-d0a0-11e8-8641-725311f55fa9.png)

This PR fixes the icons position

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/18605 : Calendar Icon is displaced at the Backend

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to the admin panel
2. Create a new product or edit an existing one
3. Check the "Set Product as New From" attribute

The icons possition should be correct

(Thank you @larsroettig for providing the detailed information)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
