### PR TITLE
Add availability to leave empty config for events.xml

### DIFF
--- a/lib/internal/Magento/Framework/Event/Test/Unit/Config/_files/invalidEventsXmlArray.php
+++ b/lib/internal/Magento/Framework/Event/Test/Unit/Config/_files/invalidEventsXmlArray.php
@@ -4,10 +4,6 @@
  * See COPYING.txt for license details.
  */
 return [
-    'without_event_handle' => [
-        '<?xml version="1.0"?><config></config>',
-        ["Element 'config': Missing child element(s). Expected is ( event ).\nLine: 1\n"],
-    ],
     'event_without_required_name_attribute' => [
         '<?xml version="1.0"?><config><event name="some_name"></event></config>',
         ["Element 'event': Missing child element(s). Expected is ( observer ).\nLine: 1\n"],

--- a/lib/internal/Magento/Framework/Event/etc/events.xsd
+++ b/lib/internal/Magento/Framework/Event/etc/events.xsd
@@ -9,7 +9,7 @@
     <xs:element name="config">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="event" type="eventDeclaration" minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="event" type="eventDeclaration" minOccurs="0" maxOccurs="unbounded">
                     <xs:unique name="uniqueObserverName">
                         <xs:annotation>
                             <xs:documentation>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The <config> node in events.xml file cannot have no any children nodes.

### Fixed Issue
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
magento/magento2#15931: events.xml cant have no childrens, others can [Magento 2.2.4]

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create new module
2. Create events.xml
3. Fill with only base node "<config>" without any children
4. Run ``php bin.magento cache:flush``

### Expected result
Upgrade + Flush + Clean should run fine trough, page is loading afterwards in developer mode

### Actual result
Cache Flush triggers the error:
```Error Message:
  [Magento\Framework\Exception\LocalizedException]                               
  Invalid XML in file /var/www/html/app/code/Vendor/Modulename/etc/events.xml:  
  Element 'config': Missing child element(s). Expected is ( event ).             
  Line: 2
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Backport for: https://github.com/magento/magento2/pull/19146