### PR TITLE
[Backport] Ensure integer values are not quoted as strings

### DIFF
--- a/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/ConditionProcessor/ProductCategoryCondition.php
+++ b/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/ConditionProcessor/ProductCategoryCondition.php
@@ -102,7 +102,7 @@ class ProductCategoryCondition implements CustomConditionInterface
             }
         }
 
-        return array_unique(array_merge($categoryIds, ...$childCategoryIds));
+        return array_map('intval', array_unique(array_merge($categoryIds, ...$childCategoryIds)));
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ProductCategoryList.php
+++ b/app/code/Magento/Catalog/Model/ProductCategoryList.php
@@ -81,7 +81,11 @@ class ProductCategoryList
                 Select::SQL_UNION_ALL
             );
 
-            $this->categoryIdList[$productId] = $this->productResource->getConnection()->fetchCol($unionSelect);
+            $this->categoryIdList[$productId] = array_map(
+                'intval',
+                $this->productResource->getConnection()->fetchCol($unionSelect)
+            );
+
         }
 
         return $this->categoryIdList[$productId];

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1791,7 +1791,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             }
             $conditions[] = $this->getConnection()->quoteInto(
                 'product_website.website_id IN(?)',
-                $filters['website_ids']
+                $filters['website_ids'],
+                'int'
             );
         } elseif (isset(
             $filters['store_id']
@@ -1803,7 +1804,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
         ) {
             $joinWebsite = true;
             $websiteId = $this->_storeManager->getStore($filters['store_id'])->getWebsiteId();
-            $conditions[] = $this->getConnection()->quoteInto('product_website.website_id = ?', $websiteId);
+            $conditions[] = $this->getConnection()->quoteInto('product_website.website_id = ?', $websiteId, 'int');
         }
 
         $fromPart = $this->getSelect()->getPart(\Magento\Framework\DB\Select::FROM);
@@ -1999,12 +2000,16 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
 
         $conditions = [
             'cat_index.product_id=e.entity_id',
-            $this->getConnection()->quoteInto('cat_index.store_id=?', $filters['store_id']),
+            $this->getConnection()->quoteInto('cat_index.store_id=?', $filters['store_id'], 'int'),
         ];
         if (isset($filters['visibility']) && !isset($filters['store_table'])) {
-            $conditions[] = $this->getConnection()->quoteInto('cat_index.visibility IN(?)', $filters['visibility']);
+            $conditions[] = $this->getConnection()->quoteInto(
+                'cat_index.visibility IN(?)',
+                $filters['visibility'],
+                'int'
+            );
         }
-        $conditions[] = $this->getConnection()->quoteInto('cat_index.category_id=?', $filters['category_id']);
+        $conditions[] = $this->getConnection()->quoteInto('cat_index.category_id=?', $filters['category_id'], 'int');
         if (isset($filters['category_is_anchor'])) {
             $conditions[] = $this->getConnection()->quoteInto('cat_index.is_parent=?', $filters['category_is_anchor']);
         }

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -284,8 +284,8 @@ class View extends \Magento\Framework\DataObject implements ViewInterface
 
                 for ($versionFrom = $lastVersionId; $versionFrom < $currentVersionId; $versionFrom += $versionBatchSize) {
                     // Don't go past the current version for atomicy.
-                    $versionTo = min($currentVersionId, $versionFrom + $versionBatchSize);
-                    $ids = $this->getChangelog()->getList($versionFrom, $versionTo);
+                    $versionTo = min($currentVersionId, $vsFrom + $versionBatchSize);
+                    $ids = array_map('intval', $this->getChangelog()->getList($vsFrom, $versionTo));
 
                     // We run the actual indexer in batches.  Chunked AFTER loading to avoid duplicates in separate chunks.
                     $chunks = array_chunk($ids, $batchSize);


### PR DESCRIPTION
### Original PR
#18611

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

In cases where indexers does a filtering in the style of WHERE entity_id IN (...) there is a performance penalty if IDs are passed as strings, rather than integer values. This is especially visible on larger data sets. This pull request should cover some common occurrences of this.

This is based on the PR #18287 , as requested.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. n/a

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. n/a

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
