### PR TITLE
18615-Field-restriction-incompatibilities-between-klarna-core-order-a…

### DIFF
--- a/app/code/Magento/Sales/etc/db_schema.xml
+++ b/app/code/Magento/Sales/etc/db_schema.xml
@@ -663,7 +663,7 @@
         <column xsi:type="varchar" name="cc_ss_start_month" nullable="true" length="128" comment="Cc Ss Start Month"/>
         <column xsi:type="varchar" name="echeck_account_type" nullable="true" length="255"
                 comment="Echeck Account Type"/>
-        <column xsi:type="varchar" name="last_trans_id" nullable="true" length="32" comment="Last Trans Id"/>
+        <column xsi:type="varchar" name="last_trans_id" nullable="true" length="255" comment="Last Trans Id"/>
         <column xsi:type="varchar" name="cc_cid_status" nullable="true" length="32" comment="Cc Cid Status"/>
         <column xsi:type="varchar" name="cc_owner" nullable="true" length="128" comment="Cc Owner"/>
         <column xsi:type="varchar" name="cc_type" nullable="true" length="32" comment="Cc Type"/>


### PR DESCRIPTION
…nd-sales-order-payment-last-trans-id

magento/magento2#18615:Field restriction incompatibilities between klarna_core_order and sales_order_payment last_trans_id

### Description (*)
Since column sales_order_payment.last_trans_id has length 32, part of information can be lost.
Increased max length to 255

### Fixed Issues (if relevant)
1. magento/magento2#18615:Field restriction incompatibilities between klarna_core_order and sales_order_payment last_trans_id

### Manual testing scenarios (*)
1. Check column last_trans_id length (should be 255) by SQL request:
show create table sales_order_payment;
2. Place order paid by Klarna 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
