### PR TITLE
Ability to configure the initial product position in category value

### DIFF
--- a/app/code/Magento/Catalog/Helper/Data.php
+++ b/app/code/Magento/Catalog/Helper/Data.php
@@ -36,6 +36,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CONFIG_PARSE_URL_DIRECTIVES = 'catalog/frontend/parse_url_directives';
 
     const XML_PATH_DISPLAY_PRODUCT_COUNT = 'catalog/layered_navigation/display_product_count';
+    
+    const CONFIG_DEFAULT_PRODUCT_POSITION = 'catalog/frontend/default_product_position';
 
     /**
      * Cache context
@@ -622,5 +624,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         } else {
             return $price;
         }
+    }
+    
+    /**
+     * @return int Default product position in category
+     */
+    public function getDefaultProductPosition(): int
+    {
+        return (int)$this->scopeConfig->getValue(self::CONFIG_DEFAULT_PRODUCT_POSITION);
     }
 }

--- a/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
@@ -19,7 +19,12 @@ class SaveHandler implements ExtensionInterface
      * @var \Magento\Catalog\Model\ResourceModel\Product\CategoryLink
      */
     private $productCategoryLink;
-
+    
+    /**
+     * @var \Magento\Catalog\Helper\Data
+     */
+    private $helper;
+    
     /**
      * @var \Magento\Framework\EntityManager\HydratorPool
      */
@@ -30,13 +35,16 @@ class SaveHandler implements ExtensionInterface
      *
      * @param \Magento\Catalog\Model\ResourceModel\Product\CategoryLink $productCategoryLink
      * @param \Magento\Framework\EntityManager\HydratorPool $hydratorPool
+     * @param \Magento\Catalog\Helper\Data $helper
      */
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Product\CategoryLink $productCategoryLink,
-        \Magento\Framework\EntityManager\HydratorPool $hydratorPool
+        \Magento\Framework\EntityManager\HydratorPool $hydratorPool,
+        \Magento\Catalog\Helper\Data $helper
     ) {
         $this->productCategoryLink = $productCategoryLink;
         $this->hydratorPool = $hydratorPool;
+        $this->helper = $helper;
     }
 
     /**
@@ -85,10 +93,12 @@ class SaveHandler implements ExtensionInterface
     {
         $result = [];
         $currentCategoryLinks = $this->productCategoryLink->getCategoryLinks($entity, $entity->getCategoryIds());
+        
+        $productPosition = $this->helper->getDefaultProductPosition();
         foreach ($entity->getCategoryIds() as $categoryId) {
             $key = array_search($categoryId, array_column($currentCategoryLinks, 'category_id'));
             if ($key === false) {
-                $result[] = ['category_id' => (int)$categoryId, 'position' => 0];
+                $result[] = ['category_id' => (int)$categoryId, 'position' => $productPosition];
             } else {
                 $result[] = $currentCategoryLinks[$key];
             }

--- a/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
+++ b/app/code/Magento/Catalog/Model/Category/Link/SaveHandler.php
@@ -40,7 +40,7 @@ class SaveHandler implements ExtensionInterface
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Product\CategoryLink $productCategoryLink,
         \Magento\Framework\EntityManager\HydratorPool $hydratorPool,
-        \Magento\Catalog\Helper\Data $helper
+        \Magento\Catalog\Helper\Data $helper = null
     ) {
         $this->productCategoryLink = $productCategoryLink;
         $this->hydratorPool = $hydratorPool;
@@ -94,7 +94,7 @@ class SaveHandler implements ExtensionInterface
         $result = [];
         $currentCategoryLinks = $this->productCategoryLink->getCategoryLinks($entity, $entity->getCategoryIds());
         
-        $productPosition = $this->helper->getDefaultProductPosition();
+        $productPosition = $this->getDataHelper()->getDefaultProductPosition();
         foreach ($entity->getCategoryIds() as $categoryId) {
             $key = array_search($categoryId, array_column($currentCategoryLinks, 'category_id'));
             if ($key === false) {
@@ -105,6 +105,19 @@ class SaveHandler implements ExtensionInterface
         }
 
         return $result;
+    }
+    
+    /**
+     * @return \Magento\Catalog\Helper\Data
+     */
+    private function getDataHelper()
+    {
+        if (null === $this->helper) {
+            $this->helper = \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Helper\Data::class);
+        }
+        
+        return $this->helper;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/CategoryLinkManagement.php
+++ b/app/code/Magento/Catalog/Model/CategoryLinkManagement.php
@@ -56,7 +56,7 @@ class CategoryLinkManagement implements \Magento\Catalog\Api\CategoryLinkManagem
     public function __construct(
         \Magento\Catalog\Api\CategoryRepositoryInterface $categoryRepository,
         \Magento\Catalog\Api\Data\CategoryProductLinkInterfaceFactory $productLinkFactory,
-        \Magento\Catalog\Helper\Data $helper
+        \Magento\Catalog\Helper\Data $helper = null
     ) {
         $this->categoryRepository = $categoryRepository;
         $this->productLinkFactory = $productLinkFactory;
@@ -107,7 +107,7 @@ class CategoryLinkManagement implements \Magento\Catalog\Api\CategoryLinkManagem
             $this->getCategoryLinkRepository()->deleteByIds($categoryId, $productSku);
         }
     
