### PR TITLE
correct param, var and return annotation values

### DIFF
--- a/lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php
+++ b/lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php
@@ -17,7 +17,7 @@ class ResourceLoader implements \Magento\Framework\Acl\LoaderInterface
     /**
      * Acl resource config
      *
-     * @var ProviderInterface $resourceProvider
+     * @var ProviderInterface
      */
     protected $_resourceProvider;
 

--- a/lib/internal/Magento/Framework/Amqp/Queue.php
+++ b/lib/internal/Magento/Framework/Amqp/Queue.php
@@ -37,7 +37,7 @@ class Queue implements QueueInterface
     private $envelopeFactory;
 
     /**
-     * @var LoggerInterface $logger
+     * @var LoggerInterface
      */
     private $logger;
 

--- a/lib/internal/Magento/Framework/Api/SearchCriteria/CollectionProcessor/JoinProcessor.php
+++ b/lib/internal/Magento/Framework/Api/SearchCriteria/CollectionProcessor/JoinProcessor.php
@@ -28,7 +28,7 @@ class JoinProcessor implements CollectionProcessorInterface
     private $appliedFields = [];
 
     /**
-     * @param CustomJoinInterface[] $customFilters
+     * @param CustomJoinInterface[] $customJoins
      * @param array $fieldMapping
      */
     public function __construct(

--- a/lib/internal/Magento/Framework/Api/Test/Unit/ExtensionAttribute/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/ExtensionAttribute/Config/SchemaLocatorTest.php
@@ -15,7 +15,7 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $model;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/App/ResourceConnection.php
+++ b/lib/internal/Magento/Framework/App/ResourceConnection.php
@@ -53,7 +53,7 @@ class ResourceConnection
     protected $connectionFactory;
 
     /**
-     * @var DeploymentConfig $deploymentConfig
+     * @var DeploymentConfig
      */
     private $deploymentConfig;
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpTest.php
@@ -246,8 +246,8 @@ class HttpTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param $serverVariables array
-     * @param $expectedResult string
+     * @param array $serverVariables
+     * @param string $expectedResult
      * @dataProvider serverVariablesProvider
      */
     public function testGetDistroBaseUrl($serverVariables, $expectedResult)
@@ -374,7 +374,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider httpSafeMethodProvider
      * @backupGlobals enabled
-     * @param string $method value of $_SERVER['REQUEST_METHOD']
+     * @param string $httpMethod value of $_SERVER['REQUEST_METHOD']
      */
     public function testIsSafeMethodTrue($httpMethod)
     {
@@ -386,7 +386,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider httpNotSafeMethodProvider
      * @backupGlobals enabled
-     * @param string $method value of $_SERVER['REQUEST_METHOD']
+     * @param string $httpMethod value of $_SERVER['REQUEST_METHOD']
      */
     public function testIsSafeMethodFalse($httpMethod)
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/ResourceConnection/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ResourceConnection/Config/SchemaLocatorTest.php
@@ -13,7 +13,7 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $model;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/App/Test/Unit/Route/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Route/Config/SchemaLocatorTest.php
@@ -12,10 +12,10 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $config;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolverMock;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/App/Utility/Classes.php
+++ b/lib/internal/Magento/Framework/App/Utility/Classes.php
@@ -236,7 +236,7 @@ class Classes
     /**
      * Check if instance is virtual type
      *
-     * @param $className string
+     * @param string $className
      * @return bool
      */
     public static function isVirtual($className)

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/Decorator/DecoratorAbstractTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/Decorator/DecoratorAbstractTest.php
@@ -54,7 +54,7 @@ class DecoratorAbstractTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param array options
+     * @param array $options
      * @expectedException \Zend_Cache_Exception
      * @dataProvider constructorExceptionDataProvider
      */

--- a/lib/internal/Magento/Framework/Composer/ComposerJsonFinder.php
+++ b/lib/internal/Magento/Framework/Composer/ComposerJsonFinder.php
@@ -13,7 +13,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ComposerJsonFinder
 {
     /**
-     * @var DirectoryList $directoryList
+     * @var DirectoryList
      */
     private $directoryList;
 

--- a/lib/internal/Magento/Framework/Config/Test/Unit/ThemeTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/ThemeTest.php
@@ -7,10 +7,10 @@ namespace Magento\Framework\Config\Test\Unit;
 
 class ThemeTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolverMock;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/AggregatedTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/AggregatedTest.php
@@ -98,9 +98,9 @@ class AggregatedTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider getFilesDataProvider
      *
-     * @param $libraryFiles array Files in lib directory
-     * @param $baseFiles array Files in base directory
-     * @param $themeFiles array Files in theme
+     * @param array $libraryFiles Files in lib directory
+     * @param array $baseFiles Files in base directory
+     * @param array $themeFiles Files in theme
      * *
      * @return void
      */

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/LibraryTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/LibraryTest.php
@@ -129,8 +129,8 @@ class LibraryTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider getFilesDataProvider
      *
-     * @param $libraryFiles array Files in lib directory
-     * @param $themeFiles array Files in theme
+     * @param array $libraryFiles Files in lib directory
+     * @param array $themeFiles Files in theme
      * *
      * @return void
      */

--- a/lib/internal/Magento/Framework/DataObject/Copy.php
+++ b/lib/internal/Magento/Framework/DataObject/Copy.php
@@ -123,7 +123,7 @@ class Copy
      * @param string $aspect a field name
      * @param array|\Magento\Framework\DataObject $source
      * @param string $root
-     * @return array $data
+     * @return array
      *
      * @api
      */
@@ -232,7 +232,7 @@ class Copy
     /**
      * Access the extension get method
      *
-     * @param \Magento\Framework\Api\ExtensibleDataInterface $object
+     * @param \Magento\Framework\Api\ExtensibleDataInterface $source
      * @param string $code
      *
      * @return mixed
@@ -265,7 +265,7 @@ class Copy
     /**
      * Access the extension set method
      *
-     * @param \Magento\Framework\Api\ExtensibleDataInterface $object
+     * @param \Magento\Framework\Api\ExtensibleDataInterface $target
      * @param string $code
      * @param mixed $value
      *

--- a/lib/internal/Magento/Framework/EntityManager/Test/Unit/TypeResolverTest.php
+++ b/lib/internal/Magento/Framework/EntityManager/Test/Unit/TypeResolverTest.php
@@ -32,7 +32,7 @@ class TypeResolverTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param object $dataObject
-     * @param string $interfaceNames
+     * @param string $interfaceName
      * @dataProvider resolveDataProvider
      */
     public function testResolve($dataObject, $interfaceName)

--- a/lib/internal/Magento/Framework/Event/Test/Unit/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/Event/Test/Unit/Config/SchemaLocatorTest.php
@@ -12,10 +12,10 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $model;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolverMock;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/Exception/BulkException.php
+++ b/lib/internal/Magento/Framework/Exception/BulkException.php
@@ -39,7 +39,7 @@ class BulkException extends AbstractAggregateException
     }
 
     /**
-     * @param $data array
+     * @param array $data
      */
     public function addData($data)
     {

--- a/lib/internal/Magento/Framework/File/Mime.php
+++ b/lib/internal/Magento/Framework/File/Mime.php
@@ -61,7 +61,7 @@ class Mime
     /**
      * List of mime types that can be defined by file extension.
      *
-     * @var array $defineByExtensionList
+     * @var array
      */
     private $defineByExtensionList = [
         'txt'  => 'text/plain',

--- a/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
@@ -17,7 +17,7 @@ class Sftp extends AbstractIo
     const SSH2_PORT = 22;
 
     /**
-     * @var \phpseclib\Net\SFTP $_connection
+     * @var \phpseclib\Net\SFTP
      */
     protected $_connection = null;
 

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/Config/SchemaLocatorTest.php
@@ -13,10 +13,10 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $model;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolverMock;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/Lock/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Lock/Backend/Database.php
@@ -139,7 +139,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      * Limited to 64 characters in MySQL.
      *
      * @param string $name
-     * @return string $name
+     * @return string
      * @throws InputException
      */
     private function addPrefix(string $name): string

--- a/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/DatabaseTest.php
+++ b/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/DatabaseTest.php
@@ -32,7 +32,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
     private $objectManager;
 
     /**
-     * @var Database $database
+     * @var Database
      */
     private $database;
 

--- a/lib/internal/Magento/Framework/Logger/Handler/Base.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/Base.php
@@ -73,7 +73,7 @@ class Base extends StreamHandler
     /**
      * {@inheritDoc}
      *
-     * @param $record array
+     * @param array $record
      *
      * @return void
      */

--- a/lib/internal/Magento/Framework/Logger/Handler/System.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/System.php
@@ -43,7 +43,7 @@ class System extends Base
     /**
      * Writes formatted record through the handler.
      *
-     * @param $record array The record metadata
+     * @param array $record The record metadata
      * @return void
      */
     public function write(array $record)

--- a/lib/internal/Magento/Framework/Message/Manager.php
+++ b/lib/internal/Magento/Framework/Message/Manager.php
@@ -67,7 +67,7 @@ class Manager implements ManagerInterface
      * @param Event\ManagerInterface $eventManager
      * @param LoggerInterface $logger
      * @param string $defaultGroup
-     * @param ExceptionMessageFactoryInterface|null exceptionMessageFactory
+     * @param ExceptionMessageFactoryInterface|null $exceptionMessageFactory exceptionMessageFactory
      */
     public function __construct(
         Session $session,

--- a/lib/internal/Magento/Framework/Message/Manager.php
+++ b/lib/internal/Magento/Framework/Message/Manager.php
@@ -67,7 +67,7 @@ class Manager implements ManagerInterface
      * @param Event\ManagerInterface $eventManager
      * @param LoggerInterface $logger
      * @param string $defaultGroup
-     * @param ExceptionMessageFactoryInterface|null $exceptionMessageFactory exceptionMessageFactory
+     * @param ExceptionMessageFactoryInterface|null $exceptionMessageFactory
      */
     public function __construct(
         Session $session,

--- a/lib/internal/Magento/Framework/Model/AbstractModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractModel.php
@@ -42,7 +42,7 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
 
     /**
      * Data changes flag (true after setData|unsetData call)
-     * @var $_hasDataChange bool
+     * @var bool
      */
     protected $_hasDataChanges = false;
 

--- a/lib/internal/Magento/Framework/Module/Setup/Context.php
+++ b/lib/internal/Magento/Framework/Module/Setup/Context.php
@@ -107,7 +107,7 @@ class Context implements \Magento\Framework\ObjectManager\ContextInterface
     }
 
     /**
-     * @return \Psr\Log\LoggerInterface $logger
+     * @return \Psr\Log\LoggerInterface
      */
     public function getLogger()
     {

--- a/lib/internal/Magento/Framework/ObjectManager/Profiler/Log.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Profiler/Log.php
@@ -11,7 +11,7 @@ use Magento\Framework\ObjectManager\Profiler\Tree\Item as Item;
 class Log
 {
     /**
-     * @var $this
+     * @var self
      */
     protected static $instance;
 

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/SchemaLocatorTest.php
@@ -12,10 +12,10 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $model;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolver;
 
-    /** @var \Magento\Framework\Config\Dom\UrnResolver $urnResolverMock */
+    /** @var \Magento\Framework\Config\Dom\UrnResolver */
     protected $urnResolverMock;
 
     protected function setUp()

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/Filter/BuilderTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/Filter/BuilderTest.php
@@ -29,7 +29,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
     private $preprocessor;
 
     /**
-     * @var ConditionManager|\PHPUnit_Framework_MockObject_MockObject $conditionManager
+     * @var ConditionManager|\PHPUnit_Framework_MockObject_MockObject
      */
     private $conditionManager;
 

--- a/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
@@ -143,7 +143,7 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
     /**
      * Deployment config
      *
-     * @var DeploymentConfig $deploymentConfig
+     * @var DeploymentConfig
      */
     private $deploymentConfig;
 

--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -149,8 +149,8 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param $httpHost string
-     * @param $url string
+     * @param string $httpHost
+     * @param string $url
      * @dataProvider getCurrentUrlProvider
      */
     public function testGetCurrentUrl($httpHost, $url)
@@ -435,7 +435,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param string $url
+     * @param string $inputUrl
      * @dataProvider getRebuiltUrlDataProvider
      */
     public function testGetRebuiltUrl($inputUrl, $outputUrl)

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -60,7 +60,7 @@ class Translate implements \Magento\Framework\TranslateInterface
     protected $_viewDesign;
 
     /**
-     * @var \Magento\Framework\Cache\FrontendInterface $cache
+     * @var \Magento\Framework\Cache\FrontendInterface
      */
     protected $_cache;
 

--- a/lib/internal/Magento/Framework/Translate/Inline/ParserInterface.php
+++ b/lib/internal/Magento/Framework/Translate/Inline/ParserInterface.php
@@ -43,7 +43,7 @@ interface ParserInterface
     /**
      * Sets the body content that is being parsed passed upon the passed in string.
      *
-     * @param $content string
+     * @param string $content
      * @return void
      */
     public function setContent($content);

--- a/lib/internal/Magento/Framework/View/Design/Theme/ThemeList.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/ThemeList.php
@@ -40,7 +40,7 @@ class ThemeList extends \Magento\Framework\Data\Collection implements ListInterf
     protected $_itemObjectClass = ThemeInterface::class;
 
     /**
-     * @var \Magento\Framework\Config\ThemeFactory $themeConfigFactory
+     * @var \Magento\Framework\Config\ThemeFactory
      */
     protected $themeConfigFactory;
 

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Config/DomMerger.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Config/DomMerger.php
@@ -341,7 +341,7 @@ class DomMerger implements DomMergerInterface
      * Validate dom document
      *
      * @param \DOMDocument $domDocument
-     * @param string|null $schemaFilePath
+     * @param string|null $schema
      * @return array of errors
      * @throws \Exception
      */

--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -195,7 +195,7 @@ class ErrorProcessor
      * Log information about exception to exception log.
      *
      * @param \Exception $exception
-     * @return string $reportId
+     * @return string
      */
     protected function _critical(\Exception $exception)
     {


### PR DESCRIPTION
This PR correct malformed annotations:

- switched `$type name`
- typos
- $this to `self` that is recognized type by IDE
- remove unused `$value` in `@var` and `@return` annotations
