### PR TITLE
Wrong Tier price on Category Page, Search Result Page and Product Lis…

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
+++ b/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
@@ -18,7 +18,7 @@ class MinimalTierPriceCalculator implements MinimalPriceCalculatorInterface
     /**
      * @var CalculatorInterface
      */
-    private $calculator;
+    protected $calculator;
 
     /**
      * @param CalculatorInterface $calculator
@@ -58,6 +58,6 @@ class MinimalTierPriceCalculator implements MinimalPriceCalculatorInterface
 
         return $value === null
             ? null
-            : $this->calculator->getAmount($value, $saleableItem, ['weee', 'weee_tax', 'tax']);
+            : $this->calculator->getAmount($value, $saleableItem, ['tax']);
     }
 }

--- a/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
+++ b/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
@@ -58,6 +58,6 @@ class MinimalTierPriceCalculator implements MinimalPriceCalculatorInterface
 
         return $value === null
             ? null
-            : $this->calculator->getAmount($value, $saleableItem);
+            : $this->calculator->getAmount($value, $saleableItem, ['weee', 'weee_tax', 'tax']);
     }
 }

--- a/app/code/Magento/Weee/Pricing/Price/MinimalTierPriceCalculator.php
+++ b/app/code/Magento/Weee/Pricing/Price/MinimalTierPriceCalculator.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Weee\Pricing\Price;
+
+use Magento\Framework\Pricing\SaleableInterface;
+use Magento\Framework\Pricing\Adjustment\CalculatorInterface;
+use Magento\Framework\Pricing\Amount\AmountInterface;
+
+/**
+ * As Low As shows minimal value of Tier Prices
+ */
+class MinimalTierPriceCalculator extends \Magento\Catalog\Pricing\Price\MinimalTierPriceCalculator
+{
+    /**
+     * Return calculated amount object that keeps "as low as" value
+     * {@inheritdoc}
+     */
+    public function getAmount(SaleableInterface $saleableItem)
+    {
+        $value = $this->getValue($saleableItem);
+
+        return $value === null
+            ? null
+            : $this->calculator->getAmount($value, $saleableItem, ['weee', 'weee_tax', 'tax']);
+    }
+}

--- a/app/code/Magento/Weee/etc/di.xml
+++ b/app/code/Magento/Weee/etc/di.xml
@@ -81,4 +81,5 @@
     <type name="Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper">
         <plugin name="weeeAttributeOptionsProcess" type="Magento\Weee\Plugin\Catalog\Controller\Adminhtml\Product\Initialization\Helper\ProcessTaxAttribute"/>
     </type>
+    <preference type="Magento\Weee\Pricing\Price\MinimalTierPriceCalculator" for="Magento\Catalog\Pricing\Price\MinimalTierPriceCalculator" />
 </config>


### PR DESCRIPTION
…ting Widget #13282

Fixed with excluding second tax calculation on tierprices.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Wrong Tier price on Category Page, Search Result Page and Product Listing Widget #13282
Fixed with excluding second tax calculation on tierprices.

### Fixed Issues (if relevant)

1. magento/magento2#13282: Wrong Tier price on Category Page, Search Result Page and Product Listing Widget


### Manual testing scenarios (*)
1. Setup some tierprices for any taxable simple product
2. Check on product listing page the "As low as" price section

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
