### PR TITLE
2.3

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -11,10 +11,10 @@ error_reporting(E_ALL);
 #ini_set('display_errors', 1);
 
 /* PHP version validation */
-if (!defined('PHP_VERSION_ID') || !(PHP_VERSION_ID === 70002 || PHP_VERSION_ID === 70004 || PHP_VERSION_ID >= 70006)) {
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70103) {
     if (PHP_SAPI == 'cli') {
-        echo 'Magento supports 7.0.2, 7.0.4, and 7.0.6 or later. ' .
-            'Please read http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html';
+        echo 'Magento supports 7.1.3 or later. ' .
+            'Please read https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html';
     } else {
         echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -18,8 +18,8 @@ if (!defined('PHP_VERSION_ID') || !(PHP_VERSION_ID === 70002 || PHP_VERSION_ID =
     } else {
         echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">
-    <p>Magento supports PHP 7.0.2, 7.0.4, and 7.0.6 or later. Please read
-    <a target="_blank" href="http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html">
+    <p>Magento supports PHP 7.1.3 or later. Please read
+    <a target="_blank" href="https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html">
     Magento System Requirements</a>.
 </div>
 HTML;


### PR DESCRIPTION
Just a small update for the minimum PHP version and the link to the documentation

Fixes issue https://github.com/magento/magento2/issues/19453

### Manual testing scenarios (*)
1. try to run M2.3 on php5.5
2. the system tells you you should have php 7.0.something, which is wrong (as from https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html)
3. with this fix the minimum php version is checked correctly and the error message is also consistent 