### PR TITLE
[Backport] Fix for currency update in crontab area

### DIFF
--- a/app/code/Magento/Directory/Model/CurrencyConfig.php
+++ b/app/code/Magento/Directory/Model/CurrencyConfig.php
@@ -57,7 +57,7 @@ class CurrencyConfig
      */
     public function getConfigCurrencies(string $path)
     {
-        $result = $this->appState->getAreaCode() === Area::AREA_ADMINHTML
+        $result = in_array($this->appState->getAreaCode(), [Area::AREA_ADMINHTML, Area::AREA_CRONTAB])
             ? $this->getConfigForAllStores($path)
             : $this->getConfigForCurrentStore($path);
         sort($result);

--- a/app/code/Magento/Directory/Test/Unit/Model/CurrencyConfigTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/CurrencyConfigTest.php
@@ -68,7 +68,7 @@ class CurrencyConfigTest extends TestCase
     }
 
     /**
-     * Test get currency config for admin and storefront areas.
+     * Test get currency config for admin, crontab and storefront areas.
      *
      * @dataProvider getConfigCurrenciesDataProvider
      * @return void
@@ -91,7 +91,7 @@ class CurrencyConfigTest extends TestCase
             ->method('getCode')
             ->willReturn('testCode');
 
-        if ($areCode === Area::AREA_ADMINHTML) {
+        if (in_array($areCode, [Area::AREA_ADMINHTML, Area::AREA_CRONTAB])) {
             $this->storeManager->expects(self::once())
                 ->method('getStores')
                 ->willReturn([$store]);
@@ -121,6 +121,7 @@ class CurrencyConfigTest extends TestCase
     {
         return [
             ['areaCode' => Area::AREA_ADMINHTML],
+            ['areaCode' => Area::AREA_CRONTAB],
             ['areaCode' => Area::AREA_FRONTEND],
         ];
     }

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/CurrencyConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/CurrencyConfigTest.php
@@ -56,7 +56,7 @@ class CurrencyConfigTest extends TestCase
     }
 
     /**
-     * Test get currency config for admin and storefront areas.
+     * Test get currency config for admin, crontab and storefront areas.
      *
      * @dataProvider getConfigCurrenciesDataProvider
      * @magentoDataFixture Magento/Store/_files/store.php
@@ -77,7 +77,7 @@ class CurrencyConfigTest extends TestCase
         $storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
         $storeManager->setCurrentStore($store->getId());
 
-        if ($areaCode === Area::AREA_ADMINHTML) {
+        if (in_array($areaCode, [Area::AREA_ADMINHTML, Area::AREA_CRONTAB])) {
             self::assertEquals($expected['allowed'], $this->currency->getConfigAllowCurrencies());
             self::assertEquals($expected['base'], $this->currency->getConfigBaseCurrencies());
             self::assertEquals($expected['default'], $this->currency->getConfigDefaultCurrencies());
@@ -112,6 +112,14 @@ class CurrencyConfigTest extends TestCase
         return [
             [
                 'areaCode' => Area::AREA_ADMINHTML,
+                'expected' => [
+                    'allowed' => ['BDT', 'BNS', 'BTD', 'EUR', 'USD'],
+                    'base' => ['BDT', 'USD'],
+                    'default' => ['BDT', 'USD'],
+                ],
+            ],
+            [
+                'areaCode' => Area::AREA_CRONTAB,
                 'expected' => [
                     'allowed' => ['BDT', 'BNS', 'BTD', 'EUR', 'USD'],
                     'base' => ['BDT', 'USD'],


### PR DESCRIPTION
### Description (*)
This PR fixes issue where cron doesn't updates currency rates if they aren't enabled in default store.
This PR is for 2.2 Release line.

### Fixed Issues (if relevant)
1. magento/magento2#18580: Currency rates not updated by crontab

### Manual testing scenarios (*)
1. Base store has only one allowed currency (EUR). So EUR is the base currency.
2. English store has 4 allowed currencies (EUR, CAD, USD, GBP).
3. Enable Fixer.io conversion service and enable it. 
4. Save manually incorrect rates for CAD, USD and GBP.
5. Run cron `currency_rates_update`
6. Confirm that all rates are updated to real values.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Backport for: https://github.com/magento/magento2/pull/18981