### PR TITLE
[UI] Fix selection of all items which are not visible in ui grid

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
@@ -153,6 +153,11 @@ define([
             var itemsType = data.excludeMode ? 'excluded' : 'selected',
                 selections = {};
 
+            if (itemsType === 'excluded' && data['selected'].length){
+                data['selected'] = _.difference(data['selected'], data['excluded']);
+                itemsType = 'selected';
+            }
+
             selections[itemsType] = data[itemsType];
 
             if (!selections[itemsType].length) {

--- a/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
@@ -153,9 +153,9 @@ define([
             var itemsType = data.excludeMode ? 'excluded' : 'selected',
                 selections = {};
 
-            if (itemsType === 'excluded' && data['selected'].length){
-                data['selected'] = _.difference(data['selected'], data['excluded']);
+            if (itemsType === 'excluded' && data.selected && data.selected.length) {
                 itemsType = 'selected';
+                data[itemsType] = _.difference(data.selected, data.excluded);
             }
 
             selections[itemsType] = data[itemsType];


### PR DESCRIPTION
### Description (*)
When you using select all option in UI grid, `massaction` js component sends only `exclude` list to server and Data Provider don't know what scope of ids should be selected from DB. In case if we will select some orders to be canceled and meanwhile some customer will place a new one, this new one order will be canceled too. This issue was fixed.

### Fixed Issues
1. magento/magento2#18983: Select all orders selecting orders which are not visible in order grid

### Manual testing scenarios (*)
1. Go to order grid
2. Select all orders on that page
3. Place an order 
4. Without  refreshing page move all orders to hold or any other status
5. Check updated order status for new order

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
