### PR TITLE
magento/magento#18901: Forgot password form should not available while customer is logged in.

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/ForgotPassword.php
+++ b/app/code/Magento/Customer/Controller/Account/ForgotPassword.php
@@ -40,10 +40,17 @@ class ForgotPassword extends \Magento\Customer\Controller\AbstractAccount
     /**
      * Forgot customer password page
      *
-     * @return \Magento\Framework\View\Result\Page
+     * @return \Magento\Framework\Controller\Result\Redirect|\Magento\Framework\View\Result\Page
      */
     public function execute()
     {
+        if ($this->session->isLoggedIn()) {
+            /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
+            $resultRedirect = $this->resultRedirectFactory->create();
+            $resultRedirect->setPath('*/*/');
+            return $resultRedirect;
+        }
+
         /** @var \Magento\Framework\View\Result\Page $resultPage */
         $resultPage = $this->resultPageFactory->create();
         $resultPage->getLayout()->getBlock('forgotPassword')->setEmailValue($this->session->getForgottenEmail());


### PR DESCRIPTION
magento/magento2#18901: Forgot password form should not available while customer is logged in

### Description 
- When you is logged in, form forgotpassword not shown, redirect to My Account occurred instead
- When you guest and go to forgotpassword form, you see forgotpassword form
- Backport of https://github.com/magento/magento2/pull/19029

### Fixed Issues 
1. magento/magento2#18901: Forgot password form should not available while customer is logged in

### Manual testing scenarios
1. Go to customer/account/forgotpassword as guest
2. See forgotpassword form
3. Login as user on FE
4. Go to customer/account/forgotpassword
5. You do not see forgotpassword form, but you redirected to My Account

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
