### PR TITLE
make sure that the removal of the custom_price is properly persisted into database

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/Updater.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Updater.php
@@ -145,8 +145,8 @@ class Updater
             $item->addOption($infoBuyRequest);
         }
 
-        $item->unsetData('custom_price');
-        $item->unsetData('original_custom_price');
+        $item->setData('custom_price', null);
+        $item->setData('original_custom_price', null);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Minor bug fix for 'Custom Price' when creating an order in backend. The 'Custom Price' is not properly reverted back the the original price when you uncheck the checkbox.

### Manual testing scenarios (*)
1. Login into Admin
2. Go to 'Sales' -> 'Orders' -> 'Create New Order'
3. Add a product to order
4. Check the 'Custom Price*' checkbox and fill in the custom price you want in the textbox below the checkbox
5. Click on 'Update Items and Quantities' to persist the custom price
6. Uncheck the 'Custom Price*' checkbox and click again on 'Update Items and Quantities', after the ajax request is done you should see the original price, but... do the next step...
7. Manually refresh the page, and you should see the price being reverted back to the custom price

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
