### PR TITLE
Framework Escaper - remove direct Object Manager usage

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -47,7 +47,6 @@ class Escaper
     private $escapeAsUrlAttributes = ['href'];
 
     /**
-     * Escaper constructor.
      * @param \Magento\Framework\ZendEscaper|null $escaper
      * @param \Psr\Log\LoggerInterface|null $logger
      */

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -47,6 +47,21 @@ class Escaper
     private $escapeAsUrlAttributes = ['href'];
 
     /**
+     * Escaper constructor.
+     * @param \Magento\Framework\ZendEscaper|null $escaper
+     * @param \Psr\Log\LoggerInterface|null $logger
+     */
+    public function __construct(
+        \Magento\Framework\ZendEscaper $escaper = null,
+        \Psr\Log\LoggerInterface $logger = null
+    ) {
+        $this->escaper = $escaper ?? \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Framework\ZendEscaper::class);
+        $this->logger = $logger ?? \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Psr\Log\LoggerInterface::class);
+    }
+
+    /**
      * Escape string for HTML context.
      *
      * AllowedTags will not be escaped, except the following: script, img, embed,
@@ -84,7 +99,7 @@ class Escaper
                     );
                 } catch (\Exception $e) {
                     restore_error_handler();
-                    $this->getLogger()->critical($e);
+                    $this->logger->critical($e);
                 }
                 restore_error_handler();
 
@@ -201,7 +216,7 @@ class Escaper
     public function escapeHtmlAttr($string, $escapeSingleQuote = true)
     {
         if ($escapeSingleQuote) {
-            return $this->getEscaper()->escapeHtmlAttr((string) $string);
+            return $this->escaper->escapeHtmlAttr((string) $string);
         }
         return htmlspecialchars((string)$string, ENT_COMPAT, 'UTF-8', false);
     }
@@ -226,7 +241,7 @@ class Escaper
      */
     public function encodeUrlParam($string)
     {
-        return $this->getEscaper()->escapeUrl($string);
+        return $this->escaper->escapeUrl($string);
     }
 
     /**
@@ -265,7 +280,7 @@ class Escaper
      */
     public function escapeCss($string)
     {
-        return $this->getEscaper()->escapeCss($string);
+        return $this->escaper->escapeCss($string);
     }
 
     /**
@@ -341,36 +356,6 @@ class Escaper
     }
 
     /**
-     * Get escaper
-     *
-     * @return \Magento\Framework\ZendEscaper
-     * @deprecated 100.2.0
-     */
-    private function getEscaper()
-    {
-        if ($this->escaper == null) {
-            $this->escaper = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Framework\ZendEscaper::class);
-        }
-        return $this->escaper;
-    }
-
-    /**
-     * Get logger
-     *
-     * @return \Psr\Log\LoggerInterface
-     * @deprecated 100.2.0
-     */
-    private function getLogger()
-    {
-        if ($this->logger == null) {
-            $this->logger = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Psr\Log\LoggerInterface::class);
-        }
-        return $this->logger;
-    }
-
-    /**
      * Filter prohibited tags.
      *
      * @param string[] $allowedTags
@@ -384,7 +369,7 @@ class Escaper
         );
 
         if (!empty($notAllowedTags)) {
-            $this->getLogger()->critical(
+            $this->logger->critical(
                 'The following tag(s) are not allowed: ' . implode(', ', $notAllowedTags)
             );
             $allowedTags = array_diff($allowedTags, $this->notAllowedTags);

--- a/lib/internal/Magento/Framework/Filter/Test/Unit/StripTagsTest.php
+++ b/lib/internal/Magento/Framework/Filter/Test/Unit/StripTagsTest.php
@@ -12,7 +12,8 @@ class StripTagsTest extends \PHPUnit\Framework\TestCase
      */
     public function testStripTags()
     {
-        $stripTags = new \Magento\Framework\Filter\StripTags(new \Magento\Framework\Escaper());
+        $escaper = $this->createMock(\Magento\Framework\Escaper::class);
+        $stripTags = new \Magento\Framework\Filter\StripTags($escaper);
         $this->assertEquals('three', $stripTags->filter('<two>three</two>'));
     }
 }

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -30,12 +30,9 @@ class EscaperTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->escaper = new Escaper();
         $this->zendEscaper = new \Magento\Framework\ZendEscaper();
         $this->loggerMock = $this->getMockForAbstractClass(\Psr\Log\LoggerInterface::class);
-        $objectManagerHelper = new ObjectManager($this);
-        $objectManagerHelper->setBackwardCompatibleProperty($this->escaper, 'escaper', $this->zendEscaper);
-        $objectManagerHelper->setBackwardCompatibleProperty($this->escaper, 'logger', $this->loggerMock);
+        $this->escaper = new Escaper($this->zendEscaper, $this->loggerMock);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -141,7 +141,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $modelProperty->setValue($model, $this->urlModifier);
 
         $zendEscaper = new \Magento\Framework\ZendEscaper();
-        $escaper = new \Magento\Framework\Escaper();
+        $escaper = $objectManager->getObject(\Magento\Framework\Escaper::class);
         $objectManager->setBackwardCompatibleProperty($escaper, 'escaper', $zendEscaper);
         $objectManager->setBackwardCompatibleProperty($model, 'escaper', $escaper);
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes direct ObjectManager calls from ```\Magento\Framework\Escaper```. Additionally, it allows for injecting different implementations of ```\Psr\Log\LoggerInterface``` via the constructor.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
