### PR TITLE
[Backport] Add missing unit test for WishlistSettings plugin

### DIFF
--- a/app/code/Magento/Wishlist/Test/Unit/Plugin/Ui/DataProvider/WishlistSettingsTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Plugin/Ui/DataProvider/WishlistSettingsTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Wishlist\Test\Unit\Plugin\Ui\DataProvider;
+
+use Magento\Catalog\Ui\DataProvider\Product\Listing\DataProvider;
+use Magento\Wishlist\Helper\Data;
+use Magento\Wishlist\Plugin\Ui\DataProvider\WishlistSettings;
+
+/**
+ * Covers \Magento\Wishlist\Plugin\Ui\DataProvider\WishlistSettings
+ */
+class WishlistSettingsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var WishlistSettings
+     */
+    private $wishlistSettings;
+
+    /**
+     * @var Data|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $helperMock;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->helperMock = $this->createMock(Data::class);
+        $this->wishlistSettings = new WishlistSettings($this->helperMock);
+    }
+
+    /**
+     * Test afterGetData method
+     *
+     * @return void
+     */
+    public function testAfterGetData()
+    {
+        /** @var DataProvider|\PHPUnit_Framework_MockObject_MockObject $subjectMock */
+        $subjectMock = $this->createMock(DataProvider::class);
+        $result = [];
+        $isAllow = true;
+        $this->helperMock->expects($this->once())->method('isAllow')->willReturn(true);
+
+        $expected = ['allowWishlist' => $isAllow];
+        $actual = $this->wishlistSettings->afterGetData($subjectMock, $result);
+        self::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
### Original Pull Request
#18906 

### Description (*)
Add missing unit test for `\Magento\Wishlist\Plugin\Ui\DataProvider\WishlistSettings` class.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
