### PR TITLE
[Backport] Allow set billing information via API with existing address

### DIFF
--- a/app/code/Magento/Quote/Model/BillingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/BillingAddressManagement.php
@@ -76,6 +76,7 @@ class BillingAddressManagement implements BillingAddressManagementInterface
     {
         /** @var \Magento\Quote\Model\Quote $quote */
         $quote = $this->quoteRepository->getActive($cartId);
+        $address->setCustomerId($quote->getCustomerId());
         $quote->removeAddress($quote->getBillingAddress()->getId());
         $quote->setBillingAddress($address);
         try {


### PR DESCRIPTION
### Original PR 
https://github.com/magento/magento2/pull/18704

### Description (*)
Not setting the customerId with an existing address caused a
`NoSuchEntityException` to be thrown during address validation https://github.com/magento/magento2/blob/56af1e73ce21867b770a7458ab6e109f4a1eface/app/code/Magento/Quote/Model/QuoteAddressValidator.php#L84

### Fixed Issues (if relevant)
1. magento/magento2#17485 Adding billing information via mine API expects costumer id

### Manual testing scenarios (*)
1. Create Customer token and a quote with items that would be used to add shipping and billing information
2. A saved customer address .
3. Hit the products REST api rest/V1/carts/mine/billing-address with generated customer token in above state with a similar body as below
```json
{
"address": {
      "customerAddressId":"{{ saved customer address id }}",
      "countryId":"MY",
      "regionId":"572",
      "regionCode":"MLK",
      "region":"Melaka",
      "street":[  
         "My home Any Floor, any Tower ,",
         "Unknown  Road"
      ],
      "telephone":"",
      "postcode":"12345",
      "city":"Melaka",
      "firstname":"Vishwas",
      "lastname":"Bhatnagar"
   }
}
```
4. Success and Returns quote address id

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
