### PR TITLE
Fixed Product Tax total on PDF for 2.3, Reference of PL #18649

### DIFF
--- a/app/code/Magento/Weee/Model/Sales/Pdf/Weee.php
+++ b/app/code/Magento/Weee/Model/Sales/Pdf/Weee.php
@@ -70,4 +70,17 @@ class Weee extends \Magento\Sales\Model\Order\Pdf\Total\DefaultTotal
 
         return $totals;
     }
+    
+    /**
+     * Check if we can display Weee total information in PDF
+     *
+     * @return bool
+     */
+    public function canDisplay()
+    {
+        $items = $this->getSource()->getAllItems();
+        $store = $this->getSource()->getStore();
+        $amount = $this->_weeeData->getTotalAmounts($items, $store);
+        return $this->getDisplayZero() === 'true' || $amount != 0;
+    }
 }


### PR DESCRIPTION
Issue of Wee Tax When using FPT, the FPT-total show up at the cart/checkout but is missing at the pdf invoice.

### Description (*)

If we enable FPT and add it to the product, after placing order, FTP amount field is displaying on Order view, Invoice view etc, when downloading Invoice Pdf, FTP amount field was missing. In this pull request
i have fixed it.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18617 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable FPT from Stores > Settings > Configurations > Sales > Tax > Fixed Product Taxes.
2. Created a new product attribute of type FPT.
3. Added this attribute to Default attribute set.
4. Saved product with FTP details.
5. Placed an order and generated invoice.
6. Print pdf.

Reference PL of #18649 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
