### PR TITLE
Fixed the issue #19347.

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Helper/ConfigProvider.php
+++ b/app/code/Magento/Checkout/Block/Cart/Helper/ConfigProvider.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Checkout\Block\Cart\Helper;
+
+class ConfigProvider
+{
+    /**
+     * @var \Magento\Checkout\Model\CompositeConfigProvider
+     */
+    private $configProvider;
+    
+    /**
+     * Config constructor.
+     *
+     * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+     */
+    public function __construct(
+        \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+    ) {
+        $this->configProvider = $configProvider;
+    }
+    
+    /**
+     * Retrieve checkout configuration
+     *
+     * @return array
+     * @codeCoverageIgnore
+     */
+    public function getCheckoutConfig()
+    {
+        return $this->configProvider->getConfig();
+    }
+    
+    /**
+     * @return bool|string
+     */
+    public function getSerializedCheckoutConfig()
+    {
+        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+    }
+}

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -25,6 +25,11 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $serializer;
+    
+    /**
+     * @var \Magento\Checkout\Block\Cart\Helper\ConfigProvider
+     */
+    private $cartConfig;
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
@@ -43,7 +48,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
         array $data = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+        \Magento\Checkout\Block\Cart\Helper\ConfigProvider $cartConfig = null
     ) {
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
@@ -51,6 +57,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         $this->_isScopePrivate = true;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->cartConfig = $cartConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Checkout\Block\Cart\Helper\ConfigProvider::class);
     }
 
     /**
@@ -61,7 +69,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      */
     public function getCheckoutConfig()
     {
-        return $this->configProvider->getConfig();
+        return $this->cartConfig->getCheckoutConfig();
     }
 
     /**
@@ -95,6 +103,6 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      */
     public function getSerializedCheckoutConfig()
     {
-        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+        return $this->cartConfig->getSerializedCheckoutConfig();
     }
 }

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -27,7 +27,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
     private $serializer;
     
     /**
-     * @var \Magento\Checkout\Block\Cart\Helper\ConfigProvider
+     * @var \Magento\Checkout\Model\Cart\ConfigProvider
      */
     private $cartConfig;
 
@@ -39,6 +39,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      * @param array $layoutProcessors
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param \Magento\Checkout\Model\Cart\ConfigProvider|null $cartConfig
      * @throws \RuntimeException
      */
     public function __construct(
@@ -49,7 +50,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         array $layoutProcessors = [],
         array $data = [],
         \Magento\Framework\Serialize\Serializer\Json $serializer = null,
-        \Magento\Checkout\Block\Cart\Helper\ConfigProvider $cartConfig = null
+        \Magento\Checkout\Model\Cart\ConfigProvider $cartConfig = null
     ) {
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
@@ -58,7 +59,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         $this->cartConfig = $cartConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Checkout\Block\Cart\Helper\ConfigProvider::class);
+            ->get(\Magento\Checkout\Model\Cart\ConfigProvider::class);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Cart/Totals.php
+++ b/app/code/Magento/Checkout/Block/Cart/Totals.php
@@ -37,12 +37,18 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
      * @var LayoutProcessorInterface[]
      */
     protected $layoutProcessors;
+    
+    /**
+     * @var \Magento\Checkout\Block\Cart\Helper\ConfigProvider
+     */
+    protected $cartConfig;
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Sales\Model\Config $salesConfig
+     * @param \Magento\Checkout\Block\Cart\Helper\Config $cartConfig
      * @param array $layoutProcessors
      * @param array $data
      * @codeCoverageIgnore
@@ -53,12 +59,15 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Sales\Model\Config $salesConfig,
         array $layoutProcessors = [],
-        array $data = []
+        array $data = [],
+        \Magento\Checkout\Block\Cart\Helper\ConfigProvider $cartConfig = null
     ) {
         $this->_salesConfig = $salesConfig;
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = true;
         $this->layoutProcessors = $layoutProcessors;
+        $this->cartConfig = $cartConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Checkout\Block\Cart\Helper\ConfigProvider::class);
     }
 
     /**
@@ -206,5 +215,13 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
             $this->_quote = $this->_checkoutSession->getQuote();
         }
         return $this->_quote;
+    }
+    
+    /**
+     * @return bool|string
+     */
+    public function getSerializedCheckoutConfig()
+    {
+        return $this->cartConfig->getSerializedCheckoutConfig();
     }
 }

--- a/app/code/Magento/Checkout/Block/Cart/Totals.php
+++ b/app/code/Magento/Checkout/Block/Cart/Totals.php
@@ -39,18 +39,24 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
     protected $layoutProcessors;
     
     /**
-     * @var \Magento\Checkout\Block\Cart\Helper\ConfigProvider
+     * @var \Magento\Checkout\Model\Cart\ConfigProvider
      */
-    protected $cartConfig;
+    private $cartConfig;
+    
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Sales\Model\Config $salesConfig
-     * @param \Magento\Checkout\Block\Cart\Helper\Config $cartConfig
      * @param array $layoutProcessors
      * @param array $data
