### PR TITLE
[Backport] Fix issue with unexpected changing of subscription status after customer saving

### DIFF
--- a/app/code/Magento/Newsletter/Model/ResourceModel/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/ResourceModel/Subscriber.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Newsletter\Model\ResourceModel;
 
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\ObjectManager;
+
 /**
  * Newsletter subscriber resource model
  *
@@ -49,21 +52,32 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     protected $mathRandom;
 
     /**
+     * Store manager
+     *
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * Construct
      *
      * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
      * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param \Magento\Framework\Math\Random $mathRandom
      * @param string $connectionName
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         \Magento\Framework\Model\ResourceModel\Db\Context $context,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Magento\Framework\Math\Random $mathRandom,
-        $connectionName = null
+        $connectionName = null,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->_date = $date;
         $this->mathRandom = $mathRandom;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()
+            ->get(StoreManagerInterface::class);
         parent::__construct($context, $connectionName);
     }
 
@@ -118,6 +132,9 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function loadByCustomerData(\Magento\Customer\Api\Data\CustomerInterface $customer)
     {
+        $storeId = (int)$customer->getStoreId() ?: $this->storeManager
+            ->getWebsite($customer->getWebsiteId())->getDefaultStore()->getId();
+
         $select = $this->connection
             ->select()
             ->from($this->getMainTable())
@@ -128,7 +145,7 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 $select,
                 [
                     'customer_id' => $customer->getId(),
-                    'store_id' => $customer->getStoreId()
+                    'store_id' => $storeId
                 ]
             );
 
@@ -146,7 +163,7 @@ class Subscriber extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 $select,
                 [
                     'subscriber_email' => $customer->getEmail(),
-                    'store_id' => $customer->getStoreId()
+                    'store_id' => $storeId
                 ]
             );
 

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -610,16 +610,17 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
 
         $this->setStatus($status);
 
+        $storeId = $customerData->getStoreId();
+        if ((int)$customerData->getStoreId() === 0) {
+            $storeId = $this->_storeManager->getWebsite($customerData->getWebsiteId())->getDefaultStore()->getId();
+        }
+
         if (!$this->getId()) {
-            $storeId = $customerData->getStoreId();
-            if ($customerData->getStoreId() == 0) {
-                $storeId = $this->_storeManager->getWebsite($customerData->getWebsiteId())->getDefaultStore()->getId();
-            }
             $this->setStoreId($storeId)
                 ->setCustomerId($customerData->getId())
                 ->setEmail($customerData->getEmail());
         } else {
-            $this->setStoreId($customerData->getStoreId())
+            $this->setStoreId($storeId)
                 ->setEmail($customerData->getEmail());
         }
 

--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriberTest.php
@@ -211,6 +211,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateSubscription()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -232,7 +233,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('getConfirmationStatus')
             ->with($customerId)
             ->willReturn('account_confirmation_required');
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
 
         $storeModel = $this->getMockBuilder(\Magento\Store\Model\Store::class)
@@ -246,6 +247,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testUnsubscribeCustomerById()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -263,7 +265,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
 
@@ -272,6 +274,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testSubscribeCustomerById()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -289,7 +292,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
 
@@ -298,6 +301,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testSubscribeCustomerById1()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -315,7 +319,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
         $this->customerAccountManagement->expects($this->once())
@@ -329,6 +333,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testSubscribeCustomerByIdAfterConfirmation()
     {
+        $storeId = 2;
         $customerId = 1;
         $customerDataMock = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
             ->getMock();
@@ -346,7 +351,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
             );
         $customerDataMock->expects($this->atLeastOnce())->method('getId')->willReturn('id');
         $this->resource->expects($this->atLeastOnce())->method('save')->willReturnSelf();
-        $customerDataMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
+        $customerDataMock->expects($this->exactly(2))->method('getStoreId')->willReturn($storeId);
         $customerDataMock->expects($this->once())->method('getEmail')->willReturn('email');
         $this->sendEmailCheck();
         $this->customerAccountManagement->expects($this->never())->method('getConfirmationStatus');

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/Plugin/PluginTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/Plugin/PluginTest.php
@@ -167,4 +167,42 @@ class PluginTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, (int)$subscriber->getId());
         return $subscriber;
     }
+
+    /**
+     * @magentoAppArea adminhtml
+     * @magentoDbIsolation enabled
+     */
+    public function testCustomerWithZeroStoreIdIsSubscribed()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+
+        $currentStore = $objectManager->get(
+            \Magento\Store\Model\StoreManagerInterface::class
+        )->getStore()->getId();
+
+        $subscriber = $objectManager->create(\Magento\Newsletter\Model\Subscriber::class);
+        /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
+        $subscriber->setStoreId($currentStore)
+            ->setCustomerId(0)
+            ->setSubscriberEmail('customer@example.com')
+            ->setSubscriberStatus(\Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED)
+            ->save();
+
+        /** @var \Magento\Customer\Api\Data\CustomerInterfaceFactory $customerFactory */
+        $customerFactory = $objectManager->get(\Magento\Customer\Api\Data\CustomerInterfaceFactory::class);
+        $customerDataObject = $customerFactory->create()
+            ->setFirstname('Firstname')
+            ->setLastname('Lastname')
+            ->setStoreId(0)
+            ->setEmail('customer@example.com');
+        /** @var \Magento\Customer\Api\Data\CustomerInterface $customer */
+        $customer = $this->accountManagement->createAccount($customerDataObject);
+
+        $this->customerRepository->save($customer);
+
+        $subscriber->loadByEmail('customer@example.com');
+
+        $this->assertEquals($customer->getId(), (int)$subscriber->getCustomerId());
+        $this->assertEquals($currentStore, (int)$subscriber->getStoreId());
+    }
 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18488

### Description
If in some cases (for example: after migration data from M1) customer will have store_id = 0 and there are subscriber that related to this customer, after re-saving customer data, it might cause unexpected "unsubscribe" letter which would confuse customer experience. 

My changes solves this problem because of adding additional checking storeId and if it's 0, getting it directly from the website.

### Manual testing scenarios
1. Create new customer 
1. Create customer
2. Go to MySQL and set store_id = 0 in customer_entity table for this customer
3. Go to MySQL and create record in newsletter_subscriber for this customer but with correct store_id and subscribe_status = 1.
4. Go to backend -> Customers and open it for edit
5. Change some customer data (for example, name) and save user

**Expected result:**
Nothing, except saving customer data, will happen

**Actual result:**
Customer will receive unsubscription letter.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
