### PR TITLE
[Backoport] Issue Fixed: Backups error from User Roles Permission 2.2.6

### DIFF
--- a/app/code/Magento/Backup/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index.php
@@ -19,7 +19,7 @@ abstract class Index extends \Magento\Backend\App\Action
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_Backend::backup';
+    const ADMIN_RESOURCE = 'Magento_Backup::backup';
 
     /**
      * Core registry


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Magento_Backup Module Permission issue fixed for Magento 2.2-develop.

### Description (*)
If Admin Users assigned a Backup module Role Resource, Still  was not able to access 
Backups controller. Now its fixed.

### Fixed Issues (if relevant)
1. #18150 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Created a new Role Settings and assigned custom permission System->Tools.
2. Logged in via the Sub admin user.
3. Now Backup Controller is accessible.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Backport for: https://github.com/magento/magento2/pull/18816