### PR TITLE
WYSIWYG unable to set default value in ui component

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -20,7 +20,6 @@ define([
     return Abstract.extend({
         defaults: {
             elementSelector: 'textarea',
-            value: '',
             $wysiwygEditorButton: '',
             links: {
                 value: '${ $.provider }:${ $.dataScope }'


### PR DESCRIPTION
### Description
Fix default value for wysiwyg component.

### Fixed Issues
1. magento/magento2#10048: WYSIWYG unable to set default value in ui component

### Manual testing scenarios
1. Add default value for content field in cms_page_form.xml
```
...
<field name="content" formElement="wysiwyg">
    <argument name="data" xsi:type="array">
        <item name="config" xsi:type="array">
            <item name="source" xsi:type="string">page</item>
            <item name="default" xsi:type="string">blabla</item> <!-- Add this item -->
        </item>
    </argument>
    <settings>
        <additionalClasses>
            <class name="admin__field-wide">true</class>
        </additionalClasses>
        <label/>
        <dataScope>content</dataScope>
    </settings>
    <formElements>
        <wysiwyg>
            <settings>
                <wysiwyg>true</wysiwyg>
            </settings>
        </wysiwyg>
    </formElements>
</field>
...
```
2. Open Cms Page creation form
3. Verify that default value present in wysiwyg

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
