### PR TITLE
Resolves 6731 by adding a custom message for refunding shipping

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -30,7 +30,7 @@ class Discount extends AbstractTotal
 
         /**
          * If credit memo's shipping amount is set and Order's shipping amount is 0,
-         *      throw exception with differente message
+         * throw exception with different message
          */
         if ( $baseShippingAmount && $order->getBaseShippingAmount() <= 0 ) {
             throw new \Magento\Framework\Exception\LocalizedException(

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -32,7 +32,7 @@ class Discount extends AbstractTotal
          * If credit memo's shipping amount is set and Order's shipping amount is 0,
          * throw exception with different message
          */
-        if ( $baseShippingAmount && $order->getBaseShippingAmount() <= 0 ) {
+        if ($baseShippingAmount && $order->getBaseShippingAmount() <= 0) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.",[])
             );

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -10,6 +10,7 @@ class Discount extends AbstractTotal
     /**
      * @param \Magento\Sales\Model\Order\Creditmemo $creditmemo
      * @return $this
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function collect(\Magento\Sales\Model\Order\Creditmemo $creditmemo)
     {
@@ -26,6 +27,16 @@ class Discount extends AbstractTotal
          * basing on how much shipping should be refunded.
          */
         $baseShippingAmount = $this->getBaseShippingAmount($creditmemo);
+
+        /**
+         * If credit memo's shipping amount is set and Order's shipping amount is 0,
+         *      throw exception with differente message
+         */
+        if ( $baseShippingAmount && $order->getBaseShippingAmount() <= 0 ) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.",[])
+            );
+        }
         if ($baseShippingAmount) {
             $baseShippingDiscount = $baseShippingAmount *
                 $order->getBaseShippingDiscountAmount() /

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -34,7 +34,7 @@ class Discount extends AbstractTotal
          */
         if ($baseShippingAmount && $order->getBaseShippingAmount() <= 0) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.",[])
+                new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.", [])
             );
         }
         if ($baseShippingAmount) {

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/DiscountTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/DiscountTest.php
@@ -74,7 +74,7 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
         $this->orderMock->expects($this->once())
             ->method('getBaseShippingDiscountAmount')
             ->willReturn(1);
-        $this->orderMock->expects($this->exactly(2))
+        $this->orderMock->expects($this->exactly(3))
             ->method('getBaseShippingAmount')
             ->willReturn(1);
         $this->orderMock->expects($this->once())
@@ -150,7 +150,7 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
         $this->orderMock->expects($this->once())
             ->method('getBaseShippingDiscountAmount')
             ->willReturn(1);
-        $this->orderMock->expects($this->exactly(2))
+        $this->orderMock->expects($this->exactly(3))
             ->method('getBaseShippingAmount')
             ->willReturn(1);
         $this->orderMock->expects($this->once())
@@ -267,6 +267,32 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
                     [1, 'base', true, 1]
                 ]
             );
+        $this->assertEquals($this->total, $this->total->collect($this->creditmemoMock));
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage You can not refund shipping if there is no shipping amount.
+     */
+    public function testCollectNonZeroShipping()
+    {
+        $this->creditmemoMock->expects($this->once())
+            ->method('setDiscountAmount')
+            ->willReturnSelf();
+        $this->creditmemoMock->expects($this->once())
+            ->method('setBaseDiscountAmount')
+            ->willReturnSelf();
+        $this->creditmemoMock->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($this->orderMock);
+        $this->creditmemoMock->expects($this->once())
+            ->method('getBaseShippingAmount')
+            ->willReturn('10.0000');
+        $this->orderMock->expects($this->never())
+            ->method('getBaseShippingDiscountAmount');
+        $this->orderMock->expects($this->once())
+            ->method('getBaseShippingAmount')
+            ->willReturn( '0.0000');
         $this->assertEquals($this->total, $this->total->collect($this->creditmemoMock));
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->



<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)

1. magento/magento2#6731: 'Exception' with message 'Warning: Division by zero in vendor/magento/module-sales/Model/Order/Creditmemo/Total/Discount.php on line 32' in vendor/magento/framework/App/ErrorHandler.php:61

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a order with free shipment
2. Invoice the order
3. Create new creditmemo
4. Refund $10 in Refund Shipping

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
