### PR TITLE
magento/magento2#19139: Empty block rendering in My Account page sidebar

### DIFF
--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -11,48 +11,5 @@
     </head>
     <body>
         <attribute name="class" value="account"/>
-        <referenceContainer name="sidebar.main">
-            <block class="Magento\Framework\View\Element\Template" name="sidebar.main.account_nav" template="Magento_Theme::html/collapsible.phtml" before="-">
-                <arguments>
-                    <argument name="block_css" xsi:type="string">account-nav</argument>
-                </arguments>
-                <block class="Magento\Customer\Block\Account\Navigation" name="customer_account_navigation" before="-">
-                    <arguments>
-                        <argument name="css_class" xsi:type="string">nav items</argument>
-                    </arguments>
-                    <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-link">
-                        <arguments>
-                            <argument name="label" xsi:type="string" translate="true">My Account</argument>
-                            <argument name="path" xsi:type="string">customer/account</argument>
-                            <argument name="sortOrder" xsi:type="number">250</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\Delimiter" name="customer-account-navigation-delimiter-1" template="Magento_Customer::account/navigation-delimiter.phtml">
-                        <arguments>
-                            <argument name="sortOrder" xsi:type="number">200</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-address-link">
-                        <arguments>
-                            <argument name="label" xsi:type="string" translate="true">Address Book</argument>
-                            <argument name="path" xsi:type="string">customer/address</argument>
-                            <argument name="sortOrder" xsi:type="number">190</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-edit-link">
-                        <arguments>
-                            <argument name="label" xsi:type="string" translate="true">Account Information</argument>
-                            <argument name="path" xsi:type="string">customer/account/edit</argument>
-                            <argument name="sortOrder" xsi:type="number">180</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\Delimiter" name="customer-account-navigation-delimiter-2" template="Magento_Customer::account/navigation-delimiter.phtml">
-                        <arguments>
-                            <argument name="sortOrder" xsi:type="number">130</argument>
-                        </arguments>
-                    </block>
-                </block>
-            </block>
-        </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When you log in Magento 2.3 you can see a space 2x more than expected created by a block rendered without content. Removed this useless empty block from layout file in Magento_Customer module
due to this block is present in app/design

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login on FE and go to customer account page
2. Check that empty block with class "account-nav" is not present in "sidebar sidebar-main" block in html

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
