### PR TITLE
[Backport] Prevent exception when option text converts to false

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -132,7 +132,7 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
      */
     protected function validateOption($attribute, $optionId)
     {
-        if (!$attribute->getSource()->getOptionText($optionId)) {
+        if ($attribute->getSource()->getOptionText($optionId) === false) {
             throw new NoSuchEntityException(
                 __('Attribute %1 does not contain option with Id %2', $attribute->getAttributeCode(), $optionId)
             );


### PR DESCRIPTION
### Original PR
https://github.com/magento/magento2/pull/18720

### Description (*)
The function would incorrectly through an exception when the option text was
set to a string that would evaluate to false such as "0"

### Fixed Issues (if relevant)
1. magento/magento2#13083 OptionManagement.validateOption throws NoSuchEntityException for "0" option label

### Manual testing scenarios (*)
1. Create a product attribute of 'dropdown' type via admin page with one option (Admin value: 0, Default Store View value: 0)
2. Programmatically delete the option using OptionManagement.delete method
3. The option should be delete w/o any errors

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
