### PR TITLE
Fix styling issue for order items table

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/order/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/items.phtml
@@ -29,9 +29,10 @@
         </thead>
         <?php $items = $block->getItems(); ?>
         <?php $giftMessage = ''?>
+        <tbody>
         <?php foreach ($items as $item): ?>
             <?php if ($item->getParentItem()) continue; ?>
-            <tbody>
+
                 <?= $block->getItemHtml($item) ?>
                 <?php if ($this->helper('Magento\GiftMessage\Helper\Message')->isMessagesAllowed('order_item', $item) && $item->getGiftMessageId()): ?>
                     <?php $giftMessage = $this->helper('Magento\GiftMessage\Helper\Message')->getGiftMessageForEntity($item); ?>
@@ -62,8 +63,8 @@
                         </td>
                     </tr>
                 <?php endif ?>
-            </tbody>
         <?php endforeach; ?>
+        </tbody>
         <tfoot>
             <?php if($block->isPagerDisplayed()): ?>
                 <tr>

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -612,10 +612,6 @@
         padding: 25px;
 
         .col {
-            &.name {
-                padding-left: 0;
-            }
-
             &.price {
                 text-align: center;
             }


### PR DESCRIPTION
Fix the issue with repetitive "tbody" tag for order items table.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
There is an issue with repetitive "tbody" tag for order items table. As result, the incorrect styles are applied for the table.
The "striped table" styles, defined in `app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less:179`, expected to be used for Luma theme.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Check the order/return items tables for both guest and customer.

### Expected result
1. There is no repetitive "tbody" for order items table.
2. As result, the "striped table" styles should be applied.

![screen shot 2018-11-21 at 1 51 28 pm](https://user-images.githubusercontent.com/11693779/48842153-2a96b100-ed9c-11e8-9744-4a6471fce475.png)

This is the expected view of the table, defined in `app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less:179`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
