### PR TITLE
[Backport] Set fallback values for email and _website columns to avoid 'undefined index' error in CustomerComposite.php

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
@@ -299,8 +299,8 @@ class CustomerComposite extends \Magento\ImportExport\Model\Import\AbstractEntit
         $rows = [];
         foreach ($source as $row) {
             $rows[] = [
-                Address::COLUMN_EMAIL => $row[Customer::COLUMN_EMAIL],
-                Address::COLUMN_WEBSITE => $row[Customer::COLUMN_WEBSITE]
+                Address::COLUMN_EMAIL => $row[Customer::COLUMN_EMAIL] ?? null,
+                Address::COLUMN_WEBSITE => $row[Customer::COLUMN_WEBSITE] ?? null
             ];
         }
         $source->rewind();


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18679

### Description
There are proper validation messages for `ERROR_CODE_COLUMN_NOT_FOUND` and `ERROR_CODE_COLUMN_NAME_INVALID` but this code is not reachable.

### Manual testing scenarios
1. Create a Customer
2. Navigate to **Customers -> All Customers** and export them all
3. Navigate to **System -> Import** and use the CSV of all your customers. Use Add/Update behavior and "Customers and Addresses (single file)" as an entity type.

**Expected result:**
At least one of the two validation messages:

`We can't find required columns: email", "_website.`

`Column names: "ID", "Name", "Email", "Group", "Phone", "ZIP", "Country", "State/Province", "Customer Since", "Web Site", "Confirmed email", "Account Created in", "Billing Address", "Shipping Address", "Date of Birth", "Tax VAT Number", "Gender", "Street Address", "City", "Fax", "VAT Number", "Company", "Billing Firstname", "Billing Lastname", "Account Lock" are invalid`

**Actual result:**
`Notice: Undefined index: email in /var/www/html/pr/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php on line 302`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
