### PR TITLE
revert type change of timeout field from "text comment" back to "text"

### DIFF
--- a/app/code/Magento/Integration/etc/adminhtml/system.xml
+++ b/app/code/Magento/Integration/etc/adminhtml/system.xml
@@ -54,7 +54,7 @@
                     <label>Maximum Login Failures to Lock Out Account</label>
                     <comment>Maximum Number of authentication failures to lock out account.</comment>
                 </field>
-                <field id="timeout" translate="label" type="text comment" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="timeout" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Lockout Time (seconds)</label>
                     <comment>Period of time in seconds after which account will be unlocked.</comment>
                 </field>


### PR DESCRIPTION
### Description (*)
After updating from Magento 2.3.0-alpha to Magento 2.3.0-beta18 opening the "admin/system_config/edit/section/oauth/" configuration page causes a ReflectionException.

Looking at the git blame showed this happened due to the following commit: https://github.com/magento/magento2/commit/007bad9ccaeb4130f000808fe19efb680a49a403

In the referenced commit above a lot of field types have been changed from "label" to "label comment". Searching the code shows that only in this system.xml file a field type "text" was changed to "text comment". So it seems to have happened accidently during the "label -> label comment" type change.

Reverting the type of the field "timeout" back from "text comment" to "text" solves the issue and the configuration page loads and saves again without any problems.

### Manual testing scenarios (*)
1. Have a Magento 2.3.0-beta store running where the https://github.com/magento/magento2/commit/007bad9ccaeb4130f000808fe19efb680a49a403 commit was already merged
2. Login as admin and open the Stores -> Configuration -> Services -> OAuth page

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
