### PR TITLE
add opportunity to cancel  invoice if invoice state == STATE_PAID

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -407,7 +407,7 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
      */
     public function cancel()
     {
-        if (!$this->canCancel()) {
+        if ($this->isCanceled()) {
             return $this;
         }
         $order = $this->getOrder();


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
We can cancel invoice if invoice state ==  self::STATE_OPEN but we can't cancel invoice if invoice state == STATE_PAID.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18509 Can't cancelled invoice if invoice state == STATE_PAID

### Manual testing scenarios (*)
1. Load an invoice programmatically where state == STATE_PAID
2. Call $invoice->cancel()

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
