### PR TITLE
Remove cart edit link extra space

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/edit.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/edit.phtml
@@ -12,8 +12,6 @@
     <a class="action action-edit"
        href="<?= /* @escapeNotVerified */ $block->getConfigureUrl() ?>"
        title="<?= $block->escapeHtml(__('Edit item parameters')) ?>">
-        <span>
-            <?= /* @escapeNotVerified */ __('Edit') ?>
-        </span>
-   </a>
+        <span><?= /* @escapeNotVerified */ __('Edit') ?></span>
+    </a>
 <?php endif ?>


### PR DESCRIPTION
### Description (*)
There is an extra space after the "Edit" link on an item line in cart.

### Manual testing scenarios (*)
1. Add an item to cart
2. Check the "Edit" link, it has an extra space at the end of the word

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
