### PR TITLE
Fixed magento text swatch switches product image even if attribute feature is disabled #16446

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminCreateProductAttributeSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminCreateProductAttributeSection.xml
@@ -13,6 +13,7 @@
         <element name="DefaultLabel" type="input" selector="#attribute_label"/>
         <element name="InputType" type="select" selector="#frontend_input"/>
         <element name="ValueRequired" type="select" selector="#is_required"/>
+        <element name="UpdateProductPreviewImage" type="select" selector="[name='update_product_preview_image']"/>
         <element name="AdvancedProperties" type="button" selector="#advanced_fieldset-wrapper"/>
         <element name="DefaultValue" type="input" selector="#default_value_text"/>
         <element name="Scope" type="select" selector="#is_global"/>

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -192,6 +192,7 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
 
     /**
      * Get number of swatches from config to show on product listing.
+     *
      * Other swatches can be shown after click button 'Show more'
      *
      * @return string
@@ -231,6 +232,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * Get swatch attributes data.
+     *
      * @return array
      */
     protected function getSwatchAttributesData()
@@ -239,6 +242,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * Init isProductHasSwatchAttribute.
+     *
      * @deprecated 100.1.5 Method isProductHasSwatchAttribute() is used instead of this.
      *
      * @codeCoverageIgnore
@@ -367,6 +372,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * Get swatch product image.
+     *
      * @param Product $childProduct
      * @param string $imageType
      * @return string
@@ -387,6 +394,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * Check if product have image.
+     *
      * @param Product $product
      * @param string $imageType
      * @return bool
@@ -397,6 +406,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * Get configurable options ids.
+     *
      * @param array $attributeData
      * @return array
      * @since 100.0.3
@@ -456,8 +467,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * @inheritDoc
      * @deprecated 100.1.5 Now is used _toHtml() directly
-     * @return string
      */
     protected function getHtmlOutput()
     {
@@ -465,6 +476,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     }
 
     /**
+     * Get media callback url.
+     *
      * @return string
      */
     public function getMediaCallback()

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -182,6 +182,9 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
                     $attributeDataArray
                 );
             }
+            if (isset($attributeDataArray['additional_data'])) {
+                $config[$attributeId]['additional_data'] = $attributeDataArray['additional_data'];
+            }
         }
 
         return $this->jsonEncoder->encode($config);

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByImageSwatchTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByImageSwatchTest.xml
@@ -41,6 +41,9 @@
         <!-- Select visual swatch -->
         <selectOption selector="{{AttributePropertiesSection.InputType}}" userInput="swatch_visual" stepKey="selectInputType"/>
 
+        <!-- Set Update Product Preview Image to Yes-->
+        <selectOption selector="{{AttributePropertiesSection.UpdateProductPreviewImage}}" userInput="Yes" stepKey="setUpdateProductPreviewImage"/>
+
         <!-- This hack is because the same <input type="file"> is re-purposed used for all uploads. -->
         <executeJS function="HTMLInputElement.prototype.click = function() { if(this.type !== 'file') HTMLElement.prototype.click.call(this); };" stepKey="disableClick"/>
 

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -753,7 +753,12 @@ define([
                     $widget.options.jsonConfig.optionPrices
                 ]);
 
-            $widget._loadMedia();
+            const checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId].additional_data);
+
+            if (checkAdditionalData.update_product_preview_image == 1) {
+                $widget._loadMedia();
+            }
+
             $input.trigger('change');
         },
 

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -713,7 +713,8 @@ define([
                 $wrapper = $this.parents('.' + $widget.options.classes.attributeOptionsWrapper),
                 $label = $parent.find('.' + $widget.options.classes.attributeSelectedOptionLabelClass),
                 attributeId = $parent.attr('attribute-id'),
-                $input = $parent.find('.' + $widget.options.classes.attributeInput);
+                $input = $parent.find('.' + $widget.options.classes.attributeInput),
+                checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId]['additional_data']);
 
             if ($widget.inProductList) {
                 $input = $widget.productForm.find(
@@ -753,9 +754,7 @@ define([
                     $widget.options.jsonConfig.optionPrices
                 ]);
 
-            var checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId]['additional_data']);
-
-            if (1 == checkAdditionalData['update_product_preview_image']) {
+            if (checkAdditionalData['update_product_preview_image'] === '1') {
                 $widget._loadMedia();
             }
 

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -753,9 +753,9 @@ define([
                     $widget.options.jsonConfig.optionPrices
                 ]);
 
-            const checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId].additional_data);
+            var checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId]['additional_data']);
 
-            if (checkAdditionalData.update_product_preview_image == 1) {
+            if (1 == checkAdditionalData['update_product_preview_image']) {
                 $widget._loadMedia();
             }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed magento text swatch switches product image even if attribute feature is disabled #16446
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16446: Fixed magento text swatch switches product image even if attribute feature is disabled 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
