### PR TITLE
patch-19386 : Fixed Links once created not deleted from The Links Sec…

### DIFF
--- a/app/code/Magento/Downloadable/Model/Link/ReadHandler.php
+++ b/app/code/Magento/Downloadable/Model/Link/ReadHandler.php
@@ -7,6 +7,7 @@ namespace Magento\Downloadable\Model\Link;
 
 use Magento\Downloadable\Api\LinkRepositoryInterface as LinkRepository;
 use Magento\Framework\EntityManager\Operation\ExtensionInterface;
+use Magento\Framework\App\RequestInterface;
 
 /**
  * Class ReadHandler
@@ -21,9 +22,16 @@ class ReadHandler implements ExtensionInterface
     /**
      * @param LinkRepository $linkRepository
      */
-    public function __construct(LinkRepository $linkRepository)
+
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    public function __construct(LinkRepository $linkRepository,RequestInterface $request)
     {
         $this->linkRepository = $linkRepository;
+        $this->request = $request;
     }
 
     /**
@@ -40,7 +48,8 @@ class ReadHandler implements ExtensionInterface
         }
         $entityExtension = $entity->getExtensionAttributes();
         $links = $this->linkRepository->getLinksByProduct($entity);
-        if ($links) {
+        $downloadable = $this->request->getPost('downloadable');
+        if ($links && isset($downloadable['link']) && is_array($downloadable['link'])) {
             $entityExtension->setDownloadableProductLinks($links);
         }
         $entity->setExtensionAttributes($entityExtension);


### PR DESCRIPTION
Links once created not deleted from The Links Section in Downloadable products 

### Description (*)
Fixed Links once created not deleted from The Links Section in Downloadable products.

### Fixed Issues (if relevant)
1. magento/magento2#19386: Links once created not deleted from The Links Section in Downloadable products 


### Manual testing scenarios (*)
1. Check with new and existing product.
2. Add new product and edit also it.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
