### PR TITLE
Use semantic theme color variables, including global primary/secondary colors

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Braintree/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Braintree/web/css/source/_module.less
@@ -9,9 +9,9 @@
 
 @braintree-input-border__color: @color-gray76;
 
-@braintree-error__color: @color-red10;
-@braintree-focus__color: @color-blue2;
-@braintree-success__color: @color-dark-green1;
+@braintree-error__color: @message-error__color;
+@braintree-focus__color: @theme__color__primary-alt;
+@braintree-success__color: @message-success__color;
 
 @braintree-paypal-icon__height: 16px;
 @braintree-paypal-icon__width: 16px;

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
@@ -16,7 +16,7 @@
 @checkout-progress-bar-item__color: @primary__color;
 @checkout-progress-bar-item__margin: @indent__s;
 @checkout-progress-bar-item__width: 185px;
-@checkout-progress-bar-item__active__background-color: @color-orange-red1;
+@checkout-progress-bar-item__active__background-color: @active__color;
 @checkout-progress-bar-item__complete__color: @link__color;
 
 @checkout-progress-bar-item-element__height: @checkout-progress-bar-item-element__width;

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -22,7 +22,7 @@
 @checkout-shipping-item__width: 100%/3;
 @checkout-shipping-item-tablet__width: 100%/2;
 @checkout-shipping-item-mobile__width: 100%;
-@checkout-shipping-item__active__border-color: @color-orange-red1;
+@checkout-shipping-item__active__border-color: @active__color;
 
 @checkout-shipping-item-icon__selected__height: 27px;
 @checkout-shipping-item-icon__selected__width: 29px;

--- a/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less
@@ -11,7 +11,7 @@
 @account-nav-color: false;
 
 @account-nav-current-border: 3px solid transparent;
-@account-nav-current-border-color: @color-orange-red1;
+@account-nav-current-border-color: @active__color;
 @account-nav-current-color: false;
 @account-nav-current-font-weight: @font-weight__semibold;
 

--- a/app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
@@ -47,7 +47,7 @@
                     }
 
                     .error-block {
-                        color: @color-red10;
+                        color: @error__color;
 
                         .error-label {
                             font-weight: @font-weight__bold;
@@ -222,7 +222,7 @@
             }
 
             .error-description {
-                color: @color-red10;
+                color: @error__color;
                 font-weight: @font-weight__regular;
                 margin-bottom: @indent__s;
                 margin-top: -@indent__s;

--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -18,7 +18,7 @@
 
 @swatch-option__selected__border: @swatch-option__hover__border;
 @swatch-option__selected__color: @swatch-option__hover__color;
-@swatch-option__selected__outline: 2px solid @color-orange-red1;
+@swatch-option__selected__outline: 2px solid @active__color;
 
 @swatch-option__disabled__background: @color-red10;
 
@@ -38,7 +38,7 @@
 
 //  Image and Color swatch
 @img-color-swatch-option__hover__border: @swatch-option__hover__border;
-@img-color-swatch-option__hover__outline: 2px solid #e00;
+@img-color-swatch-option__hover__outline: 2px solid darken(@active__color, 12%);
 
 //  Tooltip
 @swatch-option-tooltip__background: @color-white;
@@ -54,7 +54,7 @@
 @swatch-option-tooltip-layered-title__color: @swatch-option-tooltip-title__color;
 
 //  Layered Features
-@swatch-option-link-layered__focus__box-shadow: 0 0 3px 1px @color-sky-blue1;
+@swatch-option-link-layered__focus__box-shadow: 0 0 3px 1px @focus__color;
 
 //
 //  Common

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -145,12 +145,6 @@
         }
 
         &:extend(.abs-adjustment-incl-excl-tax all);
-
-        .action {
-            &.multicheckout {
-                color: @color-blue2;
-            }
-        }
     }
 
     //  Totals block

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
@@ -18,7 +18,7 @@
 @checkout-progress-bar-item__transition: background .3s;
 @checkout-progress-bar-item__width: 185px;
 
