### PR TITLE
Fixed upgrade issue if manufacturer attribute not exist in the database

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
+++ b/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
@@ -51,14 +51,14 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
         /** @var EavSetup $eavSetup */
         $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
 
-        if($manufacturerAttribute = $eavSetup->getAttribute(
+        if($manufacturer = $eavSetup->getAttribute(
             \Magento\Catalog\Model\Product::ENTITY,
             'manufacturer',
             'apply_to')
         ) {
             $relatedProductTypes = explode(
                 ',',
-                $manufacturerAttribute
+                $manufacturer
             );
 
             if (!in_array(Configurable::TYPE_CODE, $relatedProductTypes)) {

--- a/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
+++ b/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
@@ -15,8 +15,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
 /**
- * Class UpdateManufacturerAttribute
- * @package Magento\ConfigurableProduct\Setup\Patch
+ * Update manufacturer attribute if it's presented in system.
  */
 class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInterface
 {
@@ -31,7 +30,6 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
     private $eavSetupFactory;
 
     /**
-     * UpdateTierPriceAttribute constructor.
      * @param ModuleDataSetupInterface $moduleDataSetup
      * @param EavSetupFactory $eavSetupFactory
      */
@@ -44,7 +42,7 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function apply()
     {
@@ -74,7 +72,7 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getDependencies()
     {
@@ -84,7 +82,7 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}\
+     * @inheritdoc
      */
     public static function getVersion()
     {
@@ -92,7 +90,7 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getAliases()
     {

--- a/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
+++ b/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
@@ -51,11 +51,11 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
         /** @var EavSetup $eavSetup */
         $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
 
-        if($manufacturer = $eavSetup->getAttribute(
+        if ($manufacturer = $eavSetup->getAttribute(
             \Magento\Catalog\Model\Product::ENTITY,
             'manufacturer',
-            'apply_to')
-        ) {
+            'apply_to'
+        )) {
             $relatedProductTypes = explode(
                 ',',
                 $manufacturer

--- a/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
+++ b/app/code/Magento/ConfigurableProduct/Setup/Patch/Data/UpdateManufacturerAttribute.php
@@ -50,19 +50,26 @@ class UpdateManufacturerAttribute implements DataPatchInterface, PatchVersionInt
     {
         /** @var EavSetup $eavSetup */
         $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
-        $relatedProductTypes = explode(
-            ',',
-            $eavSetup->getAttribute(\Magento\Catalog\Model\Product::ENTITY, 'manufacturer', 'apply_to')
-        );
 
-        if (!in_array(Configurable::TYPE_CODE, $relatedProductTypes)) {
-            $relatedProductTypes[] = Configurable::TYPE_CODE;
-            $eavSetup->updateAttribute(
-                \Magento\Catalog\Model\Product::ENTITY,
-                'manufacturer',
-                'apply_to',
-                implode(',', $relatedProductTypes)
+        if($manufacturerAttribute = $eavSetup->getAttribute(
+            \Magento\Catalog\Model\Product::ENTITY,
+            'manufacturer',
+            'apply_to')
+        ) {
+            $relatedProductTypes = explode(
+                ',',
+                $manufacturerAttribute
             );
+
+            if (!in_array(Configurable::TYPE_CODE, $relatedProductTypes)) {
+                $relatedProductTypes[] = Configurable::TYPE_CODE;
+                $eavSetup->updateAttribute(
+                    \Magento\Catalog\Model\Product::ENTITY,
+                    'manufacturer',
+                    'apply_to',
+                    implode(',', $relatedProductTypes)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fixed upgrade issue if manufacturer attribute not exist in the database
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
A fatal error while setup:upgrade if you are upgrading to Magento v2.3 from an earlier version and manufacturer attribute not exist in the existing database.
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Have a Magento v2.2.6 clean installation.
2. Remove manufacturer attribute from Stores > Attributes > Product as it is not a system attribute.
3. Upgrade the Magento to v2.3 using command line
4. Enable the display_errors from app/bootstrap.php file.
5. **Before:** Execute setup:upgrade and while upgrading data you will notice a fatal error because of missing manufacturer attribute.
**After:** The fatal error disappear in this fix.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
