### PR TITLE
[Backport] #18979 - API: Bundle Product Option Repository Delete method removes incorrect option

### DIFF
--- a/app/code/Magento/Bundle/Model/OptionRepository.php
+++ b/app/code/Magento/Bundle/Model/OptionRepository.php
@@ -117,17 +117,18 @@ class OptionRepository implements \Magento\Bundle\Api\ProductOptionRepositoryInt
 
         $productLinks = $this->linkList->getItems($product, $optionId);
 
-        /** @var \Magento\Bundle\Api\Data\OptionInterface $option */
+        /** @var \Magento\Bundle\Api\Data\OptionInterface $optionDataObject */
         $optionDataObject = $this->optionFactory->create();
         $this->dataObjectHelper->populateWithArray(
             $optionDataObject,
             $option->getData(),
             \Magento\Bundle\Api\Data\OptionInterface::class
         );
-        $optionDataObject->setOptionId($option->getId())
-            ->setTitle($option->getTitle() === null ? $option->getDefaultTitle() : $option->getTitle())
-            ->setSku($product->getSku())
-            ->setProductLinks($productLinks);
+
+        $optionDataObject->setOptionId($option->getId());
+        $optionDataObject->setTitle($option->getTitle() === null ? $option->getDefaultTitle() : $option->getTitle());
+        $optionDataObject->setSku($product->getSku());
+        $optionDataObject->setProductLinks($productLinks);
 
         return $optionDataObject;
     }

--- a/app/code/Magento/Bundle/Model/OptionRepository.php
+++ b/app/code/Magento/Bundle/Model/OptionRepository.php
@@ -171,10 +171,11 @@ class OptionRepository implements \Magento\Bundle\Api\ProductOptionRepositoryInt
      */
     public function deleteById($sku, $optionId)
     {
-        $product = $this->getProduct($sku);
-        $optionCollection = $this->type->getOptionsCollection($product);
-        $optionCollection->setIdFilter($optionId);
-        return $this->delete($optionCollection->getFirstItem());
+        /** @var \Magento\Bundle\Api\Data\OptionInterface $option */
+        $option = $this->get($sku, $optionId);
+        $hasBeenDeleted = $this->delete($option);
+
+        return $hasBeenDeleted;
     }
 
     /**

--- a/app/code/Magento/Bundle/Test/Unit/Model/OptionRepositoryTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/OptionRepositoryTest.php
@@ -10,6 +10,7 @@
 namespace Magento\Bundle\Test\Unit\Model;
 
 use Magento\Bundle\Model\OptionRepository;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -89,7 +90,10 @@ class OptionRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->dataObjectHelperMock = $this->getMockBuilder(\Magento\Framework\Api\DataObjectHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->optionResourceMock = $this->createPartialMock(\Magento\Bundle\Model\ResourceModel\Option::class, ['delete', '__wakeup', 'save', 'removeOptionSelections']);
+        $this->optionResourceMock = $this->createPartialMock(
+            \Magento\Bundle\Model\ResourceModel\Option::class,
+            ['get', 'delete', '__wakeup', 'save', 'removeOptionSelections']
+        );
         $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->linkManagementMock = $this->createMock(\Magento\Bundle\Api\ProductLinkManagementInterface::class);
         $this->optionListMock = $this->createMock(\Magento\Bundle\Model\Product\OptionList::class);
@@ -235,32 +239,91 @@ class OptionRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->model->delete($optionMock);
     }
 
+    /**
+     * Test successful delete action for given $optionId
+     */
     public function testDeleteById()
     {
         $productSku = 'sku';
         $optionId = 100;
-        $productMock = $this->createMock(\Magento\Catalog\Api\Data\ProductInterface::class);
+
+        $optionMock = $this->createMock(\Magento\Bundle\Model\Option::class);
+        $optionMock->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn($optionId);
+
+        $optionMock->expects($this->once())
+            ->method('getData')
+            ->willReturn([
+                'title' => 'Option title',
+                'option_id' => $optionId
+            ]);
+
+        $this->optionFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($optionMock);
+
+        $productMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Product::class,
+            ['getTypeId', 'getTypeInstance', 'getStoreId', 'getPriceType', '__wakeup', 'getSku']
+        );
         $productMock->expects($this->once())
             ->method('getTypeId')
             ->willReturn(\Magento\Catalog\Model\Product\Type::TYPE_BUNDLE);
-        $this->productRepositoryMock->expects($this->once())
+        $productMock->expects($this->exactly(2))->method('getSku')->willReturn($productSku);
+
+        $this->productRepositoryMock
+            ->expects($this->once())
             ->method('get')
             ->with($productSku)
             ->willReturn($productMock);
 
-        $optionMock = $this->createMock(\Magento\Bundle\Model\Option::class);
-
         $optCollectionMock = $this->createMock(\Magento\Bundle\Model\ResourceModel\Option\Collection::class);
+        $optCollectionMock->expects($this->once())->method('getItemById')->with($optionId)->willReturn($optionMock);
         $this->typeMock->expects($this->once())
             ->method('getOptionsCollection')
             ->with($productMock)
             ->willReturn($optCollectionMock);
 
-        $optCollectionMock->expects($this->once())->method('setIdFilter')->with($optionId)->willReturnSelf();
-        $optCollectionMock->expects($this->once())->method('getFirstItem')->willReturn($optionMock);
-
-        $this->optionResourceMock->expects($this->once())->method('delete')->with($optionMock)->willReturnSelf();
         $this->assertTrue($this->model->deleteById($productSku, $optionId));
+    }
+
+    /**
+     * Tests if NoSuchEntityException thrown when provided $optionId not found
+     */
+    public function testDeleteByIdException() {
+        $productSku = 'sku';
+        $optionId = null;
+
+        $optionMock = $this->createMock(\Magento\Bundle\Model\Option::class);
+        $optionMock->expects($this->exactly(1))
+            ->method('getId')
+            ->willReturn($optionId);
+
+        $productMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Product::class,
+            ['getTypeId', 'getTypeInstance', 'getStoreId', 'getPriceType', '__wakeup', 'getSku']
+        );
+        $productMock->expects($this->once())
+            ->method('getTypeId')
+            ->willReturn(\Magento\Catalog\Model\Product\Type::TYPE_BUNDLE);
+
+        $this->productRepositoryMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($productSku)
+            ->willReturn($productMock);
+
+        $optCollectionMock = $this->createMock(\Magento\Bundle\Model\ResourceModel\Option\Collection::class);
+        $optCollectionMock->expects($this->once())->method('getItemById')->with($optionId)->willReturn($optionMock);
+        $this->typeMock->expects($this->once())
+            ->method('getOptionsCollection')
+            ->with($productMock)
+            ->willReturn($optCollectionMock);
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->model->deleteById($productSku, $optionId);
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request
#19027 

### Description (*)
Please see magento/magento2#18979 for full description.

### Fixed Issues (if relevant)
1. magento/magento2#18979

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
