### PR TITLE
changes for Wrong-Button-style-on-checkout-page-in-Sign-In-dropdown

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/authentication.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/authentication.html
@@ -75,7 +75,7 @@
                     <div class="actions-toolbar">
                         <input name="context" type="hidden" value="checkout" />
                         <div class="primary">
-                            <button type="submit" class="action action-login secondary"><span data-bind="i18n: 'Sign In'"></span></button>
+                            <button type="submit" class="action action-login primary"><span data-bind="i18n: 'Sign In'"></span></button>
                         </div>
                         <div class="secondary">
                             <a class="action action-remind" data-bind="attr: { href: forgotPasswordUrl }">


### PR DESCRIPTION
### Description (*)
    Magento Versions 2.2.6
    Wrong Button style on checkout page in Sign In dropdown.
    
### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/19563 : Wrong Button style on checkout page in Sign In drop-down

### Manual testing scenarios (*)
	1.Add any product to Cart.
	2.Go to checkout page
	3.You can see Sign In text top right side.
	4.Click on Sign In text you can see "Sign In" Button.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
