### PR TITLE
[Forwardport] Issue #19205 Fixed: Bundle Product Option with input type is checkbox and add to cart with 3 values only 2 values added to cart.

### DIFF
--- a/app/code/Magento/Bundle/Model/Product/Type.php
+++ b/app/code/Magento/Bundle/Model/Product/Type.php
@@ -827,7 +827,7 @@ class Type extends \Magento\Catalog\Model\Product\Type\AbstractType
             if (is_array($value)) {
                 $flatArray = array_merge($flatArray, $this->multiToFlatArray($value));
             } else {
-                $flatArray[$key] = $value;
+                $flatArray[] = $value;
             }
         }
 

--- a/app/code/Magento/Bundle/Model/Product/Type.php
+++ b/app/code/Magento/Bundle/Model/Product/Type.php
@@ -823,7 +823,7 @@ class Type extends \Magento\Catalog\Model\Product\Type\AbstractType
     private function multiToFlatArray(array $array)
     {
         $flatArray = [];
-        foreach ($array as $key => $value) {
+        foreach ($array as $value) {
             if (is_array($value)) {
                 $flatArray = array_merge($flatArray, $this->multiToFlatArray($value));
             } else {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19260
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
All selections of a bundle option of type check box that were checked once are added to cart -- not all selected values displaying in cart. Now fixed in this PL

### Description (*)
While adding Bundle Product having option type checkbox with 3 or more values, and other Bundle option having single value, to the Cart. It was only adding 2 product for first selection. Not its fixed.

### Fixed Issues (if relevant)

1. #19205 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Added a product having option type checkbox with 3 or more values, and other Bundle option having single value, to the Cart. Working
2. Created a new Bundle Product and checked by Adding to the cart.
3. Run the unit test command for Bundle Module, its also passed

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
