### PR TITLE
Issue #14571 - Wrong column type when creating temporary tables for flat catalog

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
@@ -7,6 +7,9 @@ namespace Magento\Catalog\Model\Indexer\Product\Flat;
 
 use Magento\Catalog\Model\Indexer\Product\Flat\Table\BuilderInterfaceFactory;
 
+/**
+ * Class TableBuilder
+ */
 class TableBuilder
 {
     /**
@@ -137,13 +140,23 @@ class TableBuilder
             );
             $flatColumns = $this->_productIndexerHelper->getFlatColumns();
 
-            $temporaryTableBuilder->addColumn('entity_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER);
+            $temporaryTableBuilder->addColumn(
+                'entity_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned'=>true]
+            );
 
             $temporaryTableBuilder->addColumn('type_id', \Magento\Framework\DB\Ddl\Table::TYPE_TEXT);
 
             $temporaryTableBuilder->addColumn('attribute_set_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER);
 
-            $valueTemporaryTableBuilder->addColumn('entity_id', \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER);
+            $valueTemporaryTableBuilder->addColumn(
+                'entity_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned'=>true]
+            );
 
             /** @var $attribute \Magento\Catalog\Model\ResourceModel\Eav\Attribute */
             foreach ($columns as $columnName => $attribute) {
@@ -198,9 +211,10 @@ class TableBuilder
      * Fill temporary entity table
      *
      * @param string $tableName
-     * @param array  $columns
-     * @param array  $changedIds
+     * @param array $columns
+     * @param array $changedIds
      * @return void
+     * @throws \Exception
      */
     protected function _fillTemporaryEntityTable($tableName, array $columns, array $changedIds = [])
     {
@@ -244,11 +258,12 @@ class TableBuilder
      * Fill temporary table by data from products EAV attributes by type
      *
      * @param string $tableName
-     * @param array  $tableColumns
-     * @param array  $changedIds
+     * @param array $tableColumns
+     * @param array $changedIds
      * @param string $valueFieldSuffix
      * @param int $storeId
      * @return void
+     * @throws \Exception
      */
     protected function _fillTemporaryTable(
         $tableName,
@@ -345,6 +360,8 @@ class TableBuilder
     }
 
     /**
+     * Get Metadata Pool
+     *
      * @return \Magento\Framework\EntityManager\MetadataPool
      * @deprecated 101.1.0
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Product Entity IDs above 2147483647 are not copied correctly and flat catalog product fails to rebuild.
Changed the entity_id column in \Magento\Catalog\Model\Indexer\Product\Flat\TableBuilder::_createTemporaryTable to be created with option to set unsigned to true to match the column from original tables.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14571: Wrong column type when creating temporary tables for flat catalog

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Load a product with an entity id of 2147483648 or greater.
2. Enable use flat catalog product configuration
3. Run bin/magento indexer:reindex catalog_product_flat

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
