### PR TITLE
Magento 2.3 Fix Notice and Exception while adding image to product programmatically

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
@@ -9,7 +9,7 @@ namespace Magento\Catalog\Model\Product\Gallery;
 use Magento\Framework\Api\Data\ImageContentInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Catalog product Media Gallery attribute processor.
@@ -60,7 +60,7 @@ class Processor
     /**
      * @var \Magento\Framework\File\Mime
      */
-    protected $mime;
+    private $mime;
 
     /**
      * @param \Magento\Catalog\Api\ProductAttributeRepositoryInterface $attributeRepository
@@ -68,7 +68,7 @@ class Processor
      * @param \Magento\Catalog\Model\Product\Media\Config $mediaConfig
      * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\Catalog\Model\ResourceModel\Product\Gallery $resourceModel
-     * @param \Magento\Framework\File\Mime $mime
+     * @param \Magento\Framework\File\Mime|null $mime
      * @throws \Magento\Framework\Exception\FileSystemException
      */
     public function __construct(
@@ -77,14 +77,14 @@ class Processor
         \Magento\Catalog\Model\Product\Media\Config $mediaConfig,
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Catalog\Model\ResourceModel\Product\Gallery $resourceModel,
-        \Magento\Framework\File\Mime $mime
+        \Magento\Framework\File\Mime $mime = null
     ) {
         $this->attributeRepository = $attributeRepository;
         $this->fileStorageDb = $fileStorageDb;
         $this->mediaConfig = $mediaConfig;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA);
         $this->resourceModel = $resourceModel;
-        $this->mime = $mime;
+        $this->mime = $mime ?: ObjectManager::getInstance()->get(\Magento\Framework\File\Mime::class);
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
@@ -88,6 +88,8 @@ class Processor
     }
 
     /**
+     * Return media_gallery attribute
+     *
      * @return \Magento\Catalog\Api\Data\ProductAttributeInterface
      * @since 101.0.0
      */
@@ -383,7 +385,8 @@ class Processor
     }
 
     /**
-     * get media attribute codes
+     * Get media attribute codes
+     *
      * @return array
      * @since 101.0.0
      */
@@ -393,6 +396,8 @@ class Processor
     }
 
     /**
+     * Trim .tmp ending from filename
+     *
      * @param string $file
      * @return string
      * @since 101.0.0
@@ -514,7 +519,6 @@ class Processor
     /**
      * Attribute value is not to be saved in a conventional way, separate table is used to store the complex value
      *
-     * {@inheritdoc}
      * @since 101.0.0
      */
     public function isScalar()

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "ext-xsl": "*",
         "ext-zip": "*",
         "lib-libxml": "*",
-        "ext-fileinfo": "*",
         "braintree/braintree_php": "3.35.0",
         "colinmollenhour/cache-backend-file": "~1.4.1",
         "colinmollenhour/cache-backend-redis": "1.10.5",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-xsl": "*",
         "ext-zip": "*",
         "lib-libxml": "*",
+        "ext-fileinfo": "*",
         "braintree/braintree_php": "3.35.0",
         "colinmollenhour/cache-backend-file": "~1.4.1",
         "colinmollenhour/cache-backend-redis": "1.10.5",

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
@@ -90,4 +90,52 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
             ['sku' => 'simple '],
         ];
     }
+
+    /**
+     * Test save product with gallery image
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_with_image.php
+     *
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\StateException
+     */
+    public function testSaveProductWithGalleryImage(): void
+    {
+        /** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
+        $mediaConfig = Bootstrap::getObjectManager()
+            ->get(\Magento\Catalog\Model\Product\Media\Config::class);
+
+        /** @var $mediaDirectory \Magento\Framework\Filesystem\Directory\WriteInterface */
+        $mediaDirectory = Bootstrap::getObjectManager()
+            ->get(\Magento\Framework\Filesystem::class)
+            ->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA);
+
+        $product = Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+        $product->load(1);
+
+        $path = $mediaConfig->getBaseMediaPath() . '/magento_image.jpg';
+        $absolutePath = $mediaDirectory->getAbsolutePath() . $path;
+        $product->addImageToMediaGallery($absolutePath, [
+            'image',
+            'small_image',
+        ], false, false);
+
+        /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+        $productRepository = Bootstrap::getObjectManager()
+            ->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+        $productRepository->save($product);
+
+        $gallery = $product->getData('media_gallery');
+        $this->assertArrayHasKey('images', $gallery);
+        $images = array_values($gallery['images']);
+
+        $this->assertNotEmpty($gallery);
+        $this->assertTrue(isset($images[0]['file']));
+        $this->assertStringStartsWith('/m/a/magento_image', $images[0]['file']);
+        $this->assertArrayHasKey('media_type', $images[0]);
+        $this->assertEquals('image', $images[0]['media_type']);
+        $this->assertStringStartsWith('/m/a/magento_image', $product->getData('image'));
+        $this->assertStringStartsWith('/m/a/magento_image', $product->getData('small_image'));
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_image.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_image.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\Data\ProductExtensionInterfaceFactory;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->reinitialize();
+
+/** @var \Magento\TestFramework\ObjectManager $objectManager */
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+$product->isObjectNew(true);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setId(1)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Simple Product')
+    ->setSku('simple')
+    ->setPrice(10)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
+
+/** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
+$mediaConfig = $objectManager->get(\Magento\Catalog\Model\Product\Media\Config::class);
+
+/** @var $mediaDirectory \Magento\Framework\Filesystem\Directory\WriteInterface */
+$mediaDirectory = $objectManager->get(\Magento\Framework\Filesystem::class)
+    ->getDirectoryWrite(DirectoryList::MEDIA);
+
+$targetDirPath = $mediaConfig->getBaseMediaPath();
+$targetTmpDirPath = $mediaConfig->getBaseTmpMediaPath();
+
+$mediaDirectory->create($targetDirPath);
+$mediaDirectory->create($targetTmpDirPath);
+
+$dist = $mediaDirectory->getAbsolutePath($mediaConfig->getBaseMediaPath() .  DIRECTORY_SEPARATOR . 'magento_image.jpg');
+copy(__DIR__ . '/magento_image.jpg', $dist);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+$productRepository->save($product);


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#6803: Product::addImageToMediaGallery throws Exception

### Preconditions

<!--- Provide a more detailed information of environment you use -->

<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->

**Magento Version** 2.3
**PHP Version** 7.2
### Steps to reproduce

<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->

```
$product = $this->productFactory->create()
            ->setName($productName)
            ->setStatus($productStatus)
            ->setSku($productSku)
$product->setAttributeSetId($product->getDefaultAttributeSetId());

$product->addImageToMediaGallery($file, [
                'image',
                'small_image',
                'thumbnail',
            ], false, false);
$this->productRepository->save($product);
```
### Expected result

Image gets added
### Actual result

Exception gets thrown:

```
Notice: Undefined index: media_type in vendor/magento/module-catalog/Model/Product.php on line 2527
```

<!--- (This may be platform independent comment) -->

There's a workaround for this issue, using the `Product::save` method instead of the `ProductRepositoryInterface::save` method, but because it's a deprecated method I would like to avoid this.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
