### PR TITLE
Set the correct tier price for alternative website (not default) on admin order create

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/GroupPrice/AbstractGroupPrice.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/GroupPrice/AbstractGroupPrice.php
@@ -331,11 +331,15 @@ abstract class AbstractGroupPrice extends Price
     /**
      * @param \Magento\Catalog\Model\Product $object
      * @param array $priceData
+     * @param int|null $storeId
      */
-    public function setPriceData($object, $priceData)
+    public function setPriceData($object, $priceData, $storeId = null)
     {
         $priceData = $this->modifyPriceData($object, $priceData);
-        $websiteId = $this->getWebsiteId($object->getStoreId());
+        if (!$storeId) {
+            $storeId = $object->getStoreId();
+        }
+        $websiteId = $this->getWebsiteId($storeId);
         if (!$object->getData('_edit_mode') && $websiteId) {
             $priceData = $this->preparePriceData($priceData, $object->getTypeId(), $websiteId);
         }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -2218,7 +2218,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
         }
         foreach ($this->getItems() as $item) {
             $productId = $item->getData($this->getLinkField());
-            $this->getBackend()->setPriceData($item, isset($tierPrices[$productId]) ? $tierPrices[$productId] : []);
+            $storeId = !$item->hasData('store_id') ? $this->getStoreId() : null;
+            $this->getBackend()->setPriceData($item, isset($tierPrices[$productId]) ? $tierPrices[$productId] : [], $storeId);
         }
     }
 

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -768,7 +768,8 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
             $productObject = $productCollection->getFirstItem();
             $productLinkFieldId = $productObject->getId();
             if ($productLinkFieldId) {
-                return $this->productRepository->getById($productLinkFieldId);
+                $storeId = $product->getData('store_id');
+                return $this->productRepository->getById($productLinkFieldId, false, $storeId);
             }
 
             foreach ($productCollection as $productObject) {


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18577: On sales/order_create/loadBlock/block Customer tier price remove

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. The reproducing scenario is specified here: https://github.com/magento/magento2/issues/18577#issuecomment-430662428
2. The changes done on the Configurable module fix the add to cart for a tier priced configurable product.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
