### PR TITLE
Fix the issue: Content overlaps the "close" button

### DIFF
--- a/lib/web/css/source/components/_modals.less
+++ b/lib/web/css/source/components/_modals.less
@@ -103,6 +103,10 @@
     &.confirm {
         .modal-inner-wrap {
             .lib-css(width, @modal-popup-confirm__width);
+
+            .modal-content {
+                padding-right: 7rem;
+            }
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The confirmation popups are broken due to the reduced width.
Looks like the expected width is `50rem`. This rule has been added by the following commit: 2f133c852f4fae8bdf193b3a7e7b7ce94eb0391f
In this case, we just need to resolve the issue related to content overlapping the "close" button.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19263: Broken backend popup view

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Affected functionality: The confirmation popups in admin panel.
1. Login to admin panel.
2. Go to `System -> Cache Management`.
3. Click "Flush Cache Storage".

### Expected result
<!--- Tell us what do you expect to happen. -->
1. Content does not overlap the "close" button. (including tablet and mobile view);

<img width="723" alt="screen shot 2018-11-18 at 5 38 23 pm" src="https://user-images.githubusercontent.com/11693779/48674786-c89a3980-eb58-11e8-89ba-90f6252a3615.png">


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
