### PR TITLE
Use mixin for common styles, to output above media queries in _extend.less

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .column {
         .block-addbysku {
             .fieldset {

--- a/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .sidebar {
         .block-addbysku {
             .fieldset {

--- a/app/design/frontend/Magento/blank/Magento_Banner/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_Banner/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-banners,
     .block-banners-inline {
         &:extend(.abs-margin-for-blocks-and-widgets);

--- a/app/design/frontend/Magento/blank/Magento_Braintree/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Braintree/web/css/source/_module.less
@@ -22,7 +22,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .payment-method-braintree {
 
         .hosted-date-wrap {

--- a/app/design/frontend/Magento/blank/Magento_Bundle/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Bundle/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .bundle-actions {
         &:extend(.abs-box-tocart all);

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
@@ -37,7 +37,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Category view
@@ -680,7 +680,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Compare Products Page

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-product-link,
     .block-category-link {
         &.widget {

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_listings.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_listings.less
@@ -21,7 +21,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     //  Product Lists
     .products {
         margin: @indent__l 0;

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -14,7 +14,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .page-products {
         .columns {
             position: relative;

--- a/app/design/frontend/Magento/blank/Magento_CatalogEvent/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_CatalogEvent/web/css/source/_module.less
@@ -10,7 +10,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Catalog Events

--- a/app/design/frontend/Magento/blank/Magento_CatalogEvent/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_CatalogEvent/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-event {
         .columns & {
             position: relative;

--- a/app/design/frontend/Magento/blank/Magento_CatalogSearch/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_CatalogSearch/web/css/source/_module.less
@@ -17,7 +17,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-search {
         margin-bottom: 0;
 

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_cart.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Shopping cart

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -16,7 +16,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Minicart

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_authentication.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_authentication.less
@@ -17,7 +17,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .authentication-dropdown {
         box-sizing: border-box;
 

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_checkout-agreements.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_checkout-agreements.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-agreements-block {
         .checkout-agreements {
             margin-bottom: @indent__base;

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_checkout.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_checkout.less
@@ -21,7 +21,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .checkout-index-index {
         .page-title-wrapper {

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Checkout Estimated Total

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_fields.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_fields.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .field {
         .control {
             &._with-tooltip {

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_modals.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_modals.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-index-index {
         .modal-popup {
             .field-tooltip {

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -20,7 +20,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Order Summary

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_payment-options.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_payment-options.less
@@ -24,7 +24,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-payment-method {
         .payment-option {
             &._active {

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -21,7 +21,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-payment-method {
         .step-title {
             border-bottom: 0;

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
@@ -36,7 +36,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Checkout Progress Bar

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping-policy.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping-policy.less
@@ -15,7 +15,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-shipping-method {
         position: relative;
     }

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -41,7 +41,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .opc-wrapper {
 

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_sidebar-shipping-information.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_sidebar-shipping-information.less
@@ -21,7 +21,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Shipping Information

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -33,7 +33,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .field-tooltip {
         cursor: pointer;

--- a/app/design/frontend/Magento/blank/Magento_Cms/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_Cms/web/css/source/_widgets.less
@@ -9,7 +9,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-static-block,
     .block-cms-link {
         &.widget {

--- a/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less
@@ -29,7 +29,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .login-container {
         .block {
             &-new-customer {

--- a/app/design/frontend/Magento/blank/Magento_Downloadable/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Downloadable/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .downloadable.samples {
         margin-bottom: @indent__base;
 

--- a/app/design/frontend/Magento/blank/Magento_GiftCard/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftCard/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .cart {
         &-summary {

--- a/app/design/frontend/Magento/blank/Magento_GiftCardAccount/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftCardAccount/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .giftcard-account {
         .please-wait {

--- a/app/design/frontend/Magento/blank/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftMessage/web/css/source/_module.less
@@ -15,7 +15,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .gift-message {
         .field {
             &:extend(.abs-clearfix all);

--- a/app/design/frontend/Magento/blank/Magento_GiftRegistry/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftRegistry/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .form-giftregistry-share,
     .form-giftregistry-edit {

--- a/app/design/frontend/Magento/blank/Magento_GiftWrapping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftWrapping/web/css/source/_module.less
@@ -24,7 +24,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .gift-wrapping {
         .label {
             .lib-css(margin, @form-field-type-label-block__margin);

--- a/app/design/frontend/Magento/blank/Magento_GroupedProduct/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GroupedProduct/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .table.grouped {
         .lib-table-bordered(

--- a/app/design/frontend/Magento/blank/Magento_Invitation/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Invitation/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form-add-invitations {
         &:extend(.abs-add-fields all);
         .action {

--- a/app/design/frontend/Magento/blank/Magento_LayeredNavigation/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_LayeredNavigation/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .block.filter {
         margin-bottom: @indent__xl;

--- a/app/design/frontend/Magento/blank/Magento_Msrp/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Msrp/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .map-popup-wrapper.popup {
         .action.close {

--- a/app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_module.less
@@ -12,7 +12,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .wishlist {
         //  Wish list split button
         &.split.button {

--- a/app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-wishlist-search {
         .form-wishlist-search {
             margin: @form-field__vertical-indent 0 0;

--- a/app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .multicheckout {
         &.results,
         &.success {

--- a/app/design/frontend/Magento/blank/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Newsletter/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Newsletter subscription
     .block.newsletter {

--- a/app/design/frontend/Magento/blank/Magento_Paypal/web/css/source/module/_billing.less
+++ b/app/design/frontend/Magento/blank/Magento_Paypal/web/css/source/module/_billing.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Paypal billing agreement
     .form-new-agreement {

--- a/app/design/frontend/Magento/blank/Magento_Paypal/web/css/source/module/_paypal-button.less
+++ b/app/design/frontend/Magento/blank/Magento_Paypal/web/css/source/module/_paypal-button.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  PayPal checkout button
     .paypal {

--- a/app/design/frontend/Magento/blank/Magento_Paypal/web/css/source/module/_review.less
+++ b/app/design/frontend/Magento/blank/Magento_Paypal/web/css/source/module/_review.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  PayPal Review Order page
     .paypal-review {

--- a/app/design/frontend/Magento/blank/Magento_ProductVideo/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_ProductVideo/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .fotorama-video-container {
         &:after {
             background: url(../Magento_ProductVideo/img/gallery-sprite.png) bottom right;
@@ -89,19 +89,18 @@
             visibility: hidden;
         }
     }
-}
 
-//
-//  Mobile
-//  _____________________________________________
+    //
+    //  Mobile
+    //  _____________________________________________
 
-//  @TODO UI: check possibility to use .media-width() mixin
-@media only screen
-and (min-device-width: 320px)
-and (max-device-width: 780px)
-and (orientation: landscape) {
-    .product-video {
-        height: 100%;
-        width: 81%;
+    @media only screen
+    and (min-device-width: 320px)
+    and (max-device-width: 780px)
+    and (orientation: landscape) {
+        .product-video {
+            height: 100%;
+            width: 81%;
+        }
     }
 }

--- a/app/design/frontend/Magento/blank/Magento_Reports/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_Reports/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block {
         &.widget {
             &.viewed {

--- a/app/design/frontend/Magento/blank/Magento_Review/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Review/web/css/source/_module.less
@@ -14,7 +14,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .rating-summary {
         .lib-rating-summary();
         
@@ -148,7 +148,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .customer-review {
         .product-details {

--- a/app/design/frontend/Magento/blank/Magento_Reward/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Reward/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-reward-info {
         .reward-rates,
         .reward-limit,

--- a/app/design/frontend/Magento/blank/Magento_Rma/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Rma/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form-create-return {
         &:extend(.abs-add-fields all);
 

--- a/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .order-links {
         border-bottom: @border-width__base solid @border-color__base;
         margin-bottom: 10px;

--- a/app/design/frontend/Magento/blank/Magento_SalesRule/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_SalesRule/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .opc-wrapper {
         .form-discount {
             max-width: 500px;

--- a/app/design/frontend/Magento/blank/Magento_SendFriend/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_SendFriend/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form.send.friend {
         &:extend(.abs-add-fields all);
     }

--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -60,7 +60,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .swatch {
         &-attribute {

--- a/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
@@ -46,7 +46,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     body {
         .lib-css(background-color, @page__background-color);

--- a/app/design/frontend/Magento/blank/Magento_Vault/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Vault/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .my-credit-cards {
         .status {
             font-style: italic;

--- a/app/design/frontend/Magento/blank/Magento_VersionsCms/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/blank/Magento_VersionsCms/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-cms-hierarchy-link {
         &.widget {
             display: block;

--- a/app/design/frontend/Magento/blank/Magento_Weee/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Weee/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .minilist {
         .weee {
             display: table-row;

--- a/app/design/frontend/Magento/blank/Magento_Wishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Wishlist/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form.wishlist.items {
         .actions-toolbar {
             &:extend(.abs-reset-left-margin all);

--- a/app/design/frontend/Magento/blank/web/css/email-fonts.less
+++ b/app/design/frontend/Magento/blank/web/css/email-fonts.less
@@ -17,8 +17,6 @@
 //  Output @font-face declarations
 //  ---------------------------------------------
 
-@media-common: true;
-
 //  Font stylesheet @import is wrapped in a media query in order to prevent it from causing problems in Outlook
 @media screen {
     @import 'source/_typography.less';

--- a/app/design/frontend/Magento/blank/web/css/source/_actions-toolbar.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_actions-toolbar.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .actions-toolbar {
         > .primary,
         > .secondary {

--- a/app/design/frontend/Magento/blank/web/css/source/_breadcrumbs.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_breadcrumbs.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .breadcrumbs {
         .lib-breadcrumbs();
     }

--- a/app/design/frontend/Magento/blank/web/css/source/_buttons.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_buttons.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Using buttons mixins
     button,

--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -11,7 +11,7 @@
 //  List default styles reset
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-reset-list {
         .lib-list-reset-styles();
         > li {
@@ -24,7 +24,7 @@
 //  Link as a button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-link-button {
         .lib-button();
         .lib-link-as-button();
@@ -54,7 +54,7 @@
     }
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-product-options-list {
         @abs-product-options-list();
     }
@@ -74,7 +74,7 @@
     .lib-button-responsive();
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-button-responsive {
         @abs-button-responsive();
     }
@@ -125,7 +125,7 @@
 //  Reset image alignment in container
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-reset-image-wrapper {
         height: auto;
         padding: 0 !important;
@@ -140,7 +140,7 @@
 //  Adaptive images
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-adaptive-images {
         display: block;
         height: auto;
@@ -159,7 +159,7 @@
 //  Title for login blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-login-block-title {
         strong {
             font-weight: @font-weight__heavier;
@@ -176,10 +176,10 @@
 //  Abstract block title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-block-title {
         margin-bottom: 15px;
-        
+
         > strong {
             .lib-heading(h3);
         }
@@ -190,11 +190,11 @@
 //  Account blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-account-blocks {
         .block-title {
             &:extend(.abs-block-title all);
-            
+
             > .action {
                 margin-left: 15px;
             }
@@ -230,7 +230,7 @@
 //  Simple Dropdown
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-dropdown-simple {
         .lib-dropdown(
             @_dropdown-list-item-padding: 5px 5px 5px 23px,
@@ -245,7 +245,7 @@
 //  Input quantity
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-input-qty {
         text-align: center;
         width: 47px;
@@ -256,7 +256,7 @@
 //  Marging for blocks & widgets
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-margin-for-blocks-and-widgets {
         margin-bottom: @indent__xl;
     }
@@ -266,7 +266,7 @@
 //  Remove button for blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-remove-button-for-blocks {
         .lib-icon-font(
             @icon-remove,
@@ -284,7 +284,7 @@
 //  Product link
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-product-link {
         font-weight: @font-weight__regular;
 
@@ -311,7 +311,7 @@
     margin-left: 0;
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-reset-left-margin {
         @abs-reset-left-margin();
     }
@@ -333,7 +333,7 @@
 //  Action with icon remove with text
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-remove {
         &:extend(.abs-action-button-as-link all);
         left: @indent__s;
@@ -359,7 +359,7 @@
 //  Add Recipient
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-add-fields {
         .fieldset {
             margin-bottom: 50px;
@@ -464,7 +464,7 @@
 //  Visibility hidden / show visibility hidden
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-hidden {
         .lib-visibility-hidden();
     }
@@ -478,7 +478,7 @@
     .lib-visually-hidden();
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-visually-hidden {
         @abs-visually-hidden();
     }
@@ -512,7 +512,7 @@
 //  Visually hidden reset
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-visually-hidden-reset {
         .lib-visually-hidden-reset();
     }
@@ -526,7 +526,7 @@
     .lib-clearfix();
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-add-clearfix {
         @abs-add-clearfix();
     }
@@ -564,7 +564,7 @@
     box-sizing: border-box;
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-add-box-sizing {
         @abs-add-box-sizing();
     }
@@ -611,7 +611,7 @@
 //  Settings icons
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-navigation-icon {
         .lib-icon-font(
             @_icon-font-content: @icon-down,
@@ -633,7 +633,7 @@
 //  Split button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-split-button {
         .lib-dropdown-split(
             @_options-selector : ~'.items',
@@ -647,7 +647,7 @@
 //  Action addto
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-addto-product {
         &:extend(.abs-action-link-button all);
         .lib-button-s();
@@ -670,7 +670,7 @@
 //  Large button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-button-l {
         .lib-button-l();
     }
@@ -680,7 +680,7 @@
 //  Button as a link
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-button-as-link {
         .lib-button-as-link(@_margin: false);
         border-radius: 0;
@@ -698,7 +698,7 @@
 //  Button revert secondary color
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-revert-secondary-color {
         .lib-button-revert-secondary-color();
     }
@@ -708,7 +708,7 @@
 //  Button revert secondary size
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-revert-secondary-size {
         .lib-button-revert-secondary-size();
     }
@@ -718,7 +718,7 @@
 //  Box-tocart block
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-box-tocart {
         margin: @indent__s 0;
     }
@@ -728,7 +728,7 @@
 //  Excl/Incl tax
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-adjustment-incl-excl-tax {
         .price-including-tax,
         .price-excluding-tax,
@@ -757,7 +757,7 @@
 //  Cart tax total
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-tax-total {
         cursor: pointer;
         padding-right: 12px;
@@ -796,7 +796,7 @@
 //  Checkout shipping methods title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-methods-shipping-title {
         .lib-font-size(14);
         font-weight: @font-weight__bold;
@@ -853,7 +853,7 @@
 //  Add colon
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-colon {
         &:after {
             content: ': ';
@@ -865,7 +865,7 @@
 //  Icon - create add
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-icon-add {
         .lib-icon-font(
             @_icon-font-content: @icon-expand,
@@ -893,7 +893,7 @@
 //  Dropdown items - create new
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-dropdown-items-new {
         .items .item:last-child {
             &:hover {
@@ -955,7 +955,7 @@
     display: none;
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-no-display {
         @abs-no-display();
     }
@@ -977,7 +977,7 @@
 //  Status
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-status {
         display: inline-block;
         margin-bottom: @indent__base;
@@ -1049,7 +1049,7 @@
 //  Items counter in blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-block-items-counter {
         .lib-css(color, @primary__color__lighter);
         .lib-font-size(12px);
@@ -1061,7 +1061,7 @@
 //  Shopping cart items
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-shopping-cart-items {
         .action {
             &.continue {
@@ -1142,7 +1142,7 @@
 //  Form Field Date
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-field-date {
         .control {
             &:extend(.abs-add-box-sizing all);
@@ -1159,7 +1159,7 @@
 //  Form Field Date Input
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-field-date-input {
         margin-right: @indent__s;
         width: calc(~'100% -' @icon-calendar__font-size + @indent__s);
@@ -1170,7 +1170,7 @@
 //  Form Field Tooltip
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-field-tooltip {
         &:extend(.abs-add-box-sizing all);
         position: relative;
@@ -1214,7 +1214,7 @@
     }
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-checkout-tooltip-content-position-top {
         @abs-checkout-tooltip-content-position-top();
     }
@@ -1230,7 +1230,7 @@
 //  Checkout title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-checkout-title {
         .lib-css(border-bottom, @checkout-step-title__border);
         .lib-css(padding-bottom, @checkout-step-title__padding);
@@ -1248,7 +1248,7 @@
 //  Shopping cart sidebar and checkout sidebar totals
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-sidebar-totals {
         .mark {
             font-weight: @font-weight__regular;
@@ -1351,7 +1351,7 @@
 //  Shopping cart and payment discount codes block
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-discount-block {
         > .title {
             border-top: @border-width__base solid @border-color__base;

--- a/app/design/frontend/Magento/blank/web/css/source/_forms.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_forms.less
@@ -14,7 +14,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .fieldset {
         .lib-form-fieldset();
         &:last-child {

--- a/app/design/frontend/Magento/blank/web/css/source/_icons.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_icons.less
@@ -3,7 +3,7 @@
 //  * See COPYING.txt for license details.
 //  */
 
-& when (@media-common = true) {
+.media-common() {
     .lib-font-face(
         @family-name: @icons__font-name,
         @font-path: @icons__font-path,

--- a/app/design/frontend/Magento/blank/web/css/source/_layout.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_layout.less
@@ -10,7 +10,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .columns {
         #lib-layout-columns();

--- a/app/design/frontend/Magento/blank/web/css/source/_loaders.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_loaders.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .load.indicator {
         .lib-loader();

--- a/app/design/frontend/Magento/blank/web/css/source/_messages.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_messages.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .message.info {
         .lib-message-icon-inner(info);

--- a/app/design/frontend/Magento/blank/web/css/source/_navigation.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_navigation.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .panel.header {
         .links,

--- a/app/design/frontend/Magento/blank/web/css/source/_pages.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_pages.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .pages {
         .lib-pager();
 

--- a/app/design/frontend/Magento/blank/web/css/source/_popups.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_popups.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Popup working with dropdown dialog
     .ui-dialog {

--- a/app/design/frontend/Magento/blank/web/css/source/_price.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_price.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Prices
     .price-style-1() {

--- a/app/design/frontend/Magento/blank/web/css/source/_reset.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_reset.less
@@ -3,6 +3,6 @@
 //  * See COPYING.txt for license details.
 //  */
 
-& when (@media-common = true) {
+.media-common() {
     .lib-magento-reset(); // Reset default styles with magento-reset
 }

--- a/app/design/frontend/Magento/blank/web/css/source/_sections.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_sections.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .product.data.items {
         .lib-data-accordion();
         margin-bottom: @indent__base;

--- a/app/design/frontend/Magento/blank/web/css/source/_tables.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_tables.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .table-wrapper {
         margin-bottom: @indent__base;
     }

--- a/app/design/frontend/Magento/blank/web/css/source/_tooltips.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_tooltips.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .tooltip.wrapper {
         .lib-tooltip(

--- a/app/design/frontend/Magento/blank/web/css/source/_typography.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_typography.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .lib-font-face(
         @family-name: @font-family-name__base,
         @font-path: '@{baseDir}fonts/opensans/light/opensans-300',
@@ -52,7 +52,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .items {
         .lib-list-reset-styles();
     }

--- a/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
@@ -31,7 +31,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .modal-custom,
     .modal-popup,
     .modal-slide {

--- a/app/design/frontend/Magento/blank/web/css/styles-l.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-l.less
@@ -30,7 +30,6 @@
 @import 'source/lib/_responsive.less';
 
 @media-target: 'desktop'; // Sets target device for this file
-@media-common: false; // Sets not to output common styles
 
 //
 //  Global variables override

--- a/app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .column {
         .block-addbysku {
             .fieldset {

--- a/app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_widgets.less
+++ b/app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_widgets.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .sidebar {
         .block-addbysku {
             .fieldset {

--- a/app/design/frontend/Magento/luma/Magento_AdvancedSearch/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_AdvancedSearch/web/css/source/_module.less
@@ -16,7 +16,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .catalogsearch-advanced-result {
         .message {
             &.error {

--- a/app/design/frontend/Magento/luma/Magento_Bundle/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Bundle/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .bundle-actions {
         margin: 0 0 @indent__l;

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -18,7 +18,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Category view
     .old-price,
@@ -787,7 +787,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Compare Products Page
@@ -1018,7 +1018,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .block.related {
         .action.select {

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_listings.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_listings.less
@@ -26,7 +26,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     //  Product Lists
     .products {
         margin: @indent__l 0;

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -19,7 +19,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .page-products {
         .columns {
             padding-top: 60px;

--- a/app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less
@@ -17,7 +17,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-search {
         margin-bottom: 0;
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -11,7 +11,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Shopping cart
@@ -503,7 +503,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     //  Cross sell
     .block {
         &.crosssell {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -16,7 +16,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Minicart

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_checkout.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_checkout.less
@@ -25,7 +25,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .checkout-index-index {
         .page-title-wrapper {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Checkout Estimated Total

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_fields.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_fields.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .field {
         .control {
             &._with-tooltip {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_modals.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_modals.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-index-index {
         .modal-popup {
             .field-tooltip {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -20,7 +20,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Order Summary

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payment-options.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payment-options.less
@@ -24,7 +24,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-payment-method {
         .payment-option {
             &._active {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -21,7 +21,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .checkout-payment-method {
         .step-title {
             border-bottom: 0;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_progress-bar.less
@@ -41,7 +41,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Checkout Progress Bar

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -41,7 +41,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .opc-wrapper {
 

--- a/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
@@ -21,7 +21,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .login-container {
         .block {
             &-new-customer {

--- a/app/design/frontend/Magento/luma/Magento_CustomerBalance/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_CustomerBalance/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-balance {
         .balance-price-label {
             &:extend(.abs-visually-hidden all);

--- a/app/design/frontend/Magento/luma/Magento_Downloadable/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Downloadable/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .table-downloadable-products {
         .product-name {
             font-weight: @font-weight__regular;

--- a/app/design/frontend/Magento/luma/Magento_GiftCard/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftCard/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .page-product-giftcard {
         .giftcard-amount {

--- a/app/design/frontend/Magento/luma/Magento_GiftCardAccount/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftCardAccount/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .giftcard-account {
         .please-wait {
             display: none;

--- a/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
@@ -24,7 +24,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .gift-message {
         .field {
             &:extend(.abs-clearfix all);

--- a/app/design/frontend/Magento/luma/Magento_GiftRegistry/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftRegistry/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form-giftregistry-share,
     .form-giftregistry-edit {
         &:extend(.abs-add-fields all);

--- a/app/design/frontend/Magento/luma/Magento_GiftWrapping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftWrapping/web/css/source/_module.less
@@ -24,7 +24,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .gift-wrapping {
         .label {
             .lib-css(margin, @form-field-type-label-block__margin);

--- a/app/design/frontend/Magento/luma/Magento_GroupedProduct/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GroupedProduct/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .table-wrapper.grouped {
         width: auto;

--- a/app/design/frontend/Magento/luma/Magento_InstantPurchase/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_InstantPurchase/web/css/source/_module.less
@@ -3,7 +3,7 @@
 //  * See COPYING.txt for license details.
 //  */
 
-& when (@media-common = true) {
+.media-common() {
     .box-tocart {
         .action.instant-purchase {
             &:extend(.abs-button-l all);

--- a/app/design/frontend/Magento/luma/Magento_Invitation/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Invitation/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .form-add-invitations {
         &:extend(.abs-add-fields all);

--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .filter {
         &.block {
             margin-bottom: 0;

--- a/app/design/frontend/Magento/luma/Magento_Msrp/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Msrp/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .map-popup-wrapper.popup {
         .action.close {

--- a/app/design/frontend/Magento/luma/Magento_MultipleWishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_MultipleWishlist/web/css/source/_module.less
@@ -16,7 +16,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .wishlist {
         //  Wish list split button
         &.split.button {

--- a/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .multicheckout {
         &.results,

--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Newsletter subscription
     .block.newsletter {

--- a/app/design/frontend/Magento/luma/Magento_Paypal/web/css/source/module/_billing.less
+++ b/app/design/frontend/Magento/luma/Magento_Paypal/web/css/source/module/_billing.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Paypal billing agreement
     .table-wrapper {

--- a/app/design/frontend/Magento/luma/Magento_Paypal/web/css/source/module/_paypal-button.less
+++ b/app/design/frontend/Magento/luma/Magento_Paypal/web/css/source/module/_paypal-button.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  PayPal checkout button
     .paypal {

--- a/app/design/frontend/Magento/luma/Magento_Paypal/web/css/source/module/_review.less
+++ b/app/design/frontend/Magento/luma/Magento_Paypal/web/css/source/module/_review.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  PayPal Review Order page
     .paypal-review {

--- a/app/design/frontend/Magento/luma/Magento_Review/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Review/web/css/source/_module.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .data.switch .counter {
         .lib-css(color, @text__color__muted);
 
@@ -262,7 +262,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .data.table.reviews {
         .rating-summary {
             margin-top: -4px;
@@ -331,7 +331,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Account
@@ -409,7 +409,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .customer-review {
         .product-details {

--- a/app/design/frontend/Magento/luma/Magento_Reward/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Reward/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .block-reward-info {
         .reward-balance {
             .lib-font-size(18);

--- a/app/design/frontend/Magento/luma/Magento_Rma/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Rma/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .order-details-items.rma {
         .order-title {
             display: none;

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .order-links {
         .item {
             line-height: @tab-control__height;

--- a/app/design/frontend/Magento/luma/Magento_SendFriend/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_SendFriend/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form.send.friend {
         &:extend(.abs-add-fields all);
     }

--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -62,7 +62,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     body {
         .lib-css(background-color, @page__background-color);
     }

--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/module/_collapsible_navigation.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/module/_collapsible_navigation.less
@@ -20,7 +20,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //
     //  Collapsible navigation

--- a/app/design/frontend/Magento/luma/Magento_Vault/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Vault/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .my-credit-cards {
         .status {
             font-style: italic;

--- a/app/design/frontend/Magento/luma/Magento_Wishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Wishlist/web/css/source/_module.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .form.wishlist.items {
         .actions-toolbar {
             &:extend(.abs-reset-left-margin all);

--- a/app/design/frontend/Magento/luma/web/css/source/_actions-toolbar.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_actions-toolbar.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     .actions-toolbar {
         > .primary,

--- a/app/design/frontend/Magento/luma/web/css/source/_breadcrumbs.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_breadcrumbs.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .breadcrumbs {
         .lib-breadcrumbs();
     }

--- a/app/design/frontend/Magento/luma/web/css/source/_buttons.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_buttons.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Using buttons mixins
     button,

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -9,7 +9,7 @@
 
 @_column-number: 1;
 
-& when (@media-common = true) {
+.media-common() {
     .abs-reset-list {
         .lib-list-reset-styles();
 
@@ -23,7 +23,7 @@
 //  Primary button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .action-primary {
         .lib-button-primary();
         .lib-css(border-radius, @button__border-radius);
@@ -34,7 +34,7 @@
 //  Secondary button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-revert-to-action-secondary {
         &:extend(.abs-revert-secondary-color all);
         .lib-css(border-radius, @button__border-radius);
@@ -53,7 +53,7 @@
 //  Link as a button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-link-button {
         .lib-button();
         .lib-link-as-button();
@@ -65,7 +65,7 @@
 //  Button as a link
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-button-as-link {
         .lib-button-as-link(@_margin: false);
         .lib-css(font-weight, @font-weight__regular);
@@ -82,7 +82,7 @@
 //  Button revert secondary color
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-revert-secondary-color {
         .lib-button-revert-secondary-color();
     }
@@ -92,7 +92,7 @@
 //  Button revert secondary size
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-revert-secondary-size {
         .lib-button-revert-secondary-size();
     }
@@ -102,7 +102,7 @@
 //  Large button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-button-l {
         .lib-button-l();
     }
@@ -130,7 +130,7 @@
     }
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-product-options-list {
         @abs-product-options-list();
     }
@@ -150,7 +150,7 @@
 //  Button reset width, floats, margins
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-button-responsive {
         .lib-button-responsive();
     }
@@ -199,7 +199,7 @@
 //  Reset image alignment in container
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-reset-image-wrapper {
         height: auto;
         padding: 0 !important;
@@ -214,7 +214,7 @@
 //  Adaptive images
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-adaptive-images {
         display: block;
         height: auto;
@@ -233,7 +233,7 @@
 //  Title for login blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-login-block-title {
         .lib-css(border-bottom, 1px solid @secondary__color);
         .lib-font-size(18);
@@ -250,7 +250,7 @@
 //  Simple Dropdown
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-dropdown-simple {
         .lib-dropdown(
         @_dropdown-list-item-padding: 5px 5px 5px 23px,
@@ -269,7 +269,7 @@
 //  Input quantity
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-input-qty {
         text-align: center;
         width: 54px;
@@ -280,7 +280,7 @@
 //  Marging for blocks & widgets
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-margin-for-blocks-and-widgets {
         margin-bottom: @indent__xl;
     }
@@ -296,7 +296,7 @@
 //  Remove button for blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-remove-button-for-blocks {
         .lib-icon-font(
         @icon-remove,
@@ -314,7 +314,7 @@
 //  Product link
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-product-link {
         font-weight: @font-weight__regular;
         > a {
@@ -336,7 +336,7 @@
 //  Link
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-like-link {
         .lib-link();
         cursor: pointer;
@@ -351,7 +351,7 @@
     margin-left: 0;
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-reset-left-margin {
         @abs-reset-left-margin();
     }
@@ -373,7 +373,7 @@
 //  Action with icon remove with text
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-action-remove {
         &:extend(.abs-action-button-as-link all);
         line-height: normal;
@@ -398,7 +398,7 @@
 //  Add Recipient
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-add-fields {
         .fieldset {
             .field {
@@ -489,7 +489,7 @@
     .lib-visibility-hidden();
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-hidden {
         @abs-hidden();
     }
@@ -503,7 +503,7 @@
     .lib-visually-hidden();
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-visually-hidden {
         @abs-visually-hidden();
     }
@@ -537,7 +537,7 @@
 //  Visually hidden reset
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-visually-hidden-reset {
         .lib-visually-hidden-reset();
     }
@@ -551,7 +551,7 @@
     .lib-clearfix();
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-add-clearfix {
         @abs-add-clearfix();
     }
@@ -589,7 +589,7 @@
     box-sizing: border-box;
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-add-box-sizing {
         @abs-add-box-sizing();
     }
@@ -636,7 +636,7 @@
 //  Settings icons
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-navigation-icon {
         .lib-icon-font(
             @_icon-font-content: @icon-down,
@@ -658,7 +658,7 @@
 //  Split button
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-split-button {
         .lib-dropdown-split(
         @_options-selector : ~'.items',
@@ -726,7 +726,7 @@
 //  Checkout shipping methods title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-methods-shipping-title {
         .lib-css(font-weight, @font-weight__semibold);
         .lib-font-size(16);
@@ -786,7 +786,7 @@
 //  Add to Actions
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-actions-addto {
         .lib-css(color, @addto-color);
         display: inline-block;
@@ -816,7 +816,7 @@
 //  Box-tocart block
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-box-tocart {
         margin: 0 0 @indent__l;
     }
@@ -868,7 +868,7 @@
     }
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-toggling-title {
         @abs-toggling-title();
         .lib-css(padding, @indent__s @indent__xl @indent__s @mobile-cart-padding);
@@ -911,7 +911,7 @@
 //  Cart discount block
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-cart-block {
         margin: 0;
 
@@ -951,7 +951,7 @@
 //  Checkout order review price
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-checkout-cart-price {
         .lib-css(color, @primary__color__lighter);
         .lib-font-size(16);
@@ -963,7 +963,7 @@
 //  Checkout order product name
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-checkout-product-name {
         .lib-font-size(18);
         font-weight: @font-weight__light;
@@ -1023,7 +1023,7 @@
 //  Account pages: title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-account-title {
         > strong,
         > span {
@@ -1051,7 +1051,7 @@
 //  Account pages: block line-height
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-account-block-line-height {
         line-height: 24px;
     }
@@ -1088,7 +1088,7 @@
 //  Account pages: order table summary
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-account-summary {
         td {
             .lib-css(background, @sidebar__background-color);
@@ -1130,7 +1130,7 @@
 //  Excl/Incl tax
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-incl-excl-tax {
         .price-including-tax,
         .price-excluding-tax {
@@ -1172,7 +1172,7 @@
 //  Cart tax total
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-tax-total {
         cursor: pointer;
         padding-right: @indent__s;
@@ -1205,7 +1205,7 @@
 //  Forms: margin-bottom for small forms
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-forms-margin-small {
         .lib-css(margin-bottom, @indent__base);
     }
@@ -1215,7 +1215,7 @@
 //  Forms: margin-bottom for small forms
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-rating-summary {
         .rating {
             &-summary {
@@ -1242,7 +1242,7 @@
 //  Account pages: actions
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-account-actions {
         &:after {
             .lib-css(border-left, 1px solid @primary__color__light);
@@ -1265,7 +1265,7 @@
 //  Account blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-account-blocks {
         .block-title {
             &:extend(.abs-account-title all);
@@ -1295,7 +1295,7 @@
 //  Add colon
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-colon {
         &:after {
             content: ': ';
@@ -1307,7 +1307,7 @@
 //  Icon - create add
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-icon-add {
         .lib-icon-font(
         @_icon-font-content: @icon-expand,
@@ -1335,7 +1335,7 @@
 //  Dropdown items - create new
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-dropdown-items-new {
         .items .item:last-child {
             &:hover {
@@ -1361,7 +1361,7 @@
     display: none;
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-no-display {
         @abs-no-display();
     }
@@ -1383,7 +1383,7 @@
 //  Status
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-status {
         .lib-css(border, 2px solid @border-color__base);
         border-radius: 3px;
@@ -1406,7 +1406,7 @@
 //  Page title - orders pages
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-title-orders {
         .page-main {
             .page-title-wrapper {
@@ -1461,7 +1461,7 @@
 //  Table striped
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-table-striped {
         .lib-table-striped(
             @_stripped-highlight: even
@@ -1524,7 +1524,7 @@
 //  Items counter in blocks
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-block-items-counter {
         .lib-css(color, @block-items__counter__color);
         .lib-font-size(12px);
@@ -1544,7 +1544,7 @@
 //  Sidebar and widget blocks title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-block-widget-title {
         margin: 0 0 @indent__base;
 
@@ -1559,7 +1559,7 @@
 //  Shopping cart items
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-shopping-cart-items {
         margin-bottom: @indent__base;
 
@@ -1605,7 +1605,7 @@
 //  Form Field Date
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-field-date {
         .control {
             position: relative;
@@ -1622,7 +1622,7 @@
 //  Form Field Date Input
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-field-date-input {
         .lib-css(margin-right, @indent__s);
         width: calc(~'100% -' @icon-calendar__font-size + @indent__s);
@@ -1633,7 +1633,7 @@
 //  Form Field Tooltip
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-field-tooltip {
         &:extend(.abs-add-box-sizing all);
         position: relative;
@@ -1677,7 +1677,7 @@
     }
 };
 
-& when (@media-common = true) {
+.media-common() {
     .abs-checkout-tooltip-content-position-top {
         @abs-checkout-tooltip-content-position-top();
     }
@@ -1693,7 +1693,7 @@
 //  Checkout title
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-checkout-title {
         .lib-css(padding-bottom, @checkout-step-title__padding);
         .lib-typography(
@@ -1710,7 +1710,7 @@
 //  Shopping cart sidebar and checkout sidebar totals
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-sidebar-totals {
         border-top: 1px solid @border-color__base;
         padding-top: 10px;
@@ -1852,7 +1852,7 @@
 //  Shopping cart and payment discount codes block
 //  ---------------------------------------------
 
-& when (@media-common = true) {
+.media-common() {
     .abs-discount-block {
         .block {
             &:extend(.abs-cart-block all);

--- a/app/design/frontend/Magento/luma/web/css/source/_forms.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_forms.less
@@ -15,7 +15,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .fieldset {
         .lib-form-fieldset();
 

--- a/app/design/frontend/Magento/luma/web/css/source/_pages.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_pages.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .pages {
         .lib-pager();
 

--- a/app/design/frontend/Magento/luma/web/css/source/_popups.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_popups.less
@@ -13,7 +13,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
 
     //  Popup working with dropdown dialog
     .ui-dialog {

--- a/app/design/frontend/Magento/luma/web/css/source/_sections.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_sections.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .product.data.items {
         .lib-data-accordion();
         border-bottom: @tab-control__border-width solid @tab-control__border-color;

--- a/app/design/frontend/Magento/luma/web/css/source/_tables.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_tables.less
@@ -7,7 +7,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .table-wrapper {
         margin-bottom: @indent__base;
     }

--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -31,7 +31,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     .modal-custom,
     .modal-popup,
     .modal-slide {

--- a/lib/web/css/source/components/_modals.less
+++ b/lib/web/css/source/components/_modals.less
@@ -139,7 +139,7 @@
 //  Common
 //  _____________________________________________
 
-& when (@media-common = true) {
+.media-common() {
     body {
         &._has-modal {
             height: 100%;

--- a/lib/web/css/source/lib/_responsive.less
+++ b/lib/web/css/source/lib/_responsive.less
@@ -11,11 +11,17 @@
 //  Media variables, that can be used for splitting styles into several files
 //  ---------------------------------------------
 
-@media-common: true; // Sets whether to output common styles (true|false)
 @media-target: 'all'; // Sets target device for styles output (all|desktop|mobile)
 
 //
-//  Media width mixin used to group styles output based on media queries
+//  Media-common mixin used to group global styles output
+//  ---------------------------------------------
+
+.media-common() {
+}
+
+//
+//  Media-width mixin used to group styles output based on media queries
 //  ---------------------------------------------
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__s) {
@@ -26,6 +32,8 @@
 //  ---------------------------------------------
 
 & when (@media-target = 'mobile'), (@media-target = 'all') {
+
+    .media-common(); // Outputs common styles
 
     @media only screen and (max-width: @screen__m) {
         .media-width('max', (@screen__m + 1));


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR modifies the implementation of common styles to use a `.media-common()` mixin instead of a check for when `@media-common = true`. This has 2 advantages (respective to the "Fixed Issues" below). The first advantage is that all common styles are called from a single location in `_responsive.less`, just as the `media-width` styles are, which allows all common styles to be output above the `max-width` styles (including from `_extend.less`, even though it's imported below `_responsive.less`). This means that all media-width styles will override common styles with the same specificity, as they ought to. The second advantage is that the `.media-common()` mixin explicitly outputs all `.abs-` styles in `_extends.less`, even when compiling with Grunt, whereas before, Grunt compilation skipped over `&:extend()` calls that were nested (e.g. `.abs-action-link-button` inside `.abs-action-addto-product`). This broke styles in a standard workflow on a local site for elements such as the PDP add-to-wishlist button.
There is one slight disadvantage of this new implementation, which is that all `.abs-` styles are explicitly output (e.g. http://take.ms/jYPaE). I'm not sure how the old implementation skipped over a few of these, because it still included most of them. However, this is a nominal difference that should be well worth the advantages.
There will be one slight breaking change, which should be documented as part of the release and can easily be fixed by simply converting all instances of `& when(@media-common = true)` in custom themes to `.media-common()`.
There should not be any other breaking changes or backwards incompatibilities, for the following reasons:
1. Since this only affects styles in `_extend.less`, which the default themes do not use, it will not break specificity of any styles in the default themes.
2. For styles that are in `_extend.less` in a custom theme in a max-width breakpoint, if they are intended to override certain common styles, they must already have higher specificity, since they were output above common styles according to the old implementation, so they will not suffer from being output below the common styles in this new implementation.
3. The only possible issue would be for styles that are in `_extend.less` in a custom theme in a max-width breakpoint, if they have the same specificity as certain common styles, since this new implementation would cause them to override those common styles (unlike before). However, such styles were probably already intended to override the common styles, but since they never would have applied according to the old implementation, they were useless to start with, and I'm afraid that any issue that arises from leaving them in the code would be due to negligence.

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [#11098](https://github.com/magento/magento2/issues/11098): 'Mobile media query inside _extend.less, wrong order in styles-m.css and styles-l.css'
    * (The issue was actually closed due to the suggestion of importing `_extend.less` before `_responsive.less`, which modifies intended behavior. However, this PR fixes the issue without doing that.)
2. [#7231](https://github.com/magento/magento2/issues/7231): 'Different results from compiling less with Grunt or with "server side compilation"'
    * (This PR effectively fixes the issue, since there are no longer visual differences on the frontend between Grunt compilation and "server-side compilation", but it's worth noting that there are still slight differences in CSS when compared line-by-line.)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a custom theme that extends Magento/blank or Magento/luma
2. Create an `_extend.less` file in the custom theme
3. Add a min-width `.media-width` group, a max-width `.media-width` group, and a `.media-common` group
4. Add various styles to each group with the same selectors and specificity
5. Recompile CSS with either Grunt or server-side compilation
6. Confirm that all common styles in `styles-m.css` (including those from `_extend.less`) are output above all media queries, so that even the max-width styles override the common styles.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
