### PR TITLE
Integration Test Framework AMQP Helper Flexibility

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
@@ -16,6 +16,7 @@ class Amqp
     const CONFIG_PATH_HOST = 'queue/amqp/host';
     const CONFIG_PATH_USER = 'queue/amqp/user';
     const CONFIG_PATH_PASSWORD = 'queue/amqp/password';
+    const DEFAULT_MANAGEMENT_PORT = '15672';
 
     /**
      * @var Curl
@@ -49,7 +50,11 @@ class Amqp
             $this->deploymentConfig->get(self::CONFIG_PATH_PASSWORD)
         );
         $this->curl->addHeader('content-type', 'application/json');
-        $this->host = sprintf('http://%s:15672/api/', $this->deploymentConfig->get(self::CONFIG_PATH_HOST));
+        $this->host = sprintf(
+            'http://%s:%s/api/',
+            $this->deploymentConfig->get(self::CONFIG_PATH_HOST),
+            defined('RABBITMQ_MANAGEMENT_PORT') ? RABBITMQ_MANAGEMENT_PORT : self::DEFAULT_MANAGEMENT_PORT
+        );
     }
 
     /**

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
@@ -40,7 +40,7 @@ class Amqp
      * @param \Magento\Framework\App\DeploymentConfig $deploymentConfig
      */
     public function __construct(
-        \Magento\Framework\App\DeploymentConfig $deploymentConfig
+        \Magento\Framework\App\DeploymentConfig $deploymentConfig = null
     ) {
         $this->deploymentConfig = $deploymentConfig ?? \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
             ->get(\Magento\Framework\App\DeploymentConfig::class);

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
@@ -13,26 +13,43 @@ namespace Magento\TestFramework\Helper;
  */
 class Amqp
 {
+    const CONFIG_PATH_HOST = 'queue/amqp/host';
+    const CONFIG_PATH_USER = 'queue/amqp/user';
+    const CONFIG_PATH_PASSWORD = 'queue/amqp/password';
+
     /**
      * @var Curl
      */
     private $curl;
 
     /**
+     * @var \Magento\Framework\App\DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
      * RabbitMQ API host
      *
      * @var string
      */
-    private $host = 'http://localhost:15672/api/';
+    private $host;
 
     /**
      * Initialize dependencies.
+     * @param \Magento\Framework\App\DeploymentConfig $deploymentConfig
      */
-    public function __construct()
-    {
+    public function __construct(
+        \Magento\Framework\App\DeploymentConfig $deploymentConfig
+    ) {
+        $this->deploymentConfig = $deploymentConfig ?? \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+            ->get(\Magento\Framework\App\DeploymentConfig::class);
         $this->curl = new Curl();
-        $this->curl->setCredentials('guest', 'guest');
+        $this->curl->setCredentials(
+            $this->deploymentConfig->get(self::CONFIG_PATH_USER),
+            $this->deploymentConfig->get(self::CONFIG_PATH_PASSWORD)
+        );
         $this->curl->addHeader('content-type', 'application/json');
+        $this->host = sprintf('http://%s:15672/api/', $this->deploymentConfig->get(self::CONFIG_PATH_HOST));
     }
 
     /**

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
@@ -53,6 +53,28 @@ class Amqp
     }
 
     /**
+     * Check that the RabbitMQ instance has the management plugin installed and the api
+     * is available.
+     *
+     * @throws \Magento\TestFramework\MessageQueue\PreconditionFailedException
+     * @return bool
+     */
+    public function isAvailable()
+    {
+        $this->curl->get($this->host . 'overview');
+        $data = $this->curl->getBody();
+        $data = json_decode($data, true);
+
+        if (isset($data['management_version'])) {
+            return true;
+        }
+
+        throw new \Magento\TestFramework\MessageQueue\PreconditionFailedException(
+            'This test relies on RabbitMQ Management Plugin.'
+        );
+    }
+
+    /**
      * Get declared exchanges.
      *
      * @return array

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Amqp.php
@@ -61,22 +61,15 @@ class Amqp
      * Check that the RabbitMQ instance has the management plugin installed and the api
      * is available.
      *
-     * @throws \Magento\TestFramework\MessageQueue\PreconditionFailedException
      * @return bool
      */
-    public function isAvailable()
+    public function isAvailable(): bool
     {
         $this->curl->get($this->host . 'overview');
         $data = $this->curl->getBody();
         $data = json_decode($data, true);
 
-        if (isset($data['management_version'])) {
-            return true;
-        }
-
-        throw new \Magento\TestFramework\MessageQueue\PreconditionFailedException(
-            'This test relies on RabbitMQ Management Plugin.'
-        );
+        return isset($data['management_version']);
     }
 
     /**

--- a/dev/tests/integration/framework/Magento/TestFramework/MessageQueue/PublisherConsumerController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/MessageQueue/PublisherConsumerController.php
@@ -80,7 +80,13 @@ class PublisherConsumerController
                 "This test relies on *nix shell and should be skipped in Windows environment."
             );
         }
-        $this->amqpHelper->isAvailable();
+
+        if (!$this->amqpHelper->isAvailable()) {
+            throw new PreconditionFailedException(
+                'This test relies on RabbitMQ Management Plugin.'
+            );
+        }
+
         $connections = $this->amqpHelper->getConnections();
         foreach (array_keys($connections) as $connectionName) {
             $this->amqpHelper->deleteConnection($connectionName);

--- a/dev/tests/integration/framework/Magento/TestFramework/MessageQueue/PublisherConsumerController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/MessageQueue/PublisherConsumerController.php
@@ -80,6 +80,7 @@ class PublisherConsumerController
                 "This test relies on *nix shell and should be skipped in Windows environment."
             );
         }
+        $this->amqpHelper->isAvailable();
         $connections = $this->amqpHelper->getConnections();
         foreach (array_keys($connections) as $connectionName) {
             $this->amqpHelper->deleteConnection($connectionName);

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -72,6 +72,8 @@
         <!-- Connection parameters for MongoDB library tests -->
         <!--<const name="MONGODB_CONNECTION_STRING" value="mongodb://localhost:27017"/>-->
         <!--<const name="MONGODB_DATABASE_NAME" value="magento_integration_tests"/>-->
+        <!-- Connection parameters for RabbitMQ tests -->
+        <!--<const name="RABBITMQ_MANAGEMENT_PORT" value="15672"/>-->
     </php>
     <!-- Test listeners -->
     <listeners>

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
@@ -47,6 +47,7 @@ class TopologyTest extends \PHPUnit\Framework\TestCase
         $name = $expectedConfig['name'];
         $this->assertArrayHasKey($name, $this->declaredExchanges);
         unset($this->declaredExchanges[$name]['message_stats']);
+        unset($this->declaredExchanges[$name]['user_who_performed_action']);
         $this->assertEquals(
             $expectedConfig,
             $this->declaredExchanges[$name],

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\MessageQueue;
 
+use Magento\TestFramework\Helper\Bootstrap;
+
 /**
  * @see dev/tests/integration/_files/Magento/TestModuleMessageQueueConfiguration
  * @see dev/tests/integration/_files/Magento/TestModuleMessageQueueConfigOverride
@@ -25,7 +27,7 @@ class TopologyTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->helper = new \Magento\TestFramework\Helper\Amqp();
+        $this->helper = Bootstrap::getObjectManager()->create(\Magento\TestFramework\Helper\Amqp::class);
         $this->declaredExchanges = $this->helper->getExchanges();
     }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
@@ -29,11 +29,11 @@ class TopologyTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->helper = Bootstrap::getObjectManager()->create(\Magento\TestFramework\Helper\Amqp::class);
-        try {
-            $this->helper->isAvailable();
-        } catch (PreconditionFailedException $e) {
-            $this->fail($e->getMessage());
+
+        if (!$this->helper->isAvailable()) {
+            $this->fail('This test relies on RabbitMQ Management Plugin.');
         }
+
         $this->declaredExchanges = $this->helper->getExchanges();
     }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/TopologyTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\MessageQueue;
 
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\MessageQueue\PreconditionFailedException;
 
 /**
  * @see dev/tests/integration/_files/Magento/TestModuleMessageQueueConfiguration
@@ -28,6 +29,11 @@ class TopologyTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->helper = Bootstrap::getObjectManager()->create(\Magento\TestFramework\Helper\Amqp::class);
+        try {
+            $this->helper->isAvailable();
+        } catch (PreconditionFailedException $e) {
+            $this->fail($e->getMessage());
+        }
         $this->declaredExchanges = $this->helper->getExchanges();
     }
 


### PR DESCRIPTION
### Description (*)
* Update AMQP helper to use host, username, and password configuration from the instance under test. This allows tests to run when the AMQP service is not using default credentials or available on localhost.
* Mark tests failed when the RabbitMQ management plugin is not available, but explicitly mention the dependency on the plugin in the failure.
* Unset exchange response property added in v3.7.0 of the management plugin. This allows integration tests to be run beyond the v3.6.x version currently used by Travis.

### Fixed Issues (if relevant)
1. magento/magento2#18953 Integration Test AMQP Helper Hardcoded Host

### Manual testing scenarios (*)
#### Scenario 1
1. Install RabbitMQ anywhere other than `localhost`
2. Create `dev/tests/integration/etc/install-config-mysql.php` with correct AMQP configuration
3. Execute Integration tests
4. Expect tests to pass

#### Scenario 2
1. Install RabbitMQ without management plugin
3. Execute Integration tests
4. Expect tests depending on the management plugin are skipped

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
