### PR TITLE
[Backport] missing use statement in layout generator

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -273,7 +273,7 @@ class Block implements Layout\GeneratorInterface
             }
         }
         if (!$block instanceof \Magento\Framework\View\Element\AbstractBlock) {
-            throw new \Magento\Framework\Exception\LocalizedException(
+            throw new LocalizedException(
                 new \Magento\Framework\Phrase(
                     'Invalid block type: %1',
                     [is_object($block) ? get_class($block) : (string) $block]

--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\View\Layout\Generator;
 
 use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManager\Config\Reader\Dom;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Layout;


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/19009

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
--> 
Simple change. LocalizedException was used in class \Magento\Framework\View\Layout\Generator\Block, but it were missing in use section. It were not causing any fatal errors because of the way how it was used in method \Magento\Framework\View\Layout\Generator\Block::handleRenderException:
```
 $message = ($cause instanceof LocalizedException) ? $cause->getLogMessage() : $cause->getMessage();
```


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.force any block to throw LocalizedException during generation, and check error message in logs. It ought to be message from the \Magento\Framework\Exception\LocalizedException::getLogMessage method

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
