### PR TITLE
Replaced ArrayInterface with OptionSourceInterface

### DIFF
--- a/app/code/Magento/AdminNotification/Model/Config/Source/Frequency.php
+++ b/app/code/Magento/AdminNotification/Model/Config/Source/Frequency.php
@@ -12,7 +12,7 @@ namespace Magento\AdminNotification\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Frequency implements \Magento\Framework\Option\ArrayInterface
+class Frequency implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/AdvancedSearch/Model/Adminhtml/Search/Grid/Options.php
+++ b/app/code/Magento/AdvancedSearch/Model/Adminhtml/Search/Grid/Options.php
@@ -11,7 +11,7 @@ namespace Magento\AdvancedSearch\Model\Adminhtml\Search\Grid;
  * @api
  * @since 100.0.2
  */
-class Options implements \Magento\Framework\Option\ArrayInterface
+class Options implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\App\RequestInterface

--- a/app/code/Magento/Analytics/Model/Config/Source/Vertical.php
+++ b/app/code/Magento/Analytics/Model/Config/Source/Vertical.php
@@ -11,7 +11,7 @@ namespace Magento\Analytics\Model\Config\Source;
  * Prepares and provides options for a selector of verticals which is located
  * in the corresponding configuration menu of the Admin area.
  */
-class Vertical implements \Magento\Framework\Option\ArrayInterface
+class Vertical implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * The list of possible verticals.

--- a/app/code/Magento/Authorizenet/Model/Source/PaymentAction.php
+++ b/app/code/Magento/Authorizenet/Model/Source/PaymentAction.php
@@ -3,28 +3,32 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\Authorizenet\Model\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Authorizenet\Model\Authorizenet;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  *
  * Authorize.net Payment Action Dropdown source
  */
-class PaymentAction implements ArrayInterface
+class PaymentAction implements OptionSourceInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
         return [
             [
-                'value' => \Magento\Authorizenet\Model\Authorizenet::ACTION_AUTHORIZE,
+                'value' => Authorizenet::ACTION_AUTHORIZE,
                 'label' => __('Authorize Only'),
             ],
             [
-                'value' => \Magento\Authorizenet\Model\Authorizenet::ACTION_AUTHORIZE_CAPTURE,
+                'value' => Authorizenet::ACTION_AUTHORIZE_CAPTURE,
                 'label' => __('Authorize and Capture')
             ]
         ];

--- a/app/code/Magento/Backup/Model/Config/Source/Type.php
+++ b/app/code/Magento/Backup/Model/Config/Source/Type.php
@@ -12,7 +12,7 @@ namespace Magento\Backup\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Type implements \Magento\Framework\Option\ArrayInterface
+class Type implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Backup data

--- a/app/code/Magento/Backup/Model/Grid/Options.php
+++ b/app/code/Magento/Backup/Model/Grid/Options.php
@@ -15,7 +15,7 @@ namespace Magento\Backup\Model\Grid;
  * @api
  * @since 100.0.2
  */
-class Options implements \Magento\Framework\Option\ArrayInterface
+class Options implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Backup\Helper\Data

--- a/app/code/Magento/Braintree/Model/Adminhtml/Source/Environment.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/Source/Environment.php
@@ -5,12 +5,12 @@
  */
 namespace Magento\Braintree\Model\Adminhtml\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * Class Environment
  */
