### PR TITLE
[Backport 2.2] issue #18931 fixed.

### DIFF
--- a/app/code/Magento/Catalog/i18n/en_US.csv
+++ b/app/code/Magento/Catalog/i18n/en_US.csv
@@ -798,3 +798,4 @@ Details,Details
 "Add To Compare","Add To Compare"
 "Learn more","Learn more"
 "Recently Viewed","Recently Viewed"
+"You added product %1 to the <a href=""%2"">comparison list</a>.","You added product %1 to the <a href=""%2"">comparison list</a>."

--- a/app/code/Magento/Checkout/i18n/en_US.csv
+++ b/app/code/Magento/Checkout/i18n/en_US.csv
@@ -181,3 +181,4 @@ Payment,Payment
 "Item in Cart","Item in Cart"
 "Items in Cart","Items in Cart"
 "Close","Close"
+"You added %1 to your <a href=""%2"">shopping cart</a>.","You added %1 to your <a href=""%2"">shopping cart</a>."


### PR DESCRIPTION
### Description (*)
Add missing translations, backport of https://github.com/magento/magento2/pull/18938

### Fixed Issues (if relevant)
1. magento/magento2#18931: Product added to shopping cart / comparison list message not translated by default

### Manual testing scenarios (*)
1. Change language to non english.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
