### PR TITLE
Fix: SalesQuoteSaveAfterObserver fails to update the checkout session quote id when applicable

### DIFF
--- a/app/code/Magento/Checkout/Observer/SalesQuoteSaveAfterObserver.php
+++ b/app/code/Magento/Checkout/Observer/SalesQuoteSaveAfterObserver.php
@@ -7,6 +7,9 @@ namespace Magento\Checkout\Observer;
 
 use Magento\Framework\Event\ObserverInterface;
 
+/**
+ * Class SalesQuoteSaveAfterObserver
+ */
 class SalesQuoteSaveAfterObserver implements ObserverInterface
 {
     /**
@@ -24,15 +27,18 @@ class SalesQuoteSaveAfterObserver implements ObserverInterface
     }
 
     /**
+     * Assign quote to session
+     *
      * @param \Magento\Framework\Event\Observer $observer
      * @return void
      */
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
+        /* @var \Magento\Quote\Model\Quote $quote */
         $quote = $observer->getEvent()->getQuote();
-        /* @var $quote \Magento\Quote\Model\Quote */
+
         if ($quote->getIsCheckoutCart()) {
-            $this->checkoutSession->getQuoteId($quote->getId());
+            $this->checkoutSession->setQuoteId($quote->getId());
         }
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Observer/SalesQuoteSaveAfterObserverTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Observer/SalesQuoteSaveAfterObserverTest.php
@@ -30,13 +30,14 @@ class SalesQuoteSaveAfterObserverTest extends \PHPUnit\Framework\TestCase
 
     public function testSalesQuoteSaveAfter()
     {
+        $quoteId = 7;
         $observer = $this->createMock(\Magento\Framework\Event\Observer::class);
         $observer->expects($this->once())->method('getEvent')->will(
             $this->returnValue(new \Magento\Framework\DataObject(
-                ['quote' => new \Magento\Framework\DataObject(['is_checkout_cart' => 1, 'id' => 7])]
+                ['quote' => new \Magento\Framework\DataObject(['is_checkout_cart' => 1, 'id' => $quoteId])]
             ))
         );
-        $this->checkoutSession->expects($this->once())->method('getQuoteId')->with(7);
+        $this->checkoutSession->expects($this->once())->method('setQuoteId')->with($quoteId);
 
         $this->object->execute($observer);
     }


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The checkout session quote id is not updated due to *line 35* in `\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver` which incorrectly calls `$this->checkoutSession->getQuoteId($quote->getId());`
In order to update the checkout session quote id, the `setQuoteId` method should be called.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19424: "\Magento\Checkout\Observer\SalesQuoteSaveAfterObserver fails to update the checkout session quote id when applicable"

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. During the guest checkout, session quote id should be set after dispatching the `sales_quote_save_after` event.
2. Verify that the guest checkout is working properly.

### Affected functionality
1. Guest Checkout

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
