### PR TITLE
magento/magento2#14849: [Forwardport] In Sales Emails no translation using order.getStatusLabel().

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -8,6 +8,7 @@ namespace Magento\Sales\Model;
 use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -1025,9 +1026,20 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     }
 
     /**
+     * Retrieve frontend label of order status
+     *
+     * @return string
+     */
+    public function getFrontendStatusLabel()
+    {
+        return $this->getConfig()->getStatusFrontendLabel($this->getStatus());
+    }
+
+    /**
      * Retrieve label of order status
      *
      * @return string
+     * @throws LocalizedException
      */
     public function getStatusLabel()
     {
@@ -1135,12 +1147,12 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Hold order
      *
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function hold()
     {
         if (!$this->canHold()) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('A hold action is not available.'));
+            throw new LocalizedException(__('A hold action is not available.'));
         }
         $this->setHoldBeforeState($this->getState());
         $this->setHoldBeforeStatus($this->getStatus());
@@ -1153,12 +1165,12 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Attempt to unhold the order
      *
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function unhold()
     {
         if (!$this->canUnhold()) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('You cannot remove the hold.'));
+            throw new LocalizedException(__('You cannot remove the hold.'));
         }
 
         $this->setState($this->getHoldBeforeState())
@@ -1202,7 +1214,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param string $comment
      * @param bool $graceful
      * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function registerCancellation($comment = '', $graceful = true)
@@ -1241,7 +1253,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
                 $this->addStatusHistoryComment($comment, false);
             }
         } elseif (!$graceful) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('We cannot cancel this order.'));
+            throw new LocalizedException(__('We cannot cancel this order.'));
         }
         return $this;
     }

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Sales\Model\Order;
 
+use Magento\Framework\Exception\LocalizedException;
+
 /**
  * Order configuration model
  *
@@ -85,7 +87,7 @@ class Config
 
     /**
      * @param string $state
-     * @return Status|null
+     * @return Status
      */
     protected function _getState($state)
     {
@@ -101,7 +103,7 @@ class Config
      * Retrieve default status for state
      *
      * @param   string $state
-     * @return  string
+     * @return  string|null
      */
     public function getStateDefaultStatus($state)
     {
@@ -115,22 +117,46 @@ class Config
     }
 
     /**
-     * Retrieve status label
+     * Get status label for a specified area
      *
-     * @param   string $code
-     * @return  string
+     * @param string $code
+     * @param string $area
+     * @return string
      */
-    public function getStatusLabel($code)
+    private function getStatusLabelForArea(string $code, string $area): string
     {
-        $area = $this->state->getAreaCode();
         $code = $this->maskStatusForArea($area, $code);
         $status = $this->orderStatusFactory->create()->load($code);
 
-        if ($area == 'adminhtml') {
+        if ($area === 'adminhtml') {
             return $status->getLabel();
         }
 
         return $status->getStoreLabel();
+    }
+
+    /**
+     * Retrieve status label for detected area
+     *
+     * @param string $code
+     * @return string
+     * @throws LocalizedException
+     */
+    public function getStatusLabel($code)
+    {
+        $area = $this->state->getAreaCode() ?: \Magento\Framework\App\Area::AREA_FRONTEND;
+        return $this->getStatusLabelForArea($code, $area);
+    }
+
+    /**
+     * Retrieve status label for area
+     *
+     * @param string $code
+     * @return string
+     */
+    public function getStatusFrontendLabel(string $code): string
+    {
+        return $this->getStatusLabelForArea($code, \Magento\Framework\App\Area::AREA_FRONTEND);
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -75,6 +75,8 @@ class Config
     }
 
     /**
+     * Get collection.
+     *
      * @return \Magento\Sales\Model\ResourceModel\Order\Status\Collection
      */
     protected function _getCollection()
@@ -86,6 +88,8 @@ class Config
     }
 
     /**
+     * Get state.
+     *
      * @param string $state
      * @return Status
      */
@@ -275,8 +279,9 @@ class Config
     }
 
     /**
-     * Get existing order statuses
-     * Visible or invisible on frontend according to passed param
+     * Get existing order statuses.
+     *
+     * Visible or invisible on frontend according to passed param.
      *
      * @param bool $visibility
      * @return array

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -109,7 +109,7 @@ class Config
      * @param   string $state
      * @return  string|null
      */
