### PR TITLE
Fix for Internet Explorer 11: Edit customer in backend leads sometimes to a "loading circle" and error object does not support method "includes"

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/country.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/country.js
@@ -49,7 +49,7 @@ define([
 
             if (!this.value()) {
                 defaultCountry = _.filter(result, function (item) {
-                    return item['is_default'] && item['is_default'].includes(value);
+                    return item['is_default'] && _.contains(item['is_default'], value);
                 });
 
                 if (defaultCountry.length) {


### PR DESCRIPTION
### Description
Replace usage of unsupported `includes` method with `_.contains`

### Fixed Issues
1. magento/magento2#18562: Internet Explorer 11: Edit customer in backend leads sometimes to a "loading circle" and error object does not support method "includes"

### Manual testing scenarios 
1. Go to admin using IE11
2. Customers > All Customers
3. Click Add New Customer
4. Open Adresses tab
5. Open developer tools
6. No JS errors in console

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
