### PR TITLE
[Backport] small performance improvement on product listing

### DIFF
--- a/app/code/Magento/Review/Model/Review.php
+++ b/app/code/Magento/Review/Model/Review.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Review\Model;
 
+use Magento\Framework\DataObject;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Review\Model\ResourceModel\Review\Product\Collection as ProductCollection;
@@ -326,6 +327,9 @@ class Review extends \Magento\Framework\Model\AbstractModel implements IdentityI
                 if ($summary->getEntityPkValue() == $item->getEntityId()) {
                     $item->setRatingSummary($summary);
                 }
+            }
+            if (!$item->getRatingSummary()) {
+                $item->setRatingSummary(new DataObject());
             }
         }
 


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/18773

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Get rid of unnecessary reviews queries on product listing:
"select review_entity_summary.* from review_entity_summary where (review_entity_summary.entity_pk_value = ?) and (store_id = ?)" 
This query was executed for each product on listing which didn't have a review summary(@see: `Magento\Review\Model\Review::appendSummary` and `Magento\Review\Block\Product\ReviewRenderer::getReviewsSummaryHtml`)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use a profiler(e.g. blackfire)
2. Go to any product listing page(category page)
3. After profiling the product listing page you should notice that for each product which doesn't have a review an additional sql query is executed: "select review_entity_summary.* from review_entity_summary where (review_entity_summary.entity_pk_value = ?) and (store_id = ?)"

E.g.: if on your product listing page you are listing 20 products, and 3 products have reviews, you will see 17 x "select review_entity_summary.* from review_entity_summary where (review_entity_summary.entity_pk_value = ?) and (store_id = ?)"

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
