### PR TITLE
Using Media Image custom attribute type could not display on frontend. #19054

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute.php
@@ -287,6 +287,12 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute\AbstractAttribute im
             }
         }
 
+        if ($this->getFrontendInput() == 'media_image') {
+            if (!$this->getFrontendModel()) {
+                $this->setFrontendModel(\Magento\Catalog\Model\Product\Attribute\Frontend\Image::class);
+            }
+        }
+
         if ($this->getBackendType() == 'gallery') {
             if (!$this->getBackendModel()) {
                 $this->setBackendModel(\Magento\Eav\Model\Entity\Attribute\Backend\DefaultBackend::class);


### PR DESCRIPTION

### Description (*)
Using Media Image custom attribute type could not display on frontend. #19054

### Fixed Issues (if relevant)
1. magento/magento2#<https://github.com/magento/magento2/issues/19054>: Using Media Image custom attribute type could not display on frontend
2. ...

### Manual testing scenarios (*)

1. Create custom attribute named 'icon_image' of product from admin.
2. Set attribute type Media Image.
3. assign icon_image attribute in attribute set.
4. Update product image and set new role 'icon_image'.
5. In .phtml template ->
```
$productImageAttr = $product->getCustomAttribute( 'icon_image' );
$productImage = $this->helper('Magento\Catalog\Helper\Image')
->init($product, 'icon_image')
->setImageFile($productImageAttr->getValue());
<img src="<?php echo $productImage->getUrl() ?>" alt="<?php echo $block->escapeHtml($product->getTitle()) ?>" />
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
