### PR TITLE
[2.3-develop] magento/magento2#14007: "Use in Layered Navigation: Filterable (no results)" property confuse for Price filter

### DIFF
--- a/app/code/Magento/LayeredNavigation/Observer/Edit/Tab/Front/ProductAttributeFormBuildFrontTabObserver.php
+++ b/app/code/Magento/LayeredNavigation/Observer/Edit/Tab/Front/ProductAttributeFormBuildFrontTabObserver.php
@@ -60,7 +60,11 @@ class ProductAttributeFormBuildFrontTabObserver implements ObserverInterface
                 'name' => 'is_filterable',
                 'label' => __("Use in Layered Navigation"),
                 'title' => __('Can be used only with catalog input type Yes/No, Dropdown, Multiple Select and Price'),
-                'note' => __('Can be used only with catalog input type Yes/No, Dropdown, Multiple Select and Price.'),
+                'note' => __(
+                    'Can be used only with catalog input type Yes/No, Dropdown, Multiple Select and Price.
+                    <br>Price is not compatible with <b>\'Filterable (no results)\'</b> option - 
+                     it will make no affect on Price filter.'
+                ),
                 'values' => [
                     ['value' => '0', 'label' => __('No')],
                     ['value' => '1', 'label' => __('Filterable (with results)')],


### PR DESCRIPTION
### Description (#14007)
"Use in Layered Navigation: Filterable (no results)" not working for `Price` attribute.
- adjust comment for "Use in Layered Navigation: Filterable (no results)" property to make it more understandable

### Fixed Issues
No issues were fixed - only adjusted "Use in Layered Navigation: Filterable (no results)" property note/comment to make it more understandable and dismiss confusion about its effect on Price attribute/filter

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