-class Environment implements ArrayInterface
+class Environment implements OptionSourceInterface
 {
     const ENVIRONMENT_PRODUCTION = 'production';
     const ENVIRONMENT_SANDBOX = 'sandbox';

--- a/app/code/Magento/Braintree/Model/Adminhtml/Source/PaymentAction.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/Source/PaymentAction.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\Braintree\Model\Adminhtml\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 use Magento\Payment\Model\MethodInterface;
 
 /**
  * Class PaymentAction
  */
-class PaymentAction implements ArrayInterface
+class PaymentAction implements OptionSourceInterface
 {
     /**
      * Possible actions on order place

--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/Country.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/Country.php
@@ -6,12 +6,12 @@
 namespace Magento\Braintree\Model\Adminhtml\System\Config;
 
 use Magento\Directory\Model\ResourceModel\Country\Collection;
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * Class Country
  */
-class Country implements ArrayInterface
+class Country implements OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Bundle/Model/Source/Option/Selection/Price/Type.php
+++ b/app/code/Magento/Bundle/Model/Source/Option/Selection/Price/Type.php
@@ -13,7 +13,7 @@ use Magento\Bundle\Api\Data\LinkInterface;
  * @api
  * @since 100.0.2
  */
-class Type implements \Magento\Framework\Option\ArrayInterface
+class Type implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Bundle/Model/Source/Option/Type.php
+++ b/app/code/Magento/Bundle/Model/Source/Option/Type.php
@@ -16,7 +16,7 @@ use Magento\Framework\Api\ExtensionAttributesFactory;
  *
  */
 class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Bundle\Api\Data\OptionTypeInterface
+    \Magento\Bundle\Api\Data\OptionTypeInterface,
     \Magento\Framework\Data\OptionSourceInterface
 {
     /**#@+

--- a/app/code/Magento/Bundle/Model/Source/Option/Type.php
+++ b/app/code/Magento/Bundle/Model/Source/Option/Type.php
@@ -16,8 +16,8 @@ use Magento\Framework\Api\ExtensionAttributesFactory;
  *
  */
 class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Framework\Option\ArrayInterface,
     \Magento\Bundle\Api\Data\OptionTypeInterface
+    \Magento\Framework\Data\OptionSourceInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Captcha/Model/Config/Font.php
+++ b/app/code/Magento/Captcha/Model/Config/Font.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Captcha\Model\Config;
 
-class Font implements \Magento\Framework\Option\ArrayInterface
+class Font implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Captcha data

--- a/app/code/Magento/Captcha/Model/Config/Form/AbstractForm.php
+++ b/app/code/Magento/Captcha/Model/Config/Form/AbstractForm.php
@@ -13,7 +13,7 @@ namespace Magento\Captcha\Model\Config\Form;
 
 use Magento\Framework\App\Config\Value;
 
-abstract class AbstractForm extends Value implements \Magento\Framework\Option\ArrayInterface
+abstract class AbstractForm extends Value implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var string

--- a/app/code/Magento/Captcha/Model/Config/Mode.php
+++ b/app/code/Magento/Captcha/Model/Config/Mode.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Captcha\Model\Config;
 
-class Mode implements \Magento\Framework\Option\ArrayInterface
+class Mode implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Get options for captcha mode selection field

--- a/app/code/Magento/Catalog/Model/Config/Source/Category.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Category.php
@@ -10,7 +10,7 @@ namespace Magento\Catalog\Model\Config\Source;
  *
  * @SuppressWarnings(PHPMD.LongVariable)
  */
-class Category implements \Magento\Framework\Option\ArrayInterface
+class Category implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Category collection factory

--- a/app/code/Magento/Catalog/Model/Config/Source/GridPerPage.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/GridPerPage.php
@@ -10,7 +10,7 @@ namespace Magento\Catalog\Model\Config\Source;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class GridPerPage implements \Magento\Framework\Option\ArrayInterface
+class GridPerPage implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Options

--- a/app/code/Magento/Catalog/Model/Config/Source/LayoutList.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/LayoutList.php
@@ -13,7 +13,7 @@ use Magento\Catalog\Model\Product\Attribute\Source\Layout;
 /**
  * Returns layout list for Web>Default Layouts>Default Product Layout/Default Category Layout
  */
-class LayoutList implements \Magento\Framework\Option\ArrayInterface
+class LayoutList implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Catalog/Model/Config/Source/ListMode.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/ListMode.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Catalog\Model\Config\Source;
 
-class ListMode implements \Magento\Framework\Option\ArrayInterface
+class ListMode implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Catalog/Model/Config/Source/ListPerPage.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/ListPerPage.php
@@ -10,7 +10,7 @@ namespace Magento\Catalog\Model\Config\Source;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class ListPerPage implements \Magento\Framework\Option\ArrayInterface
+class ListPerPage implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Pager Options

--- a/app/code/Magento/Catalog/Model/Config/Source/ListSort.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/ListSort.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Catalog\Model\Config\Source;
 
-class ListSort implements \Magento\Framework\Option\ArrayInterface
+class ListSort implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Catalog config

--- a/app/code/Magento/Catalog/Model/Config/Source/Price/Scope.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Price/Scope.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Catalog\Model\Config\Source\Price;
 
-class Scope implements \Magento\Framework\Option\ArrayInterface
+class Scope implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Catalog/Model/Config/Source/Price/Step.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Price/Step.php
@@ -6,9 +6,9 @@
 namespace Magento\Catalog\Model\Config\Source\Price;
 
 use Magento\Catalog\Model\Layer\Filter\Dynamic\AlgorithmFactory;
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class Step implements ArrayInterface
+class Step implements OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Catalog/Model/Config/Source/Product/Options/Type.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Product/Options/Type.php
@@ -8,7 +8,7 @@ namespace Magento\Catalog\Model\Config\Source\Product\Options;
 /**
  * Product option types mode source
  */
-class Type implements \Magento\Framework\Option\ArrayInterface
+class Type implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Product Option Config

--- a/app/code/Magento/Catalog/Model/Config/Source/Product/Thumbnail.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Product/Thumbnail.php
@@ -9,7 +9,7 @@ namespace Magento\Catalog\Model\Config\Source\Product;
  * Catalog products per page on Grid mode source
  *
  */
-class Thumbnail implements \Magento\Framework\Option\ArrayInterface
+class Thumbnail implements \Magento\Framework\Data\OptionSourceInterface
 {
     const OPTION_USE_PARENT_IMAGE = 'parent';
 

--- a/app/code/Magento/Catalog/Model/Config/Source/TimeFormat.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/TimeFormat.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Catalog\Model\Config\Source;
 
-class TimeFormat implements \Magento\Framework\Option\ArrayInterface
+class TimeFormat implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Catalog/Model/Config/Source/Watermark/Position.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Watermark/Position.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Catalog\Model\Config\Source\Watermark;
 
-class Position implements \Magento\Framework\Option\ArrayInterface
+class Position implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Get available options

--- a/app/code/Magento/CatalogInventory/Model/Source/Backorders.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Backorders.php
@@ -14,7 +14,7 @@ namespace Magento\CatalogInventory\Model\Source;
  * @link https://devdocs.magento.com/guides/v2.3/inventory/index.html
  * @link https://devdocs.magento.com/guides/v2.3/inventory/catalog-inventory-replacements.html
  */
-class Backorders implements \Magento\Framework\Option\ArrayInterface
+class Backorders implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Checkout/Model/Adminhtml/BillingAddressDisplayOptions.php
+++ b/app/code/Magento/Checkout/Model/Adminhtml/BillingAddressDisplayOptions.php
@@ -5,13 +5,13 @@
  */
 namespace Magento\Checkout\Model\Adminhtml;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * BillingAddressDisplayOptions gets list of configuration options for billing address displaying on
  * the Payment step on checkout
  */
-class BillingAddressDisplayOptions implements ArrayInterface
+class BillingAddressDisplayOptions implements OptionSourceInterface
 {
     /**
      * Return array of options for billing address displaying on checkout payment step

--- a/app/code/Magento/Checkout/Model/Config/Source/Cart/Summary.php
+++ b/app/code/Magento/Checkout/Model/Config/Source/Cart/Summary.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Checkout\Model\Config\Source\Cart;
 
-class Summary implements \Magento\Framework\Option\ArrayInterface
+class Summary implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Cms/Model/Config/Source/Page.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Page.php
@@ -10,7 +10,7 @@ use Magento\Cms\Model\ResourceModel\Page\CollectionFactory;
 /**
  * Class Page
  */
-class Page implements \Magento\Framework\Option\ArrayInterface
+class Page implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Cms/Model/Config/Source/Wysiwyg/Editor.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Wysiwyg/Editor.php
@@ -8,7 +8,7 @@ namespace Magento\Cms\Model\Config\Source\Wysiwyg;
 /**
  * Configuration source model for Wysiwyg toggling
  */
-class Editor implements \Magento\Framework\Option\ArrayInterface
+class Editor implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Cms/Model/Config/Source/Wysiwyg/Enabled.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Wysiwyg/Enabled.php
@@ -8,7 +8,7 @@ namespace Magento\Cms\Model\Config\Source\Wysiwyg;
 /**
  * Configuration source model for Wysiwyg toggling
  */
-class Enabled implements \Magento\Framework\Option\ArrayInterface
+class Enabled implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Config/Model/Config/Source/Admin/Page.php
+++ b/app/code/Magento/Config/Model/Config/Source/Admin/Page.php
@@ -11,7 +11,7 @@ namespace Magento\Config\Model\Config\Source\Admin;
  * @api
  * @since 100.0.2
  */
-class Page implements \Magento\Framework\Option\ArrayInterface
+class Page implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Menu model

--- a/app/code/Magento/Config/Model/Config/Source/Date/Short.php
+++ b/app/code/Magento/Config/Model/Config/Source/Date/Short.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Date;
  * @api
  * @since 100.0.2
  */
-class Short implements \Magento\Framework\Option\ArrayInterface
+class Short implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Design/Robots.php
+++ b/app/code/Magento/Config/Model/Config/Source/Design/Robots.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Design;
  * @api
  * @since 100.0.2
  */
-class Robots implements \Magento\Framework\Option\ArrayInterface
+class Robots implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Dev/Dbautoup.php
+++ b/app/code/Magento/Config/Model/Config/Source/Dev/Dbautoup.php
@@ -10,7 +10,7 @@ namespace Magento\Config\Model\Config\Source\Dev;
  * @api
  * @since 100.0.2
  */
-class Dbautoup implements \Magento\Framework\Option\ArrayInterface
+class Dbautoup implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Email/Identity.php
+++ b/app/code/Magento/Config/Model/Config/Source/Email/Identity.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Email;
  * @api
  * @since 100.0.2
  */
-class Identity implements \Magento\Framework\Option\ArrayInterface
+class Identity implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Email Identity options

--- a/app/code/Magento/Config/Model/Config/Source/Email/Method.php
+++ b/app/code/Magento/Config/Model/Config/Source/Email/Method.php
@@ -15,7 +15,7 @@ namespace Magento\Config\Model\Config\Source\Email;
  * @api
  * @since 100.0.2
  */
-class Method implements \Magento\Framework\Option\ArrayInterface
+class Method implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Email/Smtpauth.php
+++ b/app/code/Magento/Config/Model/Config/Source/Email/Smtpauth.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Email;
  * @api
  * @since 100.0.2
  */
-class Smtpauth implements \Magento\Framework\Option\ArrayInterface
+class Smtpauth implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Email/Template.php
+++ b/app/code/Magento/Config/Model/Config/Source/Email/Template.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Email;
  * @api
  * @since 100.0.2
  */
-class Template extends \Magento\Framework\DataObject implements \Magento\Framework\Option\ArrayInterface
+class Template extends \Magento\Framework\DataObject implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\Registry

--- a/app/code/Magento/Config/Model/Config/Source/Enabledisable.php
+++ b/app/code/Magento/Config/Model/Config/Source/Enabledisable.php
@@ -10,7 +10,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Enabledisable implements \Magento\Framework\Option\ArrayInterface
+class Enabledisable implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Value which equal Enable for Enabledisable dropdown.

--- a/app/code/Magento/Config/Model/Config/Source/Image/Adapter.php
+++ b/app/code/Magento/Config/Model/Config/Source/Image/Adapter.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Image;
  * @api
  * @since 100.0.2
  */
-class Adapter implements \Magento\Framework\Option\ArrayInterface
+class Adapter implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\Image\Adapter\ConfigInterface

--- a/app/code/Magento/Config/Model/Config/Source/Locale.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale.php
@@ -13,7 +13,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Locale implements \Magento\Framework\Option\ArrayInterface
+class Locale implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\Locale\ListsInterface

--- a/app/code/Magento/Config/Model/Config/Source/Locale/Country.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale/Country.php
@@ -13,7 +13,7 @@ namespace Magento\Config\Model\Config\Source\Locale;
  * @api
  * @since 100.0.2
  */
-class Country implements \Magento\Framework\Option\ArrayInterface
+class Country implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\Locale\ListsInterface

--- a/app/code/Magento/Config/Model/Config/Source/Locale/Currency.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale/Currency.php
@@ -13,7 +13,7 @@ namespace Magento\Config\Model\Config\Source\Locale;
  * @api
  * @since 100.0.2
  */
-class Currency implements \Magento\Framework\Option\ArrayInterface
+class Currency implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Config/Model/Config/Source/Locale/Currency/All.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale/Currency/All.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Locale\Currency;
  * @api
  * @since 100.0.2
  */
-class All implements \Magento\Framework\Option\ArrayInterface
+class All implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Config/Model/Config/Source/Locale/Timezone.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale/Timezone.php
@@ -13,7 +13,7 @@ namespace Magento\Config\Model\Config\Source\Locale;
  * @api
  * @since 100.0.2
  */
-class Timezone implements \Magento\Framework\Option\ArrayInterface
+class Timezone implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Timezones that works incorrect with php_intl extension

--- a/app/code/Magento/Config/Model/Config/Source/Locale/Weekdaycodes.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale/Weekdaycodes.php
@@ -13,7 +13,7 @@ namespace Magento\Config\Model\Config\Source\Locale;
  * @api
  * @since 100.0.2
  */
-class Weekdaycodes implements \Magento\Framework\Option\ArrayInterface
+class Weekdaycodes implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\Locale\ListsInterface

--- a/app/code/Magento/Config/Model/Config/Source/Locale/Weekdays.php
+++ b/app/code/Magento/Config/Model/Config/Source/Locale/Weekdays.php
@@ -13,7 +13,7 @@ namespace Magento\Config\Model\Config\Source\Locale;
  * @api
  * @since 100.0.2
  */
-class Weekdays implements \Magento\Framework\Option\ArrayInterface
+class Weekdays implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Framework\Locale\ListsInterface

--- a/app/code/Magento/Config/Model/Config/Source/Nooptreq.php
+++ b/app/code/Magento/Config/Model/Config/Source/Nooptreq.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Nooptreq implements \Magento\Framework\Option\ArrayInterface
+class Nooptreq implements \Magento\Framework\Data\OptionSourceInterface
 {
     const VALUE_NO = '';
     const VALUE_OPTIONAL = 'opt';

--- a/app/code/Magento/Config/Model/Config/Source/Reports/Scope.php
+++ b/app/code/Magento/Config/Model/Config/Source/Reports/Scope.php
@@ -15,7 +15,7 @@ namespace Magento\Config\Model\Config\Source\Reports;
  * @api
  * @since 100.0.2
  */
-class Scope implements \Magento\Framework\Option\ArrayInterface
+class Scope implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Scope filter

--- a/app/code/Magento/Config/Model/Config/Source/Store.php
+++ b/app/code/Magento/Config/Model/Config/Source/Store.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Store implements \Magento\Framework\Option\ArrayInterface
+class Store implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Config/Model/Config/Source/Web/Protocol.php
+++ b/app/code/Magento/Config/Model/Config/Source/Web/Protocol.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Web;
  * @api
  * @since 100.0.2
  */
-class Protocol implements \Magento\Framework\Option\ArrayInterface
+class Protocol implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Web/Redirect.php
+++ b/app/code/Magento/Config/Model/Config/Source/Web/Redirect.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source\Web;
  * @api
  * @since 100.0.2
  */
-class Redirect implements \Magento\Framework\Option\ArrayInterface
+class Redirect implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Config/Model/Config/Source/Website.php
+++ b/app/code/Magento/Config/Model/Config/Source/Website.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Website implements \Magento\Framework\Option\ArrayInterface
+class Website implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Config/Model/Config/Source/Website/OptionHash.php
+++ b/app/code/Magento/Config/Model/Config/Source/Website/OptionHash.php
@@ -5,14 +5,14 @@
  */
 namespace Magento\Config\Model\Config\Source\Website;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 use Magento\Store\Model\System\Store;
 
 /**
  * @api
  * @since 100.0.2
  */
-class OptionHash implements ArrayInterface
+class OptionHash implements OptionSourceInterface
 {
     /**
      * System Store Model

--- a/app/code/Magento/Config/Model/Config/Source/Yesno.php
+++ b/app/code/Magento/Config/Model/Config/Source/Yesno.php
@@ -9,7 +9,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Yesno implements \Magento\Framework\Option\ArrayInterface
+class Yesno implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Options getter

--- a/app/code/Magento/Config/Model/Config/Source/Yesnocustom.php
+++ b/app/code/Magento/Config/Model/Config/Source/Yesnocustom.php
@@ -14,7 +14,7 @@ namespace Magento\Config\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Yesnocustom implements \Magento\Framework\Option\ArrayInterface
+class Yesnocustom implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Options getter

--- a/app/code/Magento/Config/Model/Config/SourceFactory.php
+++ b/app/code/Magento/Config/Model/Config/SourceFactory.php
@@ -30,7 +30,7 @@ class SourceFactory
      * Create backend model by name
      *
      * @param string $modelName
-     * @return \Magento\Framework\Option\ArrayInterface
+     * @return \Magento\Framework\Data\OptionSourceInterface
      */
     public function create($modelName)
     {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/FieldTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/FieldTest.php
@@ -308,7 +308,7 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     public function testGetOptionsUsesOptionsInterfaceIfNoMethodIsProvided()
     {
         $this->_model->setData(['source_model' => 'Source_Model_Name'], 'scope');
-        $sourceModelMock = $this->createMock(\Magento\Framework\Option\ArrayInterface::class);
+        $sourceModelMock = $this->createMock(\Magento\Framework\Data\OptionSourceInterface::class);
         $this->_sourceFactoryMock->expects(
             $this->once()
         )->method(

--- a/app/code/Magento/Cron/Model/Config/Source/Frequency.php
+++ b/app/code/Magento/Cron/Model/Config/Source/Frequency.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Cron\Model\Config\Source;
 
-class Frequency implements \Magento\Framework\Option\ArrayInterface
+class Frequency implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Customer/Model/Config/Share.php
+++ b/app/code/Magento/Customer/Model/Config/Share.php
@@ -10,7 +10,7 @@ namespace Magento\Customer\Model\Config;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Share extends \Magento\Framework\App\Config\Value implements \Magento\Framework\Option\ArrayInterface
+class Share extends \Magento\Framework\App\Config\Value implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Xml config path to customers sharing scope value

--- a/app/code/Magento/Customer/Model/Config/Source/Address/Type.php
+++ b/app/code/Magento/Customer/Model/Config/Source/Address/Type.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Customer\Model\Config\Source\Address;
 
-class Type implements \Magento\Framework\Option\ArrayInterface
+class Type implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Retrieve possible customer address types

--- a/app/code/Magento/Customer/Model/Config/Source/Group.php
+++ b/app/code/Magento/Customer/Model/Config/Source/Group.php
@@ -9,7 +9,7 @@ use Magento\Customer\Api\GroupManagementInterface;
 use Magento\Customer\Model\Customer\Attribute\Source\GroupSourceLoggedInOnlyInterface;
 use Magento\Framework\App\ObjectManager;
 
-class Group implements \Magento\Framework\Option\ArrayInterface
+class Group implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Customer/Model/Config/Source/Group/Multiselect.php
+++ b/app/code/Magento/Customer/Model/Config/Source/Group/Multiselect.php
@@ -9,7 +9,7 @@ use Magento\Customer\Model\Customer\Attribute\Source\GroupSourceLoggedInOnlyInte
 use Magento\Customer\Api\GroupManagementInterface;
 use Magento\Framework\App\ObjectManager;
 
-class Multiselect implements \Magento\Framework\Option\ArrayInterface
+class Multiselect implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Customer groups options array

--- a/app/code/Magento/Developer/Model/Config/Source/WorkflowType.php
+++ b/app/code/Magento/Developer/Model/Config/Source/WorkflowType.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Developer\Model\Config\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * Class WorkflowType
@@ -13,7 +13,7 @@ use Magento\Framework\Option\ArrayInterface;
  * @api
  * @since 100.0.2
  */
-class WorkflowType implements ArrayInterface
+class WorkflowType implements OptionSourceInterface
 {
     /**
      * Constant for

--- a/app/code/Magento/Developer/Test/Unit/Model/Config/Source/WorkflowTypeTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Model/Config/Source/WorkflowTypeTest.php
@@ -26,7 +26,7 @@ class WorkflowTypeTest extends \PHPUnit\Framework\TestCase
 
     public function testToOptionArray()
     {
-        $this->assertInstanceOf(\Magento\Framework\Option\ArrayInterface::class, $this->model);
+        $this->assertInstanceOf(\Magento\Framework\Data\OptionSourceInterface::class, $this->model);
         $this->assertCount(2, $this->model->toOptionArray());
         $option = current($this->model->toOptionArray());
 

--- a/app/code/Magento/Dhl/Model/Source/Contenttype.php
+++ b/app/code/Magento/Dhl/Model/Source/Contenttype.php
@@ -8,7 +8,7 @@ namespace Magento\Dhl\Model\Source;
 /**
  * Source model for DHL Content Type
  */
-class Contenttype implements \Magento\Framework\Option\ArrayInterface
+class Contenttype implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Directory/Model/Config/Source/Allregion.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Allregion.php
@@ -11,7 +11,7 @@ namespace Magento\Directory\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Allregion implements \Magento\Framework\Option\ArrayInterface
+class Allregion implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Directory/Model/Config/Source/Country.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Country.php
@@ -11,7 +11,7 @@ namespace Magento\Directory\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Country implements \Magento\Framework\Option\ArrayInterface
+class Country implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Countries

--- a/app/code/Magento/Directory/Model/Config/Source/Country/Full.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Country/Full.php
@@ -13,7 +13,7 @@ namespace Magento\Directory\Model\Config\Source\Country;
  * @codeCoverageIgnore
  * @since 100.0.2
  */
-class Full extends \Magento\Directory\Model\Config\Source\Country implements \Magento\Framework\Option\ArrayInterface
+class Full extends \Magento\Directory\Model\Config\Source\Country implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @inheritdoc

--- a/app/code/Magento/Directory/Model/Config/Source/WeightUnit.php
+++ b/app/code/Magento/Directory/Model/Config/Source/WeightUnit.php
@@ -11,7 +11,7 @@ namespace Magento\Directory\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class WeightUnit implements \Magento\Framework\Option\ArrayInterface
+class WeightUnit implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Directory/Model/Currency/Import/Source/Service.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Source/Service.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Directory\Model\Currency\Import\Source;
 
-class Service implements \Magento\Framework\Option\ArrayInterface
+class Service implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Directory\Model\Currency\Import\Config

--- a/app/code/Magento/Downloadable/Model/System/Config/Source/Contentdisposition.php
+++ b/app/code/Magento/Downloadable/Model/System/Config/Source/Contentdisposition.php
@@ -10,7 +10,7 @@ namespace Magento\Downloadable\Model\System\Config\Source;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Contentdisposition implements \Magento\Framework\Option\ArrayInterface
+class Contentdisposition implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Downloadable/Model/System/Config/Source/Orderitemstatus.php
+++ b/app/code/Magento/Downloadable/Model/System/Config/Source/Orderitemstatus.php
@@ -10,7 +10,7 @@ namespace Magento\Downloadable\Model\System\Config\Source;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Orderitemstatus implements \Magento\Framework\Option\ArrayInterface
+class Orderitemstatus implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
+++ b/app/code/Magento/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Eav\Model\Adminhtml\System\Config\Source;
 
-class Inputtype implements \Magento\Framework\Option\ArrayInterface
+class Inputtype implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
@@ -15,7 +15,7 @@ namespace Magento\Eav\Model\Entity\Attribute\Source;
  */
 abstract class AbstractSource implements
     \Magento\Eav\Model\Entity\Attribute\Source\SourceInterface,
-    \Magento\Framework\Option\ArrayInterface
+    \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Reference to the attribute instance

--- a/app/code/Magento/Fedex/Model/Source/Generic.php
+++ b/app/code/Magento/Fedex/Model/Source/Generic.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Fedex\Model\Source;
 
-class Generic implements \Magento\Framework\Option\ArrayInterface
+class Generic implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Fedex\Model\Carrier

--- a/app/code/Magento/GoogleAdwords/Model/Config/Source/Language.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Source/Language.php
@@ -12,7 +12,7 @@ namespace Magento\GoogleAdwords\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Language implements \Magento\Framework\Option\ArrayInterface
+class Language implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\GoogleAdwords\Helper\Data

--- a/app/code/Magento/GoogleAdwords/Model/Config/Source/ValueType.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Source/ValueType.php
@@ -11,7 +11,7 @@ namespace Magento\GoogleAdwords\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class ValueType implements \Magento\Framework\Option\ArrayInterface
+class ValueType implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Get conversation value type option

--- a/app/code/Magento/ImportExport/Model/Source/Export/Entity.php
+++ b/app/code/Magento/ImportExport/Model/Source/Export/Entity.php
@@ -11,7 +11,7 @@ namespace Magento\ImportExport\Model\Source\Export;
  * @api
  * @since 100.0.2
  */
-class Entity implements \Magento\Framework\Option\ArrayInterface
+class Entity implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\ImportExport\Model\Export\ConfigInterface

--- a/app/code/Magento/ImportExport/Model/Source/Export/Format.php
+++ b/app/code/Magento/ImportExport/Model/Source/Export/Format.php
@@ -11,7 +11,7 @@ namespace Magento\ImportExport\Model\Source\Export;
  * @api
  * @since 100.0.2
  */
-class Format implements \Magento\Framework\Option\ArrayInterface
+class Format implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\ImportExport\Model\Export\ConfigInterface

--- a/app/code/Magento/ImportExport/Model/Source/Import/AbstractBehavior.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/AbstractBehavior.php
@@ -11,7 +11,7 @@ namespace Magento\ImportExport\Model\Source\Import;
  * @api
  * @since 100.0.2
  */
-abstract class AbstractBehavior implements \Magento\Framework\Option\ArrayInterface
+abstract class AbstractBehavior implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Get array of possible values

--- a/app/code/Magento/ImportExport/Model/Source/Import/Entity.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/Entity.php
@@ -11,7 +11,7 @@ namespace Magento\ImportExport\Model\Source\Import;
  * @api
  * @since 100.0.2
  */
-class Entity implements \Magento\Framework\Option\ArrayInterface
+class Entity implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\ImportExport\Model\Import\ConfigInterface

--- a/app/code/Magento/Integration/Model/Integration/Source/Status.php
+++ b/app/code/Magento/Integration/Model/Integration/Source/Status.php
@@ -8,7 +8,7 @@ namespace Magento\Integration\Model\Integration\Source;
 /**
  * Integration status options.
  */
-class Status implements \Magento\Framework\Option\ArrayInterface
+class Status implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Retrieve status options array.

--- a/app/code/Magento/MediaStorage/Model/Config/Source/Storage/Media/Database.php
+++ b/app/code/Magento/MediaStorage/Model/Config/Source/Storage/Media/Database.php
@@ -12,7 +12,7 @@ namespace Magento\MediaStorage\Model\Config\Source\Storage\Media;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 
-class Database implements \Magento\Framework\Option\ArrayInterface
+class Database implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var DeploymentConfig

--- a/app/code/Magento/MediaStorage/Model/Config/Source/Storage/Media/Storage.php
+++ b/app/code/Magento/MediaStorage/Model/Config/Source/Storage/Media/Storage.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\MediaStorage\Model\Config\Source\Storage\Media;
 
-class Storage implements \Magento\Framework\Option\ArrayInterface
+class Storage implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Options getter

--- a/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/GroupOptionHash.php
+++ b/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/GroupOptionHash.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Newsletter\Block\Subscribe\Grid\Options;
 
-class GroupOptionHash implements \Magento\Framework\Option\ArrayInterface
+class GroupOptionHash implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * System Store Model

--- a/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/StoreOptionHash.php
+++ b/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/StoreOptionHash.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Newsletter\Block\Subscribe\Grid\Options;
 
-class StoreOptionHash implements \Magento\Framework\Option\ArrayInterface
+class StoreOptionHash implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * System Store Model

--- a/app/code/Magento/Newsletter/Model/Queue/Options/Status.php
+++ b/app/code/Magento/Newsletter/Model/Queue/Options/Status.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Newsletter\Model\Queue\Options;
 
-class Status implements \Magento\Framework\Option\ArrayInterface
+class Status implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Return statuses option array

--- a/app/code/Magento/OfflineShipping/Model/Config/Source/Flatrate.php
+++ b/app/code/Magento/OfflineShipping/Model/Config/Source/Flatrate.php
@@ -9,7 +9,7 @@ namespace Magento\OfflineShipping\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Flatrate implements \Magento\Framework\Option\ArrayInterface
+class Flatrate implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/OfflineShipping/Model/Config/Source/Tablerate.php
+++ b/app/code/Magento/OfflineShipping/Model/Config/Source/Tablerate.php
@@ -9,7 +9,7 @@ namespace Magento\OfflineShipping\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Tablerate implements \Magento\Framework\Option\ArrayInterface
+class Tablerate implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\OfflineShipping\Model\Carrier\Tablerate

--- a/app/code/Magento/PageCache/Model/System/Config/Source/Application.php
+++ b/app/code/Magento/PageCache/Model/System/Config/Source/Application.php
@@ -9,13 +9,13 @@
  */
 namespace Magento\PageCache\Model\System\Config\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 use Magento\PageCache\Model\Config;
 
 /**
  * Class Application
  */
-class Application implements ArrayInterface
+class Application implements OptionSourceInterface
 {
     /**
      * Options getter

--- a/app/code/Magento/Payment/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Allmethods.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Payment\Model\Config\Source;
 
-class Allmethods implements \Magento\Framework\Option\ArrayInterface
+class Allmethods implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Payment data

--- a/app/code/Magento/Payment/Model/Config/Source/Allspecificcountries.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Allspecificcountries.php
@@ -9,7 +9,7 @@ namespace Magento\Payment\Model\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Allspecificcountries implements \Magento\Framework\Option\ArrayInterface
+class Allspecificcountries implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Payment/Model/Config/Source/Cctype.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Cctype.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Payment\Model\Config\Source;
 
-class Cctype implements \Magento\Framework\Option\ArrayInterface
+class Cctype implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Payment config model

--- a/app/code/Magento/Payment/Model/ResourceModel/Grid/GroupList.php
+++ b/app/code/Magento/Payment/Model/ResourceModel/Grid/GroupList.php
@@ -8,7 +8,7 @@ namespace Magento\Payment\Model\ResourceModel\Grid;
 /**
  * Sales transaction types option array
  */
-class GroupList implements \Magento\Framework\Option\ArrayInterface
+class GroupList implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Payment data

--- a/app/code/Magento/Payment/Model/ResourceModel/Grid/TypeList.php
+++ b/app/code/Magento/Payment/Model/ResourceModel/Grid/TypeList.php
@@ -8,7 +8,7 @@ namespace Magento\Payment\Model\ResourceModel\Grid;
 /**
  * Sales transaction payment method types option array
  */
-class TypeList implements \Magento\Framework\Option\ArrayInterface
+class TypeList implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Payment data

--- a/app/code/Magento/Payment/Model/Source/Cctype.php
+++ b/app/code/Magento/Payment/Model/Source/Cctype.php
@@ -13,7 +13,7 @@ namespace Magento\Payment\Model\Source;
  * @api
  * @since 100.0.2
  */
-class Cctype implements \Magento\Framework\Option\ArrayInterface
+class Cctype implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Allowed CC types

--- a/app/code/Magento/Payment/Model/Source/Invoice.php
+++ b/app/code/Magento/Payment/Model/Source/Invoice.php
@@ -13,7 +13,7 @@ namespace Magento\Payment\Model\Source;
  * @api
  * @since 100.0.2
  */
-class Invoice implements \Magento\Framework\Option\ArrayInterface
+class Invoice implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Paypal/Model/ResourceModel/Report/Settlement/Options/TransactionEvents.php
+++ b/app/code/Magento/Paypal/Model/ResourceModel/Report/Settlement/Options/TransactionEvents.php
@@ -10,7 +10,7 @@ namespace Magento\Paypal\Model\ResourceModel\Report\Settlement\Options;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class TransactionEvents implements \Magento\Framework\Option\ArrayInterface
+class TransactionEvents implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\Report\Settlement\Row

--- a/app/code/Magento/Paypal/Model/System/Config/Source/BuyerCountry.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/BuyerCountry.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for buyer countries supported by PayPal
  */
-class BuyerCountry implements \Magento\Framework\Option\ArrayInterface
+class BuyerCountry implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\ConfigFactory

--- a/app/code/Magento/Paypal/Model/System/Config/Source/FetchingSchedule.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/FetchingSchedule.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for available settlement report fetching intervals
  */
-class FetchingSchedule implements \Magento\Framework\Option\ArrayInterface
+class FetchingSchedule implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Paypal/Model/System/Config/Source/Logo.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/Logo.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for available logo types
  */
-class Logo implements \Magento\Framework\Option\ArrayInterface
+class Logo implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\ConfigFactory

--- a/app/code/Magento/Paypal/Model/System/Config/Source/MerchantCountry.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/MerchantCountry.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for merchant countries supported by PayPal
  */
-class MerchantCountry implements \Magento\Framework\Option\ArrayInterface
+class MerchantCountry implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\ConfigFactory

--- a/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for available payment actions
  */
-class PaymentActions implements \Magento\Framework\Option\ArrayInterface
+class PaymentActions implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\ConfigFactory

--- a/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions/Express.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions/Express.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source\PaymentActions;
 /**
  * Source model for available paypal express payment actions
  */
-class Express implements \Magento\Framework\Option\ArrayInterface
+class Express implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\ConfigFactory

--- a/app/code/Magento/Paypal/Model/System/Config/Source/RequireBillingAddress.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/RequireBillingAddress.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for Require Billing Address
  */
-class RequireBillingAddress implements \Magento\Framework\Option\ArrayInterface
+class RequireBillingAddress implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Paypal\Model\ConfigFactory

--- a/app/code/Magento/Paypal/Model/System/Config/Source/UrlMethod.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/UrlMethod.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Source model for url method: GET/POST
  */
-class UrlMethod implements \Magento\Framework\Option\ArrayInterface
+class UrlMethod implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Paypal/Model/System/Config/Source/Yesnoshortcut.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/Yesnoshortcut.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Model\System\Config\Source;
 /**
  * Used in creating options for Yes|No config value selection
  */
-class Yesnoshortcut implements \Magento\Framework\Option\ArrayInterface
+class Yesnoshortcut implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Options getter

--- a/app/code/Magento/Sales/Model/Config/Source/Order/Status.php
+++ b/app/code/Magento/Sales/Model/Config/Source/Order/Status.php
@@ -14,7 +14,7 @@ namespace Magento\Sales\Model\Config\Source\Order;
  * @api
  * @since 100.0.2
  */
-class Status implements \Magento\Framework\Option\ArrayInterface
+class Status implements \Magento\Framework\Data\OptionSourceInterface
 {
     const UNDEFINED_OPTION_LABEL = '-- Please Select --';
 

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/StatusList.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/StatusList.php
@@ -8,7 +8,7 @@ namespace Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid;
 /**
  * Sales creditmemo statuses option array
  */
-class StatusList implements \Magento\Framework\Option\ArrayInterface
+class StatusList implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Sales\Api\CreditmemoRepositoryInterface

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Invoice/Grid/StatusList.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Invoice/Grid/StatusList.php
@@ -8,7 +8,7 @@ namespace Magento\Sales\Model\ResourceModel\Order\Invoice\Grid;
 /**
  * Sales invoices statuses option array
  */
-class StatusList implements \Magento\Framework\Option\ArrayInterface
+class StatusList implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Sales\Api\InvoiceRepositoryInterface

--- a/app/code/Magento/Sales/Model/ResourceModel/Transaction/Grid/TypeList.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Transaction/Grid/TypeList.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\TransactionRepositoryInterface;
 /**
  * Sales transaction types option array
  */
-class TypeList implements \Magento\Framework\Option\ArrayInterface
+class TypeList implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var TransactionRepositoryInterface

--- a/app/code/Magento/SalesRule/Model/System/Config/Source/Coupon/Format.php
+++ b/app/code/Magento/SalesRule/Model/System/Config/Source/Coupon/Format.php
@@ -10,7 +10,7 @@ namespace Magento\SalesRule\Model\System\Config\Source\Coupon;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Format implements \Magento\Framework\Option\ArrayInterface
+class Format implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Sales rule coupon

--- a/app/code/Magento/Search/Model/Adminhtml/System/Config/Source/Engine.php
+++ b/app/code/Magento/Search/Model/Adminhtml/System/Config/Source/Engine.php
@@ -11,7 +11,7 @@ namespace Magento\Search\Model\Adminhtml\System\Config\Source;
  * @api
  * @since 100.0.2
  */
-class Engine implements \Magento\Framework\Option\ArrayInterface
+class Engine implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Engines list

--- a/app/code/Magento/Security/Model/Config/Source/ResetMethod.php
+++ b/app/code/Magento/Security/Model/Config/Source/ResetMethod.php
@@ -10,7 +10,7 @@ namespace Magento\Security\Model\Config\Source;
  * Source model for setting "Limit Password Reset Requests Method"
  *
  */
-class ResetMethod implements \Magento\Framework\Option\ArrayInterface
+class ResetMethod implements \Magento\Framework\Data\OptionSourceInterface
 {
     const OPTION_BY_IP_AND_EMAIL = 1;
     const OPTION_BY_IP = 2;

--- a/app/code/Magento/SendFriend/Model/Source/Checktype.php
+++ b/app/code/Magento/SendFriend/Model/Source/Checktype.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\SendFriend\Model\Source;
 
-class Checktype implements \Magento\Framework\Option\ArrayInterface
+class Checktype implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Retrieve Check Type Option array

--- a/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Shipping\Model\Config\Source;
 
-class Allmethods implements \Magento\Framework\Option\ArrayInterface
+class Allmethods implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Core store config

--- a/app/code/Magento/Shipping/Model/Config/Source/Allspecificcountries.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allspecificcountries.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Shipping\Model\Config\Source;
 
-class Allspecificcountries implements \Magento\Framework\Option\ArrayInterface
+class Allspecificcountries implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Shipping/Model/Source/HandlingAction.php
+++ b/app/code/Magento/Shipping/Model/Source/HandlingAction.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Shipping\Model\Source;
 
-class HandlingAction implements \Magento\Framework\Option\ArrayInterface
+class HandlingAction implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Shipping/Model/Source/HandlingType.php
+++ b/app/code/Magento/Shipping/Model/Source/HandlingType.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Shipping\Model\Source;
 
-class HandlingType implements \Magento\Framework\Option\ArrayInterface
+class HandlingType implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Sitemap/Model/Config/Source/Frequency.php
+++ b/app/code/Magento/Sitemap/Model/Config/Source/Frequency.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Sitemap\Model\Config\Source;
 
-class Frequency implements \Magento\Framework\Option\ArrayInterface
+class Frequency implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Sitemap/Model/Source/Product/Image/IncludeImage.php
+++ b/app/code/Magento/Sitemap/Model/Source/Product/Image/IncludeImage.php
@@ -14,7 +14,7 @@ namespace Magento\Sitemap\Model\Source\Product\Image;
  * @api
  * @since 100.0.2
  */
-class IncludeImage implements \Magento\Framework\Option\ArrayInterface
+class IncludeImage implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**#@+
      * Add Images into Sitemap possible values

--- a/app/code/Magento/Tax/Model/Config/Source/Apply/On.php
+++ b/app/code/Magento/Tax/Model/Config/Source/Apply/On.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\Config\Source\Apply;
 
-class On implements \Magento\Framework\Option\ArrayInterface
+class On implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Tax/Model/Config/Source/Basedon.php
+++ b/app/code/Magento/Tax/Model/Config/Source/Basedon.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\Config\Source;
 
-class Basedon implements \Magento\Framework\Option\ArrayInterface
+class Basedon implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Tax/Model/Config/Source/Catalog.php
+++ b/app/code/Magento/Tax/Model/Config/Source/Catalog.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\Config\Source;
 
-class Catalog implements \Magento\Framework\Option\ArrayInterface
+class Catalog implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/app/code/Magento/Tax/Model/System/Config/Source/Algorithm.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Algorithm.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\System\Config\Source;
 
-class Algorithm implements \Magento\Framework\Option\ArrayInterface
+class Algorithm implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Tax/Model/System/Config/Source/Apply.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Apply.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\System\Config\Source;
 
-class Apply implements \Magento\Framework\Option\ArrayInterface
+class Apply implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Tax/Model/System/Config/Source/PriceType.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/PriceType.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\System\Config\Source;
 
-class PriceType implements \Magento\Framework\Option\ArrayInterface
+class PriceType implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Tax/Model/System/Config/Source/Tax/Display/Type.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Tax/Display/Type.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Tax\Model\System\Config\Source\Tax\Display;
 
-class Type implements \Magento\Framework\Option\ArrayInterface
+class Type implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var array

--- a/app/code/Magento/Tax/Model/System/Config/Source/Tax/Region.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Tax/Region.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Tax\Model\System\Config\Source\Tax;
 
-class Region implements \Magento\Framework\Option\ArrayInterface
+class Region implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Directory\Model\ResourceModel\Region\CollectionFactory

--- a/app/code/Magento/Theme/Model/Layout/Source/Layout.php
+++ b/app/code/Magento/Theme/Model/Layout/Source/Layout.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Theme\Model\Layout\Source;
 
-class Layout implements \Magento\Framework\Option\ArrayInterface
+class Layout implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Theme\Model\Layout\Config

--- a/app/code/Magento/Translation/Model/Js/Config/Source/Strategy.php
+++ b/app/code/Magento/Translation/Model/Js/Config/Source/Strategy.php
@@ -7,7 +7,7 @@ namespace Magento\Translation\Model\Js\Config\Source;
 
 use Magento\Translation\Model\Js\Config;
 
-class Strategy implements \Magento\Framework\Option\ArrayInterface
+class Strategy implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/UrlRewrite/Model/OptionProvider.php
+++ b/app/code/Magento/UrlRewrite/Model/OptionProvider.php
@@ -7,12 +7,12 @@
  */
 namespace Magento\UrlRewrite\Model;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * @codeCoverageIgnore
  */
-class OptionProvider implements ArrayInterface
+class OptionProvider implements OptionSourceInterface
 {
     /**
      * Permanent redirect code

--- a/app/code/Magento/User/Model/System/Config/Source/Password.php
+++ b/app/code/Magento/User/Model/System/Config/Source/Password.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\User\Model\System\Config\Source;
 
-class Password extends \Magento\Framework\DataObject implements \Magento\Framework\Option\ArrayInterface
+class Password extends \Magento\Framework\DataObject implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Get options for select

--- a/app/code/Magento/Variable/Model/Source/Variables.php
+++ b/app/code/Magento/Variable/Model/Source/Variables.php
@@ -8,7 +8,7 @@ namespace Magento\Variable\Model\Source;
 /**
  * Store Contact Information source model.
  */
-class Variables implements \Magento\Framework\Option\ArrayInterface
+class Variables implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Variable types

--- a/app/code/Magento/Weee/Model/Config/Source/Display.php
+++ b/app/code/Magento/Weee/Model/Config/Source/Display.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Weee\Model\Config\Source;
 
-class Display implements \Magento\Framework\Option\ArrayInterface
+class Display implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Retrieve list of available options to display FPT

--- a/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance/Options/ThemeId.php
+++ b/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance/Options/ThemeId.php
@@ -12,7 +12,7 @@ namespace Magento\Widget\Model\ResourceModel\Widget\Instance\Options;
  * @deprecated 100.2.0 created new class that correctly loads theme options and whose name follows naming convention
  * @see \Magento\Widget\Model\ResourceModel\Widget\Instance\Options\Themes
  */
-class ThemeId implements \Magento\Framework\Option\ArrayInterface
+class ThemeId implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Widget\Model\Widget\Instance

--- a/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance/Options/Types.php
+++ b/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance/Options/Types.php
@@ -9,7 +9,7 @@ namespace Magento\Widget\Model\ResourceModel\Widget\Instance\Options;
 /**
  * Widget Instance Types Options
  */
-class Types implements \Magento\Framework\Option\ArrayInterface
+class Types implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Widget\Model\Widget\Instance

--- a/app/code/Magento/Widget/Model/Widget/Instance/OptionsFactory.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance/OptionsFactory.php
@@ -25,7 +25,7 @@ class OptionsFactory
      *
      * @param string $type
      * @param array $data
-     * @return \Magento\Framework\Option\ArrayInterface
+     * @return \Magento\Framework\Data\OptionSourceInterface
      */
     public function create($type, array $data = [])
     {

--- a/app/code/Magento/Wishlist/Model/Config/Source/Summary.php
+++ b/app/code/Magento/Wishlist/Model/Config/Source/Summary.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Wishlist\Model\Config\Source;
 
-class Summary implements \Magento\Framework\Option\ArrayInterface
+class Summary implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @return array

--- a/lib/internal/Magento/Framework/App/Scope/Source.php
+++ b/lib/internal/Magento/Framework/App/Scope/Source.php
@@ -6,9 +6,9 @@
 namespace Magento\Framework\App\Scope;
 
 use Magento\Framework\App\ScopeResolverPool;
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class Source implements ArrayInterface
+class Source implements OptionSourceInterface
 {
     /**
      * @var ScopeResolverPool

--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -6,7 +6,7 @@
 namespace Magento\Framework\Data;
 
 use Magento\Framework\Data\Collection\EntityFactoryInterface;
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
 /**
  * Data collection
@@ -15,7 +15,7 @@ use Magento\Framework\Option\ArrayInterface;
  *
  * @api
  */
-class Collection implements \IteratorAggregate, \Countable, ArrayInterface, CollectionDataSourceInterface
+class Collection implements \IteratorAggregate, \Countable, OptionSourceInterface, CollectionDataSourceInterface
 {
     const SORT_ORDER_ASC = 'ASC';
 

--- a/lib/internal/Magento/Framework/Option/ArrayInterface.php
+++ b/lib/internal/Magento/Framework/Option/ArrayInterface.php
@@ -7,6 +7,7 @@ namespace Magento\Framework\Option;
 
 /**
  * @todo Remove in favor of the ancestor interface
+ * @deprecated
  */
 interface ArrayInterface extends \Magento\Framework\Data\OptionSourceInterface
 {

--- a/lib/internal/Magento/Framework/Option/ArrayPool.php
+++ b/lib/internal/Magento/Framework/Option/ArrayPool.php
@@ -28,13 +28,15 @@ class ArrayPool
      *
      * @param string $model
      * @throws \InvalidArgumentException
-     * @return \Magento\Framework\Option\ArrayInterface
+     * @return \Magento\Framework\Data\OptionSourceInterface
      */
     public function get($model)
     {
         $modelInstance = $this->_objectManager->get($model);
-        if (false == $modelInstance instanceof \Magento\Framework\Option\ArrayInterface) {
-            throw new \InvalidArgumentException($model . 'doesn\'t implement \Magento\Framework\Option\ArrayInterface');
+        if (false == $modelInstance instanceof \Magento\Framework\Data\OptionSourceInterface) {
+            throw new \InvalidArgumentException(
+                $model . 'doesn\'t implement \Magento\Framework\Data\OptionSourceInterface'
+            );
         }
         return $modelInstance;
     }

--- a/lib/internal/Magento/Framework/Option/README.md
+++ b/lib/internal/Magento/Framework/Option/README.md
@@ -1,1 +1,1 @@
-This module is used to create option values in models to value-label pairs that are used in forms. The model must implement Magento\Framework\Option\ArrayInterface or an exception will be thrown.
+This module is used to create option values in models to value-label pairs that are used in forms. The model must implement Magento\Framework\Data\OptionSourceInterface or an exception will be thrown.

--- a/lib/internal/Magento/Framework/View/Design/Theme/Label.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/Label.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\Framework\View\Design\Theme;
 
-class Label implements \Magento\Framework\Option\ArrayInterface
+class Label implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * Labels collection array

--- a/lib/internal/Magento/Framework/View/Design/Theme/Label/Options.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/Label/Options.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Framework\View\Design\Theme\Label;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 
-class Options implements ArrayInterface
+class Options implements OptionSourceInterface
 {
     /**
      * @var ListInterface


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

> lib\internal\Magento\Framework\Option\ArrayInterface.php

```
/**
 * @todo Remove in favor of the ancestor interface
 */
interface ArrayInterface extends \Magento\Framework\Data\OptionSourceInterface
```

Replaced all occurrences and marked ArrayInterface as deprecated.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. n/a

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. n/a

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
