### PR TITLE
[Backport] Fix for #12969 - server port detection for errors

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -381,7 +381,7 @@ class Processor
 
     /**
      * Render page
-     * 
+     *
      * @param string $template
      * @return string
      */

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -268,10 +268,11 @@ class Processor
         $isSecure = (!empty($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] != 'off');
         $url = ($isSecure ? 'https://' : 'http://') . $host;
 
-        if (!empty($_SERVER['SERVER_PORT']) && !in_array($_SERVER['SERVER_PORT'], [80, 443])
+        $port = explode(':', $host);
+        if (isset($port[1]) && !in_array($port[1], [80, 443])
             && !preg_match('/.*?\:[0-9]+$/', $url)
         ) {
-            $url .= ':' . $_SERVER['SERVER_PORT'];
+            $url .= ':' . $port[1];
         }
         return  $url;
     }

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -380,6 +380,8 @@ class Processor
     }
 
     /**
+     * Render page
+     * 
      * @param string $template
      * @return string
      */


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18393
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Updates `getHostUrl()` method to reference `HTTP_HOST` rather than `SERVER_PORT`.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [magento/magento2#12969](https://github.com/magento/magento2/issues/12969) - processor.php getHostUrl() does not detect the server port correctly

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
