### PR TITLE
[Forwardport][2.3] of MAGETWO-93818: Magnifier function does not disappear after mouse-off the image from the bottom

### DIFF
--- a/lib/web/magnifier/magnifier.js
+++ b/lib/web/magnifier/magnifier.js
@@ -593,7 +593,7 @@
 
         $box.on('mousemove', onMousemove);
         $box.on('mouseleave', onMouseLeave);
-        
+
         _init($box, customUserOptions);
     }
 }(jQuery));

--- a/lib/web/magnifier/magnifier.js
+++ b/lib/web/magnifier/magnifier.js
@@ -554,6 +554,15 @@
             thumbObj.src = thumb.src;
         }
 
+        /**
+         * Hide magnifier when mouse exceeds image bounds.
+         */
+        function onMouseLeave() {
+            onThumbLeave();
+            isOverThumb = false;
+            $magnifierPreview.addClass(MagnifyCls.magnifyHidden);
+        }
+
         function onMousemove(e) {
             pos.x = e.clientX;
             pos.y = e.clientY;
@@ -564,15 +573,9 @@
                 isOverThumb = inBounds;
             }
 
-            if (inBounds && isOverThumb) {
-                if(gMode === 'outside'){
-                    $magnifierPreview.removeClass(MagnifyCls.magnifyHidden);
-                }
+            if (inBounds && isOverThumb && gMode === 'outside') {
+                $magnifierPreview.removeClass(MagnifyCls.magnifyHidden);
                 move();
-            } else {
-                onThumbLeave();
-                isOverThumb = false;
-                $magnifierPreview.addClass(MagnifyCls.magnifyHidden);
             }
         }
 
@@ -589,6 +592,8 @@
         });
 
         $box.on('mousemove', onMousemove);
+        $box.on('mouseleave', onMouseLeave);
+        
         _init($box, customUserOptions);
     }
 }(jQuery));


### PR DESCRIPTION
### Original PR/Commit

https://github.com/magento/magento2/commit/c55480ef23b6eb9902053a59d421c29c5eeebc4f#diff-a3d63022f922ef08dd75e31dddb0025a

This PR replicates the MAGETWO-93818 change into 2.3-develop

### Description (*)
Magnifier function does not disappear after mouse-off the image from the bottom
This PR adds the onMouseLeave event

### Fixed Issues (if relevant)
1. magento/magento2#15035: [2.2.4] Gallery Magnifier hover event does not always cancel magnifier when mouse leaves gallery

### Manual testing scenarios (*)
1. Enable magnifier zoom in themes view.xml

```
        <var name="magnifier">
            <var name="fullscreenzoom">20</var>  <!-- Zoom for fullscreen (integer)-->
            <var name="top"></var> <!-- Top position of magnifier -->
            <var name="left"></var> <!-- Left position of magnifier -->
            <var name="width"></var> <!-- Width of magnifier block -->
            <var name="height"></var> <!-- Height of magnifier block -->
            <var name="eventType">hover</var> <!-- Action that atcivates zoom (hover/click) -->
            <var name="enabled">true</var> <!-- Turn on/off magnifier (true/false) -->
            <var name="mode">outside</var> <!-- Zoom type (outside/inside) -->
        </var>

```
2. Ensure that the magnifier cancels the zoom window when your mouse pointer leaves the product image.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
