### PR TITLE
fix ordering of plugin list for after plugins

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/TwoPluginTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/TwoPluginTest.php
@@ -45,7 +45,7 @@ class TwoPluginTest extends AbstractPlugin
     public function testPluginAfterWins()
     {
         $subject = $this->_objectManager->create(\Magento\Framework\Interception\Fixture\Intercepted::class);
-        $this->assertEquals('<P:aZ/>', $subject->Z('test'));
+        $this->assertEquals('<F:aZ/>', $subject->Z('test'));
     }
 
     public function testPluginBeforeAroundWins()

--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -195,7 +195,10 @@ class PluginList extends Scoped implements InterceptionPluginList
                             if (!isset($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER])) {
                                 $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER][] = $key;
                             } else {
-                                array_unshift($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER], $key);
+                                array_unshift(
+                                    $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER],
+                                    $key
+                                );
                             }
                         }
                     }

--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -195,7 +195,7 @@ class PluginList extends Scoped implements InterceptionPluginList
                             if (!isset($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER])) {
                                 $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER][] = $key;
                             } else {
-                                array_unshift($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER],$key);
+                                array_unshift($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER], $key);
                             }
                         }
                     }

--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -192,7 +192,11 @@ class PluginList extends Scoped implements InterceptionPluginList
                             $this->_processed[$currentKey][DefinitionInterface::LISTENER_BEFORE][] = $key;
                         }
                         if ($methodTypes & DefinitionInterface::LISTENER_AFTER) {
-                            $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER][] = $key;
+                            if (!isset($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER])) {
+                                $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER][] = $key;
+                            } else {
+                                array_unshift($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER],$key);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION

### Description (*)
as described in https://devdocs.magento.com/guides/v2.2/extension-dev-guide/plugins.html#prioritizing-plugins the order of the after plugin is inversed to the before plugin sorting. currently before and after plugins are not inverse sorted on execution 

### Manual testing scenarios (*)
1. add a plugin like the \Magento\Customer\Model\Layout\DepersonalizePlugin which depends on a customer session value
2. add the plugin with the sort order below 10 (execute beforeGenerateXml before the customer plugin and execute afterGenerateXml after the customer plugin) in order to restore correctly the values within the customer session (needed for page cache segmentation)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)


unit test is currently not yet included