### PR TITLE
[Forwardport] Cart-Sales-Rule-with-negated-condition-over-special-price-does-not-work-for-configurable-products. Use configurable product`s children for shopping cart rules validation for cases when attribute exists for children only (E.g. special_price)

### DIFF
--- a/app/code/Magento/CatalogWidget/Test/Unit/Model/Rule/Condition/ProductTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Model/Rule/Condition/ProductTest.php
@@ -9,6 +9,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.LongVariable)
  */
 class ProductTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/ConfigurableProduct/Plugin/SalesRule/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/SalesRule/Model/Rule/Condition/Product.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ConfigurableProduct\Plugin\SalesRule\Model\Rule\Condition;
+
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+
+/**
+ * Class Product
+ *
+ * @package Magento\ConfigurableProduct\Plugin\SalesRule\Model\Rule\Condition
+ */
+class Product
+{
+    /**
+     * Prepare configurable product for validation.
+     *
+     * @param \Magento\SalesRule\Model\Rule\Condition\Product $subject
+     * @param \Magento\Framework\Model\AbstractModel $model
+     * @return array
+     */
+    public function beforeValidate(
+        \Magento\SalesRule\Model\Rule\Condition\Product $subject,
+        \Magento\Framework\Model\AbstractModel $model
+    ) {
+        $product = $this->getProductToValidate($subject, $model);
+        if ($model->getProduct() !== $product) {
+            // We need to replace product only for validation and keep original product for all other cases.
+            $clone = clone $model;
+            $clone->setProduct($product);
+            $model = $clone;
+        }
+
+        return [$model];
+    }
+
+    /**
+     * Select proper product for validation.
+     *
+     * @param \Magento\SalesRule\Model\Rule\Condition\Product $subject
+     * @param \Magento\Framework\Model\AbstractModel $model
+     *
+     * @return \Magento\Catalog\Api\Data\ProductInterface|\Magento\Catalog\Model\Product
+     */
+    private function getProductToValidate(
+        \Magento\SalesRule\Model\Rule\Condition\Product $subject,
+        \Magento\Framework\Model\AbstractModel $model
+    ) {
+        /** @var \Magento\Catalog\Model\Product $product */
+        $product = $model->getProduct();
+
+        $attrCode = $subject->getAttribute();
+
+        /* Check for attributes which are not available for configurable products */
+        if ($product->getTypeId() == Configurable::TYPE_CODE && !$product->hasData($attrCode)) {
+            /** @var \Magento\Catalog\Model\AbstractModel $childProduct */
+            $childProduct = current($model->getChildren())->getProduct();
+            if ($childProduct->hasData($attrCode)) {
+                $product = $childProduct;
+            }
+        }
+
+        return $product;
+    }
+}

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Plugin/SalesRule/Model/Rule/Condition/ProductTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Plugin/SalesRule/Model/Rule/Condition/ProductTest.php
@@ -1,0 +1,225 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\ConfigurableProduct\Plugin\SalesRule\Model\Rule\Condition;
+
+use Magento\Backend\Helper\Data;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Model\ResourceModel\Product;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\ConfigurableProduct\Plugin\SalesRule\Model\Rule\Condition\Product as ValidatorPlugin;
+use Magento\Directory\Model\CurrencyFactory;
+use Magento\Eav\Model\Config;
+use Magento\Eav\Model\Entity\AbstractEntity;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection;
+use Magento\Framework\App\ScopeResolverInterface;
+use Magento\Framework\Locale\Format;
+use Magento\Framework\Locale\FormatInterface;
+use Magento\Framework\Locale\ResolverInterface;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
+use Magento\Rule\Model\Condition\Context;
+use Magento\SalesRule\Model\Rule\Condition\Product as SalesRuleProduct;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ProductTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var SalesRuleProduct
+     */
+    private $validator;
+
+    /**
+     * @var \Magento\ConfigurableProduct\Plugin\SalesRule\Model\Rule\Condition\Product
+     */
+    private $validatorPlugin;
+
+    public function setUp()
+    {
+        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->validator = $this->createValidator();
+        $this->validatorPlugin = $this->objectManager->getObject(ValidatorPlugin::class);
+    }
+
+    /**
+     * @return \Magento\SalesRule\Model\Rule\Condition\Product
+     */
+    private function createValidator(): SalesRuleProduct
+    {
+        /** @var Context|\PHPUnit_Framework_MockObject_MockObject $contextMock */
+        $contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var Data|\PHPUnit_Framework_MockObject_MockObject $backendHelperMock */
+        $backendHelperMock = $this->getMockBuilder(Data::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var Config|\PHPUnit_Framework_MockObject_MockObject $configMock */
+        $configMock = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var ProductFactory|\PHPUnit_Framework_MockObject_MockObject $productFactoryMock */
+        $productFactoryMock = $this->getMockBuilder(ProductFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var ProductRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject $productRepositoryMock */
+        $productRepositoryMock = $this->getMockBuilder(ProductRepositoryInterface::class)
+            ->getMockForAbstractClass();
+        $attributeLoaderInterfaceMock = $this->getMockBuilder(AbstractEntity::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getAttributesByCode'])
+            ->getMock();
+        $attributeLoaderInterfaceMock
+            ->expects($this->any())
+            ->method('getAttributesByCode')
+            ->willReturn([]);
+        /** @var Product|\PHPUnit_Framework_MockObject_MockObject $productMock */
+        $productMock = $this->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['loadAllAttributes', 'getConnection', 'getTable'])
+            ->getMock();
+        $productMock->expects($this->any())
+        ->method('loadAllAttributes')
+        ->willReturn($attributeLoaderInterfaceMock);
+        /** @var Collection|\PHPUnit_Framework_MockObject_MockObject $collectionMock */
+        $collectionMock = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var FormatInterface|\PHPUnit_Framework_MockObject_MockObject $formatMock */
+        $formatMock = new Format(
+            $this->getMockBuilder(ScopeResolverInterface::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ResolverInterface::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(CurrencyFactory::class)->disableOriginalConstructor()->getMock()
+        );
+
+        return new SalesRuleProduct(
+            $contextMock,
+            $backendHelperMock,
+            $configMock,
+            $productFactoryMock,
+            $productRepositoryMock,
+            $productMock,
+            $collectionMock,
+            $formatMock
+        );
+    }
+
+    public function testChildIsUsedForValidation()
+    {
+        $configurableProductMock = $this->createProductMock();
+        $configurableProductMock
+            ->expects($this->any())
+            ->method('getTypeId')
+            ->willReturn(Configurable::TYPE_CODE);
+        $configurableProductMock
+            ->expects($this->any())
+            ->method('hasData')
+            ->with($this->equalTo('special_price'))
+            ->willReturn(false);
+
+        /* @var AbstractItem|\PHPUnit_Framework_MockObject_MockObject $item */
+        $item = $this->getMockBuilder(AbstractItem::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setProduct', 'getProduct', 'getChildren'])
+            ->getMockForAbstractClass();
+        $item->expects($this->any())
+            ->method('getProduct')
+            ->willReturn($configurableProductMock);
+
+        $simpleProductMock = $this->createProductMock();
+        $simpleProductMock
+            ->expects($this->any())
+            ->method('getTypeId')
+            ->willReturn(Type::TYPE_SIMPLE);
+        $simpleProductMock
+            ->expects($this->any())
+            ->method('hasData')
+            ->with($this->equalTo('special_price'))
+            ->willReturn(true);
+
+        $childItem = $this->getMockBuilder(AbstractItem::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getProduct'])
+            ->getMockForAbstractClass();
+        $childItem->expects($this->any())
+            ->method('getProduct')
+            ->willReturn($simpleProductMock);
+
+        $item->expects($this->any())
+            ->method('getChildren')
+            ->willReturn([$childItem]);
+        $item->expects($this->once())
+            ->method('setProduct')
+            ->with($simpleProductMock);
+
+        $this->validator->setAttribute('special_price');
+
+        $this->validatorPlugin->beforeValidate($this->validator, $item);
+    }
+
+    /**
+     * @return Product|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createProductMock(): \PHPUnit_Framework_MockObject_MockObject
+    {
+        $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'getAttribute',
+                'getId',
+                'setQuoteItemQty',
+                'setQuoteItemPrice',
+                'getTypeId',
+                'hasData',
+            ])
+            ->getMock();
+        $productMock
+            ->expects($this->any())
+            ->method('setQuoteItemQty')
+            ->willReturnSelf();
+        $productMock
+            ->expects($this->any())
+            ->method('setQuoteItemPrice')
+            ->willReturnSelf();
+
+        return $productMock;
+    }
+
+    public function testChildIsNotUsedForValidation()
+    {
+        $simpleProductMock = $this->createProductMock();
+        $simpleProductMock
+            ->expects($this->any())
+            ->method('getTypeId')
+            ->willReturn(Type::TYPE_SIMPLE);
+        $simpleProductMock
+            ->expects($this->any())
+            ->method('hasData')
+            ->with($this->equalTo('special_price'))
+            ->willReturn(true);
+
+        /* @var AbstractItem|\PHPUnit_Framework_MockObject_MockObject $item */
+        $item = $this->getMockBuilder(AbstractItem::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setProduct', 'getProduct'])
+            ->getMockForAbstractClass();
+        $item->expects($this->any())
+            ->method('getProduct')
+            ->willReturn($simpleProductMock);
+
+        $this->validator->setAttribute('special_price');
+
+        $this->validatorPlugin->beforeValidate($this->validator, $item);
+    }
+}

--- a/app/code/Magento/ConfigurableProduct/etc/di.xml
+++ b/app/code/Magento/ConfigurableProduct/etc/di.xml
@@ -235,4 +235,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\SalesRule\Model\Rule\Condition\Product">
+        <plugin name="apply_rule_on_configurable_children" type="Magento\ConfigurableProduct\Plugin\SalesRule\Model\Rule\Condition\Product" />
+    </type>
 </config>

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Product.php
@@ -35,12 +35,13 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
      *
      * @return string
      */
-    public function getAttribute()
+    public function getAttribute(): string
     {
         $attribute = $this->getData('attribute');
         if (strpos($attribute, '::') !== false) {
-            list (, $attribute) = explode('::', $attribute);
+            list(, $attribute) = explode('::', $attribute);
         }
+
         return $attribute;
     }
 
@@ -53,6 +54,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
         if ($this->getAttributeScope()) {
             $attribute = $this->getAttributeScope() . '::' . $attribute;
         }
+
         return $this->getAttributeOption($attribute);
     }
 
@@ -92,6 +94,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
     {
         $html = parent::getAttributeElementHtml() .
                 $this->getAttributeScopeElement()->getHtml();
+
         return $html;
     }
 
@@ -100,7 +103,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
      *
      * @return \Magento\Framework\Data\Form\Element\AbstractElement
      */
-    private function getAttributeScopeElement()
+    private function getAttributeScopeElement(): \Magento\Framework\Data\Form\Element\AbstractElement
     {
         return $this->getForm()->addField(
             $this->getPrefix() . '__' . $this->getId() . '__attribute_scope',
@@ -110,7 +113,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
                 'value' => $this->getAttributeScope(),
                 'no_span' => true,
                 'class' => 'hidden',
-                'data-form-part' => $this->getFormName()
+                'data-form-part' => $this->getFormName(),
             ]
         );
     }
@@ -119,8 +122,9 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
      * Set attribute value
      *
      * @param string $value
+     * @return void
      */
-    public function setAttribute($value)
+    public function setAttribute(string $value)
     {
         if (strpos($value, '::') !== false) {
             list($scope, $attribute) = explode('::', $value);
@@ -137,7 +141,8 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
     public function loadArray($arr)
     {
         parent::loadArray($arr);
-        $this->setAttributeScope(isset($arr['attribute_scope']) ? $arr['attribute_scope'] : null);
+        $this->setAttributeScope($arr['attribute_scope'] ?? null);
+
         return $this;
     }
 
@@ -148,6 +153,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
     {
         $out = parent::asArray($arrAttributes);
         $out['attribute_scope'] = $this->getAttributeScope();
+
         return $out;
     }
 
@@ -155,7 +161,9 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
      * Validate Product Rule Condition
      *
      * @param \Magento\Framework\Model\AbstractModel $model
+     *
      * @return bool
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function validate(\Magento\Framework\Model\AbstractModel $model)
     {


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/16342

Use configurable product`s children for shopping cart rules validation
for cases when attribute exists for children only (E.g. special_price)

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14020 Cart Sales Rule with negated condition over special_price does not work for configurable products

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable the `special_price` for promo rule conditions: 
   1. Stores > Attributes > Product
   2. Search for and edit `special_price`
   3. Storefront Properties: Use for Promo Rule Conditions: Yes
   4. Save
2. create new cart sales rule:
   1. Marketing > Cart Price Rules
   2.  Add New Rule:
       1. Rule name = "Special Price Test"
       2. Website: select all
       3. Customer Groups: select all
       4. Coupon: "Specific Coupon"
       5. Coupon Code: "special"
       6. Actions: Discount Amount: "10"
       7. Actions: Apply the rule only to cart items matching the following conditions: "if **ALL** of these conditions are **FALSE**": "Special Price **greater than 0.01**"
       8. Leave all other fields to their defaults and save
3. In the front end, add a the child product of a configurable product to the cart, such that the child product has a special price set. This product should be the only one in the cart.
4. "View and Edit Cart" > "Apply Discount Code": `special`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
