### PR TITLE
overwrite fix for 'MAGE DIRS'

### DIFF
--- a/pub/index.php
+++ b/pub/index.php
@@ -25,6 +25,7 @@ HTML;
 }
 
 $params = $_SERVER;
+unset($params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS]);
 $params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
     DirectoryList::PUB => [DirectoryList::URL_PATH => ''],
     DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
In the pub/index.php file MAGE_DIRS coming from $_SERVER are completely overwritten. This prevent someone to set a different directory (for example a different cache directory) when using the pub directory as document root.

### Fixed Issues (if relevant)
1. magento/magento2<https://github.com/magento/magento2/issues/19013>: overwrite for 'MAGE DIRS' 


### Manual testing scenarios (*)
### Preconditions (*)
1. Add a simple PHP script named test.php with the following content to the Magento's root directory:
```
`
<?php
use Magento\Framework\App\Bootstrap;
use Magento\Framework\App\Filesystem\DirectoryList;

$_SERVER[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
 DirectoryList::CACHE => [DirectoryList::PATH => 'var/cache2']
];

```
2. Add it to the Composer's autoloader:

```
 "autoload": {
        // ...
        "files": [
            "test.php"
            // ...
        ],
        // ...
    },
```

### Steps to reproduce (*)
1. Change document root to pub
2. Do the composer update
3. Go to storefront and do some actions
4. You have no other folders in var with cache

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
