### PR TITLE
[Forwardport] Fixed child items showing on My Account order view

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Items.php
@@ -71,7 +71,6 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
 
         $this->itemCollection = $this->itemCollectionFactory->create();
         $this->itemCollection->setOrderFilter($this->getOrder());
-        $this->itemCollection->filterByParent(null);
 
         /** @var \Magento\Theme\Block\Html\Pager $pagerBlock */
         $pagerBlock = $this->getChildBlock('sales_order_item_pager');


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/17889
### Description
On an attempt to view an order on My Account -> My Orders -> View Order page bundle products are displayed without child items. It's an expected behavior since on the Print Order (invoice and shipment as well) a customer is able to see children items of a bundle product. 

On building pagination logic for ordered items, the children items were excluded from the list (accidentally or for a purpose). This PR removes this step so all children products are displayed on the order view page (so we have the same behavior everywhere: on the order view page, print pages etc). As for the pagination, after the fix, it counts all products: parent and child upon building the products count and pages. However, it's not an issue since bundle products with the child items make a quite long list of information and it's a good idea to use pagination in that case. 

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/16434: Bundle Product Options not showing in Customer Account - Items Ordered

### Manual testing scenarios
1. Clean Magento installation from 2.2-develop branch with sample data installed.
2. Customize and buy "Sprite Yoga Companion Kit" bundle product as a logged in customer.
3. Go to My Account -> My Orders and view the recent order.
4. You should see information about the child items of the bundle product