-    public function getStateDefaultStatus($state)
+    public function getStateDefaultStatus($state): ?string
     {
         $status = false;
         $stateNode = $this->_getState($state);
@@ -123,11 +123,11 @@ class Config
     /**
      * Get status label for a specified area
      *
-     * @param string $code
+     * @param string|null $code
      * @param string $area
-     * @return string
+     * @return string|null
      */
-    private function getStatusLabelForArea(string $code, string $area): string
+    private function getStatusLabelForArea(?string $code, string $area): ?string
     {
         $code = $this->maskStatusForArea($area, $code);
         $status = $this->orderStatusFactory->create()->load($code);
@@ -142,8 +142,8 @@ class Config
     /**
      * Retrieve status label for detected area
      *
-     * @param string $code
-     * @return string
+     * @param string|null $code
+     * @return string|null
      * @throws LocalizedException
      */
     public function getStatusLabel($code)
@@ -155,10 +155,10 @@ class Config
     /**
      * Retrieve status label for area
      *
-     * @param string $code
-     * @return string
+     * @param string|null $code
+     * @return string|null
      */
-    public function getStatusFrontendLabel(string $code): string
+    public function getStatusFrontendLabel(?string $code): ?string
     {
         return $this->getStatusLabelForArea($code, \Magento\Framework\App\Area::AREA_FRONTEND);
     }

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo_update.html
@@ -11,7 +11,7 @@
 "var this.getUrl($store, 'customer/account/')":"Customer Account URL",
 "var order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo_update_guest.html
@@ -10,7 +10,7 @@
 "var creditmemo.increment_id":"Credit Memo Id",
 "var billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/code/Magento/Sales/view/frontend/email/invoice_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_update.html
@@ -11,7 +11,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/invoice_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_update_guest.html
@@ -10,7 +10,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/code/Magento/Sales/view/frontend/email/order_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/order_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -22,7 +22,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/code/Magento/Sales/view/frontend/email/shipment_update.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>{{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}</p>

--- a/app/code/Magento/Sales/view/frontend/email/shipment_update_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update.html
@@ -11,7 +11,7 @@
 "var this.getUrl($store, 'customer/account/')":"Customer Account URL",
 "var order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_update_guest.html
@@ -10,7 +10,7 @@
 "var creditmemo.increment_id":"Credit Memo Id",
 "var billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update.html
@@ -11,7 +11,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_update_guest.html
@@ -10,7 +10,7 @@
 "var comment":"Invoice Comment",
 "var invoice.increment_id":"Invoice Id",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status"
+"var order.getFrontendStatusLabel()":"Order Status"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -22,7 +22,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update.html
@@ -10,7 +10,7 @@
 "var order.getCustomerName()":"Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -24,7 +24,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
                 {{trans 'You can check the status of your order by <a href="%account_url">logging into your account</a>.' account_url=$this.getUrl($store,'customer/account/',[_nosid:1]) |raw}}
             </p>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_update_guest.html
@@ -9,7 +9,7 @@
 "var billing.getName()":"Guest Customer Name",
 "var comment":"Order Comment",
 "var order.increment_id":"Order Id",
-"var order.getStatusLabel()":"Order Status",
+"var order.getFrontendStatusLabel()":"Order Status",
 "var shipment.increment_id":"Shipment Id"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -23,7 +23,7 @@
                     "Your order #%increment_id has been updated with a status of <strong>%order_status</strong>."
 
                     increment_id=$order.increment_id
-                    order_status=$order.getStatusLabel()
+                    order_status=$order.getFrontendStatusLabel()
                 |raw}}
             </p>
             <p>

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderStatusHistoryAddTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderStatusHistoryAddTest.php
@@ -11,6 +11,7 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
 
 /**
  * Class OrderCommentAddTest
+ *
  * @package Magento\Sales\Service\V1
  */
 class OrderStatusHistoryAddTest extends WebapiAbstract
@@ -48,7 +49,7 @@ class OrderStatusHistoryAddTest extends WebapiAbstract
             OrderStatusHistoryInterface::CREATED_AT => null,
             OrderStatusHistoryInterface::PARENT_ID => $order->getId(),
             OrderStatusHistoryInterface::ENTITY_NAME => null,
-            OrderStatusHistoryInterface::STATUS => null,
+            OrderStatusHistoryInterface::STATUS => $order->getStatus(),
             OrderStatusHistoryInterface::IS_VISIBLE_ON_FRONT => 1,
         ];
 
@@ -69,25 +70,27 @@ class OrderStatusHistoryAddTest extends WebapiAbstract
 
         //Verification
         $comments = $order->load($order->getId())->getAllStatusHistory();
+        $comment = reset($comments);
 
-        $commentData = reset($comments);
-        foreach ($commentData as $key => $value) {
-            $this->assertEquals(
-                $commentData[OrderStatusHistoryInterface::COMMENT],
-                $statusHistoryComment->getComment()
-            );
-            $this->assertEquals(
-                $commentData[OrderStatusHistoryInterface::PARENT_ID],
-                $statusHistoryComment->getParentId()
-            );
-            $this->assertEquals(
-                $commentData[OrderStatusHistoryInterface::IS_CUSTOMER_NOTIFIED],
-                $statusHistoryComment->getIsCustomerNotified()
-            );
-            $this->assertEquals(
-                $commentData[OrderStatusHistoryInterface::IS_VISIBLE_ON_FRONT],
-                $statusHistoryComment->getIsVisibleOnFront()
-            );
-        }
+        $this->assertEquals(
+            $commentData[OrderStatusHistoryInterface::COMMENT],
+            $comment->getComment()
+        );
+        $this->assertEquals(
+            $commentData[OrderStatusHistoryInterface::PARENT_ID],
+            $comment->getParentId()
+        );
+        $this->assertEquals(
+            $commentData[OrderStatusHistoryInterface::IS_CUSTOMER_NOTIFIED],
+            $comment->getIsCustomerNotified()
+        );
+        $this->assertEquals(
+            $commentData[OrderStatusHistoryInterface::IS_VISIBLE_ON_FRONT],
+            $comment->getIsVisibleOnFront()
+        );
+        $this->assertEquals(
+            $commentData[OrderStatusHistoryInterface::STATUS],
+            $comment->getStatus()
+        );
     }
 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/14914

### Description
\Magento\Sales\Model\Order\Config::getStatusLabel(), used by template email was forcing the usage of getLabel() when in adminhtml area.
I added a new method getFrontendStatusLabel() in \Magento\Sales\Model\Order and modified email template files to use it instead of the original implementation.
I did not modify the original implementation because still in use by backend and frontend.

### Fixed Issues (if relevant)
1. magento/magento2#14849: In Sales Emails no translation using order.getStatusLabel()

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
