### PR TITLE
Fixed Issue: Customer name in admin order management is "Guest"

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -355,6 +355,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         if ($quote->getCheckoutMethod() === self::METHOD_GUEST) {
             $billingAddress = $quote->getBillingAddress();
 
+            $quote->setCustomerId(null);
             $quote->setCustomerEmail($billingAddress->getEmail());
             $quote->setCustomerFirstname($billingAddress->getFirstname());
             $quote->setCustomerMiddlename($billingAddress->getMiddlename());

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -353,8 +353,12 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         }
 
         if ($quote->getCheckoutMethod() === self::METHOD_GUEST) {
-            $quote->setCustomerId(null);
-            $quote->setCustomerEmail($quote->getBillingAddress()->getEmail());
+            $billingAddress = $quote->getBillingAddress();
+
+            $quote->setCustomerEmail($billingAddress->getEmail());
+            $quote->setCustomerFirstname($billingAddress->getFirstname());
+            $quote->setCustomerMiddlename($billingAddress->getMiddlename());
+            $quote->setCustomerLastname($billingAddress->getLastname());
             $quote->setCustomerIsGuest(true);
             $quote->setCustomerGroupId(\Magento\Customer\Api\Data\GroupInterface::NOT_LOGGED_IN_ID);
         }

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -354,8 +354,6 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
 
         if ($quote->getCheckoutMethod() === self::METHOD_GUEST) {
             $billingAddress = $quote->getBillingAddress();
-
-            $quote->setCustomerId(null);
             $quote->setCustomerEmail($billingAddress->getEmail());
             $quote->setCustomerFirstname($billingAddress->getFirstname());
             $quote->setCustomerMiddlename($billingAddress->getMiddlename());


### PR DESCRIPTION
Fixed Issue of Place an order as an guest, the displayed customer name in the admin order management is "Guest". If the guest has created an account after placing the order, it is a link that points to the customer's account management. Invoice and shipping are also affected.

### Description (*)
If Order is placed by Guest user in admin Order view, Invoice view, Shipment view, displaying Customer
name as "Guest", issue was in the quote management, its only set email for the customer, Now i have it
in this pull request.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
#18616: Customer name in adminhtml's order management is "Guest"

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Created a new order as Guest for simple product, now Customer name is visible in admin order view.
2. Created a new order as Guest for virtual product as well, now Customer name is visible in admin order view.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
