### PR TITLE
Added form fieldset before html data to \Magento\Framework\Data\Form\Element\Fieldset in getElementHtml() method

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Fieldset.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Fieldset.php
@@ -43,7 +43,8 @@ class Fieldset extends AbstractElement
      */
     public function getElementHtml()
     {
-        $html = '<fieldset id="' . $this->getHtmlId() . '"' . $this->serialize(
+        $html = $this->getBeforeElementHtml();
+        $html .= '<fieldset area-hidden="false" id="' . $this->getHtmlId() . '"' . $this->serialize(
             ['class']
         ) . $this->_getUiId() . '>' . "\n";
         if ($this->getLegend()) {


### PR DESCRIPTION
### Description 
In `\Magento\Framework\Data\Form\Element\Fieldset` class, there is not called the `getBeforeElementHtml()` method in `getElementHtml()`. This stops developers from adding needed information before the fieldset in a easy way.

### Fixed Issues (if relevant)
1. magento/magento2#2618

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
