### PR TITLE
Module Quote: fix issue with incorrect Store & Website ID init for Quote Address Request while getting rates at Admin panel

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1000,11 +1000,14 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
         $request->setFreeMethodWeight($item ? 0 : $this->getFreeMethodWeight());
 
         /**
-         * Store and website identifiers specified from StoreManager
+         * Store and website identifiers specified from Quote
          */
-        $request->setQuoteStoreId($this->getQuote()->getStoreId());
-        $request->setStoreId($this->storeManager->getStore()->getId());
-        $request->setWebsiteId($this->storeManager->getWebsite()->getId());
+        $quoteStoreId = $this->getQuote()->getStoreId();
+        $store = $this->storeManager->getStore($quoteStoreId);
+
+        $request->setQuoteStoreId($store->getId());
+        $request->setStoreId($store->getId());
+        $request->setWebsiteId($store->getWebsiteId());
         $request->setFreeShipping($this->getFreeShipping());
         /**
          * Currencies need to convert in free shipping


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR provides fix for the issue with incorrect Store and Website ID initialization for the Quote Address Request while getting rates for an order at Admin panel.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
magento/magento2#16604: Table rate shipment is taken from wrong website ID when creating an order through the admin

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
You can use steps to reproduce from the issue.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