+     * @param \Magento\Checkout\Model\Cart\ConfigProvider $cartConfig
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -60,14 +66,17 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Sales\Model\Config $salesConfig,
         array $layoutProcessors = [],
         array $data = [],
-        \Magento\Checkout\Block\Cart\Helper\ConfigProvider $cartConfig = null
+        \Magento\Checkout\Model\Cart\ConfigProvider $cartConfig = null,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         $this->_salesConfig = $salesConfig;
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = true;
         $this->layoutProcessors = $layoutProcessors;
         $this->cartConfig = $cartConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Checkout\Block\Cart\Helper\ConfigProvider::class);
+            ->get(\Magento\Checkout\Model\Cart\ConfigProvider::class);
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);;
     }
 
     /**
@@ -79,7 +88,7 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
             $this->jsLayout = $processor->process($this->jsLayout);
         }
 
-        return json_encode($this->jsLayout, JSON_HEX_TAG);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Cart/Totals.php
+++ b/app/code/Magento/Checkout/Block/Cart/Totals.php
@@ -76,7 +76,7 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
         $this->cartConfig = $cartConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Checkout\Model\Cart\ConfigProvider::class);
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);;
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
 
     /**

--- a/app/code/Magento/Checkout/Model/Cart/ConfigProvider.php
+++ b/app/code/Magento/Checkout/Model/Cart/ConfigProvider.php
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-namespace Magento\Checkout\Block\Cart\Helper;
+namespace Magento\Checkout\Model\Cart;
 
+/**
+ * Provides the checkout configuration.
+ *
+ * @api
+ */
 class ConfigProvider
 {
     /**
@@ -13,15 +19,21 @@ class ConfigProvider
      */
     private $configProvider;
     
+    /** @var \Magento\Framework\Serialize\SerializerInterface */
+    private $serializer;
+    
     /**
      * Config constructor.
      *
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      */
     public function __construct(
-        \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+        \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
     ) {
         $this->configProvider = $configProvider;
+        $this->serializer = $serializer;
     }
     
     /**
@@ -36,10 +48,12 @@ class ConfigProvider
     }
     
     /**
+     * Retrieve checkout serialized configuration
+     *
      * @return bool|string
      */
     public function getSerializedCheckoutConfig()
     {
-        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+        return $this->serializer->serialize($this->getCheckoutConfig());
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -51,6 +51,11 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $serializer;
+    
+    /**
+     * @var \Magento\Checkout\Block\Cart\Helper\ConfigProvider
+     */
+    private $cartConfig;
 
     protected function setUp()
     {
@@ -69,6 +74,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
         $this->storeManager = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->context->expects($this->once())->method('getStoreManager')->willReturn($this->storeManager);
         $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->cartConfig = $this->createMock(\Magento\Checkout\Block\Cart\Helper\ConfigProvider::class);
 
         $this->model = new \Magento\Checkout\Block\Cart\Shipping(
             $this->context,
@@ -77,7 +83,8 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
             $this->configProvider,
             [$this->layoutProcessor],
             ['jsLayout' => $this->layout],
-            $this->serializer
+            $this->serializer,
+            $this->cartConfig
         );
     }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -53,7 +53,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     private $serializer;
     
     /**
-     * @var \Magento\Checkout\Block\Cart\Helper\ConfigProvider
+     * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $cartConfig;
 
@@ -74,7 +74,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
         $this->storeManager = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->context->expects($this->once())->method('getStoreManager')->willReturn($this->storeManager);
         $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
-        $this->cartConfig = $this->createMock(\Magento\Checkout\Block\Cart\Helper\ConfigProvider::class);
+        $this->cartConfig = $this->createMock(\Magento\Checkout\Model\Cart\ConfigProvider::class);
 
         $this->model = new \Magento\Checkout\Block\Cart\Shipping(
             $this->context,
@@ -91,7 +91,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     public function testGetCheckoutConfig()
     {
         $config = ['param' => 'value'];
-        $this->configProvider->expects($this->once())->method('getConfig')->willReturn($config);
+        $this->cartConfig->expects($this->once())->method('getCheckoutConfig')->willReturn($config);
         $this->assertEquals($config, $this->model->getCheckoutConfig());
     }
 
@@ -124,7 +124,10 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     public function testGetSerializedCheckoutConfig()
     {
         $checkoutConfig = ['checkout', 'config'];
-        $this->configProvider->expects($this->once())->method('getConfig')->willReturn($checkoutConfig);
+        $this->cartConfig
+            ->expects($this->once())
+            ->method('getSerializedCheckoutConfig')
+            ->willReturn(json_encode($checkoutConfig));
 
         $this->assertEquals(json_encode($checkoutConfig), $this->model->getSerializedCheckoutConfig());
     }

--- a/app/code/Magento/Checkout/Test/Unit/Model/Cart/ConfigProviderTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/Cart/ConfigProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Checkout\Test\Unit\Model\Cart;
+
+class ConfigProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Checkout\Model\Cart\ConfigProvider
+     */
+    private $model;
+    
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cartConfigProvider;
+    
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $compositeConfigProvider;
+    
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
+    
+    protected function setUp()
+    {
+        $this->cartConfigProvider = $this->createMock(\Magento\Checkout\Model\Cart\ConfigProvider::class);
+        $this->compositeConfigProvider = $this->createMock(\Magento\Checkout\Model\CompositeConfigProvider::class);
+        $this->serializer = $this->createMock(\Magento\Framework\Serialize\SerializerInterface::class);
+    
+        $this->model = new \Magento\Checkout\Model\Cart\ConfigProvider(
+            $this->compositeConfigProvider,
+            $this->serializer
+        );
+    }
+    
+    public function testGetCheckoutConfig()
+    {
+        $config = ['param' => 'value'];
+        $this->compositeConfigProvider
+            ->expects($this->once())
+            ->method('getConfig')
+            ->willReturn($config);
+        
+        $this->assertEquals($config, $this->model->getCheckoutConfig());
+    }
+    
+    public function testGetSerializedCheckoutConfig()
+    {
+        $config = '{"param":"value"}';
+        
+        $this->serializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn($config);
+        
+        $this->assertEquals($config, $this->model->getSerializedCheckoutConfig());
+    }
+}

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
@@ -19,4 +19,16 @@
                 }
             }
     </script>
