### PR TITLE
Fixed issue with Base Currency for website is CND when PayPal Payflow…

### DIFF
--- a/app/code/Magento/Paypal/Model/Payflowpro.php
+++ b/app/code/Magento/Paypal/Model/Payflowpro.php
@@ -420,6 +420,7 @@ class Payflowpro extends \Magento\Payment\Model\Method\Cc implements GatewayInte
             $request->setTrxtype(self::TRXTYPE_SALE);
             $request->setOrigid($payment->getAdditionalInformation(self::PNREF));
             $payment->unsAdditionalInformation(self::PNREF);
+            $request->setData('currency', $payment->getOrder()->getBaseCurrencyCode());
         } elseif ($payment->getParentTransactionId()) {
             $request = $this->buildBasicRequest();
             $request->setOrigid($payment->getParentTransactionId());


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19430

### Description (*)
Customers are being billed in USD even though PayPal Payflow Pro is set to use CND. In Magento the order shows CND, but in PayPal the order displays with amounts in USD. The amounts are the same, which means customers are not paying the correct amount.

### Manual testing scenarios (*)
1. Set Base Currency as USD for default config
2. Creat Canadian website
3. Set Base Currency and Default Display Currency for Canadian store to Canadian Dollar.
4. Go to Canadian store on the storefront
5. Add product to cart
6. Complete checkout
7. Invoice the order
8. Look at different between order details and details shown in PayPal.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
