### PR TITLE
fixed js translation

### DIFF
--- a/app/code/Magento/Tax/view/frontend/web/js/view/checkout/summary/tax.js
+++ b/app/code/Magento/Tax/view/frontend/web/js/view/checkout/summary/tax.js
@@ -14,7 +14,7 @@ define([
     'Magento_Checkout/js/model/totals',
     'jquery',
     'mage/translate'
-], function (ko, Component, quote, totals, $) {
+], function (ko, Component, quote, totals, $, $t) {
     'use strict';
 
     var isTaxDisplayedInGrandTotal = window.checkoutConfig.includeTaxInGrandTotal,
@@ -24,7 +24,7 @@ define([
     return Component.extend({
         defaults: {
             isTaxDisplayedInGrandTotal: isTaxDisplayedInGrandTotal,
-            notCalculatedMessage: $.mage.__('Not yet calculated'),
+            notCalculatedMessage: $t('Not yet calculated'),
             template: 'Magento_Tax/checkout/summary/tax'
         },
         totals: quote.getTotals(),


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->
"Not yet calculated" for the tax in the summary section in the checkout was not being translated.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Now the correct function call for js translations is made.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18939: "Not yet calculated" for the tax in the summary section in the checkout is not translatable

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup a two-store site where the default store uses "en_Us" as the language and the second store uses "es_ES" (Spanish ).
2. Add Spanish translation for the text: "Not yet calculated" through the design section. i.e, in the file: `app/design/frontend/<Package>/<theme>/i18n/es_ES.csv`.
   
        "Not yet calculated","Aún no calculado"
2. Now on the frontend, switch to Spanish store. Then add a product to the cart and go for checkout.
3. In the payment step, under the summary section, you will see "Not yet calculated" is not translated for the **Tax** eventhough the same text corresponding to **Shipping** is translated.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
