### PR TITLE
Fix issue where a zero price in tiered pricing would display price in…

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Price/BasePrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/BasePrice.php
@@ -30,7 +30,7 @@ class BasePrice extends AbstractPrice
             $this->value = false;
             foreach ($this->priceInfo->getPrices() as $price) {
                 if ($price instanceof BasePriceProviderInterface && $price->getValue() !== false) {
-                    $this->value = min($price->getValue(), $this->value ?: $price->getValue());
+                    $this->value = min($price->getValue(), is_numeric($this->value) ? $this->value : $price->getValue());
                 }
             }
         }


### PR DESCRIPTION
…stead, but cart would reflect correct price of 0.

### Fixed Issues (if relevant)
None found.

### Manual testing scenarios (*)
1. Create product
2. Set Product price > 0
3. Advanced Pricing -> Price -> Create Customer Group Price with All Websites, All Groups, 1 quantity, Fixed Price, 0 cost.

Without fix, product price will display, with fix correct price of 0. Cart will display correct price of 0 in either case. 
