### PR TITLE
Validation on Product quantity in case of decimals

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -14,7 +14,8 @@ define([
     'tinycolor',
     'jquery/validate',
     'jquery/ui',
-    'mage/translate'
+    'mage/translate',
+    'mage/math'
 ], function ($, _, utils, moment, tinycolor) {
     'use strict';
 
@@ -963,7 +964,7 @@ define([
                     isMaxAllowedValid = typeof params.maxAllowed === 'undefined' ||
                         qty <= utils.parseNumber(params.maxAllowed),
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
-                        qty % utils.parseNumber(params.qtyIncrements) === 0;
+                        $.mage.getExactDivision(qty, $.mage.parseNumber(params.qtyIncrements)) === 0;
 
                 result = qty > 0;
 

--- a/lib/web/mage/math.js
+++ b/lib/web/mage/math.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+(function (root, factory) {
+    'use strict';
+
+    if (typeof define === 'function' && define.amd) {
+        define([
+            'jquery'
+        ], factory);
+    } else {
+        factory(root.jQuery);
+    }
+}(this, function ($, mage) {
+    'use strict';
+
+    $.extend(true, $, mage, {
+        mage: {
+            /**
+             * Returns the floating point remainder (modulo) of the division of the arguments
+             *
+             * @param {Number} dividend
+             * @param {Number} divisor
+             * @returns {Number}
+             */
+            getExactDivision: function (dividend, divisor) {
+                var divideEpsilon = 1000,
+                    epsilon = divisor / divideEpsilon,
+                    remainder = dividend % divisor;
+
+                if (Math.abs(remainder - divisor) < epsilon || Math.abs(remainder) < epsilon) {
+                    remainder = 0;
+                }
+
+                return remainder;
+            }
+        }
+    });
+}));

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -12,7 +12,8 @@
             'moment',
             'jquery/ui',
             'jquery/validate',
-            'mage/translate'
+            'mage/translate',
+            'mage/math'
         ], factory);
     } else {
         factory(jQuery);
@@ -1589,7 +1590,7 @@
                     isMaxAllowedValid = typeof params.maxAllowed === 'undefined' ||
                         qty <= $.mage.parseNumber(params.maxAllowed),
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
-                        qty % $.mage.parseNumber(params.qtyIncrements) === 0;
+                        $.mage.getExactDivision(qty, $.mage.parseNumber(params.qtyIncrements)) === 0;
 
                 result = qty > 0;
 


### PR DESCRIPTION
### Description (*)
- Replicated the PHP method `getExactDivision` of `Magento\Framework\Math\Division` into the Javascript
- Changed the Javascript modulus check (in `lib/web/mage/validation.js:1293` and `app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js:967`) to use `getExactDivision` method

Fixes the issue described in magento2#19209

### Fixed Issues (if relevant)
1. magento/magento2#19209

### Manual testing scenarios (*)
Available in magento/magento2#19209

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
