### PR TITLE
fixed typos for zero order credit memo feature

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -656,8 +656,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         $isRefundZero = abs($totalRefunded) < .0001;
         // Case when Adjustment Fee (adjustment_negative) has been used for first creditmemo
         $hasAdjustmentFee = abs($totalRefunded - $this->getAdjustmentNegative()) < .0001;
-        $hasActinFlag = $this->getActionFlag(self::ACTION_FLAG_EDIT) === false;
-        if ($isRefundZero || $hasAdjustmentFee || $hasActinFlag) {
+        $hasActionFlag = $this->getActionFlag(self::ACTION_FLAG_EDIT) === false;
+        if ($isRefundZero || $hasAdjustmentFee || $hasActionFlag) {
             return false;
         }
 
@@ -676,13 +676,12 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         //check if total paid is less than grandtotal
         $checkAmtTotalPaid = $totalPaid <= $this->getGrandTotal();
         //case when amount is due for invoice
-        $dueAmountCondition = $this->canInvoice() && ($checkAmtTotalPaid);
+        $hasDueAmount = $this->canInvoice() && ($checkAmtTotalPaid);
         //case when paid amount is refunded and order has creditmemo created
-
         $creditmemos = ($this->getCreditmemosCollection() === false) ?
              true : (count($this->getCreditmemosCollection()) > 0);
         $paidAmtIsRefunded = $this->getTotalRefunded() == $totalPaid && $creditmemos;
-        if (($dueAmountCondition || $paidAmtIsRefunded) ||
+        if (($hasDueAmount || $paidAmtIsRefunded) ||
             (!$checkAmtTotalPaid &&
             abs($totalRefunded - $this->getAdjustmentNegative()) < .0001)) {
             return false;

--- a/app/code/Magento/Sales/i18n/en_US.csv
+++ b/app/code/Magento/Sales/i18n/en_US.csv
@@ -795,3 +795,5 @@ Created,Created
 "PDF Shipments","PDF Shipments"
 "PDF Creditmemos","PDF Creditmemos"
 Refunds,Refunds
+"Allow Zero GrandTotal for Creditmemo","Allow Zero GrandTotal for Creditmemo"
+"Allow Zero GrandTotal","Allow Zero GrandTotal"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed typos and added proper variable names in below files:

app/code/Magento/Sales/Model/Order.php
app/code/Magento/Sales/etc/adminhtml/system.xml

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Changes done as below:

1. app/code/Magento/Sales/Model/Order.php
Line:668 - replaced $hasActinFlag to $hasActionFlag
Line:688 - replaced $dueAmountCondition to $hasDueAmount
Line:690 - replaced $creditmemos to $creditMemos

2. app/code/Magento/Sales/etc/adminhtml/system.xml
Line:52 - replaced Allow Zero GrandTotal to Allow Zero GrandTotal for Credit Memos
Line:54 - replaced Allow Zero GrandTotal for Creditmemo to Allow Zero GrandTotal for Credit Memos 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
