### PR TITLE
[Backport] [BUGFIX] [issue-10205] Always set the entity_type_id for updating pro

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -143,15 +143,6 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
             $this->validateCode($attribute->getAttributeCode());
             $this->validateFrontendInput($attribute->getFrontendInput());
 
-            $attribute->setBackendType(
-                $attribute->getBackendTypeByInput($attribute->getFrontendInput())
-            );
-            $attribute->setSourceModel(
-                $this->productHelper->getAttributeSourceModelByInputType($attribute->getFrontendInput())
-            );
-            $attribute->setBackendModel(
-                $this->productHelper->getAttributeBackendModelByInputType($attribute->getFrontendInput())
-            );
             $attribute->setIsUserDefined(1);
         }
         if (!empty($attribute->getData(AttributeInterface::OPTIONS))) {

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -106,6 +106,11 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
      */
     public function save(\Magento\Catalog\Api\Data\ProductAttributeInterface $attribute)
     {
+        $attribute->setEntityTypeId(
+            $this->eavConfig
+                ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
+                ->getId()
+        );
         if ($attribute->getAttributeId()) {
             $existingModel = $this->get($attribute->getAttributeCode());
 
@@ -138,11 +143,14 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
             $this->validateCode($attribute->getAttributeCode());
             $this->validateFrontendInput($attribute->getFrontendInput());
 
-            $this->processAttributeData($attribute);
-            $attribute->setEntityTypeId(
-                $this->eavConfig
-                    ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
-                    ->getId()
+            $attribute->setBackendType(
+                $attribute->getBackendTypeByInput($attribute->getFrontendInput())
+            );
+            $attribute->setSourceModel(
+                $this->productHelper->getAttributeSourceModelByInputType($attribute->getFrontendInput())
+            );
+            $attribute->setBackendModel(
+                $this->productHelper->getAttributeBackendModelByInputType($attribute->getFrontendInput())
             );
             $attribute->setIsUserDefined(1);
         }


### PR DESCRIPTION
### Original PR
https://github.com/magento/magento2/pull/18622

…duct attributes because the route contains the specification products/attributes

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
issue description which is solved:

> Using Magento 2.1.7 with the REST API - POST /V1/products/attributes - I can add a new attribute and configure it with settings such as is_filterable.
> 
> This is all fine but if I then want to change this setting I can't. I have tried with POST and with PUT /V1/products/attributes/{attributeCode}. The command works as in it will update, for instance, the frontend label in the eav_attribute table, but it does not seem to have any effect on values in the catalog_eav_attribute table.
> 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#10205: REST API /V1/products/attributes does not update all properties

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a new attribute using REST API - POST - /V1/products/attributes - with is_filterable set to false.
2. Update the same attribute using either the same POST url or PUT - /V1/products/attributes/{attributeCode} and set the is_filterable field to true
3. Result: attribute is not set to is_filterable
4. Apply changes
5. Update the same attribute using either the same POST url or PUT - /V1/products/attributes/{attributeCode} and set the is_filterable field to true
6. Result: attribute is set to is_filterable

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
