### PR TITLE
Save product using repository in adminhtml controller

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -128,7 +128,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
 
                 $originalSku = $product->getSku();
                 $canSaveCustomOptions = $product->getCanSaveCustomOptions();
-                $product->save();
+                $product = $this->productRepository->save($product);
                 $this->handleImageRemoveError($data, $product->getId());
                 $this->getCategoryLinkManagement()->assignProductToCategories(
                     $product->getSku(),


### PR DESCRIPTION
### Description (*)
Save product in `Magento\Catalog\Controller\Adminhtml\Product\Save` using Repository. Will be much easier to customize the flow if a plugin can be created on the `Repository::save()` method.

### Fixed Issues (if relevant)
1. None I could find.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
