### PR TITLE
Fix issue 19052- Position order showing before the text box

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Catalog/web/css/source/_module.less
@@ -15,6 +15,14 @@
     }
 }
 
+.catalog-category-edit {
+    .admin__grid-control {
+        .admin__grid-control-value {
+            display: none;
+        }
+    }  
+}
+
 .product-composite-configure-inner {
     .admin__control-text {
         &.qty {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

You will find the position order showing before the text box as well when we can find the same value in textbox as well.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19052: Position order showing before the text box 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Catalog > Category > Choose any category > Go to Product in category tab > Assign products.
2. Product position order before textbox.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
