### PR TITLE
[Backport] Fixing the customer subscribing from different stores

### DIFF
--- a/app/code/Magento/Newsletter/Model/Plugin/CustomerPlugin.php
+++ b/app/code/Magento/Newsletter/Model/Plugin/CustomerPlugin.php
@@ -6,12 +6,13 @@
 namespace Magento\Newsletter\Model\Plugin;
 
 use Magento\Customer\Api\CustomerRepositoryInterface as CustomerRepository;
-use Magento\Customer\Api\Data\CustomerInterface;
-use Magento\Newsletter\Model\SubscriberFactory;
-use Magento\Framework\Api\ExtensionAttributesFactory;
-use Magento\Newsletter\Model\ResourceModel\Subscriber;
 use Magento\Customer\Api\Data\CustomerExtensionInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Framework\App\ObjectManager;
+use Magento\Newsletter\Model\ResourceModel\Subscriber;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 class CustomerPlugin
 {
@@ -38,21 +39,29 @@ class CustomerPlugin
     private $customerSubscriptionStatus = [];
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * Initialize dependencies.
      *
      * @param SubscriberFactory $subscriberFactory
      * @param ExtensionAttributesFactory|null $extensionFactory
      * @param Subscriber|null $subscriberResource
+     * @param StoreManagerInterface|null $storeManager
      */
     public function __construct(
         SubscriberFactory $subscriberFactory,
         ExtensionAttributesFactory $extensionFactory = null,
-        Subscriber $subscriberResource = null
+        Subscriber $subscriberResource = null,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->subscriberFactory = $subscriberFactory;
         $this->extensionFactory = $extensionFactory
             ?: ObjectManager::getInstance()->get(ExtensionAttributesFactory::class);
         $this->subscriberResource = $subscriberResource ?: ObjectManager::getInstance()->get(Subscriber::class);
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 
     /**
@@ -149,6 +158,8 @@ class CustomerPlugin
     public function afterGetById(CustomerRepository $subject, CustomerInterface $customer)
     {
         $extensionAttributes = $customer->getExtensionAttributes();
+        $storeId = $this->storeManager->getStore()->getId();
+        $customer->setStoreId($storeId);
         if ($extensionAttributes === null) {
             /** @var CustomerExtensionInterface $extensionAttributes */
             $extensionAttributes = $this->extensionFactory->create(CustomerInterface::class);

--- a/app/code/Magento/Newsletter/Test/Unit/Model/Plugin/CustomerPluginTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/Plugin/CustomerPluginTest.php
@@ -10,6 +10,8 @@ use Magento\Customer\Model\ResourceModel\CustomerRepository;
 use Magento\Customer\Api\Data\CustomerExtensionInterface;
 use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Newsletter\Model\ResourceModel\Subscriber;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 
 class CustomerPluginTest extends \PHPUnit\Framework\TestCase
 {
@@ -53,6 +55,11 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
      */
     private $customerMock;
 
+    /**
+     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
     protected function setUp()
     {
         $this->subscriberFactory = $this->getMockBuilder(\Magento\Newsletter\Model\SubscriberFactory::class)
@@ -87,6 +94,8 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
             ->setMethods(["getExtensionAttributes"])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+
         $this->subscriberFactory->expects($this->any())->method('create')->willReturn($this->subscriber);
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->plugin = $this->objectManager->getObject(
@@ -94,7 +103,8 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
             [
                 'subscriberFactory' => $this->subscriberFactory,
                 'extensionFactory' => $this->extensionFactoryMock,
-                'subscriberResource' => $this->subscriberResourceMock
+                'subscriberResource' => $this->subscriberResourceMock,
+                'storeManager' => $this->storeManagerMock,
             ]
         );
     }
@@ -198,6 +208,7 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
     ) {
         $subject = $this->createMock(\Magento\Customer\Api\CustomerRepositoryInterface::class);
         $subscriber = [$subscriberStatusKey => $subscriberStatusValue];
+        $this->prepareStoreData();
         $this->extensionFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($this->customerExtensionMock);
@@ -223,6 +234,7 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
     {
         $subject = $this->createMock(\Magento\Customer\Api\CustomerRepositoryInterface::class);
         $subscriber = ['subscriber_id' => 1, 'subscriber_status' => 1];
+        $this->prepareStoreData();
         $this->customerMock->expects($this->any())
             ->method('getExtensionAttributes')
             ->willReturn($this->customerExtensionMock);
@@ -254,5 +266,18 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
             ['subscriber_status', 4, false],
             [null, null, false]
         ];
+    }
+
+    /**
+     * Prepare store information
+     *
+     * @return void
+     */
+    private function prepareStoreData()
+    {
+        $storeId = 1;
+        $storeMock = $this->createMock(Store::class);
+        $storeMock->expects($this->any())->method('getId')->willReturn($storeId);
+        $this->storeManagerMock->expects($this->any())->method('getStore')->willReturn($storeMock);
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19195

### Description (*)
This PR fixes the customer subscription from different stores.

### Fixed Issues (if relevant)
1. magento/magento2#19172: Newsletter subscription does not set the correct store_id if already subscribed

### Manual testing scenarios (*)
1. Create 2 stores: A(default) and B
2. Login on the frontend
3. Subscribe to Newsletter (which should be successfully)
4. Switch to store B
5. Subscribe to Newsletter (you get the success message, but the subscription wasn't saved)

**For details, please check the task's description.**

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
