### PR TITLE
[Backport] Adding trimming sku value function to sku backend model.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -97,6 +97,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     public function beforeSave($object)
     {
         $this->_generateUniqueSku($object);
+        $this->trimValue($object);
         return parent::beforeSave($object);
     }
 
@@ -126,5 +127,18 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
         );
         $data = $connection->fetchOne($select, $bind);
         return abs((int)str_replace($value, '', $data));
+    }
+
+    /**
+     * @param Product $object
+     * @return void
+     */
+    private function trimValue($object)
+    {
+        $attrCode = $this->getAttribute()->getAttributeCode();
+        $value = $object->getData($attrCode);
+        if ($value) {
+            $object->setData($attrCode, trim($value));
+        }
     }
 }

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
@@ -372,7 +372,8 @@ class General extends AbstractModifier
             $skuPath . static::META_CONFIG_PATH,
             $meta,
             [
-                'autoImportIfEmpty' => true
+                'autoImportIfEmpty' => true,
+                'validation' => ['no-marginal-whitespace' => true]
             ]
         );
 

--- a/app/code/Magento/Ui/i18n/en_US.csv
+++ b/app/code/Magento/Ui/i18n/en_US.csv
@@ -58,6 +58,7 @@ Keyword,Keyword
 "Letters, numbers, spaces or underscores only please","Letters, numbers, spaces or underscores only please"
 "Letters only please","Letters only please"
 "No white space please","No white space please"
+"No marginal white space please","No marginal white space please"
 "Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx","Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx"
 "A positive or negative non-decimal number please","A positive or negative non-decimal number please"
 "The specified vehicle identification number (VIN) is invalid.","The specified vehicle identification number (VIN) is invalid."

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -115,6 +115,12 @@ define([
             },
             $.mage.__('No white space please')
         ],
+        'no-marginal-whitespace': [
+            function (value) {
+                return !/^\s+|\s+$/i.test(value);
+            },
+            $.mage.__('No marginal white space please')
+        ],
         'zip-range': [
             function (value) {
                 return /^90[2-5]-\d{2}-\d{4}$/.test(value);

--- a/lib/web/i18n/en_US.csv
+++ b/lib/web/i18n/en_US.csv
@@ -27,6 +27,7 @@ Submit,Submit
 "Letters, numbers, spaces or underscores only please","Letters, numbers, spaces or underscores only please"
 "Letters only please","Letters only please"
 "No white space please","No white space please"
+"No marginal white space please","No marginal white space please"
 "Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx","Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx"
 "A positive or negative non-decimal number please","A positive or negative non-decimal number please"
 "The specified vehicle identification number (VIN) is invalid.","The specified vehicle identification number (VIN) is invalid."

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -253,6 +253,12 @@
             },
             $.mage.__('No white space please')
         ],
+        'no-marginal-whitespace': [
+            function (value, element) {
+                return this.optional(element) || !/^\s+|\s+$/i.test(value);
+            },
+            $.mage.__('No marginal white space please')
+        ],
         'zip-range': [
             function (value, element) {
                 return this.optional(element) || /^90[2-5]-\d{2}-\d{4}$/.test(value);


### PR DESCRIPTION
### Original PR
https://github.com/magento/magento2/pull/18019
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
I have added function to sku backend model which trimms value from whitespace.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/16572 Trim whitespace on SKU when saving product
2. https://github.com/magento/magento2/issues/12300 SKU values are not trimmed with the space.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Edit sku, by adding some whitespace
2. Save product.
3. Sku will be trimmed and saved in changed form.
4. Messsage that sku has been changed will be displayed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
