### PR TITLE
fixed issue "Pagination controls are missing on wishlist page" #19292

### DIFF
--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist.php
@@ -25,6 +25,16 @@ class Wishlist extends \Magento\Wishlist\Block\AbstractBlock
     protected $_optionsCfg = [];
 
     /**
+     * @var  \Magento\Wishlist\Model\ResourceModel\Item\Collection
+     */
+    protected $_collection;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $_scopeConfig;
+
+    /**
      * @var \Magento\Catalog\Helper\Product\ConfigurationPool
      */
     protected $_helperPool;
@@ -63,6 +73,8 @@ class Wishlist extends \Magento\Wishlist\Block\AbstractBlock
         $this->_helperPool = $helperPool;
         $this->currentCustomer = $currentCustomer;
         $this->postDataHelper = $postDataHelper;
+        $this->_scopeConfig = $context->getScopeConfig();
+        $this->getWishlistItems();
     }
 
     /**
@@ -78,14 +90,66 @@ class Wishlist extends \Magento\Wishlist\Block\AbstractBlock
     }
 
     /**
+     * Retrieve Wishlist Product Items collection
+     *
+     * @return \Magento\Wishlist\Model\ResourceModel\Item\Collection
+     */
+    public function getWishlistItems()
+    {
+        $page = ($this->getRequest()->getParam("p")) ? $this->getRequest()->getParam("p") : 1;
+        $limit = ($this->getRequest()->getParam("limit")) ? $this->getRequest()->getParam("limit") : 10;
+        if ($this->_collection === null) {
+            $this->_collection = $this->_createWishlistItemCollection();
+            $this->_prepareCollection($this->_collection);
+        }
+        $this->_collection
+            ->setPageSize($limit)
+            ->setCurPage($page);
+        return $this->_collection;
+    }
+
+    /**
      * Preparing global layout
      *
-     * @return void
+     * @return $this
      */
     protected function _prepareLayout()
     {
         parent::_prepareLayout();
         $this->pageConfig->getTitle()->set(__('My Wish List'));
+        $pager = $this->getLayout()
+            ->createBlock('Magento\Theme\Block\Html\Pager', 'wishlist_item_pager')
+            ->setUseContainer(
+                true
+            )->setShowAmounts(
+                true
+            )->setFrameLength(
+                $this->_scopeConfig->getValue(
+                    'design/pagination/pagination_frame',
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            )->setJump(
+                $this->_scopeConfig->getValue(
+                    'design/pagination/pagination_frame_skip',
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            )->setLimit(
+                $this->getLimit()
+            )
+            ->setCollection($this->_collection);
+        $this->setChild("pager", $pager);
+        $this->_collection->load();
+        return $this;
+    }
+
+    /**
+     * Render pagination HTML
+     *
+     * @return string
+     */
+    public function getPagerHtml()
+    {
+        return $this->getChildHtml('pager');
     }
 
     /**

--- a/app/code/Magento/Wishlist/view/frontend/templates/view.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/view.phtml
@@ -10,6 +10,9 @@
 ?>
 
 <?php if ($this->helper('Magento\Wishlist\Helper\Data')->isAllow()) : ?>
+    <?php if ($block->getPagerHtml()): ?>
+        <div class="toolbar"><?php echo $block->getPagerHtml(); ?></div>
+    <?php endif ?>
     <?= ($block->getChildHtml('wishlist.rss.link')) ?>
     <form class="form-wishlist-items" id="wishlist-view-form"
           data-mage-init='{"wishlist":{
@@ -51,5 +54,8 @@
           <input name="entity" value="<%- data.entity %>">
           <% } %>
       </form>
-  </script>
+    </script>
+    <?php if ($block->getPagerHtml()): ?>
+        <div class="toolbar"><br><?php echo $block->getPagerHtml(); ?></div>
+    <?php endif ?>
 <?php endif ?>

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1503,8 +1503,8 @@
 
         .toolbar-amount,
         .limiter {
-            position: relative;
             z-index: 1;
+            display: inline-block;
         }
 
         .toolbar-amount {
@@ -1512,9 +1512,12 @@
             padding: 0;
         }
 
+        .limiter {
+            float: right;
+        }
+
         .pages {
-            position: absolute;
-            width: 100%;
+            display: inline-block;
             z-index: 0;
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
After adding multiple items to your wishlist,there isn't a way to paginate wishlist, but as the wishlist grow it will slow down the page loading, if pagination own't exist.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #19292 Pagination controls are missing on wishlist page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add atleast 20 to 30 items to wishlist and try loading page
2. You won't see pagination

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
