### PR TITLE
[Backport] Fixes CategoryLink issue when assigning products to category

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/CategoryLink.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/CategoryLink.php
@@ -115,10 +115,14 @@ class CategoryLink
     {
         $result = ['changed' => [], 'updated' => []];
         foreach ($newCategoryPositions as $newCategoryPosition) {
-            $key = array_search(
-                $newCategoryPosition['category_id'],
-                array_column($oldCategoryPositions, 'category_id')
-            );
+            $key = false;
+
+            foreach ($oldCategoryPositions as $oldKey => $oldCategoryPosition) {
+                if ((int)$oldCategoryPosition['category_id'] === (int)$newCategoryPosition['category_id']) {
+                    $key = $oldKey;
+                    break;
+                }
+            }
 
             if ($key === false) {
                 $result['changed'][] = $newCategoryPosition;

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Test\Unit\Model\ResourceModel\Product;
 
 use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
@@ -129,9 +130,65 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                 );
         }
 
+        $expectedResult = [];
+
+        foreach ($affectedIds as $type => $ids) {
+            $expectedResult = array_merge($expectedResult, $ids);
+
+            // Verify if the correct insert, update and/or delete actions are performed:
+            switch ($type) {
+                case 'insert':
+                    $this->connectionMock
+                        ->expects($this->exactly(empty($ids) ? 0 : 1))
+                        ->method('insertArray')
+                        ->with(
+                            $this->anything(),
+                            $this->anything(),
+                            $this->callback(function ($data) use ($ids) {
+                                $foundIds = [];
+                                foreach ($data as $row) {
+                                    $foundIds[] = $row['category_id'];
+                                }
+                                return $ids === $foundIds;
+                            })
+                        );
+                    break;
+                case 'update':
+                    $this->connectionMock
+                        ->expects($this->exactly(empty($ids) ? 0 : 1))
+                        ->method('insertOnDuplicate')
+                        ->with(
+                            $this->anything(),
+                            $this->callback(function ($data) use ($ids) {
+                                $foundIds = [];
+                                foreach ($data as $row) {
+                                    $foundIds[] = $row['category_id'];
+                                }
+                                return $ids === $foundIds;
+                            })
+                        );
+                    break;
+                case 'delete':
+                    $this->connectionMock
+                        ->expects($this->exactly(empty($ids) ? 0 : 1))
+                        ->method('delete')
+                        // Verify that the correct category ID's are touched:
+                        ->with(
+                            $this->anything(),
+                            $this->callback(function ($data) use ($ids) {
+                                return array_values($data)[1] === $ids;
+                            })
+                        );
+                    break;
+            }
+        }
+
         $actualResult = $this->model->saveCategoryLinks($product, $newCategoryLinks);
+
         sort($actualResult);
-        $this->assertEquals($affectedIds, $actualResult);
+        sort($expectedResult);
+
+        $this->assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -151,7 +208,11 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                     ['category_id' => 3, 'position' => 10],
                     ['category_id' => 4, 'position' => 20],
                 ],
-                [], // Nothing to update - data not changed
+                [
+                    'update' => [],
+                    'insert' => [],
+                    'delete' => [],
+                ],
             ],
             [
                 [
@@ -162,7 +223,11 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                     ['category_id' => 3, 'position' => 10],
                     ['category_id' => 4, 'position' => 20],
                 ],
-                [3, 4, 5], // 4 - updated position, 5 - added, 3 - deleted
+                [
+                    'update' => [4],
+                    'insert' => [5],
+                    'delete' => [3],
+                ],
             ],
             [
                 [
@@ -173,7 +238,11 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                     ['category_id' => 3, 'position' => 10],
                     ['category_id' => 4, 'position' => 20],
                 ],
-                [3, 4], // 3 - updated position, 4 - deleted
+                [
+                    'update' => [3],
+                    'insert' => [],
+                    'delete' => [4],
+                ],
             ],
             [
                 [],
@@ -181,8 +250,27 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                     ['category_id' => 3, 'position' => 10],
                     ['category_id' => 4, 'position' => 20],
                 ],
-                [3, 4], // 3, 4 - deleted
+                [
+                    'update' => [],
+                    'insert' => [],
+                    'delete' => [3, 4],
+                ],
             ],