-@checkout-progress-bar-item__active__background-color: @color-orange-red1;
+@checkout-progress-bar-item__active__background-color: @active__color;
 @checkout-progress-bar-item__active__color: @primary__color;
 @checkout-progress-bar-item__active__font-weight: @font-weight__semibold;
 @checkout-progress-bar-item__complete__color: @link__color;
@@ -32,7 +32,7 @@
 @checkout-progress-bar-item-element-inner__color: @primary__color;
 @checkout-progress-bar-item-element-inner__height: @checkout-progress-bar-item-element-inner__width;
 @checkout-progress-bar-item-element-inner__width: @checkout-progress-bar-item-element__width - ( @checkout-progress-bar-item-element-outer-radius__width*2 );
-@checkout-progress-bar-item-element-inner__active__border-color: @color-orange-red1;
+@checkout-progress-bar-item-element-inner__active__border-color: @active__color;
 @checkout-progress-bar-item-element-inner__active__content: @icon-checkmark;
 
 @checkout-progress-bar-item-element-outer-radius__width: 6px;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -22,7 +22,7 @@
 @checkout-shipping-item__width: 100%/3;
 @checkout-shipping-item-tablet__width: 100%/2;
 @checkout-shipping-item-mobile__width: 100%;
-@checkout-shipping-item__active__border-color: @color-orange-red1;
+@checkout-shipping-item__active__border-color: @active__color;
 
 @checkout-shipping-item-icon__selected__height: 27px;
 @checkout-shipping-item-icon__selected__width: 29px;

