### PR TITLE
magento/magento2#10440: [Forwardport] Missing $debugHintsPath when sending email via command.

### DIFF
--- a/app/code/Magento/Developer/etc/di.xml
+++ b/app/code/Magento/Developer/etc/di.xml
@@ -240,4 +240,12 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints">
+        <arguments>
+            <argument name="debugHintsPath" xsi:type="string">dev/debug/template_hints_storefront</argument>
+            <argument name="debugHintsWithParam" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
+            <argument name="debugHintsParameter" xsi:type="string">dev/debug/template_hints_parameter_value</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Developer/etc/frontend/di.xml
+++ b/app/code/Magento/Developer/etc/frontend/di.xml
@@ -9,11 +9,4 @@
     <type name="Magento\Framework\View\TemplateEngineFactory">
         <plugin name="debug_hints" type="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints" sortOrder="10"/>
     </type>
-    <type name="Magento\Developer\Model\TemplateEngine\Plugin\DebugHints">
-        <arguments>
-            <argument name="debugHintsPath" xsi:type="string">dev/debug/template_hints_storefront</argument>
-            <argument name="debugHintsWithParam" xsi:type="string">dev/debug/template_hints_storefront_show_with_parameter</argument>
-            <argument name="debugHintsParameter" xsi:type="string">dev/debug/template_hints_parameter_value</argument>
-        </arguments>
-    </type>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Forwardport for https://github.com/magento/magento2/pull/17984

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#10440: Missing $debugHintsPath when sending email via command.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
See issue.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
