### PR TITLE
13205: Remove ___from_store if Add Store Code to Url set to Yes

### DIFF
--- a/app/code/Magento/Store/Block/Switcher.php
+++ b/app/code/Magento/Store/Block/Switcher.php
@@ -236,7 +236,9 @@ class Switcher extends \Magento\Framework\View\Element\Template
     public function getTargetStorePostData(\Magento\Store\Model\Store $store, $data = [])
     {
         $data[\Magento\Store\Api\StoreResolverInterface::PARAM_NAME] = $store->getCode();
-        $data['___from_store'] = $this->_storeManager->getStore()->getCode();
+        if (!$store->isUseStoreInUrl()) {
+            $data['___from_store'] = $this->_storeManager->getStore()->getCode();
+        }
 
         $urlOnTargetStore = $store->getCurrentUrl(false);
         $data[ActionInterface::PARAM_NAME_URL_ENCODED] = $this->urlHelper->getEncodedUrl($urlOnTargetStore);

--- a/app/code/Magento/Store/Test/Unit/Block/SwitcherTest.php
+++ b/app/code/Magento/Store/Test/Unit/Block/SwitcherTest.php
@@ -61,6 +61,9 @@ class SwitcherTest extends \PHPUnit\Framework\TestCase
             ->method('getCurrentUrl')
             ->with(false)
             ->willReturn($storeSwitchUrl);
+        $store->expects($this->once())
+            ->method('isUseStoreInUrl')
+            ->willReturn('0');
         $this->storeManager->expects($this->once())
             ->method('getStore')
             ->willReturn($this->store);
@@ -73,6 +76,36 @@ class SwitcherTest extends \PHPUnit\Framework\TestCase
         $this->corePostDataHelper->expects($this->any())
             ->method('getPostData')
             ->with($storeSwitchUrl, ['___store' => 'new-store', 'uenc' => null, '___from_store' => 'old-store']);
+
+        $this->switcher->getTargetStorePostData($store);
+    }
+
+    public function testGetTargetStorePostDataWhenStoreIsInUrl()
+    {
+        $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $store->expects($this->any())
+            ->method('getCode')
+            ->willReturn('new-store');
+        $storeSwitchUrl = 'http://domain.com/stores/store/redirect';
+        $store->expects($this->atLeastOnce())
+            ->method('getCurrentUrl')
+            ->with(false)
+            ->willReturn($storeSwitchUrl);
+        $store->expects($this->once())
+            ->method('isUseStoreInUrl')
+            ->willReturn('1');
+        $this->storeManager->expects($this->never())
+            ->method('getStore');
+        $this->store->expects($this->never())
+            ->method('getCode');
+        $this->urlBuilder->expects($this->once())
+            ->method('getUrl')
+            ->willReturn($storeSwitchUrl);
+        $this->corePostDataHelper->expects($this->any())
+            ->method('getPostData')
+            ->with($storeSwitchUrl, ['___store' => 'new-store', 'uenc' => null]);
 
         $this->switcher->getTargetStorePostData($store);
     }


### PR DESCRIPTION
### Fix 13205
- add ___from_store only if "Add Store Code to Urls" is set to "No"

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13205:  In magento 2.2.2 Url Options issue

### Manual testing scenarios (*)
1. Enable Store switcher
2. Set Add Store Code to Urls to Yes
3. While switching stores, there should not be __from_store param in URL
4. Set Add Store Code to Urls to No
5. While switching stores, there should be __from_store param in URL

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
