### PR TITLE
Replaced exception with messageManager error message due to user error and not application error

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
@@ -143,13 +143,11 @@ class NewAction extends SubscriberController
                 if ($subscriber->getId()
                     && (int) $subscriber->getSubscriberStatus() === Subscriber::STATUS_SUBSCRIBED
                 ) {
-                    throw new LocalizedException(
-                        __('This email address is already subscribed.')
-                    );
+                    $this->messageManager->addErrorMessage(__('This email address is already subscribed.'));
+                } else {
+                    $status = (int)$this->_subscriberFactory->create()->subscribe($email);
+                    $this->messageManager->addSuccessMessage($this->getSuccessMessage($status));
                 }
-
-                $status = (int) $this->_subscriberFactory->create()->subscribe($email);
-                $this->messageManager->addSuccessMessage($this->getSuccessMessage($status));
             } catch (LocalizedException $e) {
                 $this->messageManager->addExceptionMessage(
                     $e,


### PR DESCRIPTION
Replaced exception with messageManager error message due to user error and not application error


### Description (*)
When subscribing to the newsletter with an existing email address, an exception is thrown, then later caught, added as error message + logged. Since this is a user error, it should not be logged. Our log files don't need these kinds of messages.

### Fixed Issues (if relevant)
Prevent the message "This email address is already subscribed." from appearing in the logs.

### Manual testing scenarios (*)
1. Subscribe an email address that already exists.
2. You will see the error message (good), but it will also appear in the logs (unwanted)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
