### PR TITLE
[Forwardport] 17516: added Australian states

### DIFF
--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForAustralia.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForAustralia.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Directory\Setup\Patch\Data;
+
+use Magento\Directory\Setup\DataInstaller;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchVersionInterface;
+
+/**
+ * Adds Australian States
+ */
+class AddDataForAustralia implements DataPatchInterface, PatchVersionInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var \Magento\Directory\Setup\DataInstallerFactory
+     */
+    private $dataInstallerFactory;
+
+    /**
+     * AddDataForCroatia constructor.
+     *
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->dataInstallerFactory = $dataInstallerFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply()
+    {
+        /** @var DataInstaller $dataInstaller */
+        $dataInstaller = $this->dataInstallerFactory->create();
+        $dataInstaller->addCountryRegions(
+            $this->moduleDataSetup->getConnection(),
+            $this->getDataForAustralia()
+        );
+    }
+
+    /**
+     * Croatian states data.
+     *
+     * @return array
+     */
+    private function getDataForAustralia()
+    {
+        return [
+            ['AU', 'ACT', 'Australian Capital Territory'],
+            ['AU', 'NSW', 'New South Wales'],
+            ['AU', 'VIC', 'Victoria'],
+            ['AU', 'QLD', 'Queensland'],
+            ['AU', 'SA',  'South Australia'],
+            ['AU', 'TAS', 'Tasmania'],
+            ['AU', 'WA',  'Western Australia'],
+            ['AU', 'NT',  'Northern Territory']
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDependencies()
+    {
+        return [
+            InitializeDirectoryData::class,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getVersion()
+    {
+        return '2.0.3';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForAustralia.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForAustralia.php
@@ -27,8 +27,6 @@ class AddDataForAustralia implements DataPatchInterface, PatchVersionInterface
     private $dataInstallerFactory;
 
     /**
-     * AddDataForCroatia constructor.
-     *
      * @param ModuleDataSetupInterface $moduleDataSetup
      * @param \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
      */
@@ -54,7 +52,7 @@ class AddDataForAustralia implements DataPatchInterface, PatchVersionInterface
     }
 
     /**
-     * Croatian states data.
+     * Australian states data.
      *
      * @return array
      */


### PR DESCRIPTION
### Description (*)
Added Australian states to module directory.
Original PR: https://github.com/magento/magento2/pull/17516



### Manual testing scenarios (*)
1.  Navigate to the customer address, or some other places were countries and states are using
2. You should see the list of states when country Australia is selected.
![image](https://user-images.githubusercontent.com/20116393/47408891-b0a5e480-d769-11e8-91b2-94280739ac17.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
