### PR TITLE
Convert paths registered to their realpath

### DIFF
--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -51,7 +51,7 @@ class ComponentRegistrar implements ComponentRegistrarInterface
                 . 'has been already defined in \'' . self::$paths[$type][$componentName] . '\'.'
             );
         } else {
-            self::$paths[$type][$componentName] = str_replace('\\', '/', $path);
+            self::$paths[$type][$componentName] = realpath(str_replace('\\', '/', $path));
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Many Magento tools expect that the path given to the ComponentRegistrar be the real path of the directory.  As such, it is possible for extension developers to make mistakes that are difficult to debug but result in issues (such as a third party module having its Test classes compiled [BUNDLE-1798]

This change makes Magento a little less error-prone.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. BUNDLE-1798

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
