### PR TITLE
Fixed exception during creation of Credit Memo when tax and discount applies to shipping price

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -58,10 +58,10 @@ class Shipping extends AbstractTotal
         $orderBaseShippingInclTax = $order->getBaseShippingInclTax();
         $allowedTaxAmount = $order->getShippingTaxAmount() + $order->getShippingDiscountTaxCompensationAmount() - $order->getShippingTaxRefunded();
         $allowedAmountInclTax = $allowedAmount + $allowedTaxAmount;
-        $baseAllowedTaxAmount = $order->getBaseShippingTaxAmount() 
+        $baseAllowedAmountInclTax = $orderBaseShippingInclTax
             + $order->getBaseShippingDiscountTaxCompensationAmnt() 
+            - $order->getBaseShippingRefunded()
             - $order->getBaseShippingTaxRefunded();
-
         // Check if the desired shipping amount to refund was specified (from invoice or another source).
         if ($creditmemo->hasBaseShippingAmount()) {
             // For the conditional logic, we will either use amounts that always include tax -OR- never include tax.

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -56,10 +56,10 @@ class Shipping extends AbstractTotal
         // amounts including tax
         $orderShippingInclTax = $order->getShippingInclTax();
         $orderBaseShippingInclTax = $order->getBaseShippingInclTax();
-        $allowedTaxAmount = $order->getShippingTaxAmount() - $order->getShippingTaxRefunded();
+        $allowedTaxAmount = $order->getShippingTaxAmount() + $order->getShippingDiscountTaxCompensationAmount() - $order->getShippingTaxRefunded();
         $allowedAmountInclTax = $allowedAmount + $allowedTaxAmount;
-        $baseAllowedAmountInclTax = $orderBaseShippingInclTax
-            - $order->getBaseShippingRefunded()
+        $baseAllowedTaxAmount = $order->getBaseShippingTaxAmount() 
+            + $order->getBaseShippingDiscountTaxCompensationAmnt() 
             - $order->getBaseShippingTaxRefunded();
 
         // Check if the desired shipping amount to refund was specified (from invoice or another source).

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -56,7 +56,9 @@ class Shipping extends AbstractTotal
         // amounts including tax
         $orderShippingInclTax = $order->getShippingInclTax();
         $orderBaseShippingInclTax = $order->getBaseShippingInclTax();
-        $allowedTaxAmount = $order->getShippingTaxAmount() + $order->getShippingDiscountTaxCompensationAmount() - $order->getShippingTaxRefunded();
+        $allowedTaxAmount = $order->getShippingTaxAmount() 
+            + $order->getShippingDiscountTaxCompensationAmount() 
+            - $order->getShippingTaxRefunded();
         $allowedAmountInclTax = $allowedAmount + $allowedTaxAmount;
         $baseAllowedAmountInclTax = $orderBaseShippingInclTax
             + $order->getBaseShippingDiscountTaxCompensationAmnt() 


### PR DESCRIPTION
Fixed issue  #19429
Fixed exception during creation of Credit Memo when tax and discount applies to shipping price

**Steps to reproduce**
1. Make an Order with shipping cost and VAT on the shipping.
2. Use a discount fixed on cart with an amount that can apply to shipping
3. Invoice and then create a credit memo from the invoice.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