+    <script>
+        window.checkoutConfig = <?= /* @escapeNotVerified */ $block->getSerializedCheckoutConfig() ?>;
+        window.customerData = window.checkoutConfig.customerData;
+        window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
+        require([
+            'mage/url',
+            'Magento_Ui/js/block-loader'
+        ], function(url, blockLoader) {
+            blockLoader("<?= /* @escapeNotVerified */ $block->getViewFileUrl('images/loader-1.gif') ?>");
+            return url.setBaseUrl('<?= /* @escapeNotVerified */ $block->getBaseUrl() ?>');
+        })
+    </script>
 </div>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
@@ -15,20 +15,13 @@
     <script type="text/x-magento-init">
             {
                 "#cart-totals": {
-                    "Magento_Ui/js/core/app": <?= /* @escapeNotVerified */ $block->getJsLayout() ?>
+                    "Magento_Ui/js/core/app": <?= /* @escapeNotVerified */ $block->getJsLayout() ?>,
+                    "Magento_Checkout/js/totals": {
+                        "checkoutConfig":<?= /* @escapeNotVerified */ $block->getSerializedCheckoutConfig() ?>,
+                        "loaderFile":"<?= /* @escapeNotVerified */ $block->getViewFileUrl('images/loader-1.gif') ?>",
+                        "baseUrl":"<?= /* @escapeNotVerified */ $block->getBaseUrl() ?>"
+                    }
                 }
             }
-    </script>
-    <script>
-        window.checkoutConfig = <?= /* @escapeNotVerified */ $block->getSerializedCheckoutConfig() ?>;
-        window.customerData = window.checkoutConfig.customerData;
-        window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
-        require([
-            'mage/url',
-            'Magento_Ui/js/block-loader'
-        ], function(url, blockLoader) {
-            blockLoader("<?= /* @escapeNotVerified */ $block->getViewFileUrl('images/loader-1.gif') ?>");
-            return url.setBaseUrl('<?= /* @escapeNotVerified */ $block->getBaseUrl() ?>');
-        })
     </script>
 </div>

--- a/app/code/Magento/Checkout/view/frontend/web/js/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/totals.js
@@ -7,6 +7,8 @@ define([
     'mage/url',
     'Magento_Ui/js/block-loader'
 ], function(url, blockLoader) {
+    'use strict';
+    
     return function (config) {
         window.checkoutConfig = config.checkoutConfig;
         window.customerData = window.checkoutConfig.customerData;

--- a/app/code/Magento/Checkout/view/frontend/web/js/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/totals.js
@@ -6,9 +6,9 @@
 define([
     'mage/url',
     'Magento_Ui/js/block-loader'
-], function(url, blockLoader) {
+], function (url, blockLoader) {
     'use strict';
-    
+
     return function (config) {
         window.checkoutConfig = config.checkoutConfig;
         window.customerData = window.checkoutConfig.customerData;

--- a/app/code/Magento/Checkout/view/frontend/web/js/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/totals.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'mage/url',
+    'Magento_Ui/js/block-loader'
+], function(url, blockLoader) {
+    return function (config) {
+        window.checkoutConfig = config.checkoutConfig;
+        window.customerData = window.checkoutConfig.customerData;
+        window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
+
+        blockLoader(config.loaderFile);
+        url.setBaseUrl(config.baseUrl);
+    }
+});

--- a/app/code/Magento/Checkout/view/frontend/web/js/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/totals.js
@@ -16,5 +16,5 @@ define([
 
         blockLoader(config.loaderFile);
         url.setBaseUrl(config.baseUrl);
-    }
+    };
 });


### PR DESCRIPTION
2.3 pull request: https://github.com/magento/magento2/pull/19393

After removing the Estimate Shipping Costs and Tax from cart using layout the totals were not displayed.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Please check all the description in issue #19347.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19347: Removing "Estimate shipping costs and tax" from cart removes cart totals

### Manual testing scenarios (*)
The testing scenarios are described in the issue page.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
