### PR TITLE
[Up port] Fixed the issue #19347.

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -6,6 +6,8 @@
 namespace Magento\Checkout\Block\Cart;
 
 /**
+ * Cart shipping block.
+ *
  * @api
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -25,6 +27,11 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $serializer;
+    
+    /**
+     * @var \Magento\Checkout\Model\Cart\ConfigProvider
+     */
+    private $cartConfig;
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
@@ -34,6 +41,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      * @param array $layoutProcessors
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param \Magento\Checkout\Model\Cart\ConfigProvider|null $cartConfig
      * @throws \RuntimeException
      */
     public function __construct(
@@ -43,7 +51,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
         array $data = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+        \Magento\Checkout\Model\Cart\ConfigProvider $cartConfig = null
     ) {
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
@@ -51,6 +60,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         $this->_isScopePrivate = true;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->cartConfig = $cartConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Checkout\Model\Cart\ConfigProvider::class);
     }
 
     /**
@@ -61,7 +72,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      */
     public function getCheckoutConfig()
     {
-        return $this->configProvider->getConfig();
+        return $this->cartConfig->getCheckoutConfig();
     }
 
     /**
@@ -90,11 +101,13 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Get serialized checkout config.
+     *
      * @return bool|string
      * @since 100.2.0
      */
     public function getSerializedCheckoutConfig()
     {
-        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+        return $this->cartConfig->getSerializedCheckoutConfig();
     }
 }

--- a/app/code/Magento/Checkout/Block/Cart/Totals.php
+++ b/app/code/Magento/Checkout/Block/Cart/Totals.php
@@ -6,8 +6,8 @@
 
 namespace Magento\Checkout\Block\Cart;
 
-use Magento\Framework\View\Element\BlockInterface;
 use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
+use Magento\Framework\View\Element\BlockInterface;
 
 /**
  * Totals cart block.
@@ -42,12 +42,18 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
     protected $layoutProcessors;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Sales\Model\Config $salesConfig
      * @param array $layoutProcessors
      * @param array $data
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -56,12 +62,15 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Sales\Model\Config $salesConfig,
         array $layoutProcessors = [],
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         $this->_salesConfig = $salesConfig;
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = true;
         $this->layoutProcessors = $layoutProcessors;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
 
     /**
@@ -75,7 +84,7 @@ class Totals extends \Magento\Checkout\Block\Cart\AbstractCart
             $this->jsLayout = $processor->process($this->jsLayout);
         }
 
-        return json_encode($this->jsLayout, JSON_HEX_TAG);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**

--- a/app/code/Magento/Checkout/Model/Cart/ConfigProvider.php
+++ b/app/code/Magento/Checkout/Model/Cart/ConfigProvider.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Checkout\Model\Cart;
+
+/**
+ * Provides the checkout configuration.
+ */
+class ConfigProvider implements \Magento\Framework\View\Element\Block\ArgumentInterface
+{
+    /**
+     * @var \Magento\Checkout\Model\CompositeConfigProvider
+     */
+    private $configProvider;
+    
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+    
+    /**
+     * Config constructor.
+     *
+     * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     */
+    public function __construct(
+        \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
+    ) {
+        $this->configProvider = $configProvider;
+        $this->serializer = $serializer;
+    }
+    
+    /**
+     * Retrieve checkout configuration
+     *
+     * @return array
+     */
+    public function getCheckoutConfig()
+    {
+        return $this->configProvider->getConfig();
+    }
+    
+    /**
+     * Retrieve checkout serialized configuration
+     *
+     * @return bool|string
+     */
+    public function getSerializedCheckoutConfig()
+    {
+        return $this->serializer->serialize($this->getCheckoutConfig());
+    }
+}

--- a/app/code/Magento/Checkout/Model/Cart/ConfigProvider.php
+++ b/app/code/Magento/Checkout/Model/Cart/ConfigProvider.php
@@ -21,6 +21,11 @@ class ConfigProvider implements \Magento\Framework\View\Element\Block\ArgumentIn
      * @var \Magento\Framework\Serialize\SerializerInterface
      */
     private $serializer;
+
+    /**
+     * @var array
+     */
+    private $providedConfig = null;
     
     /**
      * Config constructor.
@@ -43,7 +48,11 @@ class ConfigProvider implements \Magento\Framework\View\Element\Block\ArgumentIn
      */
     public function getCheckoutConfig()
     {
-        return $this->configProvider->getConfig();
+        if (null === $this->providedConfig) {
+            $this->providedConfig = $this->configProvider->getConfig();
+        }
+
+        return $this->providedConfig;
     }
     
     /**

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Checkout\Test\Unit\Block\Cart;
 
+/**
+ * Test for Magento\Checkout\Block\Cart\Shipping class.
+ */
 class ShippingTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -51,6 +54,11 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $serializer;
