### PR TITLE
[Customer] Getting a full list of customerGroups with searchCriteria

### DIFF
--- a/app/code/Magento/Customer/Api/AllGroupsRepositoryInterface.php
+++ b/app/code/Magento/Customer/Api/AllGroupsRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Api;
+
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Customer all groups interface
+ * @since 100.0.2
+ */
+interface AllGroupsRepositoryInterface
+{
+    /**
+     * Retrieve all customer groups.
+     *
+     * This call returns an array of objects, but detailed information about each object’s attributes might not be
+     * included. See http://devdocs.magento.com/codelinks/attributes.html#GroupRepositoryInterface to determine
+     * which call to use to get detailed information about all attributes for an object.
+     *
+     * @return \Magento\Customer\Api\Data\GroupSearchResultsInterface
+     * @throws LocalizedException
+     */
+    public function getAllGroups();
+}

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -16,6 +16,8 @@
                 type="Magento\Customer\Model\CustomerGroupConfig" />
     <preference for="Magento\Customer\Api\GroupRepositoryInterface"
                 type="Magento\Customer\Model\ResourceModel\GroupRepository" />
+    <preference for="Magento\Customer\Api\AllGroupsRepositoryInterface"
+                type="Magento\Customer\Model\ResourceModel\GroupRepository" />
     <preference for="Magento\Customer\Api\Data\CustomerInterface" type="Magento\Customer\Model\Data\Customer" />
     <preference for="Magento\Customer\Api\Data\AddressInterface" type="Magento\Customer\Model\Data\Address" />
     <preference for="Magento\Customer\Api\Data\RegionInterface" type="Magento\Customer\Model\Data\Region" />

--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -47,7 +47,7 @@
     <route url="/V1/customerGroups" method="GET">
         <service class="Magento\Customer\Api\AllGroupsRepositoryInterface" method="getAllGroups"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Magento_Customer::group"/>
         </resources>
     </route>
     <route url="/V1/customerGroups" method="POST">

--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -44,6 +44,12 @@
             <resource ref="Magento_Customer::group"/>
         </resources>
     </route>
+    <route url="/V1/customerGroups" method="GET">
+        <service class="Magento\Customer\Api\AllGroupsRepositoryInterface" method="getAllGroups"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
     <route url="/V1/customerGroups" method="POST">
         <service class="Magento\Customer\Api\GroupRepositoryInterface" method="save"/>
         <resources>


### PR DESCRIPTION
This PR adds a new separated API endpoint to get all the customer groups, in order to avoid using `/V1/customerGroups/search/?searchCriteria` where **searchCriteria** isn't needed

### Description (*)
Adding a new API endpoint `/V1/customerGroups` [GET] which will return all the customer groups.

### Fixed Issues (if relevant)
1. magento/magento2#16910: Getting a full list of customerGroups with searchCriteria

### Manual testing scenarios (*)
1. Create a GET API request to `/V1/customerGroups`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