+            [
+                [
+                    ['category_id' => 3, 'position' => 10],
+                    ['category_id' => 4, 'position' => 20],
+                ],
+                [
+                    ['category_id' => 3, 'position' => 20], // swapped positions
+                    ['category_id' => 4, 'position' => 10], // swapped positions
+                ],
+                [
+                    'update' => [3, 4],
+                    'insert' => [],
+                    'delete' => [],
+                ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
@@ -134,53 +134,8 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
 
         foreach ($affectedIds as $type => $ids) {
             $expectedResult = array_merge($expectedResult, $ids);
-
             // Verify if the correct insert, update and/or delete actions are performed:
-            switch ($type) {
-                case 'insert':
-                    $this->connectionMock
-                        ->expects($this->exactly(empty($ids) ? 0 : 1))
-                        ->method('insertArray')
-                        ->with(
-                            $this->anything(),
-                            $this->anything(),
-                            $this->callback(function ($data) use ($ids) {
-                                $foundIds = [];
-                                foreach ($data as $row) {
-                                    $foundIds[] = $row['category_id'];
-                                }
-                                return $ids === $foundIds;
-                            })
-                        );
-                    break;
-                case 'update':
-                    $this->connectionMock
-                        ->expects($this->exactly(empty($ids) ? 0 : 1))
-                        ->method('insertOnDuplicate')
-                        ->with(
-                            $this->anything(),
-                            $this->callback(function ($data) use ($ids) {
-                                $foundIds = [];
-                                foreach ($data as $row) {
-                                    $foundIds[] = $row['category_id'];
-                                }
-                                return $ids === $foundIds;
-                            })
-                        );
-                    break;
-                case 'delete':
-                    $this->connectionMock
-                        ->expects($this->exactly(empty($ids) ? 0 : 1))
-                        ->method('delete')
-                        // Verify that the correct category ID's are touched:
-                        ->with(
-                            $this->anything(),
-                            $this->callback(function ($data) use ($ids) {
-                                return array_values($data)[1] === $ids;
-                            })
-                        );
-                    break;
-            }
+            $this->setupExpectationsForConnection($type, $ids);
         }
 
         $actualResult = $this->model->saveCategoryLinks($product, $newCategoryLinks);
@@ -272,5 +227,58 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                 ],
             ]
         ];
+    }
+
+    /**
+     * @param $type
+     * @param $ids
+     */
+    private function setupExpectationsForConnection($type, $ids): void
+    {
+        switch ($type) {
+            case 'insert':
+                $this->connectionMock
+                    ->expects($this->exactly(empty($ids) ? 0 : 1))
+                    ->method('insertArray')
+                    ->with(
+                        $this->anything(),
+                        $this->anything(),
+                        $this->callback(function ($data) use ($ids) {
+                            $foundIds = [];
+                            foreach ($data as $row) {
+                                $foundIds[] = $row['category_id'];
+                            }
+                            return $ids === $foundIds;
+                        })
+                    );
+                break;
+            case 'update':
+                $this->connectionMock
+                    ->expects($this->exactly(empty($ids) ? 0 : 1))
+                    ->method('insertOnDuplicate')
+                    ->with(
+                        $this->anything(),
+                        $this->callback(function ($data) use ($ids) {
+                            $foundIds = [];
+                            foreach ($data as $row) {
+                                $foundIds[] = $row['category_id'];
+                            }
+                            return $ids === $foundIds;
+                        })
+                    );
+                break;
+            case 'delete':
+                $this->connectionMock
+                    ->expects($this->exactly(empty($ids) ? 0 : 1))
+                    ->method('delete')
+                    // Verify that the correct category ID's are touched:
+                    ->with(
+                        $this->anything(),
+                        $this->callback(function ($data) use ($ids) {
+                            return array_values($data)[1] === $ids;
+                        })
+                    );
+                break;
+        }
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
@@ -225,7 +225,7 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
                     'insert' => [],
                     'delete' => [],
                 ],
-            ]
+            ],
         ];
     }
 
@@ -233,7 +233,7 @@ class CategoryLinkTest extends \PHPUnit\Framework\TestCase
      * @param $type
      * @param $ids
      */
-    private function setupExpectationsForConnection($type, $ids): void
+    private function setupExpectationsForConnection($type, $ids)
     {
         switch ($type) {
             case 'insert':


### PR DESCRIPTION
This PR fixes an issue (#14861) when products are programmatically assigned to a category, or are swapped with positions.

### Description

This PR changes the way how the key is calculated in `Magento\Catalog\Model\ResourceModel\Product\CategoryLink::processCategoryLinks()`. It also improves the unit test by not just verifying if the proper category ID's are touched, but also if the proper insert, update or delete action is performed.

### Fixed Issues

This PR fixes #14861

### Manual testing scenarios

Steps to reproduce are described in detail in #14861

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
