### PR TITLE
Add availability to leave empty config for events.xml

### DIFF
--- a/lib/internal/Magento/Framework/Event/Test/Unit/Config/_files/invalidEventsXmlArray.php
+++ b/lib/internal/Magento/Framework/Event/Test/Unit/Config/_files/invalidEventsXmlArray.php
@@ -4,10 +4,6 @@
  * See COPYING.txt for license details.
  */
 return [
-    'without_event_handle' => [
-        '<?xml version="1.0"?><config></config>',
-        ["Element 'config': Missing child element(s). Expected is ( event ).\nLine: 1\n"],
-    ],
     'event_without_required_name_attribute' => [
         '<?xml version="1.0"?><config><event name="some_name"></event></config>',
         ["Element 'event': Missing child element(s). Expected is ( observer ).\nLine: 1\n"],

--- a/lib/internal/Magento/Framework/Event/etc/events.xsd
+++ b/lib/internal/Magento/Framework/Event/etc/events.xsd
@@ -9,7 +9,7 @@
     <xs:element name="config">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="event" type="eventDeclaration" minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="event" type="eventDeclaration" minOccurs="0" maxOccurs="unbounded">
                     <xs:unique name="uniqueObserverName">
                         <xs:annotation>
                             <xs:documentation>


### PR DESCRIPTION
### Description (*)
Forwardport of PR https://github.com/magento/magento2/pull/19145
Related issue magento/magento2#15931: events.xml cant have no childrens, others can [Magento 2.2.4]
