### PR TITLE
added config for wishlist sidebar in config

### DIFF
--- a/app/code/Magento/Wishlist/etc/adminhtml/system.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/system.xml
@@ -39,7 +39,7 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="show_in_sidebar" translate="label" type="select" sortOrder="5" showInDefault="1" showinWebsite="1" showInStore="1" canRestore="1">
+                <field id="show_in_sidebar" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Show in Sidebar</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>

--- a/app/code/Magento/Wishlist/etc/adminhtml/system.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/system.xml
@@ -39,6 +39,10 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="show_in_sidebar" translate="label" type="select" sortOrder="5" showInDefault="1" showinWebsite="1" showInStore="1" canRestore="1">
+                    <label>Show in Sidebar</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="wishlist_link" translate="label" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>My Wish List Link</label>

--- a/app/code/Magento/Wishlist/etc/config.xml
+++ b/app/code/Magento/Wishlist/etc/config.xml
@@ -10,6 +10,7 @@
         <wishlist>
             <general>
                 <active>1</active>
+                <show_in_sidebar>1</show_in_sidebar>
             </general>
             <email>
                 <email_identity>general</email_identity>

--- a/app/code/Magento/Wishlist/i18n/en_US.csv
+++ b/app/code/Magento/Wishlist/i18n/en_US.csv
@@ -119,3 +119,4 @@ Configure,Configure
 Delete,Delete
 "Product Details and Comment","Product Details and Comment"
 "You must login or register to add items to your wishlist.","You must login or register to add items to your wishlist."
+"Show in Sidebar","Show in Sidebar"

--- a/app/code/Magento/Wishlist/view/frontend/layout/default.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/default.xml
@@ -18,7 +18,7 @@
             </block>
         </referenceBlock>
         <referenceContainer name="sidebar.additional">
-            <block class="Magento\Wishlist\Block\Customer\Sidebar" name="wishlist_sidebar" as="wishlist" template="Magento_Wishlist::sidebar.phtml"/>
+            <block class="Magento\Wishlist\Block\Customer\Sidebar" name="wishlist_sidebar" as="wishlist" template="Magento_Wishlist::sidebar.phtml" ifconfig="wishlist/general/show_in_sidebar"/>
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Until now there wasn't a config field to hide wishlist from sidebar.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open Backend
2. Go to Stores -> Configuration -> Customers -> Wish List
3. Set 'Show in Sidebar' to 'No'
4. Wishlist will be hidden from sidebar

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
