### PR TITLE
Fix numeric translation keys being dissolved by array_merge

### DIFF
--- a/lib/internal/Magento/Framework/App/Language/Dictionary.php
+++ b/lib/internal/Magento/Framework/App/Language/Dictionary.php
@@ -111,7 +111,9 @@ class Dictionary
             /** @var Config $languageConfig */
             $languageConfig = $packInfo['language'];
             $dictionary = $this->readPackCsv($languageConfig->getVendor(), $languageConfig->getPackage());
-            $result = array_merge($result, $dictionary);
+            foreach ($dictionary as $key => $value) {
+                $result[$key] = $value;
+            }
         }
         return $result;
     }


### PR DESCRIPTION
### Description (*)
When creating translations like "100","Hundred", the key "100" will be dissolved by array_merge when combining all the dictionaries from all language packs. For example, the new key of that translation could be 1, 2, etc. 

### Manual testing scenarios (*)
1. Create a translation like "100","Hundred".
2. Check if if the key "100" translates to "Hundred".

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
