### PR TITLE
issue fixed - Tierprice can't save float percentage value #18651

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/TierPrice/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/TierPrice/SaveHandler.php
@@ -135,12 +135,12 @@ class SaveHandler implements ExtensionInterface
      * Check whether price has percentage value.
      *
      * @param array $priceRow
-     * @return int|null
+     * @return float|null
      */
     private function getPercentage(array $priceRow): ?int
     {
         return isset($priceRow['percentage_value']) && is_numeric($priceRow['percentage_value'])
-            ? (int)$priceRow['percentage_value']
+            ? (float)$priceRow['percentage_value']
             : null;
     }
 

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/TierPrice/UpdateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/TierPrice/UpdateHandler.php
@@ -138,12 +138,12 @@ class UpdateHandler implements ExtensionInterface
      * Check whether price has percentage value.
      *
      * @param array $priceRow
-     * @return int|null
+     * @return float|null
      */
     private function getPercentage(array $priceRow): ?int
     {
         return isset($priceRow['percentage_value']) && is_numeric($priceRow['percentage_value'])
-            ? (int)$priceRow['percentage_value']
+            ? (float)$priceRow['percentage_value']
             : null;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Tierprice can't save float percentage value

### Description (*)
Add/edit a product and add new tierprice with "discount" value "12.5" and then save the product then it is converted it to integer value  then saved it in the database. I have fixed this issue in this pull request.

### Fixed Issues (if relevant)
1. #18651 

### Manual testing scenarios (*)
1. Add/Edit a product.
2. Add new tierprice with "discount" value "12.5"
3. Save Product.
4. Saving the tierprice as float "12.5".

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
