### PR TITLE
issue fixed -Wrong order total in customer information orders tab in admin panel

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Orders.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Orders.php
@@ -123,7 +123,8 @@ class Orders extends \Magento\Backend\Block\Widget\Grid\Extended
                 'header' => __('Order Total'),
                 'index' => 'grand_total',
                 'type' => 'currency',
-                'currency' => 'order_currency_code'
+                'currency' => 'order_currency_code',
+                'rate'  => 1
             ]
         );
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Wrong order total in customer information orders tab in admin panel.

### Description (*)
Customer information orders grid's order total differs from the "orders grid", Order total (in customer information orders grid) is showing wrong if order is placed except base currency. In this pull request
I have fixed it.

### Fixed Issues (if relevant)
1. #18618 

### Manual testing scenarios (*)
1. Set CHF as Default Currency
2. Set GBP currency for United Kingdom website
3. Place order from United Kingdom website.
4. View order total in customer information orders tab in admin panel

Finally Order total column value is showing correct in customer information orders tab.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
