### PR TITLE
 [Backport] Fixed subscribe to newsletter if you already have an account issue

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
@@ -77,9 +77,10 @@ class NewAction extends SubscriberController
     protected function validateEmailAvailable($email)
     {
         $websiteId = $this->_storeManager->getStore()->getWebsiteId();
-        if ($this->_customerSession->getCustomerDataObject()->getEmail() !== $email
+        if ($this->_customerSession->isLoggedIn()
+            && ($this->_customerSession->getCustomerDataObject()->getEmail() !== $email
             && !$this->customerAccountManagement->isEmailAvailable($email, $websiteId)
-        ) {
+        )) {
             throw new LocalizedException(
                 __('This email address is already assigned to another user.')
             );

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/SubscriberTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/SubscriberTest.php
@@ -53,11 +53,10 @@ class SubscriberTest extends AbstractController
         $this->getRequest()->setPostValue([
             'email' => 'customer@example.com',
         ]);
-
         $this->dispatch('newsletter/subscriber/new');
 
         $this->assertSessionMessages($this->equalTo([
-                'There was a problem with the subscription: This email address is already assigned to another user.',
+                'Thank you for your subscription.',
             ]));
         $this->assertRedirect($this->anything());
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed subscribe to newsletter if you already have an account issue
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#8952: You can't subscribe to newsletter if you already have an account

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
