### PR TITLE
#17460 Add to cart ajax not working on Simple product page with custom option type date

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
@@ -10,7 +10,7 @@
 <?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_optionId = $_option->getId() ?>
-<?php $class = ($_option->getIsRequire()) ? ' required' : ''; ?>
+<?php $class = $_option->getIsRequire() ? ' required' : ''; ?>
 <div class="field date<?= /* @escapeNotVerified */ $class ?>"
     data-mage-init='{"priceOptionDate":{"fromSelector":"#product_addtocart_form"}}'>
     <fieldset class="fieldset fieldset-product-options-inner<?= /* @escapeNotVerified */ $class ?>">
@@ -44,15 +44,6 @@
                        value=""
                        data-validate="{'validate-optional-datetime':<?= /* @escapeNotVerified */ $_optionId ?>}"/>
             <?php endif; ?>
-            <script type="text/x-magento-init">
-            {
-                "#product_addtocart_form": {
-                    "validation": {
-                        "ignore": ":hidden:not(input[name^='validate_datetime_'])"
-                    }
-                }
-            }
-        </script>
         </div>
     </fieldset>
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Add to cart Ajax is not working on Simple product page when product has a custom option type: date as a result the page reloads when product is added to the cart.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17460: Add to cart Ajax not working on Simple product page with custom option type - date

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create simple product.
2. Add custom option with option type Date > Date
3. Add price (Price Type Fixed) and option sku.
4. Go to product page and try to add to cart.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
