### PR TITLE
Write intercepted mapping to generated/metadata during compilation

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -28,6 +28,7 @@
     <preference for="Magento\Framework\App\CacheInterface" type="Magento\Framework\App\Cache\Proxy" />
     <preference for="Magento\Framework\App\Cache\StateInterface" type="Magento\Framework\App\Cache\State" />
     <preference for="Magento\Framework\App\Cache\TypeListInterface" type="Magento\Framework\App\Cache\TypeList" />
+    <preference for="Magento\Framework\App\ObjectManager\ConfigWriterInterface" type="Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem" />
     <preference for="Magento\Store\Model\StoreManagerInterface" type="Magento\Store\Model\StoreManager" />
     <preference for="Magento\Framework\View\DesignInterface" type="Magento\Theme\Model\View\Design\Proxy" />
     <preference for="Magento\Framework\View\Design\ThemeInterface" type="Magento\Theme\Model\Theme" />
@@ -410,6 +411,11 @@
             <argument name="cache" xsi:type="object">Magento\Framework\App\Cache\Type\Config</argument>
             <argument name="reader" xsi:type="object">Magento\Framework\ObjectManager\Config\Reader\Dom\Proxy</argument>
             <argument name="cacheId" xsi:type="string">interception</argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\Interception\Config\CacheManager">
+        <arguments>
+            <argument name="cache" xsi:type="object">Magento\Framework\App\Cache\Type\Config</argument>
         </arguments>
     </type>
     <type name="Magento\Framework\Interception\PluginList\PluginList">

