### PR TITLE
Correct child node load when multiple calls to CategoryManagement::ge…

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Tree.php
+++ b/app/code/Magento/Catalog/Model/Category/Tree.php
@@ -33,21 +33,30 @@ class Tree
     protected $treeFactory;
 
     /**
+     * @var \Magento\Catalog\Model\ResourceModel\Category\TreeFactory
+     */
+    private $treeResourceFactory;
+
+    /**
      * @param \Magento\Catalog\Model\ResourceModel\Category\Tree $categoryTree
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Catalog\Model\ResourceModel\Category\Collection $categoryCollection
      * @param \Magento\Catalog\Api\Data\CategoryTreeInterfaceFactory $treeFactory
+     * @param \Magento\Catalog\Model\ResourceModel\Category\TreeFactory|null $treeResourceFactory
      */
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Category\Tree $categoryTree,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Catalog\Model\ResourceModel\Category\Collection $categoryCollection,
-        \Magento\Catalog\Api\Data\CategoryTreeInterfaceFactory $treeFactory
+        \Magento\Catalog\Api\Data\CategoryTreeInterfaceFactory $treeFactory,
+        \Magento\Catalog\Model\ResourceModel\Category\TreeFactory $treeResourceFactory = null
     ) {
         $this->categoryTree = $categoryTree;
         $this->storeManager = $storeManager;
         $this->categoryCollection = $categoryCollection;
         $this->treeFactory = $treeFactory;
+        $this->treeResourceFactory = $treeResourceFactory ?? \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Model\ResourceModel\Category\TreeFactory::class);
     }
 
     /**
@@ -77,7 +86,8 @@ class Tree
     protected function getNode(\Magento\Catalog\Model\Category $category)
     {
         $nodeId = $category->getId();
-        $node = $this->categoryTree->loadNode($nodeId);
+        $categoryTree = $this->treeResourceFactory->create();
+        $node = $categoryTree->loadNode($nodeId);
         $node->loadChildren();
         $this->prepareCollection();
         $this->categoryTree->addCollectionData($this->categoryCollection);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/TreeTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/TreeTest.php
@@ -43,6 +43,11 @@ class TreeTest extends \PHPUnit\Framework\TestCase
      */
     protected $node;
 
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Category\TreeFactory
+     */
+    private $treeResourceFactoryMock;
+
     protected function setUp()
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -59,6 +64,10 @@ class TreeTest extends \PHPUnit\Framework\TestCase
             \Magento\Store\Model\StoreManagerInterface::class
         )->disableOriginalConstructor()->getMock();
 
+        $this->treeResourceFactoryMock = $this->createMock(\Magento\Catalog\Model\ResourceModel\Category\TreeFactory::class);
+        $this->treeResourceFactoryMock->method('create')
+            ->willReturn($this->categoryTreeMock);
+
         $methods = ['create'];
         $this->treeFactoryMock =
             $this->createPartialMock(\Magento\Catalog\Api\Data\CategoryTreeInterfaceFactory::class, $methods);
@@ -70,7 +79,8 @@ class TreeTest extends \PHPUnit\Framework\TestCase
                     'categoryCollection' => $this->categoryCollection,
                     'categoryTree' => $this->categoryTreeMock,
                     'storeManager' => $this->storeManagerMock,
-                    'treeFactory' => $this->treeFactoryMock
+                    'treeFactory' => $this->treeFactoryMock,
+                    'treeResourceFactory' => $this->treeResourceFactoryMock,
                 ]
             );
     }


### PR DESCRIPTION
…tTree

### Description (*)
Tree::getNode currently loads nodes using a resource singleton. The tree
resource's parent class contains the property _loaded and only loads child
nodes when _loaded is false. This behavior means only the first call to
CategoryManagement::getTree in a request returns child nodes.

### Fixed Issues (if relevant)
1. magento/magento2#17297 No children data for \Magento\Catalog\Model\CategoryManagement::getTree($categoryId) after first call

### Manual testing scenarios (*)
1. Create instance of `\Magento\Catalog\Model\CategoryManagement`
2. Call `CategoryManagement->getTree(1)->getChildrenData()` multiple times
3. The count of the result should be the same with each call

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
