### PR TITLE
Fixed configurable product widget issue

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_default_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_default_list.phtml
@@ -33,7 +33,7 @@
                                 <div class="product-item-actions">
                                     <div class="actions-primary">
                                         <?php if ($_product->isSaleable()): ?>
-                                            <?php if ($_product->getTypeInstance()->hasRequiredOptions($_product)): ?>
+                                            <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
                                                 <button type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>"
                                                         class="action tocart primary"
                                                         data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_product) ?>"}}'>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_default_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_default_list.phtml
@@ -33,7 +33,7 @@
                                 <div class="product-item-actions">
                                     <div class="actions-primary">
                                         <?php if ($_product->isSaleable()): ?>
-                                            <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
+                                            <?php if (!$_product->getTypeInstance()->isPossibleBuyFromList($_product)): ?>
                                                 <button type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>"
                                                         class="action tocart primary"
                                                         data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_product) ?>"}}'>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -66,7 +66,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                         <?php if ($showCart): ?>
                                             <div class="actions-primary">
                                                 <?php if ($_item->isSaleable()): ?>
-                                                    <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)): ?>
+                                                    <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
                                                         <button class="action tocart primary"
                                                                 data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_item) ?>"}}'
                                                                 type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
@@ -65,7 +65,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                             <?php if ($showCart): ?>
                                                 <div class="actions-primary">
                                                     <?php if ($_item->isSaleable()): ?>
-                                                        <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)): ?>
+                                                        <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
                                                             <button class="action tocart primary"
                                                                     data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_item) ?>"}}'
                                                                     type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">

--- a/app/code/Magento/CatalogWidget/view/frontend/templates/product/widget/content/grid.phtml
+++ b/app/code/Magento/CatalogWidget/view/frontend/templates/product/widget/content/grid.phtml
@@ -61,7 +61,7 @@
                                         <?php if ($showCart): ?>
                                             <div class="actions-primary">
                                                 <?php if ($_item->isSaleable()): ?>
-                                                    <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)): ?>
+                                                    <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
                                                         <button class="action tocart primary" data-mage-init='{"redirectUrl":{"url":"<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}' type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
                                                             <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
                                                         </button>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixed issue configurable products in widgets.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19315: Issue with configurable products in widgets, not added to cart

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Create a product attribute, for example Size with several values (S, M and L). This attribute must have property "use in product listing" set to Yes.
2. Create a product that uses this attribute with a configuration setting. Define different quantities for each values. Set this product as new for the current month.
3. Create a block with a widget for new products (choose the grid template) and add this block at any page.
4. On this page click on Add to cart for this new product.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
