### PR TITLE
Added default value(y) for confirmation question

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
@@ -84,7 +84,8 @@ class ConfigSetCommand extends AbstractSetupCommand
             if (($currentValue !== null) && ($inputOptions[$option->getName()] !== null)) {
                 $dialog = $this->getHelperSet()->get('question');
                 $question = new Question(
-                    '<question>Overwrite the existing configuration for ' . $option->getName() . '?[Y/n]</question>'
+                    '<question>Overwrite the existing configuration for ' . $option->getName() . '?[Y/n]</question>',
+                    'y'
                 );
                 if (strtolower($dialog->ask($input, $output, $question)) !== 'y') {
                     $inputOptions[$option->getName()] = null;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Default value is assumed as "y" for ConfigSetCommand confirmation.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18965: 2.3-beta32: DB credentials are not updated in non-interactive mode by bin/magento setup:config:set

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set any config value requiring configuration in non-interactive mode with bin/magento setup:config:set -n
2. Check that value is updated

### Contribution checklist (*)
 - [* ] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [*] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
