### PR TITLE
[Backport] catalog:images:resize total images count calculates incorrectly #18387

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
@@ -12,7 +12,7 @@ use Magento\Framework\DB\Query\Generator;
 use Magento\Framework\DB\Select;
 use Magento\Framework\App\ResourceConnection;
 
-/*
+/**
  * Class for retrieval of all product images
  */
 class Image

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
@@ -12,8 +12,8 @@ use Magento\Framework\DB\Query\Generator;
 use Magento\Framework\DB\Select;
 use Magento\Framework\App\ResourceConnection;
 
-/**
- * Class for fast retrieval of all product images
+/*
+ * Class for retrieval of all product images
  */
 class Image
 {
@@ -76,6 +76,7 @@ class Image
 
     /**
      * Get the number of unique pictures of products
+     *
      * @return int
      */
     public function getCountAllProductImages(): int
@@ -91,6 +92,8 @@ class Image
     }
 
     /**
+     * Return Select to fetch all products images
+     *
      * @return Select
      */
     private function getVisibleImagesSelect(): Select

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
@@ -80,7 +80,13 @@ class Image
      */
     public function getCountAllProductImages(): int
     {
-        $select = $this->getVisibleImagesSelect()->reset('columns')->columns('count(*)');
+        $select = $this->getVisibleImagesSelect()
+            ->reset('columns')
+            ->reset('distinct')
+            ->columns(
+                new \Zend_Db_Expr('count(distinct value)')
+            );
+
         return (int) $this->connection->fetchOne($select);
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -210,10 +210,12 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     public function dataProvider(): array
     {
         return [
+            [300, 300],
             [300, 100],
             [139, 100],
             [67, 10],
-            [154, 47]
+            [154, 47],
+            [0, 100]
         ];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -36,7 +36,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      */
     protected $resourceMock;
 
-    protected function setUp(): void
+    protected function setUp()
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->connectionMock = $this->createMock(AdapterInterface::class);
@@ -75,7 +75,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      * @param int $imagesCount
      * @dataProvider dataProvider
      */
-    public function testGetCountAllProductImages(int $imagesCount): void
+    public function testGetCountAllProductImages(int $imagesCount)
     {
         $selectMock = $this->getVisibleImagesSelectMock();
         $selectMock->expects($this->exactly(2))
@@ -113,7 +113,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      * @param int $batchSize
      * @dataProvider dataProvider
      */
-    public function testGetAllProductImages(int $imagesCount, int $batchSize): void
+    public function testGetAllProductImages(int $imagesCount, int $batchSize)
     {
         $this->connectionMock->expects($this->once())
             ->method('select')

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Test\Unit\Model\ResourceModel\Product;
+
+use Magento\Catalog\Model\ResourceModel\Product\Image;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Query\Generator;
+use Magento\Framework\DB\Select;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Catalog\Model\ResourceModel\Product\Gallery;
+
+class ImageTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var AdapterInterface | \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $connectionMock;
+
+    /**
+     * @var Generator | \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $generatorMock;
+
+    /**
+     * @var ResourceConnection | \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resourceMock;
+
+    /**
+     * @var Image
+     */
+    protected $imageModel;
+
+    /**
+     * @var int
+     */
+    protected $imagesCount = 50;
+
+    /**
+     * @var int
+     */
+    protected $batchSize = 10;
+
+    protected function setUp(): void
+    {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->connectionMock = $this->createMock(AdapterInterface::class);
+
+        $this->resourceMock = $this->createMock(ResourceConnection::class);
+        $this->resourceMock->method('getConnection')->willReturn($this->connectionMock);
+        $this->resourceMock->method('getTableName')->willReturnArgument(0);
+
+        $this->generatorMock = $this->createMock(Generator::class);
+
+        $this->imageModel = $objectManager->getObject(
+            Image::class,
+            [
+                'generator' => $this->generatorMock,
+                'resourceConnection' => $this->resourceMock,
+                'batchSize' => $this->batchSize
+            ]
+        );
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getVisibleImagesSelectMock(): \PHPUnit_Framework_MockObject_MockObject
+    {
+        $selectMock = $this->getMockBuilder(Select::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $selectMock->expects($this->once())
+            ->method('distinct')
+            ->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('from')
+            ->with(
+                ['images' => Gallery::GALLERY_TABLE],
+                'value as filepath'
+            )->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('where')
+            ->with('disabled = 0')
+            ->willReturnSelf();
+
+        return $selectMock;
+    }
+
+    public function testGetCountAllProductImages(): void
+    {
+        $selectMock = $this->getVisibleImagesSelectMock();
+        $selectMock->expects($this->exactly(2))
+            ->method('reset')
+            ->withConsecutive(
+                ['columns'],
+                ['distinct']
+            )->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('columns')
+            ->with(new \Zend_Db_Expr('count(distinct value)'))
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($selectMock);
+        $this->connectionMock->expects($this->once())
+            ->method('fetchOne')
+            ->with($selectMock)
+            ->willReturn($this->imagesCount);
+
+        $this->assertSame($this->imagesCount, $this->imageModel->getCountAllProductImages());
+    }
+
+    public function testGetAllProductImages(): void
+    {
+        $getBatchIteratorMock = function ($selectMock, $imagesCount, $batchSize): array {
+            $result = [];
+            $count = $imagesCount / $batchSize;
+            while ($count) {
+                $count--;
+                $result[$count] = $selectMock;
+            }
+
+            return $result;
+        };
+
+        $getAllProductImagesSelectFetchResults = function ($batchSize): array {
+            $result = [];
+            $count = $batchSize;
+            while ($count) {
+                $count--;
+                $result[$count] = $count;
+            }
+
+            return $result;
+        };
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->getVisibleImagesSelectMock());
+
+        $fetchResult = $getAllProductImagesSelectFetchResults($this->batchSize);
+        $this->connectionMock->expects($this->exactly($this->imagesCount / $this->batchSize))
+            ->method('fetchAll')
+            ->willReturn($fetchResult);
+
+        /** @var Select | \PHPUnit_Framework_MockObject_MockObject $selectMock */
+        $selectMock = $this->getMockBuilder(Select::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $batchIteratorMock = $getBatchIteratorMock($selectMock, $this->imagesCount, $this->batchSize);
+        $this->generatorMock->expects($this->once())
+            ->method('generate')
+            ->with(
+                'value_id',
+                $selectMock,
+                $this->batchSize,
+                \Magento\Framework\DB\Query\BatchIteratorInterface::NON_UNIQUE_FIELD_ITERATOR
+            )->willReturn($batchIteratorMock);
+
+        $this->assertCount($this->imagesCount, $this->imageModel->getAllProductImages());
+    }
+}

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -131,7 +131,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             return $result;
         };
 
-        $getAllProductImagesSelectFetchResults = function ($batchSize): array {
+        $getFetchResults = function ($batchSize): array {
             $result = [];
             $count = $batchSize;
             while ($count) {
@@ -146,7 +146,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             ->method('select')
             ->willReturn($this->getVisibleImagesSelectMock());
 
-        $fetchResult = $getAllProductImagesSelectFetchResults($this->batchSize);
+        $fetchResult = $getFetchResults($this->batchSize);
         $this->connectionMock->expects($this->exactly($this->imagesCount / $this->batchSize))
             ->method('fetchAll')
             ->willReturn($fetchResult);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -187,9 +187,8 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     protected function getBatchIteratorCallback(
         \PHPUnit_Framework_MockObject_MockObject $selectMock,
         int $batchCount
-    ): \Closure
-    {
-        $getBatchIteratorCallback = function () use ($batchCount, $selectMock): array {
+    ): \Closure {
+        $iteratorCallback = function () use ($batchCount, $selectMock): array {
             $result = [];
             $count = $batchCount;
             while ($count) {
@@ -200,7 +199,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             return $result;
         };
 
-        return $getBatchIteratorCallback;
+        return $iteratorCallback;
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -13,6 +13,8 @@ use Magento\Framework\DB\Query\Generator;
 use Magento\Framework\DB\Select;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Catalog\Model\ResourceModel\Product\Gallery;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\Framework\DB\Query\BatchIteratorInterface;
 
 class ImageTest extends \PHPUnit\Framework\TestCase
 {
@@ -22,34 +24,37 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     protected $objectManager;
 
     /**
-     * @var AdapterInterface | \PHPUnit_Framework_MockObject_MockObject
+     * @var AdapterInterface | MockObject
      */
     protected $connectionMock;
 
     /**
-     * @var Generator | \PHPUnit_Framework_MockObject_MockObject
+     * @var Generator | MockObject
      */
     protected $generatorMock;
 
     /**
-     * @var ResourceConnection | \PHPUnit_Framework_MockObject_MockObject
+     * @var ResourceConnection | MockObject
      */
     protected $resourceMock;
 
     protected function setUp()
     {
-        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->objectManager =
+            new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->connectionMock = $this->createMock(AdapterInterface::class);
         $this->resourceMock = $this->createMock(ResourceConnection::class);
-        $this->resourceMock->method('getConnection')->willReturn($this->connectionMock);
-        $this->resourceMock->method('getTableName')->willReturnArgument(0);
+        $this->resourceMock->method('getConnection')
+            ->willReturn($this->connectionMock);
+        $this->resourceMock->method('getTableName')
+            ->willReturnArgument(0);
         $this->generatorMock = $this->createMock(Generator::class);
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
-    protected function getVisibleImagesSelectMock(): \PHPUnit_Framework_MockObject_MockObject
+    protected function getVisibleImagesSelectMock(): MockObject
     {
         $selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
@@ -105,7 +110,10 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->assertSame($imagesCount, $imageModel->getCountAllProductImages());
+        $this->assertSame(
+            $imagesCount,
+            $imageModel->getCountAllProductImages()
+        );
     }
 
     /**
@@ -113,8 +121,10 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      * @param int $batchSize
      * @dataProvider dataProvider
      */
-    public function testGetAllProductImages(int $imagesCount, int $batchSize)
-    {
+    public function testGetAllProductImages(
+        int $imagesCount,
+        int $batchSize
+    ) {
         $this->connectionMock->expects($this->once())
             ->method('select')
             ->willReturn($this->getVisibleImagesSelectMock());
@@ -125,7 +135,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             ->method('fetchAll')
             ->will($this->returnCallback($fetchResultsCallback));
 
-        /** @var Select | \PHPUnit_Framework_MockObject_MockObject $selectMock */
+        /** @var Select | MockObject $selectMock */
         $selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -136,8 +146,12 @@ class ImageTest extends \PHPUnit\Framework\TestCase
                 'value_id',
                 $selectMock,
                 $batchSize,
-                \Magento\Framework\DB\Query\BatchIteratorInterface::NON_UNIQUE_FIELD_ITERATOR
-            )->will($this->returnCallback($this->getBatchIteratorCallback($selectMock, $batchCount)));
+                BatchIteratorInterface::NON_UNIQUE_FIELD_ITERATOR
+            )->will(
+                $this->returnCallback(
+                    $this->getBatchIteratorCallback($selectMock, $batchCount)
+                )
+            );
 
         $imageModel = $this->objectManager->getObject(
             Image::class,
@@ -156,10 +170,13 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      * @param int $batchSize
      * @return \Closure
      */
-    protected function getFetchResultCallbackForBatches(int $imagesCount, int $batchSize): \Closure
-    {
+    protected function getFetchResultCallbackForBatches(
+        int $imagesCount,
+        int $batchSize
+    ): \Closure {
         $fetchResultsCallback = function () use (&$imagesCount, $batchSize) {
-            $batchSize = ($imagesCount >= $batchSize) ? $batchSize : $imagesCount;
+            $batchSize =
+                ($imagesCount >= $batchSize) ? $batchSize : $imagesCount;
             $imagesCount -= $batchSize;
 
             $getFetchResults = function ($batchSize): array {
@@ -180,12 +197,12 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param Select | \PHPUnit_Framework_MockObject_MockObject $selectMock
+     * @param Select | MockObject $selectMock
      * @param int $batchCount
      * @return \Closure
      */
     protected function getBatchIteratorCallback(
-        \PHPUnit_Framework_MockObject_MockObject $selectMock,
+        MockObject $selectMock,
         int $batchCount
     ): \Closure {
         $iteratorCallback = function () use ($batchCount, $selectMock): array {

--- a/lib/internal/Magento/Framework/DB/Query/BatchRangeIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchRangeIterator.php
@@ -107,7 +107,7 @@ class BatchRangeIterator implements BatchIteratorInterface
     public function current()
     {
         if (null === $this->currentSelect) {
-            $this->isValid = ($this->currentOffset + $this->batchSize) <= $this->totalItemCount;
+            $this->isValid = $this->currentOffset < $this->totalItemCount;
             $this->currentSelect = $this->initSelectObject();
         }
         return $this->currentSelect;
@@ -138,7 +138,7 @@ class BatchRangeIterator implements BatchIteratorInterface
         if (null === $this->currentSelect) {
             $this->current();
         }
-        $this->isValid = ($this->batchSize + $this->currentOffset) <= $this->totalItemCount;
+        $this->isValid = $this->currentOffset < $this->totalItemCount;
         $select = $this->initSelectObject();
         if ($this->isValid) {
             $this->iteration++;

--- a/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchRangeIteratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchRangeIteratorTest.php
@@ -116,6 +116,6 @@ class BatchRangeIteratorTest extends \PHPUnit\Framework\TestCase
             $iterations++;
         }
 
-        $this->assertEquals(10, $iterations);
+        $this->assertEquals(11, $iterations);
     }
 }


### PR DESCRIPTION
### Original pull request (https://github.com/magento/magento2/pull/18807)

### Description (#18387)
Assumption from issue: >>"catalog:images:resize fails to process all images -> Possible underlying Magento/Framework/DB/Query/Generator issue".
However, there is a problem with total images count calculation select (distinct by image path is not used in `count(*)` ) - functionality by itself works correctly and process all images.

### Fixed Issues 
magento/magento2#18387: catalog:images:resize fails to process all images -> Possible underlying Magento/Framework/DB/Query/Generator issue
1. fixed `getCountAllProductImages` method that calculates total images count incorrectly;
2. covered `\Magento\Catalog\Model\ResourceModel\Product\Image` with unit tests;

`UPD from 27.10.2018:`
3. Ranged selects always miss the last range - [backport] of https://github.com/magento/magento2/pull/12624


### Manual testing scenarios
#### Variant I
1. Magento 2.3-develop
2. Sample data deployed (in order to easily have several test images in store)

##### Expected result
You do see total images count 801.

##### Actual result
You do see total images count 3422.

#### Variant II (synthetic case)
1. Magento 2.3-develop
2. Generate products iwth images:
`php bin/magento setup:performance:generate-fixtures setup/performance-toolkit/profiles/ce/medium.xml`
3. apply the same image paths for all products - so images for product will become duplicated. 
For details check `catalog_product_entity_media_gallery` table.
example SQL to do this:
`create temporary table zzz as (select NULL as value_id, c.attribute_id, c.value, c.media_type, c.disabled from catalog_product_entity_media_gallery as c);
insert into catalog_product_entity_media_gallery select * from zzz;`

##### Expected result
Total images count will be equal to the value from `setup/performance-toolkit/profiles/ce/medium.xml` in `images-count` node ( 1000 ).

##### Actual result
Total images count will be 2 times higher that their exact value.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
