### PR TITLE
[Backport] ISSUE-5021 - fixed place order for custom shipping methods with under…

### DIFF
--- a/app/code/Magento/Checkout/Model/PaymentInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/PaymentInformationManagement.php
@@ -114,9 +114,8 @@ class PaymentInformationManagement implements \Magento\Checkout\Api\PaymentInfor
             $quote->setDataChanges(true);
             $shippingAddress = $quote->getShippingAddress();
             if ($shippingAddress && $shippingAddress->getShippingMethod()) {
-                $shippingDataArray = explode('_', $shippingAddress->getShippingMethod());
-                $shippingCarrier = array_shift($shippingDataArray);
-                $shippingAddress->setLimitCarrier($shippingCarrier);
+                $shippingRate = $shippingAddress->getShippingRateByCode($shippingAddress->getShippingMethod());
+                $shippingAddress->setLimitCarrier($shippingRate->getCarrier());
             }
         }
         $this->paymentMethodManagement->set($cartId, $paymentMethod);

--- a/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/PaymentInformationManagementTest.php
@@ -168,9 +168,11 @@ class PaymentInformationManagementTest extends \PHPUnit\Framework\TestCase
         $billingAddressId = 1;
         $quoteMock = $this->createMock(\Magento\Quote\Model\Quote::class);
         $quoteBillingAddress = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
+        $shippingRate = $this->createPartialMock(\Magento\Quote\Model\Quote\Address\Rate::class, []);
+        $shippingRate->setCarrier('flatrate');
         $quoteShippingAddress = $this->createPartialMock(
             \Magento\Quote\Model\Quote\Address::class,
-            ['setLimitCarrier', 'getShippingMethod']
+            ['setLimitCarrier', 'getShippingMethod', 'getShippingRateByCode']
         );
         $this->cartRepositoryMock->expects($this->any())->method('getActive')->with($cartId)->willReturn($quoteMock);
         $quoteMock->expects($this->once())->method('getBillingAddress')->willReturn($quoteBillingAddress);
@@ -179,6 +181,7 @@ class PaymentInformationManagementTest extends \PHPUnit\Framework\TestCase
         $quoteMock->expects($this->once())->method('removeAddress')->with($billingAddressId);
         $quoteMock->expects($this->once())->method('setBillingAddress')->with($billingAddressMock);
         $quoteMock->expects($this->once())->method('setDataChanges')->willReturnSelf();
+        $quoteShippingAddress->expects($this->any())->method('getShippingRateByCode')->willReturn($shippingRate);
         $quoteShippingAddress->expects($this->any())->method('getShippingMethod')->willReturn('flatrate_flatrate');
         $quoteShippingAddress->expects($this->once())->method('setLimitCarrier')->with('flatrate')->willReturnSelf();
     }


### PR DESCRIPTION
### Original PR
https://github.com/magento/magento2/pull/18689

…score in carrier code

This fix allows to add custom shipping method with underscore in custom carrier code.

### Description (*)

This fix avoid problem with incorrect shipping method code when logged in customer want to place order using custom shipping method with underscore in carrier code or method.
Issue was reproduced on versions:
- 2.1.9
- 2.2.5
- 2.3

### Fixed Issues (if relevant)

1. magento/magento2#5021: "Please specify a shipping method" Exception

### Manual testing scenarios (*)

1. Create custom shipping method module with underscore '_' in carrier code eg. "custom_shipping"
2. Enable custom shipping method 
3. Create account and log in
4. Add product to cart
5. Go to checkout and select custom shipping method
4. Place order

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
