### PR TITLE
Fix mass product update with group min cart qty

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -104,17 +104,17 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
     /**
      * Returns min_sale_qty configuration for the ALL Customer Group
      *
-     * @return int
+     * @return float
      */
     public function getDefaultMinSaleQty()
     {
         $default = $this->stockConfiguration->getDefaultConfigValue('min_sale_qty');
         if (!is_numeric($default)) {
             $default = $this->serializer->unserialize($default);
-            $default = isset($default[GroupInterface::CUST_GROUP_ALL]) ? $default[GroupInterface::CUST_GROUP_ALL] : 1;
+            $default = $default[GroupInterface::CUST_GROUP_ALL] ?? 1;
         }
 
-        return (int) $default;
+        return (float) $default;
     }
 
     /**

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -41,6 +41,7 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
      * @param \Magento\CatalogInventory\Model\Source\Backorders $backorders
      * @param \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration
      * @param array $data
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
@@ -80,11 +81,13 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
      * Retrieve current store id
      *
      * @return int
+     * @SuppressWarnings(PHPMD.RequestAwareBlockMethod)
      */
     public function getStoreId()
     {
-        $storeId = $this->getRequest()->getParam('store');
-        return (int) $storeId;
+        $storeId = (int)$this->getRequest()->getParam('store');
+
+        return $storeId;
     }
 
     /**
@@ -100,6 +103,7 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
 
     /**
      * Returns min_sale_qty configuration for the ALL Customer Group
+     *
      * @return int
      */
     public function getDefaultMinSaleQty()
@@ -124,6 +128,8 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
     }
 
     /**
+     * Return Tab title.
+     *
      * @return \Magento\Framework\Phrase
      */
     public function getTabTitle()
@@ -132,7 +138,7 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
     }
 
     /**
-     * @return bool
+     * @inheritdoc
      */
     public function canShowTab()
     {
@@ -140,7 +146,7 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
     }
 
     /**
-     * @return bool
+     * @inheritdoc
      */
     public function isHidden()
     {
@@ -148,6 +154,8 @@ class Inventory extends \Magento\Backend\Block\Widget implements \Magento\Backen
     }
 
     /**
+     * Get availability status.
+     *
      * @param string $fieldName
      * @return bool
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)

--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/InventoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/InventoryTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Catalog\Test\Unit\Block\Adminhtml\Product\Edit\Action\Attribute\Tab;
 
+use Magento\Customer\Api\Data\GroupInterface;
+
 /**
  * Class InventoryTest
  */
@@ -68,7 +70,8 @@ class InventoryTest extends \PHPUnit\Framework\TestCase
             [
                 'context' => $this->contextMock,
                 'backorders' => $this->backordersMock,
-                'stockConfiguration' => $this->stockConfigurationMock
+                'stockConfiguration' => $this->stockConfigurationMock,
+                'serializer' => new \Magento\Framework\Serialize\Serializer\Json(),
             ]
         );
     }
@@ -124,6 +127,32 @@ class InventoryTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue('return-value'));
 
         $this->assertEquals('return-value', $this->inventory->getDefaultConfigValue('field-name'));
+    }
+
+    /**
+     * @dataProvider getDefaultMinSaleQtyDataProvider
+     * @param string $expected
+     * @param string $default
+     */
+    public function testGetDefaultMinSaleQty($expected, $default)
+    {
+        $this->stockConfigurationMock->method('getDefaultConfigValue')->willReturn($default);
+        $this->assertEquals($expected, $this->inventory->getDefaultMinSaleQty());
+    }
+
+    public function getDefaultMinSaleQtyDataProvider()
+    {
+        return [
+            'single-default-value' => [
+                22, '22'
+            ],
+            'no-default-for-all-group' => [
+                1, json_encode(['12' => '111'])
+            ],
+            'default-for-all-group' => [
+                5, json_encode(['12' => '111', GroupInterface::CUST_GROUP_ALL => '5'])
+            ]
+        ];
     }
 
     /**

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml
@@ -132,7 +132,7 @@
                     <div class="field">
                         <input type="text" class="input-text validate-number" id="inventory_min_sale_qty"
                                name="<?= /* @escapeNotVerified */ $block->getFieldSuffix() ?>[min_sale_qty]"
-                               value="<?= /* @escapeNotVerified */ $block->getDefaultConfigValue('min_sale_qty') * 1 ?>"
+                               value="<?= /* @escapeNotVerified */ $block->getDefaultMinSaleQty() * 1 ?>"
                                disabled="disabled"/>
                     </div>
                     <div class="field choice">


### PR DESCRIPTION
### Description (*)
Resolves warning when using the product edit mass-action after configuring
global group cart min qty

### Fixed Issues (if relevant)
1. magento/magento2#17592 Mass attribute update fails with E_WARNING

### Manual testing scenarios (*)
1. Add some values to System > Configuration > Catalog > Inventory > Product Stock Options > Minimum Qty Allowed in Shopping Cart
2. Clean config cache
3. Go to the Catalog > Products
4. Select some products in the list
5. Select "Update attributes" mass-action

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
