### PR TITLE
magento/magento2#19071: Password strength indicator shows No Password…

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/password-strength-indicator.js
@@ -83,7 +83,7 @@ define([
                 } else {
                     isValid = $.validator.validateSingleElement(this.options.cache.input);
                     zxcvbnScore = zxcvbn(password).score;
-                    displayScore = isValid ? zxcvbnScore : 1;
+                    displayScore = isValid && zxcvbnScore > 0 ? zxcvbnScore : 1;
                 }
             }
 


### PR DESCRIPTION
… even when a password is entered

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The password strength indicator shows "No Password" at times when there is a password entered and "Number of Required Character Classes" option has value "1". There is an situation when zxcvbn() method returns 0 score value and password is valid. In this case displayScore variable will be 0 and as result text "Password Strength: No Password" is visible despite the fact that "Password" field is filled.
Added additional condition that checks if zxcvbn() returns 0 and pass is valid, then displayScore = 1 and
"Password Strength: Weak"

Link to the same PR for 2.2-develop : https://github.com/magento/magento2/pull/19073

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Goto AdminPanel->Stores->Configuration->Customers->Customer Configuration->Password Options
2. Set "Number of Required Character Classes" to 1
3. Go to "Create account" page
4. Type to "Password" field any words which have 8 lowercase letters like "password", "aaaaaaaa", etc
Check that "Password Strength:" not equal "No Password" in this case

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
