### PR TITLE
[Forwardport] Module Catalog URL Rewrite: fix issue with product URL Rewrites re-generation after changing product URL Key for product with existing url_path attribute value

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
@@ -33,8 +33,8 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
     private $productUrlPathGenerator;
 
     /**
-     * @param ProductUrlRewriteGenerator   $productUrlRewriteGenerator
-     * @param UrlPersistInterface          $urlPersist
+     * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
+     * @param UrlPersistInterface $urlPersist
      * @param ProductUrlPathGenerator|null $productUrlPathGenerator
      */
     public function __construct(

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
@@ -6,11 +6,15 @@
 namespace Magento\CatalogUrlRewrite\Observer;
 
 use Magento\Catalog\Model\Product;
+use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\Framework\App\ObjectManager;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
-use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\Framework\Event\ObserverInterface;
 
+/**
+ * Class ProductProcessUrlRewriteSavingObserver
+ */
 class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
 {
     /**
@@ -24,21 +28,32 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
     private $urlPersist;
 
     /**
-     * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
-     * @param UrlPersistInterface $urlPersist
+     * @var ProductUrlPathGenerator
+     */
+    private $productUrlPathGenerator;
+
+    /**
+     * @param ProductUrlRewriteGenerator   $productUrlRewriteGenerator
+     * @param UrlPersistInterface          $urlPersist
+     * @param ProductUrlPathGenerator|null $productUrlPathGenerator
      */
     public function __construct(
         ProductUrlRewriteGenerator $productUrlRewriteGenerator,
-        UrlPersistInterface $urlPersist
+        UrlPersistInterface $urlPersist,
+        ProductUrlPathGenerator $productUrlPathGenerator = null
     ) {
         $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
         $this->urlPersist = $urlPersist;
+        $this->productUrlPathGenerator = $productUrlPathGenerator ?: ObjectManager::getInstance()
+            ->get(ProductUrlPathGenerator::class);
     }
 
     /**
      * Generate urls for UrlRewrite and save it in storage
+     *
      * @param \Magento\Framework\Event\Observer $observer
      * @return void
+     * @throws \Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
@@ -51,6 +66,8 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
             || $product->dataHasChangedFor('visibility')
         ) {
             if ($product->isVisibleInSiteVisibility()) {
+                $product->unsUrlPath();
+                $product->setUrlPath($this->productUrlPathGenerator->getUrlPath($product));
                 $this->urlPersist->replace($this->productUrlRewriteGenerator->generate($product));
             }
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18566

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Hiving saved product attribute `URL Path` value causes broken Product URL Rewrites regeneration after changing product `URL key`.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If there is a product with set `URL Path` attribute value, product URL Rewrites can't be re-generated clearly after changing product `URL Key` from Admin panel.
For example, after migrating from Magento 1, there are a lot of values for product attribute `URL Path`.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
magento/magento2#5929: Saving Product does not update URL rewrite in Magento 2.1.0.

### Causes Issues
magento/magento2#18532: Module Catalog: product "Save and Duplicate" causes getting infinite loop.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set attribute `URL Path` value for any product.
1.1. For example, execute following SQL query:
```sql
SET @catalogProductEntityTypeId = (SELECT `entity_type_id`
                                   FROM `eav_entity_type`
                                   WHERE entity_type_code = 'catalog_product');

SET @productUrlPathAttributeId = (SELECT `attribute_id`
                                  FROM `eav_attribute`
                                  WHERE `attribute_code` = 'url_path'
                                    AND entity_type_id = @catalogProductEntityTypeId);

SET @productUrlKeyAttributeId = (SELECT `attribute_id`
                                 FROM `eav_attribute`
                                 WHERE `attribute_code` = 'url_key'
                                   AND `entity_type_id` = @catalogProductEntityTypeId);

SET @storeId = 1; -- change Store ID if it's required

SET @testProductId = 1; -- change Product ID if it's required

SET @existingProductUrlKey = (SELECT `value`
                              FROM `catalog_product_entity_varchar`
                              WHERE `entity_id` = @testProductId
                                AND `attribute_id` = @productUrlKeyAttributeId); -- any value could be there

INSERT INTO `catalog_product_entity_varchar` (`attribute_id`, `store_id`, `entity_id`, `value`)
    VALUES (@productUrlPathAttributeId, @storeId, @testProductId, @existingProductUrlKey);

```
2. Go to Admin panel -> Catalog -> Inventory -> Products.
3. Find and open testable product.
4. Change `URL Key` field value.
5. Save product.
6. Go to product page on frontend by new `URL Key`.

### Expected result
Product is available by the new `URL Key`.

### Actual result
Product is not available by the new `URL Key`, but available by the previous one.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
