### PR TITLE
Allow to read HTTP/2 response header in curl client.

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -438,7 +438,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     {
         if ($this->_headerCount == 0) {
             $line = explode(" ", trim($data), 3);
-            if (count($line) != 3) {
+            if (count($line) < 2) {
                 $this->doError("Invalid response line returned from server: " . $data);
             }
             $this->_responseStatus = (int)$line[1];


### PR DESCRIPTION
This change fixes ability to read response from third-party servers that use HTTP/2 if your server use HTTP/2 too.

### Description
The issue is HTTP/2 sends the following headers `HTTP/2 200`, `HTTP/2 401` and so on. It doesn't have third parameter like HTTP/1.1 has: `HTTP/2 200 OK`

### Fixed Issues
1. magento/magento2#19127: Cannot connect to Magento 2 market place

### Manual testing scenarios
1. Enable HTTP/2 on your server
2. Try to login to marketplace from [System > Web Setup Wizard](https://docs.magento.com/marketplace/user_guide/buyers/install-extension.html). You can use invalid credentials too.
3. You will see a message about invalid response line instead of "Bad Credentials" message.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
