### PR TITLE
Replace erroneous usage of unsData method

### DIFF
--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -236,7 +236,7 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
      */
     public function flushAssociatedProductsCache($product)
     {
-        return $product->unsData($this->_keyAssociatedProducts);
+        return $product->unsetData($this->_keyAssociatedProducts);
     }
 
     /**

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/Type/GroupedTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/Type/GroupedTest.php
@@ -611,9 +611,9 @@ class GroupedTest extends \PHPUnit\Framework\TestCase
 
     public function testFlushAssociatedProductsCache()
     {
-        $productMock = $this->createPartialMock(\Magento\Catalog\Model\Product::class, ['unsData']);
+        $productMock = $this->createPartialMock(\Magento\Catalog\Model\Product::class, ['unsetData']);
         $productMock->expects($this->once())
-            ->method('unsData')
+            ->method('unsetData')
             ->with('_cache_instance_associated_products')
             ->willReturnSelf();
         $this->assertEquals($productMock, $this->_model->flushAssociatedProductsCache($productMock));

--- a/app/code/Magento/Reports/Model/Product/Index/AbstractIndex.php
+++ b/app/code/Magento/Reports/Model/Product/Index/AbstractIndex.php
@@ -252,7 +252,7 @@ abstract class AbstractIndex extends \Magento\Framework\Model\AbstractModel
     public function registerIds($productIds)
     {
         $this->_getResource()->registerIds($this, $productIds);
-        $this->_getSession()->unsData($this->_countCacheKey);
+        $this->_getSession()->unsetData($this->_countCacheKey);
         return $this;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/ManageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/ManageTest.php
@@ -40,7 +40,7 @@ class ManageTest extends \Magento\TestFramework\TestCase\AbstractController
     protected function tearDown()
     {
         $this->customerSession->setCustomerId(null);
-        $this->coreSession->unsData('_form_key');
+        $this->coreSession->unsetData('_form_key');
     }
 
     /**


### PR DESCRIPTION
### Description (*)

This pull request replaces incorrect usages of the magic `unsData` method. Note that there is nothing inherently wrong with magic methods like `unsData()`, but calling the `uns` or `has` variants with any arguments is a mistake.

For example,

```php
// Syntactically correct, but probably doesn't do what you think it does
$object->unsData('_form_key');
//          ^^^^
// __call method takes the key from the method name, not from the method argument
```

The above statement is functionally equivalent to the following code:

```php
// We're unsetting the "data" key which is not what we wanted.
// This usually results in no data being unset from the object 
$object->unsetData('data');
```

Since the `unsData` method is being called with an argument, it is almost certainly the case that the original author(s) intended to use the `unsetData` method instead.

```php
// Corrected code
$object->unsetData('_form_key');
```

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)

1. Expect for all test results to stay exactly the same.
2. If any test results change, then the tests should be re-examined for correctness.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