-        $productPosition = $this->helper->getDefaultProductPosition();
+        $productPosition = $this->getDataHelper()->getDefaultProductPosition();
         foreach (array_diff($categoryIds, $assignedCategories) as $categoryId) {
             /** @var \Magento\Catalog\Api\Data\CategoryProductLinkInterface $categoryProductLink */
             $categoryProductLink = $this->productLinkFactory->create();
@@ -121,6 +121,19 @@ class CategoryLinkManagement implements \Magento\Catalog\Api\CategoryLinkManagem
             $productCategoryIndexer->reindexRow($product->getId());
         }
         return true;
+    }
+    
+    /**
+     * @return \Magento\Catalog\Helper\Data
+     */
+    private function getDataHelper()
+    {
+        if (null === $this->helper) {
+            $this->helper = \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Helper\Data::class);
+        }
+        
+        return $this->helper;
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Model\Category\Link\SaveHandler;
 use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\Framework\EntityManager\HydratorInterface;
 use Magento\Framework\EntityManager\HydratorPool;
+use Magento\Catalog\Helper\Data;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Indexer\IndexerRegistry;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -38,6 +39,11 @@ class SaveHandlerTest extends \PHPUnit\Framework\TestCase
      * @var HydratorPool|MockObject
      */
     private $hydratorPool;
