### PR TITLE
Magento 2.2 Fix Product::addImageToMediaGallery throws Exception

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
@@ -208,7 +208,7 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
      * @throws \Magento\Framework\Exception\InputException
      * @throws \Magento\Framework\Exception\StateException
      */
-    public function testSaveProductWithGalleryImage(): void
+    public function testSaveProductWithGalleryImage()
     {
         /** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
         $mediaConfig = Bootstrap::getObjectManager()

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
@@ -198,4 +198,52 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertGreaterThanOrEqual(1, $count);
     }
+
+    /**
+     * Test save product with gallery image
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_with_image.php
+     *
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\StateException
+     */
+    public function testSaveProductWithGalleryImage(): void
+    {
+        /** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
+        $mediaConfig = Bootstrap::getObjectManager()
+            ->get(\Magento\Catalog\Model\Product\Media\Config::class);
+
+        /** @var $mediaDirectory \Magento\Framework\Filesystem\Directory\WriteInterface */
+        $mediaDirectory = Bootstrap::getObjectManager()
+            ->get(\Magento\Framework\Filesystem::class)
+            ->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA);
+
+        $product = Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+        $product->load(1);
+
+        $path = $mediaConfig->getBaseMediaPath() . '/magento_image.jpg';
+        $absolutePath = $mediaDirectory->getAbsolutePath() . $path;
+        $product->addImageToMediaGallery($absolutePath, [
+            'image',
+            'small_image',
+        ], false, false);
+
+        /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+        $productRepository = Bootstrap::getObjectManager()
+            ->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+        $productRepository->save($product);
+
+        $gallery = $product->getData('media_gallery');
+        $this->assertArrayHasKey('images', $gallery);
+        $images = array_values($gallery['images']);
+
+        $this->assertNotEmpty($gallery);
+        $this->assertTrue(isset($images[0]['file']));
+        $this->assertStringStartsWith('/m/a/magento_image', $images[0]['file']);
+        $this->assertArrayHasKey('media_type', $images[0]);
+        $this->assertEquals('image', $images[0]['media_type']);
+        $this->assertStringStartsWith('/m/a/magento_image', $product->getData('image'));
+        $this->assertStringStartsWith('/m/a/magento_image', $product->getData('small_image'));
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_image.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_image.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\Data\ProductExtensionInterfaceFactory;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->reinitialize();
+
+/** @var \Magento\TestFramework\ObjectManager $objectManager */
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+$product->isObjectNew(true);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setId(1)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Simple Product')
+    ->setSku('simple')
+    ->setPrice(10)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
+
+/** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
+$mediaConfig = $objectManager->get(\Magento\Catalog\Model\Product\Media\Config::class);
+
+/** @var $mediaDirectory \Magento\Framework\Filesystem\Directory\WriteInterface */
+$mediaDirectory = $objectManager->get(\Magento\Framework\Filesystem::class)
+    ->getDirectoryWrite(DirectoryList::MEDIA);
+
+$targetDirPath = $mediaConfig->getBaseMediaPath();
+$targetTmpDirPath = $mediaConfig->getBaseTmpMediaPath();
+
+$mediaDirectory->create($targetDirPath);
+$mediaDirectory->create($targetTmpDirPath);
+
+$dist = $mediaDirectory->getAbsolutePath($mediaConfig->getBaseMediaPath() .  DIRECTORY_SEPARATOR . 'magento_image.jpg');
+copy(__DIR__ . '/magento_image.jpg', $dist);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+$productRepository->save($product);


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#6803: Product::addImageToMediaGallery throws Exception

### Preconditions

<!--- Provide a more detailed information of environment you use -->

<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->

**Magento Version** 2.2.6
**PHP Version** 7.1
### Steps to reproduce

<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->

```
$product = $this->productFactory->create()
            ->setName($productName)
            ->setStatus($productStatus)
            ->setSku($productSku)
$product->setAttributeSetId($product->getDefaultAttributeSetId());

$product->addImageToMediaGallery($file, [
                'image',
                'small_image',
                'thumbnail',
            ], false, false);
$this->productRepository->save($product);
```
### Expected result

Image gets added
### Actual result

Exception gets thrown:

```
Notice: Undefined index: media_type in vendor/magento/module-catalog/Model/Product.php on line 2527
```

<!--- (This may be platform independent comment) -->

There's a workaround for this issue, using the `Product::save` method instead of the `ProductRepositoryInterface::save` method, but because it's a deprecated method I would like to avoid this.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
