### PR TITLE
Add child identities to products instead of parent identities

### DIFF
--- a/app/code/Magento/Bundle/Model/Plugin/Product.php
+++ b/app/code/Magento/Bundle/Model/Plugin/Product.php
@@ -24,6 +24,8 @@ class Product
     }
 
     /**
+     * Add child identities to product identities
+     *
      * @param CatalogProduct $product
      * @param array $identities
      * @return string[]
@@ -32,9 +34,12 @@ class Product
         CatalogProduct $product,
         array $identities
     ) {
-        foreach ($this->type->getParentIdsByChild($product->getEntityId()) as $parentId) {
-            $identities[] = CatalogProduct::CACHE_TAG . '_' . $parentId;
+        foreach ($this->type->getChildrenIds($product->getEntityId()) as $optionId => $childIds) {
+            foreach ($childIds as $childId) {
+                $identities[] = CatalogProduct::CACHE_TAG . '_' . $childId;
+            }
         }
-        return $identities;
+
+        return array_unique($identities);
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Model/Plugin/ProductIdentitiesExtender.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Plugin/ProductIdentitiesExtender.php
@@ -37,7 +37,7 @@ class ProductIdentitiesExtender
     }
 
     /**
-     * Add parent identities to product identities
+     * Add child identities to product identities
      *
      * @param Product $subject
      * @param array $identities
@@ -48,9 +48,10 @@ class ProductIdentitiesExtender
     {
         $identities = (array) $identities;
 
-        foreach ($this->configurableType->getParentIdsByChild($subject->getId()) as $parentId) {
-            $parentProduct = $this->productRepository->getById($parentId);
-            $identities = array_merge($identities, (array) $parentProduct->getIdentities());
+        foreach ($this->configurableType->getChildrenIds($subject->getId()) as $key => $childIds) {
+            foreach ($childIds as $childId) {
+                $identities[] = Product::CACHE_TAG . '_' . $childId;
+            }
         }
 
         return array_unique($identities);


### PR DESCRIPTION
### Description
For Bundle and Configurable products the parent identities are added to the default identities with a plugin afterGetIdentities. From my point of view you don't need to have the identities from the parent products but from the child products.

We've got a shop with photo cameras. We sell a lot of (570) bundle products that include a specific memory card. This specific memory card is also connected as a related product to a lot of products. Currently when you do `getIdentities` on this simple product you will get a very large list of cache tags. And when you ask one of the bundle products for its identities you don't get any of the child products because those aren't added by the plugin. Only the parent identities are added and the bundle itself doesn't have any parent products.

From my point of view you don't need to know that a simple product has 570 parent identities, but you do want to know that a bundle has, for example, 5 child identities.

All the identities on a page are also being used by Full Page Cache to create the header `X-Magento-Tags`. This header is also being used by Varnish. But when this header is to big Varnish will stop working. In article https://devdocs.magento.com/guides/v2.2/config-guide/varnish/tshoot-varnish-503.html is described to allow larges headers for Varnish. In this case that isn't very stable. Because when I create 100 more bundle products where this simple product (memory card) is being used i get 100 more cache tags in my header.

On a vanilla Magento 2.2.6 shop I duplicated the bundle product 570 times with a SCV import. The result of the `getIdentities` is shown below in a screenshot. Notice that the bundle product `Sprite Yoga Companion Kit` doesn't contain the identities of the child products. But the simple product `Sprite Foam Roller` contains all 470 bundle products it's connected to.

![screen shot 2018-11-20 at 13 18 13](https://user-images.githubusercontent.com/9214557/48774420-87299b80-ecca-11e8-9506-f257ec9fafc3.png)

After the fix I propose the simple product will not show the identities of all the products it's connected to anymore and the bundle product will contain all the identities of the products connected to that product.

![screen shot 2018-11-20 at 13 21 30](https://user-images.githubusercontent.com/9214557/48774429-8c86e600-ecca-11e8-9c83-fc0e61c980e3.png)

Now the identites you're expecting are being returned and the X-Magento-Tags isn't polluted by a lot of cache tags that don't influence the content of the page. You can still run in to the problem that the server won't allow a large header for X-Magento-Tags like described in https://devdocs.magento.com/guides/v2.2/config-guide/varnish/tshoot-varnish-503.html. But at least now the correct cache tags are being returned instead of all the parents of a simple product.

This same issue is also the case for configurable products. For example when a simple product is visible in the catalog and connected to a lot of configurable products this simple product will return a lot of identities and the configurable product won't return the identities of its child products.

### Manual testing scenarios (*)
1. Install vanilla Magento with sample data
2. Import products to create 570 bundle products [catalog_product_20181120_114259.csv.zip](https://github.com/magento/magento2/files/2599754/catalog_product_20181120_114259.csv.zip)
3. Edit the file `Magento_Catalog::view/frontend/templates/product/list.phtml` and output the entities for each product `<?php var_dump($_product->getIdentities()); ?>`
4. Notice that there are more identities being used for the simple product then needed.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
