### PR TITLE
[Forwardport] Fix/add expresion

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
@@ -346,7 +346,9 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
             $fullExpression = str_replace('{{' . $fieldKey . '}}', $fieldItem, $fullExpression);
         }
 
-        $this->getSelect()->columns([$alias => $fullExpression]);
+        $fullExpression = new \Zend_Db_Expr($fullExpression);
+        $this->_fieldsToSelect[$alias] = $fullExpression;
+        $this->_fieldsToSelectChanged = true;
 
         return $this;
     }

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
@@ -267,10 +267,11 @@ class AbstractCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider addExpressionFieldToSelectDataProvider
      */
-    public function testAddExpressionFieldToSelect($alias, $expression, $fields, $expected)
+    public function testAddExpressionFieldToSelect($alias, $expression, $fields, $expectedFieldsToSelect)
     {
-        $this->selectMock->expects($this->once())->method('columns')->with($expected);
         $this->assertTrue($this->uut->addExpressionFieldToSelect($alias, $expression, $fields) instanceof Uut);
+        $this->assertEquals($expectedFieldsToSelect, $this->uut->getFieldsToSelect());
+        $this->assertTrue($this->uut->wereFieldsToSelectChanged());
     }
 
     /**

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
@@ -267,10 +267,10 @@ class AbstractCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider addExpressionFieldToSelectDataProvider
      */
-    public function testAddExpressionFieldToSelect($alias, $expression, $fields, $expectedFieldsToSelect)
+    public function testAddExpressionFieldToSelect($alias, $expression, $fields, $expected)
     {
         $this->assertTrue($this->uut->addExpressionFieldToSelect($alias, $expression, $fields) instanceof Uut);
-        $this->assertEquals($expectedFieldsToSelect, $this->uut->getFieldsToSelect());
+        $this->assertEquals($expected, $this->uut->getFieldsToSelect());
         $this->assertTrue($this->uut->wereFieldsToSelectChanged());
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17915

### Title

Fix  Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection method addExpressionFieldToSelect result gets overwritten by addFieldToSelect.

### Description
Fix Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection method addExpressionFieldToSelect result gets overwriten if called before addFieldToSelect. It happened in _initSelectFields method, if some columns were set before that method call they were overwirtten by it.
I changed the behaviour of addExpressionFieldToSelect method to not modify columns and instead insert expression into _fieldsToSelect private variable (same as addFieldToSelect does). 

### Fixed Issues (if relevant)

1. magento/magento2#17635: addExpressionFieldToSelect has to be called after all addFieldToSelect

### Manual testing scenarios
-create a collection
$bookingCollection = $this->_bookingCollectionFactory->create();
$bookingCollection->addExpressionFieldToSelect('stime_part', 'time(start_time)', []);
$bookingCollection->addFieldToSelect('finish_time', 'finish_date');

Expected result after the fix.
Field 'stime_part' populated with calculated data.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
