### PR TITLE
Fix incorrect totals amount for discounted orders on dashboard for #18754

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -827,7 +827,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             ? '(main_table.base_subtotal - %2$s - %1$s)'
             : '((main_table.base_subtotal - %1$s - %2$s) '
                 . ' * main_table.base_to_global_rate)';
-        return sprintf($template, $baseSubtotalRefunded);
+        return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled);
     }
 
     /**

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -827,7 +827,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             ? '(main_table.base_subtotal - %2$s - %1$s)'
             : '((main_table.base_subtotal - %1$s - %2$s) '
                 . ' * main_table.base_to_global_rate)';
-        return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountCanceled);
+        return sprintf($template, $baseSubtotalRefunded);
     }
 
     /**

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -824,8 +824,8 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
         $baseDiscountCanceled
     ) {
         $template = ($storeId != 0)
-            ? '(main_table.base_subtotal - %2$s - %1$s - ABS(main_table.base_discount_amount) - %3$s)'
-            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) - %3$s) '
+            ? '(main_table.base_subtotal - %2$s - %1$s)'
+            : '((main_table.base_subtotal - %1$s - %2$s) '
                 . ' * main_table.base_to_global_rate)';
         return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountCanceled);
     }


### PR DESCRIPTION
### Description (*)
When cancelling or refunding an order, the amount shown in the dashboard's latest orders section becomes incorrect (negative).

This PR fixes it by removing the base_discount_amount and base_discount_canceled fields used in Magento\Reports\Model\ResourceModel\Order\Collection::getTotalsExpression as they are not necessary - from what I can tell.

The $baseSubtotalCanceled and $baseSubtotalRefunded variables are now no longer needed in the getTotalsExpression method, however I'm not sure whether or not to just remove these for compatibility reasons?

### Fixed Issues
1. magento/magento2#18754: Negative order amount in dashboard latest order when order is cancelled where coupon has been used

### Manual testing scenarios (*)
1. Place a discounted order using a coupon code (cart price rule)
2. Cancel or refund the order
3. Navigate to the dashboard and look at the 'Latest orders' section to see the incorrect total amount

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
