### PR TITLE
issue #18655 fixed: Magento 2.3.0-beta18: ReflectionException on Backend -> Stores -> Configuration -> Services -> OAuth page

### DIFF
--- a/app/code/Magento/Integration/etc/adminhtml/system.xml
+++ b/app/code/Magento/Integration/etc/adminhtml/system.xml
@@ -54,7 +54,7 @@
                     <label>Maximum Login Failures to Lock Out Account</label>
                     <comment>Maximum Number of authentication failures to lock out account.</comment>
                 </field>
-                <field id="timeout" translate="label" type="text comment" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="timeout" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Lockout Time (seconds)</label>
                     <comment>Period of time in seconds after which account will be unlocked.</comment>
                 </field>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fixed, Admin Page "Stores -> Configuration -> Services -> OAuth" throws Reflection Exception.
### Description (*)

When navigating to Stores -> Configuration -> Services -> OAuth and open this section,
Page displays blank and throws an exception: **main.CRITICAL: Class text comment does not exist**
I have fixed it in this pull request.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18655 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. After fixed, opens Stores -> Configuration -> Services -> OAuth section, now configurable options
are visible.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
