### PR TITLE
Prefix dropdown in checkout doesn't select empty value by default if required

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -44,7 +44,7 @@ define([
         nodes = _.map(nodes, function (node) {
             value = node.value;
 
-            if (value == '') {
+            if (value === '') {
                 node.label = ' ';
 
                 return node;

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -43,10 +43,8 @@ define([
 
         nodes = _.map(nodes, function (node) {
         value = node.value;
-
             if (value == '') {
                 node.label = ' ';
-
                 return node;
             }
             

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -42,8 +42,8 @@ define([
             value;
 
         nodes = _.map(nodes, function (node) {
-            value = node.value;
-            
+        value = node.value;
+
             if (value == "") {
                 node.label = " ";
                 return node;

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -43,11 +43,13 @@ define([
 
         nodes = _.map(nodes, function (node) {
         value = node.value;
+
             if (value == '') {
                 node.label = ' ';
+
                 return node;
             }
-            
+
             if (value === null || value === captionValue) {
                 if (_.isUndefined(caption)) {
                     caption = node.label;

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -44,10 +44,12 @@ define([
         nodes = _.map(nodes, function (node) {
         value = node.value;
 
-            if (value == "") {
-                node.label = " ";
+            if (value == '') {
+                node.label = ' ';
+
                 return node;
             }
+            
             if (value === null || value === captionValue) {
                 if (_.isUndefined(caption)) {
                     caption = node.label;

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -43,7 +43,11 @@ define([
 
         nodes = _.map(nodes, function (node) {
             value = node.value;
-
+            
+            if (value == "") {
+                node.label = " ";
+                return node;
+            }
             if (value === null || value === captionValue) {
                 if (_.isUndefined(caption)) {
                     caption = node.label;

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -42,7 +42,7 @@ define([
             value;
 
         nodes = _.map(nodes, function (node) {
-        value = node.value;
+            value = node.value;
 
             if (value == '') {
                 node.label = ' ';


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Resolved prefix  default selection issue.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18823: Prefix dropdown in checkout doesn't select empty value by default if required


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. In Admin Backend go to Stores > Configuration > Customers > Name and Address Options
2. Set "Show Prefix" to "Required"
3. Set "Prefix Dropdown Options" to ";Mr.;Mrs."
4. Save Config
5. Go to your store
6. Add a item to your cart
7. Go to checkout

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
