### PR TITLE
[Forwardport] Remove unnecessary class import, see #18280

### DIFF
--- a/app/code/Magento/Customer/Model/GroupManagement.php
+++ b/app/code/Magento/Customer/Model/GroupManagement.php
@@ -15,7 +15,6 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SortOrderBuilder;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
-use Magento\Framework\Data\Collection;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -170,7 +169,7 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
             ->create();
         $groupNameSortOrder = $this->sortOrderBuilder
             ->setField('customer_group_code')
-            ->setDirection(Collection::SORT_ORDER_ASC)
+            ->setAscendingDirection()
             ->create();
         $searchCriteria = $this->searchCriteriaBuilder
             ->addFilters($notLoggedInFilter)


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18670
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

In magento2/#18280 this was added to sort the collection ...

```
use Magento\Framework\Data\Collection;`
...
->setDirection(Collection::SORT_ORDER_ASC)
```

Instead we can use `setAscendingDirection()`. If not `Magento\Framework\Api\SortOrder::SORT_ASC` would be more correct. (?)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
