### PR TITLE
Fixes theme header logo and icon upload

### DIFF
--- a/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
+++ b/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
@@ -54,7 +54,7 @@
                 <collapsible>true</collapsible>
                 <label translate="true">HTML Head</label>
             </settings>
-            <field name="head_shortcut_icon" formElement="fileUploader">
+            <field name="head_shortcut_icon" formElement="imageUploader">
                 <settings>
                     <notice translate="true">Not all browsers support all these formats!</notice>
                     <label translate="true">Favicon Icon</label>
@@ -151,7 +151,7 @@
                 <collapsible>true</collapsible>
                 <label translate="true">Header</label>
             </settings>
-            <field name="header_logo_src" formElement="fileUploader">
+            <field name="header_logo_src" formElement="imageUploader">
                 <settings>
                     <label translate="true">Logo Image</label>
                     <componentType>imageUploader</componentType>


### PR DESCRIPTION
### Description (*)
With the change of "fileuploader" to "imageuploader" the correct formElement was not updated to match the new "imageuploader". 

### Fixed Issues (if relevant)

1. magento/magento2#18688: Unable to upload Logo, Magento 2.3.0 Beta18
2. ...

### Manual testing scenarios (*)

1. Use magento2.3 development branche
2. Content -> Design -> Configuration -> edit any Default Store View
3. Other Settings -> Header -> try to upload a favicon or logo

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
