### PR TITLE
remove condition from invoice cancel

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -445,10 +445,6 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
         $order->setBaseDiscountInvoiced($order->getBaseDiscountInvoiced() - $this->getBaseDiscountAmount());
         $order->setBaseTotalInvoicedCost($order->getBaseTotalInvoicedCost() - $this->getBaseCost());
 
-        if ($this->getState() == self::STATE_PAID) {
-            $order->setTotalPaid($order->getTotalPaid() - $this->getGrandTotal());
-            $order->setBaseTotalPaid($order->getBaseTotalPaid() - $this->getBaseGrandTotal());
-        }
         $this->setState(self::STATE_CANCELED);
         $order->setState(\Magento\Sales\Model\Order::STATE_PROCESSING)
             ->setStatus($order->getConfig()->getStateDefaultStatus(\Magento\Sales\Model\Order::STATE_PROCESSING));


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
regarding the #18509
you can't cancel invoice if state == paid, If state == paid, you can do the credit memo.

When you create an invoice and realise that it needs to be cancelled, be aware that there are some legal restrictions involved. Technically, you should never delete an issued invoice but instead use a credit note to cancel the invoice.

This code doesn't make sense



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
