### PR TITLE
Fix dependency between Elasticsearch configuration fields

### DIFF
--- a/app/code/Magento/Elasticsearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/Elasticsearch/etc/adminhtml/system.xml
@@ -92,15 +92,15 @@
                 <field id="elasticsearch5_username" translate="label" type="text" sortOrder="65" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Elasticsearch HTTP Username</label>
                     <depends>
-                        <field id="elasticsearch_enable_auth">1</field>
                         <field id="engine">elasticsearch5</field>
+                        <field id="elasticsearch5_enable_auth">1</field>
                     </depends>
                 </field>
                 <field id="elasticsearch5_password" translate="label" type="text" sortOrder="66" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Elasticsearch HTTP Password</label>
                     <depends>
-                        <field id="elasticsearch_enable_auth">1</field>
                         <field id="engine">elasticsearch5</field>
+                        <field id="elasticsearch5_enable_auth">1</field>
                     </depends>
                 </field>
                 <field id="elasticsearch5_server_timeout" translate="label" type="text" sortOrder="67" showInDefault="1" showInWebsite="0" showInStore="0">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There is a small typo in the Elasticsearch adminhtml configuration that causes the persistent hiding of the `Elasticsearch HTTP Username` and `Elasticsearch HTTP Password` fields when Elasticsearch 5.0+ is used as search engine even with the HTTP authentication activated.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log in to the back office.
2. Go to Stores > Configuration > Catalog > Catalog > Catalog Search.
3. Select the `Elasticsearch 5.0+` value in `Search Engine`.
4. Select the `Yes` value in `Enable Elasticsearch HTTP Auth`.
5. Both `Elasticsearch HTTP Username` and `Elasticsearch HTTP Password` fields are still hidden.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
