### PR TITLE
Fixed - Default tax region/state appears in customer & order data #16684

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
@@ -25,6 +25,8 @@ define([
         if (countryId) {
             if (addressData.region && addressData.region['region_id']) {
                 regionId = addressData.region['region_id'];
+            } else if (!addressData['region_id']) {
+                regionId = null;
             } else if (countryId === window.checkoutConfig.defaultCountryId) {
                 regionId = window.checkoutConfig.defaultRegionId;
             }

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
@@ -26,7 +26,7 @@ define([
             if (addressData.region && addressData.region['region_id']) {
                 regionId = addressData.region['region_id'];
             } else if (!addressData['region_id']) {
-                regionId = null;
+                regionId = undefined;
             } else if (countryId === window.checkoutConfig.defaultCountryId) {
                 regionId = window.checkoutConfig.defaultRegionId;
             }


### PR DESCRIPTION
### Description (*)
Fixed issue of default tax region/state appears in customer & order data

### Fixed Issues (if relevant)

1. magento/magento2#16684: Default tax region/state appears in customer & order data

### Manual testing scenarios (*)
1. Set a default tax region in Stores > Configuration > Sales > Tax
2. Complete an order

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
