### PR TITLE
Make the function to import shipping rate data public

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate.php
+++ b/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate.php
@@ -220,7 +220,7 @@ class Tablerate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @throws \Magento\Framework\Exception\LocalizedException
      * @return void
      */
-    private function importData(array $fields, array $values)
+    public function importData(array $fields, array $values)
     {
         $connection = $this->getConnection();
         $connection->beginTransaction();


### PR DESCRIPTION
### Description
There should be an option to create shipping rate data programmtically (i.e. via Setup Script) without having to create a CSV file. This PR just makes a private method public in order to archieve that.

### Manual testing scenarios
1. Create a setup script
2. Add `\Magento\OfflineShipping\Model\ResourceModel\Carrier\Tablerate` to the constructor, create a class variable `$tablerate` and assign the retrieved object to it in the constructor.
3. Call `$this->tablerate->importData($fields, $values)` from your own method.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