+    
+    /**
+     * @var Data|MockObject
+     */
+    private $helper;
 
     /**
      * @inheritdoc
@@ -51,10 +57,12 @@ class SaveHandlerTest extends \PHPUnit\Framework\TestCase
         $this->hydratorPool = $this->getMockBuilder(HydratorPool::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->helper = $this->getMockBuilder(Data::class)->disableOriginalConstructor()->getMock();
 
         $this->saveHandler = new SaveHandler(
             $this->productCategoryLink,
-            $this->hydratorPool
+            $this->hydratorPool,
+            $this->helper
         );
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryLinkManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryLinkManagementTest.php
@@ -22,6 +22,11 @@ class CategoryLinkManagementTest extends \PHPUnit\Framework\TestCase
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     protected $productLinkFactoryMock;
+    
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $catalogDataHelperMock;
 
     protected function setUp()
     {
@@ -33,6 +38,9 @@ class CategoryLinkManagementTest extends \PHPUnit\Framework\TestCase
         $indexerRegistry = $this->getMockBuilder(\Magento\Framework\Indexer\IndexerRegistry::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->catalogDataHelperMock = $this->getMockBuilder(\Magento\Catalog\Helper\Data::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->productLinkFactoryMock = $this->createPartialMock(
             \Magento\Catalog\Api\Data\CategoryProductLinkInterfaceFactory::class,
             ['create']
@@ -40,7 +48,8 @@ class CategoryLinkManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->model = new \Magento\Catalog\Model\CategoryLinkManagement(
             $this->categoryRepositoryMock,
-            $this->productLinkFactoryMock
+            $this->productLinkFactoryMock,
+            $this->catalogDataHelperMock
         );
 
         $this->setProperties($this->model, [

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryLinkManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryLinkManagementTest.php
@@ -26,7 +26,7 @@ class CategoryLinkManagementTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    protected $catalogDataHelperMock;
+    protected $dataHelperMock;
 
     protected function setUp()
     {
@@ -38,7 +38,7 @@ class CategoryLinkManagementTest extends \PHPUnit\Framework\TestCase
         $indexerRegistry = $this->getMockBuilder(\Magento\Framework\Indexer\IndexerRegistry::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->catalogDataHelperMock = $this->getMockBuilder(\Magento\Catalog\Helper\Data::class)
+        $this->dataHelperMock = $this->getMockBuilder(\Magento\Catalog\Helper\Data::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->productLinkFactoryMock = $this->createPartialMock(
@@ -49,7 +49,7 @@ class CategoryLinkManagementTest extends \PHPUnit\Framework\TestCase
         $this->model = new \Magento\Catalog\Model\CategoryLinkManagement(
             $this->categoryRepositoryMock,
             $this->productLinkFactoryMock,
-            $this->catalogDataHelperMock
+            $this->dataHelperMock
         );
 
         $this->setProperties($this->model, [

--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -88,6 +88,9 @@
                     <comment>Applies to category pages</comment>
                     <source_model>Magento\Catalog\Model\Config\Source\ListSort</source_model>
                 </field>
+                <field id="default_product_position" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Product Position in Category Default Value</label>
+                </field>
                 <field id="list_allow_all" translate="label comment" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Allow All Products per Page</label>
                     <comment>Whether to show "All" option in the "Show X Per Page" dropdown</comment>

--- a/app/code/Magento/Catalog/etc/config.xml
+++ b/app/code/Magento/Catalog/etc/config.xml
@@ -29,6 +29,7 @@
                 <list_per_page>10</list_per_page>
                 <flat_catalog_category>0</flat_catalog_category>
                 <default_sort_by>position</default_sort_by>
+                <default_product_position>0</default_product_position>
                 <parse_url_directives>1</parse_url_directives>
             </frontend>
             <product>

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1355,13 +1355,18 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         if ($categoriesData) {
             $categoriesIn = [];
             $delProductId = [];
-
+            
+            $position = $this->_catalogData->getDefaultProductPosition();
             foreach ($categoriesData as $delSku => $categories) {
                 $productId = $this->skuProcessor->getNewSku($delSku)['entity_id'];
                 $delProductId[] = $productId;
 
                 foreach (array_keys($categories) as $categoryId) {
-                    $categoriesIn[] = ['product_id' => $productId, 'category_id' => $categoryId, 'position' => 1];
+                    $categoriesIn[] = [
+                        'product_id' => $productId,
+                        'category_id' => $categoryId,
+                        'position' => $position
+                    ];
                 }
             }
             if (Import::BEHAVIOR_APPEND != $this->getBehavior()) {


### PR DESCRIPTION
### Description (*)
*Issue:* When adding a new category-product link, "position" value for a product is set to "0". Also, when importing products from file, "position" value is set to "1". As a result - new (and in some cases - not yet prepared) products appear in the beginning of the category.
*Solution:* Added an ability to configure the initial product position value in the Admin Panel. The default value for this config is "0".

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios (*)
*Configuration:*
1. Go to Stores -> Configuration
2. Select tab Catalog -> Catalog, then expand Storefront
3. Set up a new value for "Product Position in Category Default Value" and save the config

*Adding new category to the product:*
1. Go to "Edit" page of any existing product
2. Add a category to the product
3. Save changes
4. Check "position" value for the product in the added category

*Importing products:*
1. Go to the Import page, choose "Entity Type -> Products" and "Import Behavior -> Add / Update"
2. Upload a file with new products ("categories" column must be filled)
3. Check "position" values for the imported products in corresponding categories

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
