### PR TITLE
[Backport][2.2] Made logo clickable on home page

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Header/Logo.php
+++ b/app/code/Magento/Theme/Block/Html/Header/Logo.php
@@ -43,6 +43,10 @@ class Logo extends \Magento\Framework\View\Element\Template
     /**
      * Check if current url is url for home page
      *
+     * @deprecated This function is no longer used. It was previously used by
+     * Magento/Theme/view/frontend/templates/html/header/logo.phtml
+     * to check if the logo should be clickable on the homepage.
+     *
      * @return bool
      */
     public function isHomePage()

--- a/app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml
@@ -12,19 +12,11 @@
 ?>
 <?php $storeName = $block->getThemeName() ? $block->getThemeName() : $block->getLogoAlt();?>
 <span data-action="toggle-nav" class="action nav-toggle"><span><?= /* @escapeNotVerified */ __('Toggle Nav') ?></span></span>
-<?php if ($block->isHomePage()):?>
-    <strong class="logo">
-<?php else: ?>
-    <a class="logo" href="<?= $block->getUrl('') ?>" title="<?= /* @escapeNotVerified */ $storeName ?>">
-<?php endif ?>
-        <img src="<?= /* @escapeNotVerified */ $block->getLogoSrc() ?>"
-             title="<?= /* @escapeNotVerified */ $block->getLogoAlt() ?>"
-             alt="<?= /* @escapeNotVerified */ $block->getLogoAlt() ?>"
-             <?= $block->getLogoWidth() ? 'width="' . $block->getLogoWidth() . '"' : '' ?>
-             <?= $block->getLogoHeight() ? 'height="' . $block->getLogoHeight() . '"' : '' ?>
-        />
-<?php if ($block->isHomePage()):?>
-    </strong>
-<?php else:?>
-    </a>
-<?php endif?>
+<a class="logo" href="<?= $block->getUrl('') ?>" title="<?= /* @escapeNotVerified */ $storeName ?>">
+    <img src="<?= /* @escapeNotVerified */ $block->getLogoSrc() ?>"
+         title="<?= /* @escapeNotVerified */ $block->getLogoAlt() ?>"
+         alt="<?= /* @escapeNotVerified */ $block->getLogoAlt() ?>"
+         <?= $block->getLogoWidth() ? 'width="' . $block->getLogoWidth() . '"' : '' ?>
+         <?= $block->getLogoHeight() ? 'height="' . $block->getLogoHeight() . '"' : '' ?>
+    />
+</a>


### PR DESCRIPTION
### Original PR (*)
1. magento/magento2#19198: [2.3] Made logo clickable on home page

### Description (*)
Removed checks that prevent the logo being clickable on the home page. It is now clickable on all pages, including the home page (essentially refreshes the homepage)

### Fixed Issues (if relevant)
1. magento/magento2#19142: Home page store loge should be clickable to reload page

### Manual testing scenarios (*)
1. Go to home page, click logo, does page reload?
2. Go to any other page, click logo, does homepage load.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
