### PR TITLE
[Backport] Fixed typo from heght to height for image validation rule

### DIFF
--- a/app/code/Magento/Customer/Model/Metadata/Form/Image.php
+++ b/app/code/Magento/Customer/Model/Metadata/Form/Image.php
@@ -133,7 +133,7 @@ class Image extends File
 
         $maxImageHeight = ArrayObjectSearch::getArrayElementByName(
             $rules,
-            'max_image_heght'
+            'max_image_height'
         );
         if ($maxImageHeight !== null) {
             if ($maxImageHeight < $imageProp[1]) {

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/ImageTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/ImageTest.php
@@ -259,7 +259,7 @@ class ImageTest extends AbstractFormTestCase
         )->getMockForAbstractClass();
         $validationRuleMock->expects($this->any())
             ->method('getName')
-            ->willReturn('max_image_heght');
+            ->willReturn('max_image_height');
         $validationRuleMock->expects($this->any())
             ->method('getValue')
             ->willReturn($maxImageHeight);

--- a/app/code/Magento/Eav/Model/Attribute/Data/Image.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Image.php
@@ -54,9 +54,9 @@ class Image extends \Magento\Eav\Model\Attribute\Data\File
                 $errors[] = __('"%1" width exceeds allowed value of %2 px.', $label, $r);
             }
         }
-        if (!empty($rules['max_image_heght'])) {
-            if ($rules['max_image_heght'] < $imageProp[1]) {
-                $r = $rules['max_image_heght'];
+        if (!empty($rules['max_image_height'])) {
+            if ($rules['max_image_height'] < $imageProp[1]) {
+                $r = $rules['max_image_height'];
                 $errors[] = __('"%1" height exceeds allowed value of %2 px.', $label, $r);
             }
         }

--- a/app/code/Magento/Eav/Test/Unit/Model/Attribute/Data/ImageTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Attribute/Data/ImageTest.php
@@ -135,7 +135,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 'originalValue' => 'value',
                 'isRequired' => true,
                 'isAjaxRequest' => false,
-                'rules' => ['max_image_heght' => 2],
+                'rules' => ['max_image_height' => 2],
                 'expectedResult' => ['"Label" height exceeds allowed value of 2 px.']
             ],
             [
@@ -143,7 +143,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 'originalValue' => 'value',
                 'isRequired' => true,
                 'isAjaxRequest' => false,
-                'rules' => ['max_image_heght' => 2000],
+                'rules' => ['max_image_height' => 2000],
                 'expectedResult' => true
             ],
             [
@@ -151,7 +151,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 'originalValue' => 'value',
                 'isRequired' => true,
                 'isAjaxRequest' => false,
-                'rules' => ['max_image_heght' => 2, 'max_image_width' => 2],
+                'rules' => ['max_image_height' => 2, 'max_image_width' => 2],
                 'expectedResult' => [
                     '"Label" width exceeds allowed value of 2 px.',
                     '"Label" height exceeds allowed value of 2 px.',


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18540
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fixed typo from heght to height for image validation rule
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
