### PR TITLE
Update method 'afterConvert' of Magento\Tax\Model\Quote\ToOrderConverter to set order extension attributes type as declared in the extension_attributes.xml file

### DIFF
--- a/app/code/Magento/Tax/Model/Quote/ToOrderConverter.php
+++ b/app/code/Magento/Tax/Model/Quote/ToOrderConverter.php
@@ -3,11 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Tax\Model\Quote;
 
-use Magento\Sales\Api\Data\OrderInterface;
-use Magento\Quote\Model\Quote\Address\ToOrder as QuoteAddressToOrder;
+use Magento\Framework\App\ObjectManager;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use Magento\Quote\Model\Quote\Address\ToOrder as QuoteAddressToOrder;
+use Magento\Sales\Api\Data\OrderExtensionFactory;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Tax\Api\Data\AppliedTaxRateInterface;
+use Magento\Tax\Api\Data\AppliedTaxRateInterfaceFactory;
+use Magento\Tax\Api\Data\OrderTaxDetailsAppliedTaxExtensionFactory;
+use Magento\Tax\Api\Data\OrderTaxDetailsAppliedTaxExtensionInterface;
+use Magento\Tax\Api\Data\OrderTaxDetailsAppliedTaxInterface;
+use Magento\Tax\Api\Data\OrderTaxDetailsAppliedTaxInterfaceFactory;
+use Magento\Tax\Api\Data\OrderTaxDetailsItemExtensionFactory;
+use Magento\Tax\Api\Data\OrderTaxDetailsItemInterface;
+use Magento\Tax\Api\Data\OrderTaxDetailsItemInterfaceFactory;
+use Magento\Tax\Model\TaxDetails\AppliedTaxRateFactory;
 
 class ToOrderConverter
 {
@@ -17,17 +31,63 @@ class ToOrderConverter
     protected $quoteAddress;
 
     /**
-     * @var \Magento\Sales\Api\Data\OrderExtensionFactory
+     * @var OrderExtensionFactory
      */
     protected $orderExtensionFactory;
+    
+    /**
+     * @var OrderTaxDetailsAppliedTaxInterfaceFactory
+     */
+    private $orderTaxDetailsAppliedTaxInterfaceFactory;
+    
+    /**
+     * @var OrderTaxDetailsItemInterfaceFactory
+     */
+    private $orderTaxDetailsItemInterfaceFactory;
 
     /**
-     * @param \Magento\Sales\Api\Data\OrderExtensionFactory $orderExtensionFactory
+     * @var OrderTaxDetailsAppliedTaxExtensionInterface
+     */
+    private $orderTaxDetailsAppliedTaxExtensionFactory;
+
+    /**
+     * @var AppliedTaxRateFactory
+     */
+    private $appliedTaxRateInterfaceFactory;
+
+    /**
+     * @var OrderTaxDetailsItemExtensionFactory
+     */
+    private $orderTaxDetailsItemExtensionFactory;
+
+    /**
+     * @param OrderExtensionFactory $orderExtensionFactory
+     * @param OrderTaxDetailsAppliedTaxInterfaceFactory $orderTaxDetailsAppliedTaxInterfaceFactory
+     * @param OrderTaxDetailsAppliedTaxExtensionFactory $orderTaxDetailsAppliedTaxExtensionFactory
+     * @param OrderTaxDetailsItemInterfaceFactory $orderTaxDetailsItemInterfaceFactory
+     * @param AppliedTaxRateInterfaceFactory $appliedTaxRateInterfaceFactory
+     * @param OrderTaxDetailsItemExtensionFactory $orderTaxDetailsItemExtensionFactory
      */
     public function __construct(
-        \Magento\Sales\Api\Data\OrderExtensionFactory $orderExtensionFactory
+        OrderExtensionFactory $orderExtensionFactory,
+        OrderTaxDetailsAppliedTaxInterfaceFactory $orderTaxDetailsAppliedTaxInterfaceFactory = null,
+        OrderTaxDetailsAppliedTaxExtensionFactory $orderTaxDetailsAppliedTaxExtensionFactory = null,
+        OrderTaxDetailsItemInterfaceFactory $orderTaxDetailsItemInterfaceFactory = null,
+        AppliedTaxRateInterfaceFactory $appliedTaxRateInterfaceFactory = null,
+        OrderTaxDetailsItemExtensionFactory $orderTaxDetailsItemExtensionFactory = null
     ) {
         $this->orderExtensionFactory = $orderExtensionFactory;
+        $this->orderTaxDetailsAppliedTaxInterfaceFactory = $orderTaxDetailsAppliedTaxInterfaceFactory
+            ?: ObjectManager::getInstance(OrderTaxDetailsAppliedTaxInterfaceFactory::class);
+        $this->orderTaxDetailsItemInterfaceFactory = $orderTaxDetailsItemInterfaceFactory ?:
+            ObjectManager::getInstance(OrderTaxDetailsAppliedTaxExtensionFactory::class);
+        $this->orderTaxDetailsAppliedTaxExtensionFactory = $orderTaxDetailsAppliedTaxExtensionFactory
+            ?: ObjectManager::getInstance(OrderTaxDetailsItemInterfaceFactory::class);
+        $this->appliedTaxRateInterfaceFactory = $appliedTaxRateInterfaceFactory
+            ?: ObjectManager::getInstance(AppliedTaxRateInterfaceFactory::class);
+        $this->orderTaxDetailsItemExtensionFactory = $orderTaxDetailsItemExtensionFactory
+            ?: ObjectManager::getInstance(OrderTaxDetailsItemExtensionFactory::class);
+
     }
 
     /**
@@ -37,7 +97,7 @@ class ToOrderConverter
      * @return array
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeConvert(QuoteAddressToOrder $subject, QuoteAddress $address, $additional = [])
+    public function beforeConvert(QuoteAddressToOrder $subject, QuoteAddress $address, $additional = []): array
     {
         $this->quoteAddress = $address;
         return [$address, $additional];
@@ -49,42 +109,107 @@ class ToOrderConverter
      * @return OrderInterface
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterConvert(QuoteAddressToOrder $subject, OrderInterface $order)
+    public function afterConvert(QuoteAddressToOrder $subject, OrderInterface $order): OrderInterface
     {
         /** @var \Magento\Sales\Model\Order $order */
         $taxes = $this->quoteAddress->getAppliedTaxes();
-        $extensionAttributes = $order->getExtensionAttributes();
-        if ($extensionAttributes == null) {
-            $extensionAttributes = $this->orderExtensionFactory->create();
+        $orderExtensionAttributes = $order->getExtensionAttributes();
+        
+        if ($orderExtensionAttributes == null) {
+            $orderExtensionAttributes = $this->orderExtensionFactory->create();
         }
+        
         if (!empty($taxes)) {
-            foreach ($taxes as $key => $tax) {
-                $tax['extension_attributes']['rates'] = $tax['rates'];
-                unset($tax['rates']);
-                $taxes[$key] = $tax;
-            }
-            $extensionAttributes->setAppliedTaxes($taxes);
-            $extensionAttributes->setConvertingFromQuote(true);
+            $orderTaxDetailsApplied = $this->getOrderAppliedTaxes($taxes);
+            $orderExtensionAttributes->setAppliedTaxes($orderTaxDetailsApplied);
+            $orderExtensionAttributes->setConvertingFromQuote(true);
         }
 
+        /** @var array|null $itemAppliedTaxes */
         $itemAppliedTaxes = $this->quoteAddress->getItemsAppliedTaxes();
-        $itemAppliedTaxesModified = [];
         if (!empty($itemAppliedTaxes)) {
-            foreach ($itemAppliedTaxes as $key => $itemAppliedTaxItem) {
-                if (is_array($itemAppliedTaxItem) && !empty($itemAppliedTaxItem)) {
-                    foreach ($itemAppliedTaxItem as $itemAppliedTax) {
-                        $itemAppliedTaxesModified[$key]['type'] = $itemAppliedTax['item_type'];
-                        $itemAppliedTaxesModified[$key]['item_id'] = $itemAppliedTax['item_id'];
-                        $itemAppliedTaxesModified[$key]['associated_item_id'] = $itemAppliedTax['associated_item_id'];
-                        $itemAppliedTax['extension_attributes']['rates'] = $itemAppliedTax['rates'];
-                        unset($itemAppliedTax['rates']);
-                        $itemAppliedTaxesModified[$key]['applied_taxes'][] = $itemAppliedTax;
-                    }
+            $itemAppliedTaxes = $this->getItemAppliedTaxes($itemAppliedTaxes);
+            $orderExtensionAttributes->setItemAppliedTaxes($itemAppliedTaxes);
+        }
+
+        $order->setExtensionAttributes($orderExtensionAttributes);
+
+        return $order;
+    }
+
+    /**
+     * @param array $taxes
+     * @return OrderTaxDetailsAppliedTaxInterface[]
+     */
+    private function getOrderAppliedTaxes(array $taxes): array
+    {
+        $orderAppliedTaxDetails = [];
+
+        foreach ($taxes as $key => $tax) {
+            /** @var OrderTaxDetailsAppliedTaxInterface $orderTaxDetailsApplied */
+            $orderTaxDetailsApplied = $this->orderTaxDetailsAppliedTaxInterfaceFactory->create();
+
+            $orderTaxDetailsApplied->setAmount($tax['amount']);
+            $orderTaxDetailsApplied->setBaseAmount($tax['base_amount']);
+            $orderTaxDetailsApplied->setCode($tax['id']);
+            $orderTaxDetailsApplied->setPercent($tax['percent']);
+            $orderTaxDetailsApplied->setTitle($tax['id']);
+
+            $orderTaxDetailsAppliedExtensionAttributes = $orderTaxDetailsApplied->getExtensionAttributes();
+            if (!$orderTaxDetailsAppliedExtensionAttributes) {
+                /** @var OrderTaxDetailsAppliedTaxExtensionInterface $orderTaxDetailsAppliedExtensionAttributes */
+                $orderTaxDetailsAppliedExtensionAttributes = $this->orderTaxDetailsAppliedTaxExtensionFactory->create();
+            }
+
+            /** @var AppliedTaxRateInterface[] $taxRates */
+            $taxRates = [];
+            if (isset($tax['rates'])) {
+                foreach ($tax['rates'] as $taxRate) {
+                    /** @var AppliedTaxRateInterface $taxRateData */
+                    $taxRateData = $this->appliedTaxRateInterfaceFactory->create();
+                    $taxRateData->setCode($taxRate['code']);
+                    $taxRateData->setTitle($taxRate['title']);
+                    $taxRateData->setPercent($taxRate['percent']);
+
+                    $taxRates[] = $taxRateData;
                 }
             }
-            $extensionAttributes->setItemAppliedTaxes($itemAppliedTaxesModified);
+
+            $orderTaxDetailsAppliedExtensionAttributes->setRates($taxRates);
+            $orderTaxDetailsApplied->setExtensionAttributes($orderTaxDetailsAppliedExtensionAttributes);
+
+            $orderAppliedTaxDetails[] = $orderTaxDetailsApplied;
         }
-        $order->setExtensionAttributes($extensionAttributes);
-        return $order;
+
+        return $orderAppliedTaxDetails;
+    }
+
+    /**
+     * @param array $taxes
+     *
+     * @return OrderTaxDetailsItemInterface[]
+     */
+    private function getItemAppliedTaxes(array $taxes): array
+    {
+        $itemAppliedTaxes = [];
+
+        foreach ($taxes as $key => $itemAppliedTaxItem) {
+            if (is_array($itemAppliedTaxItem) && !empty($itemAppliedTaxItem)) {
+                foreach ($itemAppliedTaxItem as $itemAppliedTax) {
+                    /** @var OrderTaxDetailsItemInterface $itemAppliedTaxData */
+                    $itemAppliedTaxData = $this->orderTaxDetailsItemInterfaceFactory->create();
+                    $appliedTaxes = $this->getOrderAppliedTaxes($itemAppliedTaxItem);
+
+                    $itemAppliedTaxData->setAssociatedItemId($itemAppliedTax['associated_item_id']);
+                    $itemAppliedTaxData->setItemId($itemAppliedTax['item_id']);
+                    $itemAppliedTaxData->setType($itemAppliedTax['item_type']);
+                    $itemAppliedTaxData->setAppliedTaxes($appliedTaxes);
+
+                    $itemAppliedTaxes[] = $itemAppliedTaxData;
+                }
+            }
+        }
+
+        return $itemAppliedTaxes;
     }
 }


### PR DESCRIPTION
### Description (*)
Please check magento/magento2#6092 description

### Fixed Issues (if relevant)
1. magento/magento2#6092

### Manual testing scenarios (*)
Check issue description

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
