### PR TITLE
Autoload for vendor root folders

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -28,6 +28,9 @@ $vendorAutoload = BP . "/{$vendorDir}/autoload.php";
 /* 'composer install' validation */
 if (file_exists($vendorAutoload)) {
     $composerAutoloader = include $vendorAutoload;
+} else if (file_exists("{$vendorDir}/autoload.php")) {
+	$vendorAutoload = "{$vendorDir}/autoload.php";
+	$composerAutoloader = include $vendorAutoload;
 } else {
     throw new \Exception(
         'Vendor autoload is not found. Please run \'composer install\' under application root directory.'


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added a validation for existing autoload file.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17753: Magento cannot run with custom Composer vendor directories

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a temporary directory for vendor data: mkdir /tmp/composer-vendor-dir
2. Create a project directory: mkdir ~/magento-project
3. Set the Composer vendor directory: export COMPOSER_VENDOR_DIR="/tmp/composer-vendor-dir"
4. Create a Magento project: composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition ~/magento-project
5. Observe successful Composer installation
6. Attempt to access Magento CLI: php bin/magento

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
