### PR TITLE
Fix for incorrectly escapeHtml'd JSON in commit b8f78cc6

### DIFF
--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -108,7 +108,7 @@ require([
             fileTypes: /^image\/(gif|jpeg|png)$/,
             maxFileSize: <?= (int) $block->getFileSizeService()->getMaxFileSize() ?> * 10
         },
-        <?= $resizeConfig ?>,
+        <?= /* @noEscape */ $resizeConfig ?>,
         {
             action: 'save'
         }]

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -108,7 +108,7 @@ require([
             fileTypes: /^image\/(gif|jpeg|png)$/,
             maxFileSize: <?= (int) $block->getFileSizeService()->getMaxFileSize() ?> * 10
         },
-        <?= $block->escapeHtml($resizeConfig) ?>,
+        <?= $resizeConfig ?>,
         {
             action: 'save'
         }]


### PR DESCRIPTION
This commit fixes a bug where the resize JSON configuration was incorrectly being HTML encoded before being output, preventing CMS image uploads in the admin due to the Javascript failing on the encoded single quote -> `&#039;` in the code. Relates to new resize code introduced in MAGETWO-94988, commit b8f78cc6.