### PR TITLE
[Backport] Issue Fixed: Missing Fixed Product Tax total on PDF

### DIFF
--- a/app/code/Magento/Weee/Model/Sales/Pdf/Weee.php
+++ b/app/code/Magento/Weee/Model/Sales/Pdf/Weee.php
@@ -70,4 +70,17 @@ class Weee extends \Magento\Sales\Model\Order\Pdf\Total\DefaultTotal
 
         return $totals;
     }
+
+    /**
+     * Check if we can display Weee total information in PDF
+     *
+     * @return bool
+     */
+    public function canDisplay()
+    {
+        $items = $this->getSource()->getAllItems();
+        $store = $this->getSource()->getStore();
+        $amount = $this->_weeeData->getTotalAmounts($items, $store);
+        return $this->getDisplayZero() === 'true' || $amount != 0;
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Issue of Wee Tax When using FPT, the FPT-total show up at the cart/checkout but is missing at the pdf invoice.

### Description (*)
If we enable FPT and add it to the product, after placing order, FTP amount field is displaying on Order view, Invoice view etc, when downloading Invoice Pdf, FTP amount field was missing. In this pull request
i have fixed it. 

### Fixed Issues (if relevant)

1. #18617 

### Manual testing scenarios (*)
1. Enable FPT from Stores > Settings > Configurations > Sales > Tax > Fixed Product Taxes.
2. Created a new product attribute of type FPT.
3. Added this attribute to Default attribute set.
4. Saved product with FTP details.
5. Placed an order and generated invoice.
6. Print pdf.

Finally FPT column is visible on invoice pdf.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Backport for: https://github.com/magento/magento2/pull/19061