### PR TITLE
Don't return categoryId from registry if the product doesn't belong in the current category

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -727,7 +727,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     public function getCategoryId()
     {
         $category = $this->_registry->registry('current_category');
-        if ($category) {
+        if ($category && in_array($category->getId(), $this->getCategoryIds())) {
             return $category->getId();
         }
         return false;

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
@@ -549,6 +549,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
 
     public function testGetCategory()
     {
+        $this->model->setData('category_ids', [10]);
         $this->category->expects($this->any())->method('getId')->will($this->returnValue(10));
         $this->registry->expects($this->any())->method('registry')->will($this->returnValue($this->category));
         $this->categoryRepository->expects($this->any())->method('get')->will($this->returnValue($this->category));
@@ -557,12 +558,21 @@ class ProductTest extends \PHPUnit\Framework\TestCase
 
     public function testGetCategoryId()
     {
-        $this->category->expects($this->once())->method('getId')->will($this->returnValue(10));
+        $this->model->setData('category_ids', [10]);
+        $this->category->expects($this->any())->method('getId')->will($this->returnValue(10));
 
         $this->registry->expects($this->at(0))->method('registry');
         $this->registry->expects($this->at(1))->method('registry')->will($this->returnValue($this->category));
         $this->assertFalse($this->model->getCategoryId());
         $this->assertEquals(10, $this->model->getCategoryId());
+    }
+
+    public function testGetCategoryIdWhenProductNotInCurrentCategory()
+    {
+        $this->model->setData('category_ids', [12]);
+        $this->category->expects($this->once())->method('getId')->will($this->returnValue(10));
+        $this->registry->expects($this->any())->method('registry')->will($this->returnValue($this->category));
+        $this->assertFalse($this->model->getCategoryId());
     }
 
     public function testGetIdBySku()

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductExternalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductExternalTest.php
@@ -69,7 +69,7 @@ class ProductExternalTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse($this->_model->getCategoryId());
         $category = new \Magento\Framework\DataObject(['id' => 5]);
-
+        $this->_model->setCategoryIds([5]);
         $this->objectManager->get(\Magento\Framework\Registry::class)->register('current_category', $category);
         try {
             $this->assertEquals(5, $this->_model->getCategoryId());
@@ -83,6 +83,7 @@ class ProductExternalTest extends \PHPUnit\Framework\TestCase
     public function testGetCategory()
     {
         $this->assertEmpty($this->_model->getCategory());
+        $this->_model->setCategoryIds([3]);
 
         $this->objectManager->get(\Magento\Framework\Registry::class)
             ->register('current_category', new \Magento\Framework\DataObject(['id' => 3]));


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
 I added is_array check to \Magento\Catalog\Model\Product:getCategoryId that check whether the product belongs to the current_category set in registry. This fixes getProductUrl function not returning correct url since there isn't url rewrite for product in that category.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17819: Wrong product url from getProductUrl when current category has not product object

### Manual testing scenarios (*)

1. Create two category category1 and category2 with url-keys category-1 and category-2 respectively
2. Create product with url key product-1, assign it to category1
3. Add created categories to topmenu (turn on "include to menu" checkbox)
5. Create custom module Vendor_Module I have example here if you want to get it fast https://github.com/ErikPel/17819-TestScenario
6. Create template; add it to category layout
7. In the template get product collection with all products in it
8. In foreach loop call $product->getCategory() or $product->getProductUrl()
9. Before getCategory would return the current_category from registry even though the product doesn't belong to the category we are in. And getProductUrl would return http://example.com/catalog/product/view/id/1/s/product-1/category/2 instead of  http://example.com/product-1

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
