### PR TITLE
Save downloadable product links for order items

### DIFF
--- a/app/code/Magento/Catalog/CustomerData/CompareProducts.php
+++ b/app/code/Magento/Catalog/CustomerData/CompareProducts.php
@@ -20,6 +20,11 @@ class CompareProducts implements SectionSourceInterface
     protected $productUrl;
 
     /**
+     * @var \Magento\Catalog\Helper\Output
+     */
+    private $outputHelper;
+
+    /**
      * @param \Magento\Catalog\Helper\Product\Compare $helper
      * @param \Magento\Catalog\Model\Product\Url $productUrl
      * @param \Magento\Catalog\Helper\Output $outputHelper
@@ -54,6 +59,7 @@ class CompareProducts implements SectionSourceInterface
     protected function getItems()
     {
         $items = [];
+        /** @var \Magento\Catalog\Model\Product $item */
         foreach ($this->helper->getItemCollection() as $item) {
             $items[] = [
                 'id' => $item->getId(),

--- a/app/code/Magento/Downloadable/etc/events.xml
+++ b/app/code/Magento/Downloadable/etc/events.xml
@@ -6,10 +6,10 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="sales_order_item_save_commit_after">
+    <event name="sales_order_item_save_after">
         <observer name="downloadable_observer" instance="Magento\Downloadable\Observer\SaveDownloadableOrderItemObserver" />
     </event>
-    <event name="sales_order_save_commit_after">
+    <event name="sales_order_save_after">
         <observer name="downloadable_observer" instance="Magento\Downloadable\Observer\SetLinkStatusObserver" />
     </event>
     <event name="sales_model_service_quote_submit_success">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fix save of downloadable links for guest checkout.

### Fixed Issues (if relevant)
1. magento/magento2#18323: Order confirmation email for guest checkout does not include download links

### Manual testing scenarios (*)
Please see issue: #18323

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
