### PR TITLE
Add config setting for advanced search link on/off

### DIFF
--- a/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
@@ -19,6 +19,10 @@
                 <field id="engine" canRestore="1">
                     <backend_model>Magento\CatalogSearch\Model\Adminhtml\System\Config\Backend\Engine</backend_model>
                 </field>
+                <field id="show_advanced_search_link" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Show Advanced Search Link</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="min_query_length" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Minimal Query Length</label>
                     <validate>validate-digits</validate>

--- a/app/code/Magento/CatalogSearch/etc/config.xml
+++ b/app/code/Magento/CatalogSearch/etc/config.xml
@@ -12,6 +12,7 @@
                 <search_terms>1</search_terms>
             </seo>
             <search>
+                <show_advanced_search_link>1</show_advanced_search_link>
                 <engine>mysql</engine>
                 <min_query_length>1</min_query_length>
                 <max_query_length>128</max_query_length>

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/default.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/default.xml
@@ -8,10 +8,10 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="top.search">
-            <block class="Magento\Framework\View\Element\Template" name="advanced-search-link" template="Magento_CatalogSearch::advanced/link.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="advanced-search-link" template="Magento_CatalogSearch::advanced/link.phtml" ifconfig="catalog/search/show_advanced_search_link" />
         </referenceBlock>
         <referenceBlock name="footer_links">
-            <block class="Magento\Framework\View\Element\Html\Link\Current" name="catalog-search-advanced-link">
+            <block class="Magento\Framework\View\Element\Html\Link\Current" name="catalog-search-advanced-link" ifconfig="catalog/search/show_advanced_search_link">
                 <arguments>
                     <argument name="label" xsi:type="string" translate="true">Advanced Search</argument>
                     <argument name="path" xsi:type="string">catalogsearch/advanced</argument>


### PR DESCRIPTION

### Description (*)
I created a config setting so the Advanced Search link can be turned on and off. Defaults to "on", so it won't change existing installations.

### Fixed Issues (if relevant)
1. The "Advanced Search" link cannot be hidden without development

### Manual testing scenarios (*)
1. Turn the new setting off and see the link disappear!

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
