### PR TITLE
Allow numbers in xsd declaration, modelName type, for product type instances and product options

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsMergedXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsMergedXmlArray.php
@@ -9,22 +9,22 @@ return [
         ["Element 'inputType': This element is not expected. Expected is ( option ).\nLine: 1\n"],
     ],
     'inputType_node_is_required' => [
-        '<?xml version="1.0"?><config><option name="name_one" label="Label One" renderer="one"/></config>',
+        '<?xml version="1.0"?><config><option name="name_one" label="Label One" renderer="One"/></config>',
         ["Element 'option': Missing child element(s). Expected is ( inputType ).\nLine: 1\n"],
     ],
     'options_node_without_required_attributes' => [
         '<?xml version="1.0"?><config><option name="name_one" label="label one"><inputType name="name" label="one"/>' .
-        '</option><option name="name_two" renderer="renderer"><inputType name="name_two" label="one" /></option>' .
-        '<option label="label three" renderer="renderer"><inputType name="name_one" label="one"/></option></config>',
+        '</option><option name="name_two" renderer="Renderer"><inputType name="name_two" label="one" /></option>' .
+        '<option label="label three" renderer="Renderer"><inputType name="name_one" label="one"/></option></config>',
         [
             "Element 'option': The attribute 'renderer' is required but missing.\nLine: 1\n",
-            "Element 'option': The attribute " . "'label' is required but missing.\nLine: 1\n",
+            "Element 'option': The attribute 'label' is required but missing.\nLine: 1\n",
             "Element 'option': The attribute 'name' is required but missing.\nLine: 1\n"
         ],
     ],
     'inputType_node_without_required_attributes' => [
-        '<?xml version="1.0"?><config><option name="name_one" label="label one" renderer="renderer">' .
-        '<inputType name="name_one"/></option><option name="name_two" renderer="renderer" label="label">' .
+        '<?xml version="1.0"?><config><option name="name_one" label="label one" renderer="Renderer">' .
+        '<inputType name="name_one"/></option><option name="name_two" renderer="Renderer" label="label">' .
         '<inputType label="name_two"/></option></config>',
         [
             "Element 'inputType': The attribute 'label' is required but missing.\nLine: 1\n",

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
@@ -28,13 +28,23 @@ return [
             "'uniqueInputTypeName'.\nLine: 1\n"
         ],
     ],
-    'renderer_attribute_with_invalid_value' => [
+    'renderer_attribute_with_invalid_value_starting_with_lowercase' => [
         '<?xml version="1.0"?><config><option name="name_one" renderer="true12"><inputType name="name_one"/>' .
         '</option></config>',
         [
             "Element 'option', attribute 'renderer': [facet 'pattern'] The value 'true12' is not accepted by the " .
-            "pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
+            "pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
             "Element 'option', attribute 'renderer': 'true12' is not a valid value of the atomic" .
+            " type 'modelName'.\nLine: 1\n"
+        ],
+    ],
+    'renderer_attribute_with_invalid_value_starting_with_number' => [
+        '<?xml version="1.0"?><config><option name="name_one" renderer="12true"><inputType name="name_one"/>' .
+        '</option></config>',
+        [
+            "Element 'option', attribute 'renderer': [facet 'pattern'] The value '12true' is not accepted by the " .
+            "pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'option', attribute 'renderer': '12true' is not a valid value of the atomic" .
             " type 'modelName'.\nLine: 1\n"
         ],
     ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/product_options_merged_valid.xml
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/product_options_merged_valid.xml
@@ -12,4 +12,7 @@
     <option name="name_two" label="Label Two" renderer="Name_One_Three">
         <inputType name="input_name_two" label="Label Three" disabled="true" />
     </option>
+    <option name="name_three" label="Label Three" renderer="Renderer_With_Number_1">
+        <inputType name="input_name" label="Label Three" />
+    </option>
 </config>

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/product_options_valid.xml
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/product_options_valid.xml
@@ -12,4 +12,7 @@
     <option name="name_two" >
         <inputType name="input_name_two" disabled="true" />
     </option>
+    <option name="name_three" label="Label Three" renderer="Renderer_With_Number_1">
+        <inputType name="input_name" label="Label Three" />
+    </option>
 </config>

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesMergedXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesMergedXmlArray.php
@@ -5,33 +5,43 @@
  */
 return [
     'type_without_required_name' => [
-        '<?xml version="1.0" encoding="UTF-8"?><config><type label="some label" modelInstance="model_name" /></config>',
+        '<?xml version="1.0" encoding="UTF-8"?><config><type label="some label" modelInstance="Model_name" /></config>',
         [
             "Element 'type': The attribute 'name' is required but missing.\nLine: 1\n",
             "Element 'type': Not all fields of key identity-constraint 'productTypeKey' evaluate to a node.\nLine: 1\n"
         ],
     ],
     'type_without_required_label' => [
-        '<?xml version="1.0" encoding="UTF-8"?><config><type name="some_name" modelInstance="model_name" /></config>',
+        '<?xml version="1.0" encoding="UTF-8"?><config><type name="some_name" modelInstance="Model_name" /></config>',
         ["Element 'type': The attribute 'label' is required but missing.\nLine: 1\n"],
     ],
     'type_without_required_modelInstance' => [
         '<?xml version="1.0" encoding="UTF-8"?><config><type label="some_label" name="some_name" /></config>',
         ["Element 'type': The attribute 'modelInstance' is required but missing.\nLine: 1\n"],
     ],
+    'type_with_invalid_modelinstance_value' => [
+        '<?xml version="1.0" encoding="UTF-8"?><config>' .
+        '<type name="some_name" label="some_label" modelInstance="model_name" /></config>',
+        [
+            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value 'model_name' is not " .
+            "accepted by the pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'type', attribute 'modelInstance': 'model_name' is not a valid value of the atomic type" .
+            " 'modelName'.\nLine: 1\n",
+        ],
+    ],
     'type_pricemodel_without_required_instance_attribute' => [
         '<?xml version="1.0" encoding="UTF-8"?><config>' .
-        '<type label="some_label" name="some_name" modelInstance="model_name"><priceModel/></type></config>',
+        '<type label="some_label" name="some_name" modelInstance="Model_name"><priceModel/></type></config>',
         ["Element 'priceModel': The attribute 'instance' is required but missing.\nLine: 1\n"],
     ],
     'type_indexmodel_without_required_instance_attribute' => [
         '<?xml version="1.0" encoding="UTF-8"?><config>' .
-        '<type label="some_label" name="some_name" modelInstance="model_name"><indexerModel/></type></config>',
+        '<type label="some_label" name="some_name" modelInstance="Model_name"><indexerModel/></type></config>',
         ["Element 'indexerModel': The attribute 'instance' is required but missing.\nLine: 1\n"],
     ],
     'type_stockindexermodel_without_required_instance_attribute' => [
         '<?xml version="1.0" encoding="UTF-8"?><config><type label="some_label" ' .
-        'name="some_name" modelInstance="model_name"><stockIndexerModel/></type></config>',
+        'name="some_name" modelInstance="Model_name"><stockIndexerModel/></type></config>',
         ["Element 'stockIndexerModel': The attribute 'instance' is required but missing.\nLine: 1\n"],
     ]
 ];

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
@@ -19,12 +19,21 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"  notallowed="text"/></config>',
         ["Element 'type', attribute 'notallowed': The attribute 'notallowed' is not allowed.\nLine: 1\n"],
     ],
-    'type_modelinstance_invalid_value' => [
+    'type_modelinstance_invalid_value_starting_with_number' => [
         '<?xml version="1.0"?><config><type name="some_name" modelInstance="123" /></config>',
         [
             "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value '123' is not accepted by the" .
-            " pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
+            " pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
             "Element 'type', attribute 'modelInstance': '123' is not a valid value of the atomic type" .
+            " 'modelName'.\nLine: 1\n"
+        ],
+    ],
+    'type_modelinstance_invalid_value_starting_with_lowercase_letter' => [
+        '<?xml version="1.0"?><config><type name="some_name" modelInstance="model_name" /></config>',
+        [
+            "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value 'model_name'" .
+            " is not accepted by the pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
+            "Element 'type', attribute 'modelInstance': 'model_name' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
     ],
@@ -57,7 +66,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"><priceModel instance="123123" /></type></config>',
         [
             "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value '123123' is not accepted " .
-            "by the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
+            "by the pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
             "Element 'priceModel', attribute 'instance': '123123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -66,7 +75,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"><indexerModel instance="123" /></type></config>',
         [
             "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value '123' is not accepted by " .
-            "the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
+            "the pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
             "Element 'indexerModel', attribute 'instance': '123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -83,7 +92,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"><stockIndexerModel instance="1234"/></type></config>',
         [
             "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value '1234' is not " .
-            "accepted by the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[A-Z]+[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
             "Element 'stockIndexerModel', attribute 'instance': '1234' is not a valid value of the atomic " .
             "type 'modelName'.\nLine: 1\n"
         ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/valid_product_types.xml
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/valid_product_types.xml
@@ -15,4 +15,13 @@
             <type name="second_type" />
         </allowedSelectionTypes>
     </type>
+    <type name="some_name2" label="label_name" modelInstance="Test_Instance_With_Number_1" composite='true' indexPriority="40">
+        <priceModel instance="Second_Test" />
+        <indexerModel instance="Test_Instance_Name" />
+        <stockIndexerModel instance="Test_Instance_Name" />
+        <allowedSelectionTypes>
+            <type name="first_type" />
+            <type name="second_type" />
+        </allowedSelectionTypes>
+    </type>
 </config>

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/valid_product_types_merged.xml
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/valid_product_types_merged.xml
@@ -6,24 +6,33 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Catalog:etc/product_types_merged.xsd">
-    <type label="some_label" name="some_name" modelInstance="model_name">
+    <type label="some_label" name="some_name" modelInstance="Model_name">
         <allowedSelectionTypes>
             <type name="some_name" />
         </allowedSelectionTypes>
-        <priceModel instance="instance_name" />
-        <indexerModel instance="instance_name" />
-        <stockIndexerModel instance="instance_name"/>
+        <priceModel instance="Instance_name" />
+        <indexerModel instance="Instance_name" />
+        <stockIndexerModel instance="Instance_name"/>
     </type>
-    <type label="some_label" name="some_name2" modelInstance="model_name">
+    <type label="some_label" name="some_name2" modelInstance="Model_name">
         <allowedSelectionTypes>
             <type name="some_name" />
         </allowedSelectionTypes>
-        <priceModel instance="instance_name" />
-        <indexerModel instance="instance_name" />
-        <stockIndexerModel instance="instance_name"/>
+        <priceModel instance="Instance_name" />
+        <indexerModel instance="Instance_name" />
+        <stockIndexerModel instance="Instance_name"/>
+    </type>
+    <type label="some_label" name="some_name3" modelInstance="Test_Instance_With_Number_1">
+        <allowedSelectionTypes>
+            <type name="some_name3" />
+        </allowedSelectionTypes>
+        <priceModel instance="Second_Test" />
+        <indexerModel instance="Test_Instance_Name" />
+        <stockIndexerModel instance="Test_Instance_Name" />
     </type>
     <composableTypes>
         <type name="some_name"/>
         <type name="some_name2"/>
+        <type name="some_name3"/>
     </composableTypes>
 </config>

--- a/app/code/Magento/Catalog/etc/product_options.xsd
+++ b/app/code/Magento/Catalog/etc/product_options.xsd
@@ -61,11 +61,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [a-zA-Z_\\].
+                Model name can contain only [A-Z]+[a-zA-Z0-9_\\]+.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_\\]+" />
+            <xs:pattern value="[A-Z]+[a-zA-Z0-9_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/Catalog/etc/product_types_base.xsd
+++ b/app/code/Magento/Catalog/etc/product_types_base.xsd
@@ -92,11 +92,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [a-zA-Z_\\].
+                Model name can contain only [A-Z]+[a-zA-Z0-9_\\]+.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_\\]+" />
+            <xs:pattern value="[A-Z]+[a-zA-Z0-9_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
This PR tries to allow numbers in xsd declaration, in modelName type, for product type instances and product options.

### Description (*)
New product types are not allowed to have its model instances under a namespace containing numbers.

### Fixed Issues (if relevant)
Improvement

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