--- a/dev/tests/integration/testsuite/Magento/Framework/App/ObjectManager/ConfigWriter/FilesystemTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/ObjectManager/ConfigWriter/FilesystemTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\App\ObjectManager\ConfigWriter;
+
+class FilesystemTest extends \PHPUnit\Framework\TestCase
+{
+    const CACHE_KEY = 'filesystemtest';
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem
+     */
+    private $configWriter;
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigLoader
+     */
+    private $configReader;
+
+    protected function setUp()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->configWriter = $objectManager->create(
+            \Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class
+        );
+        $this->configReader = $objectManager->create(
+            \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class
+        );
+    }
+
+    public function testWrite()
+    {
+        $sampleData = [
+            'classA' => true,
+            'classB' => false,
+        ];
+
+        $this->configWriter->write(self::CACHE_KEY, $sampleData);
+        $this->assertEquals($sampleData, $this->configReader->load(self::CACHE_KEY));
+    }
+
+    public function testOverwrite()
+    {
+        $this->configWriter->write(self::CACHE_KEY, ['hello' => 'world']);
+
+        $sampleData = [
+            'classC' => false,
+            'classD' => true,
+        ];
+
+        $this->configWriter->write(self::CACHE_KEY, $sampleData);
+        $this->assertEquals($sampleData, $this->configReader->load(self::CACHE_KEY));
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/AbstractPlugin.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/AbstractPlugin.php
@@ -59,7 +59,8 @@ abstract class AbstractPlugin extends \PHPUnit\Framework\TestCase
         $areaList->expects($this->any())->method('getCodes')->will($this->returnValue([]));
         $configScope = new \Magento\Framework\Config\Scope($areaList, 'global');
         $cache = $this->createMock(\Magento\Framework\Config\CacheInterface::class);
-        $cache->expects($this->any())->method('load')->will($this->returnValue(false));
+        $cacheManager = $this->createMock(\Magento\Framework\Interception\Config\CacheManager::class);
+        $cacheManager->method('load')->willReturn(null);
         $definitions = new \Magento\Framework\ObjectManager\Definition\Runtime();
         $relations = new \Magento\Framework\ObjectManager\Relations\Runtime();
         $interceptionConfig = new Config\Config(
@@ -68,7 +69,10 @@ abstract class AbstractPlugin extends \PHPUnit\Framework\TestCase
             $cache,
             $relations,
             $config,
-            $definitions
+            $definitions,
+            'interception',
+            null,
+            $cacheManager
         );
         $interceptionDefinitions = new Definition\Runtime();
         $json = new \Magento\Framework\Serialize\Serializer\Json();

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/AbstractPlugin.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/AbstractPlugin.php
@@ -7,25 +7,35 @@ namespace Magento\Framework\Interception;
 
 /**
  * Class GeneralTest
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 abstract class AbstractPlugin extends \PHPUnit\Framework\TestCase
 {
     /**
+     * Config reader
+     *
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     protected $_configReader;
 
     /**
+     * Object Manager
+     *
      * @var \Magento\Framework\ObjectManagerInterface
      */
     protected $_objectManager;
 
     /**
+     * Applicartion Object Manager
+     *
      * @var \Magento\Framework\ObjectManagerInterface
      */
     private $applicationObjectManager;
 
+    /**
+     * Set up
+     */
     public function setUp()
     {
         if (!$this->_objectManager) {
@@ -36,11 +46,17 @@ abstract class AbstractPlugin extends \PHPUnit\Framework\TestCase
         \Magento\Framework\App\ObjectManager::setInstance($this->_objectManager);
     }
 
+    /**
+     * Tear down
+     */
     public function tearDown()
     {
         \Magento\Framework\App\ObjectManager::setInstance($this->applicationObjectManager);
     }
 
+    /**
+     * Set up Interception Config
+     */
     public function setUpInterceptionConfig($pluginConfig)
     {
         $config = new \Magento\Framework\Interception\ObjectManager\Config\Developer();

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/CacheManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/CacheManagerTest.php
@@ -10,7 +10,7 @@ namespace Magento\Framework\Interception\Config;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
 
-class ConfigTest extends \PHPUnit\Framework\TestCase
+class CacheManagerTest extends \PHPUnit\Framework\TestCase
 {
     const CACHE_ID = 'interceptiontest';
 
@@ -68,9 +68,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->configWriter->write(self::CACHE_ID, $testConfig);
         $config = $this->getConfig();
 
-        foreach ($testConfig as $className => $hasPlugins) {
-            $this->assertEquals($hasPlugins, $config->hasPlugins($className));
-        }
+        $this->assertEquals($testConfig, $config->load(self::CACHE_ID));
     }
 
     /**
@@ -83,9 +81,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->cache->save($this->serializer->serialize($testConfig), self::CACHE_ID);
         $config = $this->getConfig();
 
-        foreach ($testConfig as $className => $hasPlugins) {
-            $this->assertEquals($hasPlugins, $config->hasPlugins($className));
-        }
+        $this->assertEquals($testConfig, $config->load(self::CACHE_ID));
     }
 
     public function interceptionCompiledConfigDataProvider()
@@ -121,16 +117,15 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
      * from altering the interception config that may have been generated during application
      * installation. Inject a new instance of the compileLoaded to bypass it's caching.
      *
-     * @return \Magento\Framework\Interception\Config\Config
+     * @return \Magento\Framework\Interception\Config\CacheManager
      */
     private function getConfig()
     {
         return $this->objectManager->create(
-            \Magento\Framework\Interception\Config\Config::class,
+            \Magento\Framework\Interception\Config\CacheManager::class,
             [
                 'cacheId' => self::CACHE_ID,
                 'compiledLoader' => $this->objectManager->create(\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class),
-                'serializer' => $this->serializer,
             ]
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/CacheManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/CacheManagerTest.php
@@ -40,7 +40,8 @@ class CacheManagerTest extends \PHPUnit\Framework\TestCase
 
         $this->serializer = $this->objectManager->get(\Magento\Framework\Serialize\SerializerInterface::class);
         $this->cache = $this->objectManager->get(\Magento\Framework\App\CacheInterface::class);
-        $this->configWriter = $this->objectManager->get(\Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class);
+        $this->configWriter = 
+            $this->objectManager->get(\Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class);
 
         $this->initializeMetadataDirectory();
     }
@@ -125,7 +126,9 @@ class CacheManagerTest extends \PHPUnit\Framework\TestCase
             \Magento\Framework\Interception\Config\CacheManager::class,
             [
                 'cacheId' => self::CACHE_ID,
-                'compiledLoader' => $this->objectManager->create(\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class),
+                'compiledLoader' => $this->objectManager->create(
+                    \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class
+                ),
             ]
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/ConfigTest.php
@@ -38,7 +38,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
 
-        $this->serializer = $this->objectManager->get(\Magento\Framework\Serialize\Serializer\Serialize::class);
+        $this->serializer = $this->objectManager->get(\Magento\Framework\Serialize\SerializerInterface::class);
         $this->cache = $this->objectManager->get(\Magento\Framework\App\CacheInterface::class);
         $this->configWriter = $this->objectManager->get(\Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class);
 
@@ -130,6 +130,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             [
                 'cacheId' => self::CACHE_ID,
                 'compiledLoader' => $this->objectManager->create(\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class),
+                'serializer' => $this->serializer,
             ]
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/Config/ConfigTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\Interception\Config;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+class ConfigTest extends \PHPUnit\Framework\TestCase
+{
+    const CACHE_ID = 'interceptiontest';
+
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var \Magento\Framework\Cache\FrontendInterface
+     */
+    private $cache;
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigWriterInterface
+     */
+    private $configWriter;
+
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+        $this->serializer = $this->objectManager->get(\Magento\Framework\Serialize\Serializer\Serialize::class);
+        $this->cache = $this->objectManager->get(\Magento\Framework\App\CacheInterface::class);
+        $this->configWriter = $this->objectManager->get(\Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class);
+
+        $this->initializeMetadataDirectory();
+    }
+
+    /**
+     * Delete compiled file if it was created and clear cache data
+     */
+    protected function tearDown()
+    {
+        $compiledPath = \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::getFilePath(self::CACHE_ID);
+        if (file_exists($compiledPath)) {
+            unlink($compiledPath);
+        }
+
+        $this->cache->remove(self::CACHE_ID);
+    }
+
+    /**
+     * Test load interception cache from generated/metadata
+     * @dataProvider interceptionCompiledConfigDataProvider
+     * @param array $testConfig
+     */
+    public function testInstantiateFromCompiled(array $testConfig)
+    {
+        $this->configWriter->write(self::CACHE_ID, $testConfig);
+        $config = $this->getConfig();
+
+        foreach ($testConfig as $className => $hasPlugins) {
+            $this->assertEquals($hasPlugins, $config->hasPlugins($className));
+        }
+    }
+
+    /**
+     * Test load interception cache from backend cache
+     * @dataProvider interceptionCacheConfigDataProvider
+     * @param array $testConfig
+     */
+    public function testInstantiateFromCache(array $testConfig)
+    {
+        $this->cache->save($this->serializer->serialize($testConfig), self::CACHE_ID);
+        $config = $this->getConfig();
+
+        foreach ($testConfig as $className => $hasPlugins) {
+            $this->assertEquals($hasPlugins, $config->hasPlugins($className));
+        }
+    }
+
+    public function interceptionCompiledConfigDataProvider()
+    {
+        return [
+            [['classA' => true, 'classB' => false]],
+            [['classA' => false, 'classB' => true]],
+        ];
+    }
+
+    public function interceptionCacheConfigDataProvider()
+    {
+        return [
+            [['classC' => true, 'classD' => false]],
+            [['classC' => false, 'classD' => true]],
+        ];
+    }
+
+    /**
+     * Ensure generated/metadata exists
+     */
+    private function initializeMetadataDirectory()
+    {
+        $diPath = DirectoryList::getDefaultConfig()[DirectoryList::GENERATED_METADATA][DirectoryList::PATH];
+        $fullPath = BP . DIRECTORY_SEPARATOR . $diPath;
+        if (!file_exists($fullPath)) {
+            mkdir($fullPath);
+        }
+    }
+
+    /**
+     * Create instance of Config class with specific cacheId. This is done to prevent our test
+     * from altering the interception config that may have been generated during application
+     * installation. Inject a new instance of the compileLoaded to bypass it's caching.
+     *
+     * @return \Magento\Framework\Interception\Config\Config
+     */
+    private function getConfig()
+    {
+        return $this->objectManager->create(
+            \Magento\Framework\Interception\Config\Config::class,
+            [
+                'cacheId' => self::CACHE_ID,
+                'compiledLoader' => $this->objectManager->create(\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class),
+            ]
+        );
+    }
+}

--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -13,9 +13,9 @@ case $TEST_SUITE in
 
         test_set_list=$(find testsuite/* -maxdepth 1 -mindepth 1 -type d | sort)
         test_set_count=$(printf "$test_set_list" | wc -l)
-        test_set_size[1]=$(printf "%.0f" $(echo "$test_set_count*0.17" | bc))  #17%
-        test_set_size[2]=$(printf "%.0f" $(echo "$test_set_count*0.27" | bc))  #27%
-        test_set_size[3]=$((test_set_count-test_set_size[1]-test_set_size[2])) #56%
+        test_set_size[1]=$(printf "%.0f" $(echo "$test_set_count*0.13" | bc))  #13%
+        test_set_size[2]=$(printf "%.0f" $(echo "$test_set_count*0.30" | bc))  #30%
+        test_set_size[3]=$((test_set_count-test_set_size[1]-test_set_size[2])) #55%
         echo "Total = ${test_set_count}; Batch #1 = ${test_set_size[1]}; Batch #2 = ${test_set_size[2]}; Batch #3 = ${test_set_size[3]};";
 
         echo "==> preparing integration testsuite on index $INTEGRATION_INDEX with set size of ${test_set_size[$INTEGRATION_INDEX]}"

--- a/lib/internal/Magento/Framework/App/ObjectManager/ConfigWriter/Filesystem.php
+++ b/lib/internal/Magento/Framework/App/ObjectManager/ConfigWriter/Filesystem.php
@@ -1,20 +1,20 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
-namespace Magento\Setup\Module\Di\Compiler\Config\Writer;
+declare(strict_types=1);
+
+namespace Magento\Framework\App\ObjectManager\ConfigWriter;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Setup\Module\Di\Compiler\Config\WriterInterface;
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
 
 /**
- * @deprecated Moved to Framework to allow broader reuse
- * @see \Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem
+ * @inheritdoc
  */
-class Filesystem implements WriterInterface
+class Filesystem implements ConfigWriterInterface
 {
     /**
      * @var DirectoryList
@@ -22,12 +22,11 @@ class Filesystem implements WriterInterface
     private $directoryList;
 
     /**
-     * Constructor
-     *
      * @param DirectoryList $directoryList
      */
-    public function __construct(DirectoryList $directoryList)
-    {
+    public function __construct(
+        DirectoryList $directoryList
+    ) {
         $this->directoryList = $directoryList;
     }
 
@@ -38,7 +37,7 @@ class Filesystem implements WriterInterface
      * @param array $config
      * @return void
      */
-    public function write($key, array $config)
+    public function write(string $key, array $config)
     {
         $this->initialize();
         $configuration = sprintf('<?php return %s;', var_export($config, true));

--- a/lib/internal/Magento/Framework/App/ObjectManager/ConfigWriterInterface.php
+++ b/lib/internal/Magento/Framework/App/ObjectManager/ConfigWriterInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\App\ObjectManager;
+
+/**
+ * Write compiled object manager configuration to storage
+ */
+interface ConfigWriterInterface
+{
+    /**
+     * Writes config in storage
+     *
+     * @param string $key
+     * @param array $config
+     * @return void
+     */
+    public function write(string $key, array $config);
+}

--- a/lib/internal/Magento/Framework/Interception/Config/CacheManager.php
+++ b/lib/internal/Magento/Framework/Interception/Config/CacheManager.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\Interception\Config;
+
+/**
+ * Interception cache manager responsible for handling interaction with compiled and
+ * uncompiled interception data
+ */
+class CacheManager
+{
+    /**
+     * @var \Magento\Framework\Cache\FrontendInterface
+     */
+    private $cache;
+
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigWriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @var \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled
+     */
+    private $compiledLoader;
+
+    /**
+     * @param \Magento\Framework\Cache\FrontendInterface $cache
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Magento\Framework\App\ObjectManager\ConfigWriterInterface $configWriter
+     * @param \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled $compiledLoader
+     */
+    public function __construct(
+        \Magento\Framework\Cache\FrontendInterface $cache,
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Framework\App\ObjectManager\ConfigWriterInterface $configWriter,
+        \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled $compiledLoader
+    ) {
+        $this->cache = $cache;
+        $this->serializer = $serializer;
+        $this->configWriter = $configWriter;
+        $this->compiledLoader = $compiledLoader;
+    }
+
+    /**
+     * Load the interception config from cache
+     *
+     * @param string $key
+     * @return array|null
+     */
+    public function load(string $key): ?array
+    {
+        if ($this->isCompiled($key)) {
+            return $this->compiledLoader->load($key);
+        }
+
+        $intercepted = $this->cache->load($key);
+        return $intercepted ? $this->serializer->unserialize($intercepted) : null;
+    }
+
+    /**
+     * Save config to cache backend
+     *
+     * @param string $key
+     * @param array $data
+     */
+    public function save(string $key, array $data)
+    {
+        $this->cache->save($this->serializer->serialize($data), $key);
+    }
+
+    /**
+     * Save config to filesystem
+     *
+     * @param string $key
+     * @param array $data
+     */
+    public function saveCompiled(string $key, array $data)
+    {
+        $this->configWriter->write($key, $data);
+    }
+
+    /**
+     * Purge interception cache
+     *
+     * @param string $key
+     */
+    public function clean(string $key)
+    {
+        $this->cache->clean(\Zend_Cache::CLEANING_MODE_MATCHING_TAG, [$key]);
+    }
+
+    /**
+     * Check for the compiled config with the generated metadata
+     *
+     * @param string $key
+     * @return bool
+     */
+    private function isCompiled(string $key): bool
+    {
+        return file_exists(\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::getFilePath($key));
+    }
+}

--- a/lib/internal/Magento/Framework/Interception/Config/CacheManager.php
+++ b/lib/internal/Magento/Framework/Interception/Config/CacheManager.php
@@ -9,8 +9,9 @@ declare(strict_types=1);
 namespace Magento\Framework\Interception\Config;
 
 /**
- * Interception cache manager responsible for handling interaction with compiled and
- * uncompiled interception data
+ * Interception cache manager.
+ *
+ * Responsible for handling interaction with compiled and uncompiled interception data
  */
 class CacheManager
 {

--- a/lib/internal/Magento/Framework/Interception/Config/Config.php
+++ b/lib/internal/Magento/Framework/Interception/Config/Config.php
@@ -79,7 +79,7 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
     private $serializer;
 
     /**
-     * @var \Magento\Setup\Module\Di\Compiler\Config\Writer\Filesystem
+     * @var \Magento\Framework\App\ObjectManager\ConfigWriterInterface
      */
     private $configWriter;
 
@@ -99,7 +99,7 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
      * @param \Magento\Framework\ObjectManager\DefinitionInterface $classDefinitions
      * @param string $cacheId
      * @param SerializerInterface|null $serializer
-     * @param \Magento\Setup\Module\Di\Compiler\Config\Writer\Filesystem $configWriter
+     * @param \Magento\Framework\App\ObjectManager\ConfigWriterInterface $configWriter
      * @param \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled $compiledLoader
      */
     public function __construct(
@@ -111,7 +111,7 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
         \Magento\Framework\ObjectManager\DefinitionInterface $classDefinitions,
         $cacheId = 'interception',
         SerializerInterface $serializer = null,
-        \Magento\Setup\Module\Di\Compiler\Config\Writer\Filesystem $configWriter = null,
+        \Magento\Framework\App\ObjectManager\ConfigWriterInterface $configWriter = null,
         \Magento\Framework\App\ObjectManager\ConfigLoader\Compiled $compiledLoader = null
     ) {
         $this->_omConfig = $omConfig;
@@ -124,7 +124,7 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(Serialize::class);
         $this->configWriter = $configWriter ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Setup\Module\Di\Compiler\Config\Writer\Filesystem::class);
+            ->get(\Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class);
         $this->compiledLoader = $compiledLoader ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::class);
         $intercepted = $this->loadIntercepted();

--- a/lib/internal/Magento/Framework/Interception/Config/Config.php
+++ b/lib/internal/Magento/Framework/Interception/Config/Config.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Interception config. Responsible for providing list of plugins configured for instance
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -9,6 +7,11 @@ namespace Magento\Framework\Interception\Config;
 
 use Magento\Framework\Serialize\SerializerInterface;
 
+/**
+ * Interception config.
+ *
+ * Responsible for providing list of plugins configured for instance
+ */
 class Config implements \Magento\Framework\Interception\ConfigInterface
 {
     /**
@@ -110,7 +113,8 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
         $this->_cacheId = $cacheId;
         $this->_reader = $reader;
         $this->_scopeList = $scopeList;
-        $this->cacheManager = $cacheManager ?? \Magento\Framework\App\ObjectManager::getInstance()->get(CacheManager::class);
+        $this->cacheManager = 
+            $cacheManager ?? \Magento\Framework\App\ObjectManager::getInstance()->get(CacheManager::class);
         $intercepted = $this->cacheManager->load($cacheId);
         if ($intercepted !== null) {
             $this->_intercepted = $intercepted;
@@ -166,7 +170,7 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function hasPlugins($type)
     {
@@ -193,7 +197,7 @@ class Config implements \Magento\Framework\Interception\ConfigInterface
     /**
      * Generate intercepted array to store in compiled metadata or frontend cache
      *
-     * @param $classDefinitions
+     * @param array $classDefinitions
      */
     private function generateIntercepted($classDefinitions)
     {

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -307,8 +307,8 @@ class DiCompileCommand extends Command
     {
         $this->objectManager->configure(
             [
-                'preferences' => [\Magento\Setup\Module\Di\Compiler\Config\WriterInterface::class =>
-                    \Magento\Setup\Module\Di\Compiler\Config\Writer\Filesystem::class,
+                'preferences' => [\Magento\Framework\App\ObjectManager\ConfigWriterInterface::class =>
+                    \Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem::class,
                 ], \Magento\Setup\Module\Di\Compiler\Config\ModificationChain::class => [
                     'arguments' => [
                         'modificationsList' => [

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -103,7 +103,7 @@ class DiCompileCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configure()
     {
@@ -132,7 +132,7 @@ class DiCompileCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
+++ b/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
@@ -28,7 +28,7 @@ class Area implements OperationInterface
     private $configReader;
 
     /**
-     * @var Config\WriterInterface
+     * @var \Magento\Framework\App\ObjectManager\ConfigWriterInterface
      */
     private $configWriter;
 
@@ -46,7 +46,7 @@ class Area implements OperationInterface
      * @param App\AreaList $areaList
      * @param \Magento\Setup\Module\Di\Code\Reader\Decorator\Area $areaInstancesNamesList
      * @param Config\Reader $configReader
-     * @param Config\WriterInterface $configWriter
+     * @param \Magento\Framework\App\ObjectManager\ConfigWriterInterface $configWriter
      * @param \Magento\Setup\Module\Di\Compiler\Config\ModificationChain $modificationChain
      * @param array $data
      */
@@ -54,7 +54,7 @@ class Area implements OperationInterface
         App\AreaList $areaList,
         \Magento\Setup\Module\Di\Code\Reader\Decorator\Area $areaInstancesNamesList,
         Config\Reader $configReader,
-        Config\WriterInterface $configWriter,
+        \Magento\Framework\App\ObjectManager\ConfigWriterInterface $configWriter,
         Config\ModificationChain $modificationChain,
         $data = []
     ) {

--- a/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
+++ b/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
@@ -10,6 +10,9 @@ use Magento\Framework\App;
 use Magento\Setup\Module\Di\Compiler\Config;
 use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
 
+/**
+ * Area configuration aggregation
+ */
 class Area implements OperationInterface
 {
     /**
@@ -67,7 +70,7 @@ class Area implements OperationInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function doOperation()
     {

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Writer/Filesystem.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Writer/Filesystem.php
@@ -11,6 +11,8 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Setup\Module\Di\Compiler\Config\WriterInterface;
 
 /**
+ * Class for writing DI Compiler Configuration
+ *
  * @deprecated Moved to Framework to allow broader reuse
  * @see \Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem
  */

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/WriterInterface.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/WriterInterface.php
@@ -9,7 +9,8 @@ namespace Magento\Setup\Module\Di\Compiler\Config;
 
 /**
  * Interface \Magento\Setup\Module\Di\Compiler\Config\WriterInterface
- *
+ * @deprecated Moved to Framework to allow broader reuse
+ * @see \Magento\Framework\App\ObjectManager\ConfigWriterInterface
  */
 interface WriterInterface
 {

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/App/Task/AreaTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/App/Task/AreaTest.php
@@ -48,7 +48,7 @@ class AreaTest extends \PHPUnit\Framework\TestCase
         $this->configReaderMock = $this->getMockBuilder(\Magento\Setup\Module\Di\Compiler\Config\Reader::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->configWriterMock = $this->getMockBuilder(\Magento\Setup\Module\Di\Compiler\Config\WriterInterface::class)
+        $this->configWriterMock = $this->getMockBuilder(\Magento\Framework\App\ObjectManager\ConfigWriterInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->configChain = $this->getMockBuilder(\Magento\Setup\Module\Di\Compiler\Config\ModificationChain::class)

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/App/Task/AreaTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/App/Task/AreaTest.php
@@ -48,7 +48,8 @@ class AreaTest extends \PHPUnit\Framework\TestCase
         $this->configReaderMock = $this->getMockBuilder(\Magento\Setup\Module\Di\Compiler\Config\Reader::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->configWriterMock = $this->getMockBuilder(\Magento\Framework\App\ObjectManager\ConfigWriterInterface::class)
+        $this->configWriterMock = 
+            $this->getMockBuilder(\Magento\Framework\App\ObjectManager\ConfigWriterInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->configChain = $this->getMockBuilder(\Magento\Setup\Module\Di\Compiler\Config\ModificationChain::class)


### PR DESCRIPTION
### Description (*)
This prevents the intercepted cache from being cleared following compilation
by writing the compiled interception cache to `generated/metadata`. The
mapping is stored in the frontend cache when the mapping metadata file is
not present, ie developer, default modes.

### Fixed Issues (if relevant)
1. magento/magento2#17680 : [2.2.3+][CE/EE][Performance] Interception Cache compilation useless

### Manual testing scenarios (*)
1. Install clean Magento 2.3-deveop Community/Commerce with sample data
2. Add profiler start/stop for next methods:
    * \Magento\Framework\Interception\Config\Config::__construct
    * \Magento\Framework\Interception\PluginList\PluginList::_loadScopedData
    * \Magento\Framework\ObjectManager\Config\Reader\Dom::read
    Note: Profiler start/stop can be added like this:
    ```
     \Magento\Framework\Profiler::start(__METHOD__);
     //Method code here
     \Magento\Framework\Profiler::stop(__METHOD__);
    ```
3. Enable CSV profiler - execute "bin/magento dev:profiler:enable csvfile"
4. Enable PROD mode - execute "bin/magento deploy:mode:set production". This will run setup:di:compile + static:content:deploy
Note step # 4 of di:compile - "Interception cache generation".
5. Run cache:flush
6. Try to open any URL of your store.
7. Inspect profiler results in "var/log/profiler.csv".

### Expected result
1. Our custom profiler records should be executed in less than second together:
    * `Config::__construct`
    * `PluginList::_loadScopedData`
    * `Dom::read`
2. Interception config should be compiled and stored to filesystem like other compiled configs in `generated/metadata` folder. E.g. by using next calls:
    * `\Magento\Setup\Module\Di\Compiler\Config\Writer\Filesystem::write`
    * `\Magento\Framework\App\ObjectManager\ConfigLoader\Compiled::load`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
