### PR TITLE
fixed issue #18934 : Magento version dev-2.3-develop Alert widget gets close when click anywhere on screen

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/modal-component.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal-component.js
@@ -93,7 +93,7 @@ define([
          * @returns {Object} Chainable.
          */
         initModalEvents: function () {
-            this.options.keyEventHandlers.escapeKey = this.options.outerClickHandler = this[this.onCancel].bind(this);
+            this.options.keyEventHandlers.escapeKey = this[this.onCancel].bind(this);
 
             return this;
         },

--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -424,8 +424,7 @@ define([
          * Creates overlay, append it to wrapper, set previous click event on overlay.
          */
         _createOverlay: function () {
-            var events,
-                outerClickHandler = this.options.outerClickHandler || this.closeModal;
+            var events;
 
             this.overlay = $('.' + this.options.overlayClass);
 
@@ -437,7 +436,6 @@ define([
             }
             events = $._data(this.overlay.get(0), 'events');
             events ? this.prevOverlayHandler = events.click[0].handler : false;
-            this.options.clickableOverlay ? this.overlay.unbind().on('click', outerClickHandler) : false;
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In older version of magento when we click delete button of minicart then alert widget display for confirm to delete item from cart.This popup was only close when click on "cancel", "ok" & "close" button.But earlier version of magento 2.3-develop it is closing click anywhere on screen.In this PR i have fixed this issue.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18934 : Magento version dev-2.3-develop Alert widget gets close when click anywhere on screen

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1 - Add product into cart.
2- Click on cart logo and delete item from cart.
3 - Now popup will open for confirm.
4 - Click anywhere on screen.Now popup will not close.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
