### PR TITLE
[forwardport] Resolves 6731 by adding a custom message for refunding shipping

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -35,11 +35,11 @@ class Discount extends AbstractTotal
 
         /**
          * If credit memo's shipping amount is set and Order's shipping amount is 0,
-         * throw exception with different message
+         *      throw exception with differente message
          */
-        if ($baseShippingAmount && $order->getBaseShippingAmount() <= 0) {
+        if ( $baseShippingAmount && $order->getBaseShippingAmount() <= 0 ) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                __("You can not refund shipping if there is no shipping amount.")
+                new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.",[])
             );
         }
         if ($baseShippingAmount) {

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -35,7 +35,7 @@ class Discount extends AbstractTotal
 
         /**
          * If credit memo's shipping amount is set and Order's shipping amount is 0,
-         *      throw exception with differente message
+         * throw exception with different message
          */
         if ( $baseShippingAmount && $order->getBaseShippingAmount() <= 0 ) {
             throw new \Magento\Framework\Exception\LocalizedException(

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -37,7 +37,7 @@ class Discount extends AbstractTotal
          * If credit memo's shipping amount is set and Order's shipping amount is 0,
          * throw exception with different message
          */
-        if ( $baseShippingAmount && $order->getBaseShippingAmount() <= 0 ) {
+        if ($baseShippingAmount && $order->getBaseShippingAmount() <= 0) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.",[])
             );

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -39,7 +39,7 @@ class Discount extends AbstractTotal
          */
         if ($baseShippingAmount && $order->getBaseShippingAmount() <= 0) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.",[])
+                new \Magento\Framework\Phrase("You can not refund shipping if there is no shipping amount.", [])
             );
         }
         if ($baseShippingAmount) {


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18844 

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->



<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)

1. magento/magento2#6731: 'Exception' with message 'Warning: Division by zero in vendor/magento/module-sales/Model/Order/Creditmemo/Total/Discount.php on line 32' in vendor/magento/framework/App/ErrorHandler.php:61

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a order with free shipment
2. Invoice the order
3. Create new creditmemo
4. Refund $10 in Refund Shipping

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
