### PR TITLE
[Backport] #13157 - Last Ordered Items block - bad js code

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
@@ -26,14 +26,18 @@
             <ol id="cart-sidebar-reorder" class="product-items product-items-names"
                 data-bind="foreach: lastOrderedItems().items">
                 <li class="product-item">
-                    <div class="field item choice no-display" data-bind="css: {'no-display': !is_saleable}">
+                    <div class="field item choice">
                         <label class="label" data-bind="attr: {'for': 'reorder-item-' + id}">
                             <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
                         </label>
                         <div class="control">
                             <input type="checkbox" name="order_items[]"
-                                   data-bind="attr: {id: 'reorder-item-' + id, value: id}"
-                                   title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>"
+                                   data-bind="attr: {
+                                        id: 'reorder-item-' + id,
+                                        value: id,
+                                        title: is_saleable ? '<?= /* @escapeNotVerified */ __('Add to Cart') ?>' : '<?= /* @escapeNotVerified */ __('Product is not salable.') ?>'
+                                   },
+                                   disable: !is_saleable"
                                    class="checkbox" data-validate='{"validate-one-checkbox-required-by-name": true}'/>
                         </div>
                     </div>
@@ -46,8 +50,8 @@
             </ol>
             <div id="cart-sidebar-reorder-advice-container"></div>
             <div class="actions-toolbar">
-                <div class="primary no-display"
-                     data-bind="css: {'no-display': !lastOrderedItems().isShowAddToCart}">
+                <div class="primary"
+                     data-bind="visible: lastOrderedItems.isShowAddToCart">
                     <button type="submit" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>" class="action tocart primary">
                         <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
                     </button>

--- a/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
@@ -51,7 +51,7 @@
             <div id="cart-sidebar-reorder-advice-container"></div>
             <div class="actions-toolbar">
                 <div class="primary"
-                     data-bind="visible: lastOrderedItems.isShowAddToCart">
+                     data-bind="visible: isShowAddToCart">
                     <button type="submit" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>" class="action tocart primary">
                         <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
                     </button>

--- a/app/code/Magento/Sales/view/frontend/web/js/view/last-ordered-items.js
+++ b/app/code/Magento/Sales/view/frontend/web/js/view/last-ordered-items.js
@@ -5,8 +5,9 @@
 
 define([
     'uiComponent',
-    'Magento_Customer/js/customer-data'
-], function (Component, customerData) {
+    'Magento_Customer/js/customer-data',
+    'underscore'
+], function (Component, customerData, _) {
     'use strict';
 
     return Component.extend({

--- a/app/code/Magento/Sales/view/frontend/web/js/view/last-ordered-items.js
+++ b/app/code/Magento/Sales/view/frontend/web/js/view/last-ordered-items.js
@@ -12,18 +12,14 @@ define([
     return Component.extend({
         /** @inheritdoc */
         initialize: function () {
-            var isShowAddToCart = false,
-                item;
+            var isShowAddToCart;
 
             this._super();
             this.lastOrderedItems = customerData.get('last-ordered-items');
 
-            for (item in this.lastOrderedItems.items) {
-                if (item['is_saleable']) {
-                    isShowAddToCart = true;
-                    break;
-                }
-            }
+            isShowAddToCart = _.some(this.lastOrderedItems().items, {
+                'is_saleable': true
+            });
 
             this.lastOrderedItems.isShowAddToCart = isShowAddToCart;
         }

--- a/app/code/Magento/Sales/view/frontend/web/js/view/last-ordered-items.js
+++ b/app/code/Magento/Sales/view/frontend/web/js/view/last-ordered-items.js
@@ -11,18 +11,37 @@ define([
     'use strict';
 
     return Component.extend({
+        defaults: {
+            isShowAddToCart: false
+        },
+
         /** @inheritdoc */
         initialize: function () {
-            var isShowAddToCart;
-
             this._super();
             this.lastOrderedItems = customerData.get('last-ordered-items');
+            this.lastOrderedItems.subscribe(this.checkSalableItems.bind(this));
+            this.checkSalableItems();
 
-            isShowAddToCart = _.some(this.lastOrderedItems().items, {
+            return this;
+        },
+
+        /** @inheritdoc */
+        initObservable: function () {
+            this._super()
+                .observe('isShowAddToCart');
+
+            return this;
+        },
+
+        /**
+         * Check if items is_saleable and change add to cart button visibility.
+         */
+        checkSalableItems: function () {
+            var isShowAddToCart = _.some(this.lastOrderedItems().items, {
                 'is_saleable': true
             });
 
-            this.lastOrderedItems.isShowAddToCart = isShowAddToCart;
+            this.isShowAddToCart(isShowAddToCart);
         }
     });
 });


### PR DESCRIPTION
### Original Pull Request
#19039 

### Description
Fix logic in last-order-items.js and Recently Ordered block.

### Fixed Issues
magento/magento2#13157: Last Ordered Items block - bad js code

### Manual testing scenarios
1. Create order for registered customer
2. Verify that Add to Cart button in Recently Ordered block reflects is_salable property of recently ordered product

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
