### PR TITLE
[Backport] Sections LESS mixins: fix the issue with missing rules and incorrect default variables

### DIFF
--- a/lib/web/css/source/lib/_sections.less
+++ b/lib/web/css/source/lib/_sections.less
@@ -49,16 +49,16 @@
     @_tab-control-color: @tab-control__color,
     @_tab-control-text-decoration: @tab-control__text-decoration,
 
-    @_tab-control-color-visited: @tab-control__color,
-    @_tab-control-text-decoration-visited: @tab-control__text-decoration,
+    @_tab-control-color-visited: @tab-control__visited__color,
+    @_tab-control-text-decoration-visited: @tab-control__visited__text-decoration,
 
     @_tab-control-background-color-hover: @tab-control__hover__background-color,
     @_tab-control-color-hover: @tab-control__hover__color,
-    @_tab-control-text-decoration-hover: @tab-control__text-decoration,
+    @_tab-control-text-decoration-hover: @tab-control__hover__text-decoration,
 
     @_tab-control-background-color-active: @tab-control__active__background-color,
     @_tab-control-color-active: @tab-control__active__color,
-    @_tab-control-text-decoration-active: @tab-control__text-decoration,
+    @_tab-control-text-decoration-active: @tab-control__active__text-decoration,
 
     @_tab-control-height: @tab-control__height,
     @_tab-control-margin-right: @tab-control__margin-right,
@@ -121,6 +121,7 @@
         &.active > .switch:hover {
             .lib-css(background, @_tab-control-background-color-active);
             .lib-css(color, @_tab-control-color-active);
+            .lib-css(text-decoration, @_tab-control-text-decoration-active);
         }
 
         &.active > .switch,
@@ -200,8 +201,8 @@
     @_accordion-control-color: @accordion-control__color,
     @_accordion-control-text-decoration: @accordion-control__text-decoration,
 
-    @_accordion-control-color-visited: @accordion-control__color,
-    @_accordion-control-text-decoration-visited: @accordion-control__text-decoration,
+    @_accordion-control-color-visited: @accordion-control__visited__color,
+    @_accordion-control-text-decoration-visited: @accordion-control__visited__text-decoration,
 
     @_accordion-control-background-color-hover: @accordion-control__hover__background-color,
     @_accordion-control-color-hover: @accordion-control__hover__color,
@@ -275,6 +276,8 @@
         &.active > .switch:focus,
         &.active > .switch:hover {
             .lib-css(background, @_accordion-control-background-color-active);
+            .lib-css(color, @_accordion-control-color-active);
+            .lib-css(text-decoration, @_accordion-control-text-decoration-active);
             .lib-css(padding-bottom, @_accordion-control-padding-bottom);
         }
     }

--- a/lib/web/css/source/lib/variables/_sections.less
+++ b/lib/web/css/source/lib/variables/_sections.less
@@ -40,8 +40,8 @@
 @tab-control__active__color: @text__color;
 @tab-control__active__text-decoration: @tab-control__text-decoration;
 
-@tab-control__visited__color: @accordion-control__color;
-@tab-control__visited__text-decoration: @accordion-control__text-decoration;
+@tab-control__visited__color: @tab-control__color;
+@tab-control__visited__text-decoration: @tab-control__text-decoration;
 
 @tab-content__background-color: @tab-control__active__background-color;
 @tab-content__border-top-status: false;

--- a/lib/web/css/source/lib/variables/_sections.less
+++ b/lib/web/css/source/lib/variables/_sections.less
@@ -40,6 +40,9 @@
 @tab-control__active__color: @text__color;
 @tab-control__active__text-decoration: @tab-control__text-decoration;
 
+@tab-control__visited__color: @accordion-control__color;
+@tab-control__visited__text-decoration: @accordion-control__text-decoration;
+
 @tab-content__background-color: @tab-control__active__background-color;
 @tab-content__border-top-status: false;
 @tab-content__border: @tab-control__border-width solid @tab-control__border-color;
@@ -72,8 +75,8 @@
 @accordion-control__padding-bottom: @tab-control__padding-bottom;
 @accordion-control__padding-left: @accordion-control__padding-right;
 
-@accordion-control__visited__color: @accordion-control__color;
-@accordion-control__visited__text-decoration: @accordion-control__text-decoration;
+@accordion-control__visited__color: @tab-control__visited__color;
+@accordion-control__visited__text-decoration: @tab-control__visited__text-decoration;
 
 @accordion-control__hover__background-color: @tab-control__hover__background-color;
 @accordion-control__hover__color: @tab-control__hover__color;


### PR DESCRIPTION
### Original PR
https://github.com/magento/magento2/pull/18730

There are couple of issues when trying to use mixins for "tabs" and "accordion".

The issue is related to `lib/web/css/source/lib/_sections.less`.
The default variables are predefined in `lib/web/css/source/lib/variables/_sections.less`.

### Description (*)
When you try to customize the view of "tabs" and "accordion" components by redefining the default variables in the scope of a custom theme, the following issues appear:

1. The text color for active "accordion" control is not applied.
2. The text-decoration for active control is not working for both "accordion" and "tabs" components.
3. There are also incorrectly defined default variables for mixins. (e.g. accordion control visited and tab control hover variables etc.).


### Fixed Issues (if relevant)
1. magento/magento2#18729: Bug in "_sections.less" mixins: missing rules and incorrect default variables

### Manual testing scenarios (*)
Let's try to define the following variables in the scope of a custom theme.

```
@tab-control__active__background-color: yellow;
@tab-control__active__color: red;
@tab-control__active__text-decoration: underline;
```

Assuming that those variables are not defined elsewhere (in the scope of current or parent theme) except the default lib variables file `lib/web/css/source/lib/variables/_sections.less`.

### Expected Result
There are red color, yellow background and underline text decoration applied for both accordion and tabs active controls.

<img width="363" alt="screen shot 2018-10-21 at 8 41 00 pm" src="https://user-images.githubusercontent.com/11693779/47270654-c0f66d80-d577-11e8-8724-ea853a85df76.png">
<img width="558" alt="screen shot 2018-10-21 at 8 52 33 pm" src="https://user-images.githubusercontent.com/11693779/47270655-c0f66d80-d577-11e8-98ac-01be9ca5a1df.png">

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
