### PR TITLE
[Backport] Create empty modelData array to avoid undefined var error

### DIFF
--- a/app/code/Magento/Developer/Console/Command/SourceThemeDeployCommand.php
+++ b/app/code/Magento/Developer/Console/Command/SourceThemeDeployCommand.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Developer\Console\Command;
 
-use Magento\Framework\App\State;
 use Magento\Framework\Validator\Locale;
 use Magento\Framework\View\Asset\Repository;
 use Symfony\Component\Console\Command\Command;

--- a/app/code/Magento/NewRelicReporting/Model/Cron/ReportModulesInfo.php
+++ b/app/code/Magento/NewRelicReporting/Model/Cron/ReportModulesInfo.php
@@ -64,6 +64,7 @@ class ReportModulesInfo
             $moduleData = $this->collect->getModuleData();
             if (count($moduleData['changes']) > 0) {
                 foreach ($moduleData['changes'] as $change) {
+                    $modelData = [];
                     switch ($change['type']) {
                         case Config::ENABLED:
                             $modelData = [

--- a/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
+++ b/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
@@ -31,7 +31,7 @@ class NewRelicWrapper
     /**
      * Wrapper for 'newrelic_notice_error' function
      *
-     * @param  Exception $exception
+     * @param  \Exception $exception
      * @return void
      */
     public function reportError($exception)


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18529

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Create empty modelData array to avoid undefined var error further in the function if the change type is not one of the listed cases

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
None

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
-

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
