### PR TITLE
[Forwardport] fixed - Magento 2.2.6 Default values are not rendering on Wishlist product edit page

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/options-updater.js
@@ -61,6 +61,7 @@ define([
             this.setProductOptions(cartData());
             this.updateOptions();
         }.bind(this));
+        this.updateOptions();
     },
 
     /**


### PR DESCRIPTION
### Original Pull Request
#18967 

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
While editing wishlist item that has configuration, it will not visible selected on configuration page. But after applying this fix it will work.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18555: Magento 2.2.6 Default values are not rendering on Wishlist product edit page


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add any configurable product with configured attributes to wishlist
2. Now edit the item from wishlist to change the configuration.
3. On Item configuration page the previously opted option will get selected automatically.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
