### PR TITLE
Fix for issue magento/magento2#18630

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
@@ -21,6 +21,21 @@ define([
         },
 
         /**
+         * Initializes observable properties of instance
+         *
+         * @returns {Abstract} Chainable.
+         */
+        initObservable: function () {
+            this._super();
+
+            this.value.equalityComparer = function(a, b) {
+                return (!a && !b) || (a == b);
+            };
+
+            return this;
+        },
+
+        /**
          * @param {String} value
          */
         update: function (value) {


### PR DESCRIPTION
### Description (*)

When in the `core_config_data` table the setting for `tax/defaults/postcode` is NULL the compare on the frontend is breaking because NULL != " ". This fix resolves that issue. 

### Fixed Issues
1. magento/magento2#18630: Postcode / Zipcode in checkout form already validated on page load

### Manual testing scenarios (*)

See steps in issue to reproduce original issue. 