### PR TITLE
19082-Fatal-error-Uncaught-Error-Cannot-call-abstract-method-Magento-…

### DIFF
--- a/app/code/Magento/Catalog/Controller/Product/Compare.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare.php
@@ -139,4 +139,13 @@ abstract class Compare extends \Magento\Framework\App\Action\Action
         $this->_customerId = $customerId;
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        return $this->_redirect('catalog/product_compare');
+    }
+
 }


### PR DESCRIPTION
…Framework-App-ActionInterface-execute

add execute method to prevent fatal error when go to catalog/product/compare/

### Description (#19082)
Fatal error when go to path catalog/product/compare/

### Fixed Issues (#19082)
1. magento/magento2#19082: Fatal error: Uncaught Error: Cannot call abstract method Magento\Framework\App\ActionInterface::execute()

### Manual testing scenarios (*)
1. Go to by path catalog/product/compare/
2. Expected results:
redirect to catalog/product_compare/ instead of 500 error

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
