### PR TITLE
Properly handle item collections in \Magento\Framework\Reflection\DataObjectProcessor

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\Reflection;
 
 use Magento\Framework\Api\CustomAttributesDataInterface;
+use Magento\Framework\Data\CollectionDataSourceInterface;
 use Magento\Framework\Phrase;
 
 /**
@@ -102,9 +103,12 @@ class DataObjectProcessor
                     continue;
                 }
             } else {
-                if (is_object($value) && !is_iterable($value) && !($value instanceof Phrase)) {
+                if (is_object($value)
+                    && !($value instanceof CollectionDataSourceInterface)
+                    && !($value instanceof Phrase)
+                ) {
                     $value = $this->buildOutputDataArray($value, $returnType);
-                } elseif (is_iterable($value)) {
+                } elseif (is_array($value) || $value instanceof CollectionDataSourceInterface) {
                     $valueResult = [];
                     $arrayElementType = substr($returnType, 0, -2);
                     foreach ($value as $singleValue) {

--- a/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
@@ -102,9 +102,9 @@ class DataObjectProcessor
                     continue;
                 }
             } else {
-                if (is_object($value) && !($value instanceof Phrase)) {
+                if (is_object($value) && !is_iterable($value) && !($value instanceof Phrase)) {
                     $value = $this->buildOutputDataArray($value, $returnType);
-                } elseif (is_array($value)) {
+                } elseif (is_iterable($value)) {
                     $valueResult = [];
                     $arrayElementType = substr($returnType, 0, -2);
                     foreach ($value as $singleValue) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
\Magento\Framework\Reflection\DataObjectProcessor gives the error:
```
report.CRITICAL: Class \Magento\Sales\Api\Data\InvoiceItemInterface[] does not exist
```
This happens when you put an \Magento\Sales\Api\Data\InvoiceInterface in `\Magento\Framework\Webapi\ServiceOutputProcessor::convertValue()`

The reason for this is that getItems on an invoice returns a `\Magento\Sales\Model\ResourceModel\Order\Invoice\Item\Collection` instead of a `\Magento\Sales\Api\Data\InvoiceItemInterface[]` as defined in the interface. 

Because a collection is traversable it can and should be used in the foreach loop in `\Magento\Framework\Reflection\DataObjectProcessor` and effectively be treated as an array.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Convert a `\Magento\Sales\Api\Data\InvoiceInterface` using `\Magento\Framework\Webapi\ServiceOutputProcessor::convertValue()`.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
