### PR TITLE
SortTotals function retrieves config setting without scopeType

### DIFF
--- a/app/code/Magento/Checkout/Model/Layout/AbstractTotalsProcessor.php
+++ b/app/code/Magento/Checkout/Model/Layout/AbstractTotalsProcessor.php
@@ -40,7 +40,10 @@ abstract class AbstractTotalsProcessor
      */
     public function sortTotals($totals)
     {
-        $configData = $this->scopeConfig->getValue('sales/totals_sort');
+        $configData = $this->scopeConfig->getValue(
+            'sales/totals_sort',
+            \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE
+        );
         foreach ($totals as $code => &$total) {
             //convert JS naming style to config naming style
             $code = str_replace('-', '_', $code);


### PR DESCRIPTION
### Description
After working with the totals I needed to change the sort order of the totals on website level. In my case the US store needed tax with sort order 40 and the Europe stores needed tax below grand total, so with a sort order of 110. In the magento 2 backend this can be covered on website level, but it didn't work on the frontend. So after reviewing the code part, I saw the sortTotals function in `module-checkout/Model/Layout/AbstractTotalsProcessor.php` pulled the `'sales/totals_sort'` setting, but without a scopeType Param.

Because totals can be changed on website level we need to use the following scopetype: `\Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE` to fetch the correct settings.

### Manual testing scenarios
1. Make sure you have set up multiple websites in magento
2. Change scope to website level.
3. Go to System > Configuration > Sales > Sales > Checkout Totals Sort Order.
4. Change the order of some totals.
5. Test in the checkout if totals sort order is changed, without this fix it will not change.

### Contribution checklist 
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)

At the moment the sortTotals function in `module-checkout/Model/Layout/AbstractTotalsProcessor.php` is not covered in a test, so I can't update any tests. And I do not know how to test this feature myself.