### PR TITLE
[Forwardport] Ensure integer values are not quoted as strings

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductCategoryList.php
+++ b/app/code/Magento/Catalog/Model/ProductCategoryList.php
@@ -80,7 +80,7 @@ class ProductCategoryList
                 Select::SQL_UNION_ALL
             );
 
-            $this->categoryIdList[$productId] = array_map('intval', $this->productResource->getConnection()->fetchCol($unionSelect));
+            $this->categoryIdList[$productId] = $this->productResource->getConnection()->fetchCol($unionSelect);
         }
 
         return $this->categoryIdList[$productId];

--- a/app/code/Magento/Catalog/Model/ProductCategoryList.php
+++ b/app/code/Magento/Catalog/Model/ProductCategoryList.php
@@ -79,7 +79,7 @@ class ProductCategoryList
                 $unionTables,
                 Select::SQL_UNION_ALL
             );
-            
+
             $this->categoryIdList[$productId] = array_map(
                 'intval',
                 $this->productResource->getConnection()->fetchCol($unionSelect)

--- a/app/code/Magento/Catalog/Model/ProductCategoryList.php
+++ b/app/code/Magento/Catalog/Model/ProductCategoryList.php
@@ -79,8 +79,11 @@ class ProductCategoryList
                 $unionTables,
                 Select::SQL_UNION_ALL
             );
-
-            $this->categoryIdList[$productId] = $this->productResource->getConnection()->fetchCol($unionSelect);
+            
+            $this->categoryIdList[$productId] = array_map(
+                'intval',
+                $this->productResource->getConnection()->fetchCol($unionSelect)
+            );
         }
 
         return $this->categoryIdList[$productId];

--- a/app/code/Magento/Catalog/Model/ProductCategoryList.php
+++ b/app/code/Magento/Catalog/Model/ProductCategoryList.php
@@ -80,10 +80,7 @@ class ProductCategoryList
                 Select::SQL_UNION_ALL
             );
 
-            $this->categoryIdList[$productId] = array_map(
-                'intval',
-                $this->productResource->getConnection()->fetchCol($unionSelect)
-            );
+            $this->categoryIdList[$productId] = array_map('intval', $this->productResource->getConnection()->fetchCol($unionSelect));
         }
 
         return $this->categoryIdList[$productId];

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -2021,11 +2021,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $this->getConnection()->quoteInto('cat_index.store_id=?', $filters['store_id'], 'int'),
         ];
         if (isset($filters['visibility']) && !isset($filters['store_table'])) {
-            $conditions[] = $this->getConnection()->quoteInto(
-                'cat_index.visibility IN(?)',
-                $filters['visibility'],
-                'int'
-            );
+            $conditions[] = $this->getConnection()->quoteInto('cat_index.visibility IN(?)', $filters['visibility'], 'int');
         }
         $conditions[] = $this->getConnection()->quoteInto('cat_index.category_id=?', $filters['category_id'], 'int');
         if (isset($filters['category_is_anchor'])) {

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -284,8 +284,8 @@ class View extends \Magento\Framework\DataObject implements ViewInterface
 
                 for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {
                     // Don't go past the current version for atomicy.
-                    $versionTo = min($currentVersionId, $vsFrom + $versionBatchSize);
-                    $ids = array_map('intval', $this->getChangelog()->getList($vsFrom, $versionTo));
+                    $versionTo = min($currentVersionId, $versionFrom + $versionBatchSize);
+                    $ids = array_map('intval', $this->getChangelog()->getList($versionFrom, $versionTo));
 
                     // We run the actual indexer in batches.
                     // Chunked AFTER loading to avoid duplicates in separate chunks.

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -282,7 +282,7 @@ class View extends \Magento\Framework\DataObject implements ViewInterface
                     ? $this->changelogBatchSize[$this->getChangelog()->getViewId()]
                     : self::DEFAULT_BATCH_SIZE;
 
-                for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {
+                for ($versionFrom = $lastVersionId; $versionFrom < $currentVersionId; $versionFrom += $versionBatchSize) {
                     // Don't go past the current version for atomicy.
                     $versionTo = min($currentVersionId, $versionFrom + $versionBatchSize);
                     $ids = array_map('intval', $this->getChangelog()->getList($versionFrom, $versionTo));


### PR DESCRIPTION
### Original Pull Request
[#18287](https://github.com/magento/magento2/pull/18287)
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

In cases where indexers does a filtering in the style of `WHERE entity_id IN (...)` there is a performance penalty if IDs are passed as strings, rather than integer values. This is especially visible on larger data sets. This pull request should cover some common occurrences of this.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. n/a

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. n/a

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
