### PR TITLE
magento/magento2#18840: Invalid Unit Test Annotations.

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
@@ -268,7 +268,7 @@ class GalleryManagementTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionText Such image doesn't exist
+     * @expectedExceptionMessage Such image doesn't exist
      */
     public function testGetWithNonExistingImage()
     {

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/PriceModifierTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/PriceModifierTest.php
@@ -56,7 +56,7 @@ class PriceModifierTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedMessage This product doesn't have tier price
+     * @expectedExceptionMessage Product hasn't group price with such data: customerGroupId = '1', website = 1, qty = 3
      */
     public function testRemoveWhenTierPricesNotExists()
     {
@@ -72,7 +72,7 @@ class PriceModifierTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedMessage For current  customerGroupId = '10' with 'qty' = 15 any tier price exist'.
+     * @expectedExceptionMessage Product hasn't group price with such data: customerGroupId = '10', website = 1, qty = 5
      */
     public function testRemoveTierPriceForNonExistingCustomerGroup()
     {
@@ -83,7 +83,7 @@ class PriceModifierTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($this->prices));
         $this->productMock->expects($this->never())->method('setData');
         $this->productRepositoryMock->expects($this->never())->method('save');
-        $this->priceModifier->removeTierPrice($this->productMock, 10, 15, 1);
+        $this->priceModifier->removeTierPrice($this->productMock, 10, 5, 1);
     }
 
     public function testSuccessfullyRemoveTierPriceSpecifiedForAllGroups()

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/TierPriceManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/TierPriceManagementTest.php
@@ -188,7 +188,7 @@ class TierPriceManagementTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @message Such product doesn't exist
+     * @expectedExceptionMessage No such entity.
      */
     public function testDeleteTierPriceFromNonExistingProduct()
     {

--- a/app/code/Magento/Checkout/Test/Unit/Model/SidebarTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/SidebarTest.php
@@ -94,7 +94,7 @@ class SidebarTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\LocalizedException
-     * @exceptedExceptionMessage We can't find the quote item.
+     * @expectedExceptionMessage We can't find the quote item.
      */
     public function testCheckQuoteItemWithException()
     {

--- a/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
@@ -89,7 +89,7 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\LocalizedException
-     * @exectedExceptionMessage Please set resource file and link type.
+     * @expectedExceptionMessage Please set resource file and link type.
      */
     public function testGetFileSizeNoResource()
     {

--- a/app/code/Magento/GiftMessage/Test/Unit/Model/Plugin/OrderSaveTest.php
+++ b/app/code/Magento/GiftMessage/Test/Unit/Model/Plugin/OrderSaveTest.php
@@ -128,7 +128,7 @@ class OrderSaveTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\CouldNotSaveException
-     * @expectedMessage Could not add gift message to order:Test message
+     * @expectedExceptionMessage Could not add gift message to order: "Test message"
      */
     public function testAfterSaveIfGiftMessagesNotExist()
     {
@@ -146,7 +146,7 @@ class OrderSaveTest extends \PHPUnit\Framework\TestCase
         $this->giftMessageOrderRepositoryMock
             ->expects($this->once())
             ->method('save')
-            ->willThrowException(new \Exception('TestMessage'));
+            ->willThrowException(new \Exception('Test message'));
 
         // save Gift Messages on item level
         $this->orderMock->expects($this->never())->method('getItems');
@@ -155,7 +155,7 @@ class OrderSaveTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\CouldNotSaveException
-     * @expectedMessage Could not add gift message to order:Test message
+     * @expectedExceptionMessage Could not add gift message to order's item: "Test message"
      */
     public function testAfterSaveIfItemGiftMessagesNotExist()
     {
@@ -185,7 +185,7 @@ class OrderSaveTest extends \PHPUnit\Framework\TestCase
         $this->giftMessageOrderItemRepositoryMock
             ->expects($this->once())->method('save')
             ->with($orderId, $orderItemId, $this->giftMessageMock)
-            ->willThrowException(new \Exception('TestMessage'));
+            ->willThrowException(new \Exception('Test message'));
         $this->plugin->afterSave($this->orderRepositoryMock, $this->orderMock);
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/GuestCartManagement/Plugin/AuthorizationTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/GuestCartManagement/Plugin/AuthorizationTest.php
@@ -36,7 +36,7 @@ class AuthorizationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\StateException
-     * @expectedMessage Cannot assign customer to the given cart. You don't have permission for this operation.
+     * @expectedExceptionMessage Cannot assign customer to the given cart. You don't have permission for this operation.
      */
     public function testBeforeAssignCustomer()
     {

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/UpdaterTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/UpdaterTest.php
@@ -92,7 +92,7 @@ class UpdaterTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @ExceptedExceptionMessage The qty value is required to update quote item.
+     * @expectedExceptionMessage The qty value is required to update quote item.
      */
     public function testUpdateNoQty()
     {

--- a/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
@@ -100,7 +100,7 @@ class ShippingAddressManagementTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expected ExceptionMessage error345
+     * @expectedExceptionMessage error345
      */
     public function testSetAddressValidationFailed()
     {

--- a/app/code/Magento/Search/Test/Unit/Model/SynonymGroupRepositoryTest.php
+++ b/app/code/Magento/Search/Test/Unit/Model/SynonymGroupRepositoryTest.php
@@ -53,7 +53,7 @@ class SynonymGroupRepositoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Search\Model\Synonym\MergeConflictException
-     * @expecteExceptionMessage (c,d,e)
+     * @expectedExceptionMessage Merge conflict with existing synonym group(s): (a,b,c)
      */
     public function testSaveCreateMergeConflict()
     {
@@ -138,7 +138,7 @@ class SynonymGroupRepositoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Search\Model\Synonym\MergeConflictException
-     * @expecteExceptionMessage (d,h,i)
+     * @expectedExceptionMessage (d,h,i)
      */
     public function testSaveUpdateMergeConflict()
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Source/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Source/ThemeTest.php
@@ -10,7 +10,6 @@ use \Magento\Theme\Model\Theme\Source\Theme;
 class ThemeTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @true
      * @return void
      * @covers \Magento\Theme\Model\Theme\Source\Theme::__construct
      * @covers \Magento\Theme\Model\Theme\Source\Theme::getAllOptions

--- a/app/code/Magento/Ui/Test/Unit/Component/Filters/FilterModifierTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Filters/FilterModifierTest.php
@@ -66,7 +66,8 @@ class FilterModifierTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @return void
-     * @assertException \Magento\Framework\Exception\LocalizedException
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     * @expectedExceptionMessage Condition type "not_allowed" is not allowed
      */
     public function testApplyFilterModifierWithNotAllowedCondition()
     {
@@ -78,7 +79,7 @@ class FilterModifierTest extends \PHPUnit\Framework\TestCase
                 ]
             ]);
         $this->dataProvider->expects($this->never())->method('addFilter');
-        $this->unit->applyFilterModifier($this->dataProvider, 'test');
+        $this->unit->applyFilterModifier($this->dataProvider, 'filter');
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/ErrorHandlerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ErrorHandlerTest.php
@@ -53,9 +53,9 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
         $errorFile = 'test_file';
         $errorLine = 'test_error_line';
 
-        $exceptedExceptionMessage = sprintf('%s: %s in %s on line %s', $errorPhrase, $errorStr, $errorFile, $errorLine);
+        $expectedExceptionMessage = sprintf('%s: %s in %s on line %s', $errorPhrase, $errorStr, $errorFile, $errorLine);
         $this->expectException('Exception');
-        $this->expectExceptionMessage($exceptedExceptionMessage);
+        $this->expectExceptionMessage($expectedExceptionMessage);
 
         $this->object->handler($errorNo, $errorStr, $errorFile, $errorLine);
     }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/Http/FileFactoryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/Http/FileFactoryTest.php
@@ -67,7 +67,7 @@ class FileFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Exception
-     * @exceptedExceptionMessage File not found
+     * @expectedExceptionMessage File not found
      */
     public function testCreateIfFileNotExist()
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/ViewTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ViewTest.php
@@ -122,7 +122,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @exceptedExceptionMessage 'Layout must be loaded only once.'
+     * @expectedExceptionMessage Layout must be loaded only once.
      */
     public function testLoadLayoutWhenLayoutAlreadyLoaded()
     {

--- a/lib/internal/Magento/Framework/Profiler/Test/Unit/Driver/Standard/StatTest.php
+++ b/lib/internal/Magento/Framework/Profiler/Test/Unit/Driver/Standard/StatTest.php
@@ -395,7 +395,7 @@ class StatTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedMessage Timer "foo" doesn't exist.
+     * @expectedExceptionMessage Timer "foo" doesn't exist.
      */
     public function testFetchInvalidTimer()
     {
@@ -404,7 +404,7 @@ class StatTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedMessage Timer "foo" doesn't have value for "bar".
+     * @expectedExceptionMessage Timer "foo" doesn't have value for "bar".
      */
     public function testFetchInvalidKey()
     {

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/ParserTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/ParserTest.php
@@ -41,7 +41,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
      * @param array $jsFiles
      * @param array $phpMap
      * @param array $jsMap
-     * @paran array $phraseFactoryMap
+     * @param array $phraseFactoryMap
      * @param array $expectedResult
      * @dataProvider addPhraseDataProvider
      */


### PR DESCRIPTION
### Description (*)
Fixed invalid unit tests annotations that assert exception messages. With these changes, unit tests will assert exception messages correctly
Backport to 2.2.
Fix commit in accordance to 2.2 exception messages.

### Fixed Issues (if relevant)
1. magento/magento2#18840: Invalid Unit Test Annotations

### Manual testing scenarios (*)
No manual testing neede. All changes are covered with unit tests

### Contribution checklist (*)
 - [] Pull request has a meaningful description of its purpose
 - [] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
