### PR TITLE
Fixed issue related to attribute 'product_type', as it is a system reserved attribute for magento.

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -84,6 +84,14 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $response->setError(true);
             $response->setProductAttribute($attribute->toArray());
         }
+        
+        if(in_array($attributeCode, \Magento\Catalog\Model\ResourceModel\Eav\Attribute::DEFAULT_ATTRIBUTE)){
+    		$message = 	__('Cannot create attribute (%1) as it is already used in catalog',$attributeCode);
+    		$this->setMessageToResponse($response, [$message]);
+    		$response->setError(true);
+    		$response->setProductAttribute($attribute->toArray());
+    	}
+        
         if ($this->getRequest()->has('new_attribute_set_name')) {
             $setName = $this->getRequest()->getParam('new_attribute_set_name');
             /** @var $attributeSet \Magento\Eav\Model\Entity\Attribute\Set */

--- a/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
@@ -40,7 +40,8 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute implements
     const ENTITY = 'catalog_eav_attribute';
 
     const KEY_IS_GLOBAL = 'is_global';
-
+        
+    CONST DEFAULT_ATTRIBUTE =  ['product_type'];
     /**
      * @var LockValidatorInterface
      */


### PR DESCRIPTION
Fixed issue - #19346
Import data 2.2.6 Value for 'product_type' attribute contains incorrect value

Since 'product_attribute' is reserved attribute,so we can restrict this type of attribute to be created by user.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
