### PR TITLE
Update typeReferenceBlock definition

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -313,6 +313,7 @@
         </xs:choice>
         <xs:attribute type="elementNameType" name="name" use="required"/>
         <xs:attribute type="xs:string" name="template" use="optional"/>
+        <xs:attribute type="xs:string" name="class" use="optional"/>
         <xs:attribute type="xs:boolean" name="display" default="true" use="optional"/>
         <xs:attribute type="xs:boolean" name="remove" use="optional"/>
     </xs:complexType>


### PR DESCRIPTION
### Description (*)
Including the "class" attribute to the typeReferenceBlock definition allows you to update a the class attribute of a block tag when overriding or updating a layout XML file without the need to remove the original block and re-add it with the same name but different class and without using a preference in the Dependency Injector.

### Manual testing scenarios (*)
Simple scenario:
1. On your custom module, create a layout file
2. Add the tag **update** with the handle to the any other layout you wish to use as basis.
3. Add a referenceBlock tag to any block found in the original layout, using the same name as the original but with a new value for the **class attribute**.
4. Create your own block class in the Vendor/Module/Block directory and voilá, you are now able to have your own module, with a layout based on any other module, with a new block behavior and, since you didn't use any preference, the original module still works the same.

Scenario I applied:

My wish was to create my own Admin Report using the Magento's Report *New Accounts* as a basis, but without the "Period" dropdown in the toolbar, so here's what I did:

1. On my module MyVendor_CustomReports I've created the file **view/adminhtml/layout/report_customer_vip_grid.xml** with the following content:
```
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <update handle="reports_report_grid"/>
    <body>
        <referenceBlock name="adminhtml.report.grid" class="MyVendor\CustomReports\Block\Adminhtml\Grid">
            ...
        </referenceBlock>
    </body>
</page>
```

2. I created the new Block class **MyVendor\CustomReports\Block\Adminhtml\Grid** extending the **\Magento\Reports\Block\Adminhtml\Grid** class.

3. I overrided the value of the attribute $_template to _MyVendor_CustomReports::grid.phtml_.

4. I copied **Magento/Reports/view/templates/grid.phtml** to **MyVendor/CustomReports/view/templates/grid.phtml** and edited it to erase the select element.

This worked as fine as any other fallback, but it was only possible editing the elements.xsd file (this PR), otherwise you get a "invalid attribute 'class'" exception.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
