### PR TITLE
do not force toolbar to be child of product list block (fixes #7253)

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -258,7 +258,7 @@ class ListProduct extends AbstractProduct implements IdentityInterface
      */
     public function getToolbarHtml()
     {
-        return $this->getChildHtml('toolbar');
+        return $this->getToolbarBlock()->toHtml();
     }
 
     /**
@@ -506,6 +506,5 @@ class ListProduct extends AbstractProduct implements IdentityInterface
         }
         // set collection to toolbar and apply sort
         $toolbar->setCollection($collection);
-        $this->setChild('toolbar', $toolbar);
     }
 }


### PR DESCRIPTION
### Description (*)
This should finally fix #7253. The current implementation forces the toolbar block (when defined via `setToolbarBlockName`) to __always__ be a child block of the product list block, even though there is no reason for it anymore. My guess is those lines of code were simply overlooked in the last attempt to fix the toolbar/product list relationship.

This PR simply removes the `setChild` call and instead uses
```php
$this->getToolbarBlock()->toHtml();
```
within `getToolbarHtml` instead of the old `$this->getChildHtml('toolbar');`.

### Fixed Issues (if relevant)
magento/magento2/#7253: I cannot move the block

### Manual testing scenarios (*)
Simply create a `catalog_category_view.xml` with the following content for example:
```xml
<?xml version="1.0"?>
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="3columns" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <body>
        <move element="product_list_toolbar" destination="content" />
    </body>
</page>
```
This will successfully move the toolbar into the "content" container.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
