### PR TITLE
[Backport] fix: remove old code in tabs, always set tabindex to 0 when tabs are …

### DIFF
--- a/lib/web/mage/tabs.js
+++ b/lib/web/mage/tabs.js
@@ -83,7 +83,7 @@ define([
 
         /**
          * When the widget gets instantiated, the first tab that is not disabled receive focusable property
-         * Updated: for accessibility all tabs receive tabIndex 0
+         * All tabs receive tabIndex 0
          * @private
          */
         _processTabIndex: function () {
@@ -91,17 +91,8 @@ define([
 
             self.triggers.attr('tabIndex', 0);
             $.each(this.collapsibles, function (i) {
-                if (!$(this).collapsible('option', 'disabled')) {
-                    self.triggers.eq(i).attr('tabIndex', 0);
-
-                    return false;
-                }
-            });
-            $.each(this.collapsibles, function (i) {
-                $(this).on('beforeOpen', function () {
-                    self.triggers.attr('tabIndex', 0);
-                    self.triggers.eq(i).attr('tabIndex', 0);
-                });
+                self.triggers.attr('tabIndex', 0);
+                self.triggers.eq(i).attr('tabIndex', 0);
             });
         },
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19326
…initialized

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There seems to be old code which is duplicate. We always want to set the tabindex to `0` so it can be removed.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
