### PR TITLE
[BUGFIX] GITHUB-18264 Backport of #17799 for the 2.2 branch

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
@@ -190,7 +190,7 @@ class BaseFinalPrice
         $specialFromExpr = "{$specialFrom} IS NULL OR {$specialFromDate} <= {$currentDate}";
         $specialToExpr = "{$specialTo} IS NULL OR {$specialToDate} >= {$currentDate}";
         $specialPriceExpr = $connection->getCheckSql(
-            "{$specialPrice} IS NOT NULL AND {$specialFromExpr} AND {$specialToExpr}",
+            "{$specialPrice} IS NOT NULL AND ({$specialFromExpr}) AND ({$specialToExpr})",
             $specialPrice,
             $maxUnsignedBigint
         );


### PR DESCRIPTION
### Description

This PR is a backport of #17799 for the 2.2 branch. It fixes issue #18264 where the price indexer would generate unwanted results if a special price date is set, but the actual special price is omitted.

### Fixed Issues (if relevant)

1. magento/magento2#18264

### Manual testing scenarios

1. Create some products with different prices.
2. Give them no special price (empty field), but give them a special price from date in the past and/or a special price to date in the future.
3. Run the price reindexer.
4. The products that have special price set to (empty field), are now set to the regular price as min_price, resulting in a correct working price sorting.

### Contribution checklist

 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
