### PR TITLE
[2.2 develop] [backport #19018] [issue #17833] child theme does not inherit translations from parent theme

### DIFF
--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework;
 
@@ -327,16 +328,21 @@ class Translate implements \Magento\Framework\TranslateInterface
     }
 
     /**
-     * Load current theme translation
+     * Load current theme translation according to fallback
      *
      * @return $this
      */
     protected function _loadThemeTranslation()
     {
-        $file = $this->_getThemeTranslationFile($this->getLocale());
-        if ($file) {
-            $this->_addData($this->_getFileData($file));
+        $themeFiles = $this->getThemeTranslationFilesList($this->getLocale());
+
+        /** @var string $file */
+        foreach ($themeFiles as $file) {
+            if ($file) {
+                $this->_addData($this->_getFileData($file));
+            }
         }
+
         return $this;
     }
 
@@ -378,10 +384,72 @@ class Translate implements \Magento\Framework\TranslateInterface
     }
 
     /**
+     * Get theme translation locale file name
+     *
+     * @param string $locale
+     * @param array $config
+     * @return string
+     */
+    private function getThemeTranslationFileName(string $locale, array $config): string
+    {
+        return $this->_viewFileSystem->getLocaleFileName(
+            'i18n' . '/' . $locale . '.csv',
+            $config
+        );
+    }
+
+    /**
+     * Get parent themes for the current theme in fallback order
+     *
+     * @return array
+     */
+    private function getParentThemesList(): array
+    {
+        $themes = [];
+
+        $parentTheme = $this->_viewDesign->getDesignTheme()->getParentTheme();
+        while($parentTheme) {
+            $themes[] = $parentTheme;
+            $parentTheme = $parentTheme->getParentTheme();
+        }
+        $themes = array_reverse($themes);
+
+        return $themes;
+    }
+
+    /**
+     * Retrieve translation files for themes according to fallback
+     *
+     * @param string $locale
+     *
+     * @return array
+     */
+    private function getThemeTranslationFilesList($locale): array
+    {
+        $translationFiles = [];
+
+        /** @var \Magento\Framework\View\Design\ThemeInterface $theme */
+        foreach ($this->getParentThemesList() as $theme) {
+            $config = $this->_config;
+            $config['theme'] = $theme->getCode();
+            $translationFiles[] = $this->getThemeTranslationFileName($locale, $config);
+        }
+
+        $translationFiles[] = $this->getThemeTranslationFileName($locale, $this->_config);
+
+        return $translationFiles;
+    }
+
+
+    /**
      * Retrieve translation file for theme
      *
      * @param string $locale
      * @return string
+     *
+     * @deprecated
+     *
+     * @see \Magento\Framework\Translate::getThemeTranslationFilesList
      */
     protected function _getThemeTranslationFile($locale)
     {

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -408,7 +408,7 @@ class Translate implements \Magento\Framework\TranslateInterface
         $themes = [];
 
         $parentTheme = $this->_viewDesign->getDesignTheme()->getParentTheme();
-        while($parentTheme) {
+        while ($parentTheme) {
             $themes[] = $parentTheme;
             $parentTheme = $parentTheme->getParentTheme();
         }

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -388,14 +388,16 @@ class Translate implements \Magento\Framework\TranslateInterface
      *
      * @param string $locale
      * @param array $config
-     * @return string
+     * @return string|null
      */
-    private function getThemeTranslationFileName(string $locale, array $config): string
+    private function getThemeTranslationFileName(string $locale, array $config): ?string
     {
-        return $this->_viewFileSystem->getLocaleFileName(
+        $fileName = $this->_viewFileSystem->getLocaleFileName(
             'i18n' . '/' . $locale . '.csv',
             $config
         );
+
+        return $fileName ? $fileName : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -390,7 +390,7 @@ class Translate implements \Magento\Framework\TranslateInterface
      * @param array $config
      * @return string|null
      */
-    private function getThemeTranslationFileName(string $locale, array $config): ?string
+    private function getThemeTranslationFileName(string $locale, array $config)
     {
         $fileName = $this->_viewFileSystem->getLocaleFileName(
             'i18n' . '/' . $locale . '.csv',

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -386,11 +386,11 @@ class Translate implements \Magento\Framework\TranslateInterface
     /**
      * Get theme translation locale file name
      *
-     * @param string $locale
+     * @param string|null $locale
      * @param array $config
      * @return string|null
      */
-    private function getThemeTranslationFileName(string $locale, array $config)
+    private function getThemeTranslationFileName($locale, array $config)
     {
         $fileName = $this->_viewFileSystem->getLocaleFileName(
             'i18n' . '/' . $locale . '.csv',

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -442,7 +442,6 @@ class Translate implements \Magento\Framework\TranslateInterface
         return $translationFiles;
     }
 
-
     /**
      * Retrieve translation file for theme
      *


### PR DESCRIPTION
### Original pull request ( https://github.com/magento/magento2/pull/19018 )

### Description ( #17833 )
Child theme does not inherit translations from parent theme.
Theme inheritance does not work as expected with [translation dictionaries][1].  The child theme does not use any translations defined in it's parent theme's `en_US.csv` translation dictionary.

### Fixed Issues
1. magento/magento2#17833: Child theme does not inherit translations from parent theme

### Preconditions
I'm working on a Magento ver 2.2.5 installation with two websites & two corresponding theme's.  Each with their own [translation dictionary][1], and one theme inheriting from the other.

### Manual testing scenarios
1. Set up a magento instance with two websites and with two theme's, one inheriting from luma and the other inheriting from the other theme you created.  See theme structure below.
2. Add a the translation string `"Create New Customer Account","Create New Account"` to the parent theme's `en_US.csv` translation dictionary.
3. Go to the _/customer/account/create/_ URL for the website with the child theme applied.

**Expected result**
The page title should be _Create New Account_


**Actual result**
The page title is still _Create New Customer Account_

- If go to the _/customer/account/create/_ URL for the website with the parent theme applied, the page title should is _Create New Account_.  So the child theme is not picking up translations from the parent theme.
- If you add the translation string `"Create New Customer Account","Create New Account"` to the Child theme's `en_US.csv` translation dictionary you can see the translation string applied corectly on the website with the child theme applied.

Is this a bug with Magento or am I doing something wrong?

Is the [translation dictionary][1] documentation incorrect and this is actually the correct behaviour?

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
