### PR TITLE
[Backport] Add additional check if password hash is empty in auth process

### DIFF
--- a/app/code/Magento/Customer/Model/Authentication.php
+++ b/app/code/Magento/Customer/Model/Authentication.php
@@ -167,7 +167,7 @@ class Authentication implements AuthenticationInterface
     {
         $customerSecure = $this->customerRegistry->retrieveSecureData($customerId);
         $hash = $customerSecure->getPasswordHash();
-        if (!$this->encryptor->validateHash($password, $hash)) {
+        if (!$hash || !$this->encryptor->validateHash($password, $hash)) {
             $this->processAuthenticationFailure($customerId);
             if ($this->isLocked($customerId)) {
                 throw new UserLockedException(__('The account is locked.'));


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19066
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added additional check for password hash if the customer was created without a password from admin area.

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19060: User created by admin cannot login

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create customer at admin area (without password)
2. Try to login at frontend as a customer

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
