### PR TITLE
[BACKPORT] [FEATURE] Added Catalog Product Scope Hints

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/form/field.html
+++ b/app/code/Magento/Ui/view/base/web/templates/form/field.html
@@ -38,6 +38,18 @@
 
         <div class="admin__additional-info" if="$data.additionalInfo" html="$data.additionalInfo"></div>
 
+        <div class="admin__scope-hints" if="$data.scopeHints">
+            <p class="lead-text">
+                <span data-bind="i18n: 'This field is overridden at the following scope(s):'"/>
+            </p>
+            <dl class="overridden-hint-list" data-bind="foreach: $data.scopeHints">
+                <dt class="override-scope">
+                    <span text="scopeType"></span>
+                    <a data-bind= "attr: { href: scopeUrl }" target="_blank" text="scopeLabel"></a>
+                </dt>
+            </dl>
+        </div>
+
         <render args="$data.service.template" if="$data.hasService()"/>
     </div>
 </div>

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -465,6 +465,11 @@
     padding-top: @indent__s;
 }
 
+//  Field scope-hints information
+.admin__scope-hints {
+    padding-top: @indent__s;
+}
+
 //  Field containing checkbox or radio
 .admin__field-option {
     padding-top: @field-option__padding-top;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->
same as PR #18448

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When there is a value set (when `Use Default` has been disabled) on website or storeview level there will be shown a notice in the Product Form

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set up a Multi Website
2. Create a Product through the Admin
3. Change the Scope to a storeview
4. Add a Storeview or website Specific Value
5. Change the Scope to the Default Scope
6. Now you can see that there is a Storeview or Website Specific value for the changed attribute
7. Click on the link and then it will open the Product Edit Page on that specific Storeview (when it is on Website scope it will open the default store of that website because it is not possible to change scope to website)

![image](https://user-images.githubusercontent.com/6040343/46596266-370cc600-cadc-11e8-873c-73fc574f6aec.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
