### PR TITLE
MAGE_DIRS overwrite fix in pub/index.php

### DIFF
--- a/pub/index.php
+++ b/pub/index.php
@@ -25,12 +25,15 @@ HTML;
 }
 
 $params = $_SERVER;
-$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
-    DirectoryList::PUB => [DirectoryList::URL_PATH => ''],
-    DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],
-    DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
-    DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
-];
+$params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = array_replace_recursive(
+    $params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS],
+    [
+        DirectoryList::PUB => [DirectoryList::URL_PATH => ''],
+        DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],
+        DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
+        DirectoryList::UPLOAD => [DirectoryList::URL_PATH => 'media/upload'],
+    ]
+);
 $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $params);
 /** @var \Magento\Framework\App\Http $app */
 $app = $bootstrap->createApplication(\Magento\Framework\App\Http::class);


### PR DESCRIPTION
### Description (*)
In the `pub/index.php` file `MAGE_DIRS` coming from `$_SERVER` are completely overwritten. This prevent someone to set a different directory (for example a different cache directory) when using the `pub` directory as document root.

### Manual testing scenarios (*)
1. Add a simple PHP script named `test.php` with the following content to the Magento's root directory:
```php
<?php

$_SERVER['MAGE_DIRS'] = ['cache' => ['path' => 'var/other-cache-dir']]
```
2. Add it to the Composer's autoloader:
```json
    "autoload": {
        // ...
        "files": [
            "test.php"
            // ...
        ],
        // ...
    },
```
3. Run `php bin/magento cache:clean` and note that cache file are still generated in the `var/cache` directory instead of `var/other-cache-dir` directory.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
