### PR TITLE
Provide ViewModels the ability to set identities on their parent block

### DIFF
--- a/lib/internal/Magento/Framework/DataObject/IdentityInterface.php
+++ b/lib/internal/Magento/Framework/DataObject/IdentityInterface.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\DataObject;
 /**
  * Interface for
  * 1. models which require cache refresh when it is created/updated/deleted
- * 2. blocks which render this information to front-end
+ * 2. blocks/viewmodels which render this information to front-end
  */
 interface IdentityInterface
 {

--- a/lib/internal/Magento/Framework/View/Element/Template.php
+++ b/lib/internal/Magento/Framework/View/Element/Template.php
@@ -3,9 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\View\Element;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Filesystem;
 
 /**
@@ -369,7 +371,7 @@ class Template extends AbstractBlock implements IdentityInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Return unique ID(s) for each object in system
      *
      * Merges the identities of all child elements so ViewModels may alter the cache identifier.
      *

--- a/lib/internal/Magento/Framework/View/Element/Template.php
+++ b/lib/internal/Magento/Framework/View/Element/Template.php
@@ -28,7 +28,7 @@ use Magento\Framework\Filesystem;
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Template extends AbstractBlock
+class Template extends AbstractBlock implements IdentityInterface
 {
     /**
      * Config path to 'Allow Symlinks' template settings
@@ -366,5 +366,24 @@ class Template extends AbstractBlock
             $this->mediaDirectory = $this->_filesystem->getDirectoryRead(DirectoryList::MEDIA);
         }
         return $this->mediaDirectory;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Merges the identities of all child elements so ViewModels may alter the cache identifier.
+     *
+     * @return string[]
+     */
+    public function getIdentities()
+    {
+        $childIdentities = [];
+        foreach ($this->getData() as $datum) {
+            if ($datum instanceof IdentityInterface) {
+                $childIdentities[] = $datum->getIdentities();
+            }
+        }
+
+        return array_merge_recursive(...$childIdentities);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

While ViewModels are now the whos-who of layout updates, there is one major reason integrations still need to create custom blocks - caching.

This modification updates the TemplateBlock to pull all the identities from its arguments implementing IdentityInterface - thus allowing ViewModels to declare their identities and have the parent block cached accordingly.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