+    
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cartConfig;
 
     protected function setUp()
     {
@@ -69,6 +77,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
         $this->storeManager = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->context->expects($this->once())->method('getStoreManager')->willReturn($this->storeManager);
         $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->cartConfig = $this->createMock(\Magento\Checkout\Model\Cart\ConfigProvider::class);
 
         $this->model = new \Magento\Checkout\Block\Cart\Shipping(
             $this->context,
@@ -77,14 +86,15 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
             $this->configProvider,
             [$this->layoutProcessor],
             ['jsLayout' => $this->layout],
-            $this->serializer
+            $this->serializer,
+            $this->cartConfig
         );
     }
 
     public function testGetCheckoutConfig()
     {
         $config = ['param' => 'value'];
-        $this->configProvider->expects($this->once())->method('getConfig')->willReturn($config);
+        $this->cartConfig->expects($this->once())->method('getCheckoutConfig')->willReturn($config);
         $this->assertEquals($config, $this->model->getCheckoutConfig());
     }
 
@@ -117,7 +127,10 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     public function testGetSerializedCheckoutConfig()
     {
         $checkoutConfig = ['checkout', 'config'];
-        $this->configProvider->expects($this->once())->method('getConfig')->willReturn($checkoutConfig);
+        $this->cartConfig
+            ->expects($this->once())
+            ->method('getSerializedCheckoutConfig')
+            ->willReturn(json_encode($checkoutConfig));
 
         $this->assertEquals(json_encode($checkoutConfig), $this->model->getSerializedCheckoutConfig());
     }

--- a/app/code/Magento/Checkout/Test/Unit/Model/Cart/ConfigProviderTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/Cart/ConfigProviderTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Checkout\Test\Unit\Model\Cart;
+
+/**
+ * Test for Magento\Checkout\Model\Cart\ConfigProvider class.
+ */
+class ConfigProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Checkout\Model\Cart\ConfigProvider
+     */
+    private $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cartConfigProvider;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $compositeConfigProvider;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
+
+    protected function setUp()
+    {
+        $this->cartConfigProvider = $this->createMock(\Magento\Checkout\Model\Cart\ConfigProvider::class);
+        $this->compositeConfigProvider = $this->createMock(\Magento\Checkout\Model\CompositeConfigProvider::class);
+        $this->serializer = $this->createMock(\Magento\Framework\Serialize\SerializerInterface::class);
+
+        $this->model = new \Magento\Checkout\Model\Cart\ConfigProvider(
+            $this->compositeConfigProvider,
+            $this->serializer
+        );
+    }
+
+    public function testGetCheckoutConfig()
+    {
+        $config = ['param' => 'value'];
+        $this->compositeConfigProvider
+            ->expects($this->once())
+            ->method('getConfig')
+            ->willReturn($config);
+
+        $this->assertEquals($config, $this->model->getCheckoutConfig());
+    }
+
+    public function testGetSerializedCheckoutConfig()
+    {
+        $config = '{"param":"value"}';
+
+        $this->serializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn($config);
+
+        $this->assertEquals($config, $this->model->getSerializedCheckoutConfig());
+    }
+}

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
@@ -133,6 +133,7 @@
                             <container name="checkout.cart.totals.container" as="totals" label="Shopping Cart Totals">
                                 <block class="Magento\Checkout\Block\Cart\Totals" name="checkout.cart.totals" template="Magento_Checkout::cart/totals.phtml">
                                     <arguments>
+                                        <argument name="cart_config" xsi:type="object">Magento\Checkout\Model\Cart\ConfigProvider</argument>
                                         <argument name="jsLayout" xsi:type="array">
                                             <item name="components" xsi:type="array">
                                                 <item name="block-totals" xsi:type="array">

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
@@ -15,7 +15,14 @@
     <script type="text/x-magento-init">
             {
                 "#cart-totals": {
-                    "Magento_Ui/js/core/app": <?= /* @escapeNotVerified */ $block->getJsLayout() ?>
+                    "Magento_Ui/js/core/app": <?= $block->getJsLayout() ?>,
+                    "Magento_Checkout/js/totals": {
+                        <?php // phpcs:disable Magento2.Security.XssTemplate?>
+                        "checkoutConfig":<?=  $block->getCartConfig()->getSerializedCheckoutConfig() ?>,
+                        "loaderFile":"<?= $block->getViewFileUrl('images/loader-1.gif') ?>",
+                        "baseUrl":"<?= $block->getBaseUrl() ?>"
+                        <?php // phpcs:enable?>
+                    }
                 }
             }
     </script>

--- a/app/code/Magento/Checkout/view/frontend/web/js/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/totals.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'mage/url',
+    'Magento_Ui/js/block-loader'
+], function (url, blockLoader) {
+    'use strict';
+
+    return function (config) {
+        window.checkoutConfig = config.checkoutConfig;
+        window.customerData = window.checkoutConfig.customerData;
+        window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
+
+        blockLoader(config.loaderFile);
+        url.setBaseUrl(config.baseUrl);
+    };
+});


### PR DESCRIPTION
After removing the Estimate Shipping Costs and Tax from cart using layout the totals were not displayed.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Please check all the description in issue #19347.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19347: Removing "Estimate shipping costs and tax" from cart removes cart totals

### Manual testing scenarios (*)
The testing scenarios are described in the issue page.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
