### PR TITLE
Magneto 2.3 Fix Product::addImageToMediaGallery throws Exception

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
@@ -138,4 +138,52 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertStringStartsWith('/m/a/magento_image', $product->getData('image'));
         $this->assertStringStartsWith('/m/a/magento_image', $product->getData('small_image'));
     }
+
+    /**
+     * Test save product with gallery image
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_with_image.php
+     *
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\StateException
+     */
+    public function testSaveProductWithGalleryImage(): void
+    {
+        /** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
+        $mediaConfig = Bootstrap::getObjectManager()
+            ->get(\Magento\Catalog\Model\Product\Media\Config::class);
+
+        /** @var $mediaDirectory \Magento\Framework\Filesystem\Directory\WriteInterface */
+        $mediaDirectory = Bootstrap::getObjectManager()
+            ->get(\Magento\Framework\Filesystem::class)
+            ->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA);
+
+        $product = Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+        $product->load(1);
+
+        $path = $mediaConfig->getBaseMediaPath() . '/magento_image.jpg';
+        $absolutePath = $mediaDirectory->getAbsolutePath() . $path;
+        $product->addImageToMediaGallery($absolutePath, [
+            'image',
+            'small_image',
+        ], false, false);
+
+        /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+        $productRepository = Bootstrap::getObjectManager()
+            ->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+        $productRepository->save($product);
+
+        $gallery = $product->getData('media_gallery');
+        $this->assertArrayHasKey('images', $gallery);
+        $images = array_values($gallery['images']);
+
+        $this->assertNotEmpty($gallery);
+        $this->assertTrue(isset($images[0]['file']));
+        $this->assertStringStartsWith('/m/a/magento_image', $images[0]['file']);
+        $this->assertArrayHasKey('media_type', $images[0]);
+        $this->assertEquals('image', $images[0]['media_type']);
+        $this->assertStringStartsWith('/m/a/magento_image', $product->getData('image'));
+        $this->assertStringStartsWith('/m/a/magento_image', $product->getData('small_image'));
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductRepositoryTest.php
@@ -148,7 +148,7 @@ class ProductRepositoryTest extends \PHPUnit\Framework\TestCase
      * @throws \Magento\Framework\Exception\InputException
      * @throws \Magento\Framework\Exception\StateException
      */
-    public function testSaveProductWithGalleryImage(): void
+    public function testSaveProductWithGalleryImage()
     {
         /** @var $mediaConfig \Magento\Catalog\Model\Product\Media\Config */
         $mediaConfig = Bootstrap::getObjectManager()


### PR DESCRIPTION
### Original Pull Request
#18951 

### Fixed Issues (if relevant)
1. magento/magento2#6803: Product::addImageToMediaGallery throws Exception

### Preconditions

<!--- Provide a more detailed information of environment you use -->

<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->

**Magento Version** 2.2.6
**PHP Version** 7.1
### Steps to reproduce

<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->

```
$product = $this->productFactory->create()
            ->setName($productName)
            ->setStatus($productStatus)
            ->setSku($productSku)
$product->setAttributeSetId($product->getDefaultAttributeSetId());

$product->addImageToMediaGallery($file, [
                'image',
                'small_image',
                'thumbnail',
            ], false, false);
$this->productRepository->save($product);
```
### Expected result

Image gets added
### Actual result

Exception gets thrown:

```
Notice: Undefined index: media_type in vendor/magento/module-catalog/Model/Product.php on line 2527
```

<!--- (This may be platform independent comment) -->

There's a workaround for this issue, using the `Product::save` method instead of the `ProductRepositoryInterface::save` method, but because it's a deprecated method I would like to avoid this.


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
