### PR TITLE
Introduce select-use-config component

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/select-use-config.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select-use-config.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'Magento_Ui/js/form/element/select'
+], function (Component) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            isUseDefault: false,
+            isUseConfig: false,
+            listens: {
+                'isUseConfig': 'toggleElement',
+                'isUseDefault': 'toggleElement'
+            }
+        },
+
+        /**
+         * @inheritdoc
+         */
+        initObservable: function () {
+
+            return this
+                ._super()
+                .observe('isUseConfig');
+        },
+
+        /**
+         * Toggle element
+         */
+        toggleElement: function () {
+            this.disabled(this.isUseDefault() || this.isUseConfig());
+
+            if (this.source) {
+                this.source.set('data.use_default.' + this.index, Number(this.isUseDefault()));
+            }
+        }
+    });
+});


### PR DESCRIPTION
### Description (*)
Can toggle state of select element while using Use Config Settings checkbox on product edit page.

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios (*)
1. Add new DataProvider in `Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool`.
2. Modify `$meta` to add `Use Config Settings` settings to attributes which are of type select.
3. There is no components to use that can trigger the disabled state when clicking the `Use Config Settings`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
