### PR TITLE
Force cast to string when escaping

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -71,7 +71,7 @@ class Escaper
                         throw new \Exception($errorString, $errorNumber);
                     }
                 );
-                $string = mb_convert_encoding($data, 'HTML-ENTITIES', 'UTF-8');
+                $string = mb_convert_encoding((string)$data, 'HTML-ENTITIES', 'UTF-8');
                 try {
                     $domDocument->loadHTML(
                         '<html><body id="' . $wrapperElementId . '">' . $string . '</body></html>'


### PR DESCRIPTION
### Description (*)
The escaper does not force the input to string which can cause issues when the input to the escaper is an object and not a string. I've seen a case where a translation Phrase object is not properly rendered because the escaper did not trigger to __toString() method in the Phrase object.

The same could also apply to other objects, so I'm adding these 3 harmless characters here.

### Manual testing scenarios (*)
1. When adding a product to cart, sometimes I would see: "You added %1 to the shopping cart." The placeholder "%1" is not properly replaced, because the escaper did not trigger the toString method.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
