### PR TITLE
magento/magento2#16852 Attribute option does not validate for existin…

### DIFF
--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -931,6 +931,7 @@ class EavSetup
         } elseif (isset($option['values'])) {
             foreach ($option['values'] as $sortOrder => $label) {
                 // add option
+                $this->setup->getConnection()->delete($optionTable, ['attribute_id =?' =>$option['attribute_id'], 'sort_order =?' => $sortOrder]);
                 $data = ['attribute_id' => $option['attribute_id'], 'sort_order' => $sortOrder];
                 $this->setup->getConnection()->insert($optionTable, $data);
                 $intOptionId = $this->setup->getConnection()->lastInsertId($optionTable);


### PR DESCRIPTION
### Description (*)

<!---
    Please provide as detailed information about your environment as possible.
    For example Magento version, tag, HEAD, PHP & MySQL version, etc..
-->
When creating product attribute and their options dynamically magento does not validate the data before inserting it into the database,

1. Magento2.2.3
2. 

### Steps to reproduce
<!---
    It is important to provide a set of clear steps to reproduce this bug.
    If relevant please include code samples
-->
1. Create a product eav attribute dynamically using class (Magento\Catalog\Model\ResourceModel\Eav\Attribute) and set the entity type Id to the type id of catalog_product (See sample code below)  (eg: attribute code = colors)
2. generate a list of possible options and then add those options into that product EAV attribute by using (Magento\Eav\Setup\EavSetup -> AddOption()) (optionarray = 'Black, Blue, White')
3. Generate some more options (pick some of those which are already existed) and add then add them into the product attribute by following the same step describe in step 2. ('White, Green, Purple')

### Expected result
<!--- Tell us what should happen -->
1. Magento should validate the option Array and check if any of the item already exist or not, If it exist then it should not insert that (Possible options need to be in the attribute code should be 'Black, Blue, White, Green, Purple')

### Actual result
<!--- Tell us what happens instead -->
1. Magento create duplicate option for the same store even the option already exists. Data in the current option array are ( 'Black, Blue, White, White,  Green, Purple')) check the repetative entry for the option value 'White.'

![image](https://user-images.githubusercontent.com/12829227/42747766-47391122-8910-11e8-90b0-8970e8ce459b.png)

here are the sample code:

For step 1: 

Inject the EaV Attribute Factory in your constructor and perform this action
```
$attributeData = [
                    'attribute_code' => $code,
                    'is_global' => 1,
                    'frontend_label' => $code,
                    'frontend_input' => 'select',
                    'default_value_text' => '',
                    'default_value_yesno' => 0,
                    'default_value_date' => '',
                    'default_value_textarea' => '',
                    'is_unique' => 0,
                    'apply_to' => 0,
                    'is_required' => 0,
                    'is_configurable' => 1,
                    'is_searchable' => 1,
                    'is_comparable' => 1,
                    'is_user_defined' => 1,
                    'is_visible_in_advanced_search' => 1,
                    'is_used_for_price_rules' => 0,
                    'is_wysiwyg_enabled' => 0,
                    'is_html_allowed_on_front' => 1,
                    'is_visible_on_front' => 0,
                    'used_in_product_listing' => 0,
                    'used_for_sort_by' => 1,
                    'is_filterable' => 1,
                    'is_filterable_in_search' => 1,
                    'backend_type' => 'varchar'
                ];
/*** Magento\Catalog\Model\ResourceModel\Eav\AttributeFactory  */ 
                $this->_eavAttributeFactory->create()
                    ->addData($attributeData)
                    ->setEntityTypeId($this->getEntityTypeId('catalog_product'))
                    ->save();
```
Step 2: 
```
        $attribute_code = 'COLOURS';
        $options        =   array('Black', 'Green');

  /*** Magento\Eav\Setup\EavSetup  */
        $this->eavSetupFactory->create()
            ->addAttributeOption(
                [
                    'values' => $options,
                    'attribute_id' => $this->getAttributeIdbyCode($attribute_code) := '4'
                ]
            );
```
Step 3:
```
        $attribute_code = 'COLOURS';
        $options        =   array('Black', 'White');

  /*** Magento\Eav\Setup\EavSetup  */
        $this->eavSetupFactory->create()
            ->addAttributeOption(
                [
                    'values' => $options,
                    'attribute_id' => $this->getAttributeIdbyCode($attribute_code) := '4'
                ]
            );
```

Has been implemented suggested solution.


### Fixed Issue
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16852: Magento2 Attribute option does not validate for existing records before insert

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
