### PR TITLE
Reference PL for #19192 fixed for 2.2-develop

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -63,6 +63,16 @@ class ToOrderItem
             'to_order_item',
             $item
         );
+        if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
+            $orderItemData= array_merge(
+                $orderItemData,
+               $this->objectCopyService->getDataFromFieldset(
+                   'quote_convert_address_item',
+                   'to_order_item',
+                   $item
+               )
+           );
+       }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,
@@ -73,10 +83,7 @@ class ToOrderItem
                 )
             );
         }
-        if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
-            $orderItemData['quote_item_id'] = $item->getQuoteItemId();
-        }
-
+        
         $orderItem = $this->orderItemFactory->create();
         $this->dataObjectHelper->populateWithArray(
             $orderItem,

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -63,9 +63,6 @@ class ToOrderItem
             'to_order_item',
             $item
         );
-        if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
-            $orderItemData['quote_item_id'] = $item->getQuoteItemId();
-        }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,
@@ -75,6 +72,9 @@ class ToOrderItem
                     $item
                 )
             );
+        }
+        if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
+            $orderItemData['quote_item_id'] = $item->getQuoteItemId();
         }
 
         $orderItem = $this->orderItemFactory->create();

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -63,6 +63,9 @@ class ToOrderItem
             'to_order_item',
             $item
         );
+        if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
+            $orderItemData['quote_item_id'] = $item->getQuoteItemId();
+        }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -64,15 +64,15 @@ class ToOrderItem
             $item
         );
         if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
-            $orderItemData= array_merge(
+            $orderItemData = array_merge(
                 $orderItemData,
-               $this->objectCopyService->getDataFromFieldset(
-                   'quote_convert_address_item',
-                   'to_order_item',
-                   $item
-               )
-           );
-       }
+                $this->objectCopyService->getDataFromFieldset(
+                    'quote_convert_address_item',
+                    'to_order_item',
+                    $item
+                )
+            );
+        }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,
@@ -83,7 +83,7 @@ class ToOrderItem
                 )
             );
         }
-        
+
         $orderItem = $this->orderItemFactory->create();
         $this->dataObjectHelper->populateWithArray(
             $orderItem,

--- a/app/code/Magento/Quote/etc/fieldset.xml
+++ b/app/code/Magento/Quote/etc/fieldset.xml
@@ -186,6 +186,11 @@
                 <aspect name="to_order_address" />
             </field>
         </fieldset>
+        <fieldset id="quote_convert_address_item">
+            <field name="quote_item_id">
+                <aspect name="to_order_item" />
+            </field>
+        </fieldset>
         <fieldset id="quote_convert_item">
             <field name="sku">
                 <aspect name="to_order_item" />


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Incorrect quote_item_id saved on order items during multiple address checkout issue fixed.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When order placed using Multiple address checkout then there were incorrect **quote_item_id**  in 
sales_order_item table.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18349 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Placed and Order with Multi address checkout, now **quote_item_id** is correct.
2. Placed an order with Onestep checkout **quote_item_id** is correct as well.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
