### PR TITLE
Cache Magento product version

### DIFF
--- a/app/code/Magento/Version/Plugin/App/CacheProductVersion.php
+++ b/app/code/Magento/Version/Plugin/App/CacheProductVersion.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Version\Plugin\App;
+
+/**
+ * Class CacheProductVersion
+ *
+ * Caches the product version result.
+ */
+class CacheProductVersion
+{
+    /**
+     * @var \Magento\Framework\App\CacheInterface
+     */
+    private $cache;
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * CacheProductVersion constructor.
+     * @param \Magento\Framework\App\CacheInterface $cache
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     */
+    public function __construct(
+        \Magento\Framework\App\CacheInterface $cache,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
+    ) {
+        $this->cache = $cache;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Cache version result.
+     *
+     * @param \Magento\Framework\App\ProductMetadata $subject
+     * @param callable $proceed
+     * @return array|bool|float|int|null|string
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function aroundGetVersion(\Magento\Framework\App\ProductMetadata $subject, callable $proceed)
+    {
+        $cache = false;
+        if ($this->getCacheKey() && $this->getCacheLifetime()) {
+            $cache = $this->cache->load($this->getCacheKey());
+        }
+
+        if ($cache) {
+            return $this->serializer->unserialize($cache);
+        }
+
+        $version = $proceed();
+
+        if ($this->getCacheKey() && $this->getCacheLifetime()) {
+            $this->cache->save(
+                $this->getCacheKey(),
+                $version,
+                ['version'],
+                $this->getCacheLifetime()
+            );
+        }
+
+        return $version;
+    }
+
+    /**
+     * Get cache key.
+     *
+     * @return string
+     */
+    public function getCacheKey(): string
+    {
+        return 'magento_product_version';
+    }
+
+    /**
+     * Get cache lifetime.
+     *
+     * @return int
+     */
+    public function getCacheLifetime(): int
+    {
+        return 3600;
+    }
+}

--- a/app/code/Magento/Version/Plugin/App/CacheProductVersion.php
+++ b/app/code/Magento/Version/Plugin/App/CacheProductVersion.php
@@ -1,10 +1,8 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Version\Plugin\App;
 
 /**

--- a/app/code/Magento/Version/etc/di.xml
+++ b/app/code/Magento/Version/etc/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\App\ProductMetadata">
+        <plugin name="CacheProductVersion" type="Magento\Version\Plugin\App\CacheProductVersion"/>
+    </type>
+</config>


### PR DESCRIPTION
Cache Magento product version to improve performance.

### Description (*)
Fetching the product version is quite a slow process. It can take up to 200 milliseconds, which is quite slow for such a simple method. I added caching, because this totally is something that could be cached, since the value doesn't change very often.

A few questions from my side:
- Do I need  to add some tests?
- I think the cache lifetime should be 24 hours, because it's such a static value. What are your thoughts?

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a module which calls `\Magento\Framework\App\ProductMetadata::getVersion()` two times.
2. In the first request, the second call should be faster than the first.
3. In a second request, the first should be as fast as the second one.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
