### PR TITLE
Remove unnecesary "header" block redeclaration

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
@@ -15,11 +15,6 @@
                 </arguments>
             </block>
         </referenceBlock>
-        <block class="Magento\Theme\Block\Html\Header" name="header" as="header">
-            <arguments>
-                <argument name="show_part" xsi:type="string">welcome</argument>
-            </arguments>
-        </block>
         <move element="header" destination="header.links" before="-"/>
         <move element="register-link" destination="header.links"/>
         <move element="top.links" destination="customer"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removed because the "header" block was already created in module Magento_Theme, so this redeclaration is just unnecesary

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
None found on the Magento 2 issues

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create new module.
2. Create new default.xml and try to use referenceBlock to set the template. Example:
` <referenceBlock name="header">
            <arguments>
                <argument name="template" xsi:type="string">Samuel27m_Welcome::html/header.phtml</argument>
            </arguments>
        </referenceBlock>`

3. Doesn't work, because Luma theme XML files are compiled after all modules and overrides the custom module modifications.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