--- a/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
@@ -60,8 +60,8 @@
     }
 
     .gift-summary {
-        position: relative;
         margin-top: @indent__s;
+        position: relative;
 
         .actions-toolbar {
             > .secondary {

--- a/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
@@ -12,7 +12,7 @@
 @gift-item-block__border-color: @color-gray-light5;
 @gift-item-block__border-width: @border-width__base;
 
-@gift-item-block-title__color: @color-blue1;
+@gift-item-block-title__color: @link__color;
 @gift-item-block-title-icon__content: @icon-down;
 @gift-item-block-title-icon__active__content: @icon-up;
 @gift-item-block-title-icon__color: @color-gray52;

--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/web/css/source/_module.less
@@ -32,7 +32,7 @@
 
                 &[data-count]:after {
                     .lib-css(color, @color-white);
-                    background: @color-orange-red1;
+                    background: @theme__color__secondary;
                     border-radius: 2px;
                     content: attr(data-count);
                     display: inline-block;

--- a/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
@@ -48,7 +48,7 @@
                     }
 
                     .error-block {
-                        color: @color-red10;
+                        color: @error__color;
 
                         .error-label {
                             font-weight: @font-weight__bold;
@@ -230,7 +230,7 @@
             }
 
             .error-description {
-                color: @color-red10;
+                color: @error__color;
                 font-weight: @font-weight__regular;
                 margin-bottom: @indent__s;
                 margin-top: -@indent__s;

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1859,7 +1859,7 @@
 
             > .title {
                 strong {
-                    color: @color-blue1;
+                    color: @link__color;
                     font-weight: @font-weight__regular;
                 }
             }

--- a/app/design/frontend/Magento/luma/web/css/source/_theme.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_theme.less
@@ -28,7 +28,7 @@
 @h3__margin-top: @indent__base;
 
 //  Links
-@link__color: @color-blue2;
+@link__color: @theme__color__primary-alt;
 
 //  Focus
 @focus__color: @color-blue3;
@@ -60,13 +60,8 @@
 
 @navigation__background: @color-gray94;
 @navigation-level0-item__active__color: @primary__color;
-@navigation-level0-item__active__border-color: @active__color;
-@navigation-desktop-level0-item__active__border-color: @active__color;
 
-@submenu-desktop-item__active__border-color: @active__color;
-@submenu-item__active__border-color: @active__color;
 @submenu-item__active__color: @navigation-level0-item__active__color;
-
 
 //  Desktop navigation
 @navigation-desktop-level0-item__line-height: 47px;
@@ -225,7 +220,6 @@
 
 @rating-icon__font-size: 16px;
 @rating-icon__letter-spacing: 2px;
-@rating-icon__active__color: @active__color;
 
 //
 //  Dropdowns
@@ -252,7 +246,7 @@
 @breadcrumbs-icon__font-margin: 0 @indent__s;
 
 @breadcrumbs-current__color: @color-gray-middle5;
-@breadcrumbs-link__color: @color-blue2;
+@breadcrumbs-link__color: @link__color;
 @breadcrumbs-link__visited__color: @breadcrumbs-link__color;
 @breadcrumbs-link__hover__color: @breadcrumbs-link__color;
 @breadcrumbs-link__active__color: @breadcrumbs-link__color;

--- a/lib/web/css/source/lib/variables/_buttons.less
+++ b/lib/web/css/source/lib/variables/_buttons.less
@@ -57,14 +57,14 @@
 @button-primary__gradient: false;
 @button-primary__gradient-direction: false;
 
-@button-primary__background: @color-blue1;
-@button-primary__border: 1px solid @color-blue1;
+@button-primary__background: @theme__color__primary;
+@button-primary__border: 1px solid @theme__color__primary;
 @button-primary__color: @color-white;
 @button-primary__gradient-color-start: false;
 @button-primary__gradient-color-end: false;
 
-@button-primary__hover__background: @color-blue2;
-@button-primary__hover__border: 1px solid @color-blue2;
+@button-primary__hover__background: @theme__color__primary-alt;
+@button-primary__hover__border: 1px solid @theme__color__primary-alt;
 @button-primary__hover__color: @button-primary__color;
 @button-primary__hover__gradient-color-start: false;
 @button-primary__hover__gradient-color-end: false;

--- a/lib/web/css/source/lib/variables/_colors.less
+++ b/lib/web/css/source/lib/variables/_colors.less
@@ -78,7 +78,7 @@
 @color-sky-blue1: #68a8e0;
 
 @color-pink1: #fae5e5;
-@color-dark-pink1: #800080;
+@color-dark-pink1: #800080; // Legacy pink
 
 @color-brownie1: #6f4400;
 @color-brownie-light1: #c07600;
@@ -92,6 +92,10 @@
 //  Color nesting
 //  ---------------------------------------------
 
+@theme__color__primary: @color-blue1;
+@theme__color__primary-alt: @color-blue2;
+@theme__color__secondary: @color-orange-red1;
+
 @primary__color: @color-gray20;
 @primary__color__dark: darken(@primary__color, 35%); // #000
 @primary__color__darker: darken(@primary__color, 13.5%); // #111
@@ -104,5 +108,5 @@
 @page__background-color: @color-white;
 @panel__background-color: darken(@page__background-color, 6%);
 
-@active__color: @color-orange-red1;
+@active__color: @theme__color__secondary;
 @error__color: @color-red10;

--- a/lib/web/css/source/lib/variables/_navigation.less
+++ b/lib/web/css/source/lib/variables/_navigation.less
@@ -23,7 +23,7 @@
 @navigation-level0-item__text-decoration: none;
 
 @navigation-level0-item__active__background: '';
-@navigation-level0-item__active__border-color: @color-orange-red1;
+@navigation-level0-item__active__border-color: @active__color;
 @navigation-level0-item__active__border-style: solid;
 @navigation-level0-item__active__border-width: 0 0 0 8px;
 @navigation-level0-item__active__color: '';
@@ -47,7 +47,7 @@
 
 @submenu-item__active__background: '';
 @submenu-item__active__border: 8px;
-@submenu-item__active__border-color: @color-orange-red1;
+@submenu-item__active__border-color: @active__color;
 @submenu-item__active__border-style: solid;
 @submenu-item__active__border-width: 0 0 0 @submenu-item__active__border;
 @submenu-item__active__color: '';
@@ -77,7 +77,7 @@
 @navigation-desktop-level0-item__hover__text-decoration: @navigation-desktop-level0-item__text-decoration;
 
 @navigation-desktop-level0-item__active__background: '';
-@navigation-desktop-level0-item__active__border-color: @color-orange-red1;
+@navigation-desktop-level0-item__active__border-color: @active__color;
 @navigation-desktop-level0-item__active__border-style: solid;
 @navigation-desktop-level0-item__active__border-width: 0 0 3px;
 @navigation-desktop-level0-item__active__color: @navigation-desktop-level0-item__hover__color;
@@ -109,7 +109,7 @@
 @submenu-desktop-item__hover__text-decoration: @navigation-desktop-level0-item__text-decoration;
 
 @submenu-desktop-item__active__background: '';
-@submenu-desktop-item__active__border-color: @color-orange-red1;
+@submenu-desktop-item__active__border-color: @active__color;
 @submenu-desktop-item__active__border-style: solid;
 @submenu-desktop-item__active__border-width: 0 0 0 3px;
 @submenu-desktop-item__active__color: '';

--- a/lib/web/css/source/lib/variables/_rating.less
+++ b/lib/web/css/source/lib/variables/_rating.less
@@ -14,6 +14,6 @@
 @rating-icon__letter-spacing: -10px;
 @rating-icon__color: @color-gray78;
 
-@rating-icon__active__color: @color-orange-red1;
+@rating-icon__active__color: @active__color;
 
 @rating-label__hide: false;

--- a/lib/web/css/source/lib/variables/_typography.less
+++ b/lib/web/css/source/lib/variables/_typography.less
@@ -83,13 +83,13 @@
 //  Links
 //  ---------------------------------------------
 
-@link__color: @color-blue1;
+@link__color: @theme__color__primary;
 @link__text-decoration: none;
 
 @link__visited__color: @link__color;
 @link__visited__text-decoration: none;
 
-@link__hover__color: @color-blue2;
+@link__hover__color: @theme__color__primary-alt;
 @link__hover__text-decoration: underline;
 
 @link__active__color: @active__color;

--- a/lib/web/mage/gallery/gallery.less
+++ b/lib/web/mage/gallery/gallery.less
@@ -181,8 +181,8 @@
 
 .fotorama__active {
     .fotorama__dot {
-        background-color: @color-orange-red1;
-        border-color: @color-orange-red1;
+        background-color: @active__color;
+        border-color: @active__color;
     }
 }
 
@@ -237,7 +237,7 @@
     &:extend(.fotorama-print-background);
     backface-visibility: hidden;
     background-image: linear-gradient(to bottom right, rgba(255, 255, 255, 0.25), rgba(64, 64, 64, 0.1));
-    border: 1px solid @color-orange-red1;
+    border: 1px solid @active__color;
     left: 0;
     position: absolute;
     top: 0;

--- a/lib/web/mage/gallery/module/_extends.less
+++ b/lib/web/mage/gallery/module/_extends.less
@@ -42,7 +42,7 @@
 .fotorama-focus-overlay {
     &:after {
         &:extend(.fotorama-stretch);
-        background-color: @color-blue2;
+        background-color: @theme__color__primary-alt;
         border-radius: inherit;
         content: '';
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR updates instances of the predominant blue and orange colors in the Blank and Luma themes to use more semantic variables.
Additionally, it implements global primary and secondary theme colors to make basic global theme changes much easier and more reliable.
There are no visual changes to the default themes on the frontend (except a couple fixes for minor inconsistencies in Luma), and all existing variables (such as button colors) can still be redefined just as before.
However, setting new brand colors in child themes is now much easier and requires fewer code changes.

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
#### Preconditions
1. Magento 2.x
2. A custom theme which extends from either Magento/blank or Magento/luma

#### Steps to reproduce
1. In the custom theme, create web/css/source/_theme.less
2. Redefine `@active__color`

#### Expected result
1. All elements which use `@color-orange-red1` for their active state should be updated to use the new active color.

#### Actual result
1. In many instances, the orange color persists. Examples: Active item border in account sidebar, active thumbnail in PDP image gallery, active checkout step. (This includes obscure places, such as the selected address for a user with multiple addresses in the shipping step in checkout.)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a custom theme which extends from either Magento/blank or Magento/luma
2. In the custom theme, create web/css/source/_theme.less
3. Redefine `@theme__color__primary`, `@theme__color__primary-alt`, and `@theme__color__secondary`.
4. Redeploy static content
5. Confirm that all instances of default blue and orange have been updated to use new colors (e.g. active item border in account sidebar, active thumbnail in PDP image gallery, active checkout step, etc.)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
