### PR TITLE
fixed Sorting by Price in Catalog Product grid returns the incorrect number of products.

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1888,7 +1888,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     protected function _productLimitationJoinPrice()
     {
-        return $this->_productLimitationPrice();
+        return $this->_productLimitationPrice(true);
     }
 
     /**

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -399,7 +399,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
      */
     public function addFieldToFilter($attribute, $condition = null)
     {
-        return $this->addAttributeToFilter($attribute, $condition);
+        return $this->addAttributeToFilter($attribute, $condition,'left');
     }
 
     /**

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -399,7 +399,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
      */
     public function addFieldToFilter($attribute, $condition = null)
     {
-        return $this->addAttributeToFilter($attribute, $condition,'left');
+        return $this->addAttributeToFilter($attribute, $condition);
     }
 
     /**


### PR DESCRIPTION
**Description (*)**

fixed issue #7522
 Sorting by Price in Catalog Product grid returns the incorrect number of products.

Sorting by the Price column in the admin Catalog Product grid gives an incorrect "records found" count at the top of the grid. This occurs because when sorting by price, products with status set to "disabled" are ignored.
Preconditions

   1. Magento CE 2.1.2

Steps to reproduce

  1.  Open the admin dashboard.
  2.  In the admin menu, navigate to Products > Catalog
  3. Ensure that the status of one or more products is set to "disabled".
  4.  Note the "records found" product count at the top of grid.
  5. Click in the Price column header to sort by price.
  6.  Note the updated "records found" product count. It should be lower that in Step 4 by the number of disabled products.

Expected result

  1. The number of records found should remain the same when sorting on different columns in the Catalog Product grid.

Actual result

  1. When sorting by price, the product count is reduced by the number of disabled products.
