### PR TITLE
Fix for category tree structure being deformed

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
@@ -101,7 +101,6 @@ class CategoryTree
 
         $collection->addFieldToFilter('level', ['gt' => $level]);
         $collection->addFieldToFilter('level', ['lteq' => $level + $depth - self::DEPTH_OFFSET]);
-        $collection->setOrder('level');
         $collection->getSelect()->orWhere(
             $this->metadata->getMetadata(CategoryInterface::class)->getIdentifierField() . ' = ?',
             $rootCategoryId


### PR DESCRIPTION
### Description (*)
Currently running the following Graph Ql query

```
{
    category(id: 2) {
        children {
            name
            children {
                name
                children {
                    name
                    children {
                        name
                    }
                }
            }
        }
    }
}
```

Will give categories that are sorted according to their levels where last items in a level get all the children.
```
Cat 1
Cat 2
- Cat 1 subcategory
- Cat 2 subcategory 
```

### Fixed Issues (if relevant)
1. magento/magento2#18735: Graph Ql category tree structure is lost (children all grouped with last item)

### Manual testing scenarios (*)
Run the following query 
```
{
    category(id: 2) {
        children {
            name
            children {
                name
                children {
                    name
                    children {
                        name
                    }
                }
            }
        }
    }
}
```


### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [-] All new or changed code is covered with unit/integration tests (if applicable)
 - [+] All automated tests passed successfully (all builds on Travis CI are green)
