### PR TITLE
[Backport] MAGENTO-18131: Fixed EAV attributes values query

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1232,7 +1232,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
 
         if ($entity->getEntityTable() == \Magento\Eav\Model\Entity::DEFAULT_ENTITY_TABLE && $entity->getTypeId()) {
             $select->where(
-                'entity_type_id =?',
+                't_d.entity_type_id =?',
                 $entity->getTypeId()
             );
         }


### PR DESCRIPTION
### Original Pull Request
#18437 

### Description
SQL Join error when using the custom EAV entity together with the standard eav_entity entity table.
Had to add the table alias into the entity_type_id filter condition.

### Fixed Issues (if relevant)
1. magento/magento2#18131: Entity Type ID at Join 

### Manual testing scenarios
See issue description

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
