### PR TITLE
Improve error handling/make more graceful the decryption process

### DIFF
--- a/lib/internal/Magento/Framework/Encryption/Adapter/SodiumChachaIetf.php
+++ b/lib/internal/Magento/Framework/Encryption/Adapter/SodiumChachaIetf.php
@@ -58,13 +58,17 @@ class SodiumChachaIetf implements EncryptionAdapterInterface
         $nonce = mb_substr($data, 0, SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES, '8bit');
         $payload = mb_substr($data, SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES, null, '8bit');
 
-        $plainText = sodium_crypto_aead_chacha20poly1305_ietf_decrypt(
-            $payload,
-            $nonce,
-            $nonce,
-            $this->key
-        );
+        try {
+            $plainText = sodium_crypto_aead_chacha20poly1305_ietf_decrypt(
+                $payload,
+                $nonce,
+                $nonce,
+                $this->key
+            );
+        } catch (\Exception $error) {
+            return $data;
+        }
 
-        return $plainText;
+        return $plainText === false ? $data : $plainText;
     }
 }

--- a/lib/internal/Magento/Framework/Encryption/Test/Unit/Adapter/SodiumChachaIetfTest.php
+++ b/lib/internal/Magento/Framework/Encryption/Test/Unit/Adapter/SodiumChachaIetfTest.php
@@ -22,6 +22,7 @@ class SodiumChachaIetfTest extends \PHPUnit\Framework\TestCase
         foreach ($result as &$cryptParams) {
             $cryptParams['encrypted'] = base64_decode($cryptParams['encrypted']);
         }
+
         unset($cryptParams);
 
         return $result;

--- a/lib/internal/Magento/Framework/Encryption/Test/Unit/Crypt/_files/_sodium_chachaieft_fixtures.php
+++ b/lib/internal/Magento/Framework/Encryption/Test/Unit/Crypt/_files/_sodium_chachaieft_fixtures.php
@@ -32,4 +32,14 @@ return [
         'encrypted' => 'UglO9dEgslFpwPwejJmrK89PmBicv+I1pfdaXaEI69IrETD8LpdzOLF7',
         'decrypted' => 'Hello World!!!',
     ],
+    5 => [
+        'key' => '6wRADHwwCBGgdxbcHhovGB0upmg0mbsN',
+        'encrypted' => '',
+        'decrypted' => '',
+    ],
+    6 => [
+        'key' => '6wRADHwwCBGgdxbcHhovGB0upmg0mbsN',
+        'encrypted' => 'bWFsZm9ybWVkLWlucHV0',
+        'decrypted' => 'malformed-input',
+    ],
 ];


### PR DESCRIPTION
### Description (*)
Under certain conditions, the new Sodium adapter for encryption processing throws an exception when a decryption attempt is made with malformed/bad input. While this might be expected behavior, it does not adhere to the given `@return` annotation and, as I've seen in a particular use case, caused Magento to halt in various places, including CLI usage and deployment procedures.

This PR attempts to make the handling of decryption errors more graceful and in compliance with the expected return type. Under this PR, when decryption fails, the original input is returned as-is. I'm open to other suggestions (eg: return empty string), but there ought to be a reliable expectation for failing conditions.

### Fixed Issues (if relevant)
1. magento/magento2#19590: M2.3 – Sodium crypto adapter errors on unexpected input

### Manual testing scenarios (*)
Before this update, run the following code:

```
// Adjust path to environment
require '/vagrant/app/bootstrap.php';

class CustomApp
    extends \Magento\Framework\App\Http
        implements \Magento\Framework\AppInterface
{

    public function launch()
    {
        $encryptor = \Magento\Framework\App\ObjectManager::getInstance()->create(
            '\Magento\Framework\Encryption\Adapter\SodiumChachaIetf',
            ['key' => 'aggaHLvRCxRRyebpsrGAdLAIfSrufYrN']
        );

        var_dump($encryptor->decrypt('bad-input'));
	exit;
    }

    public function catchException(\Magento\Framework\App\Bootstrap $bootstrap, \Exception $exception)
    {
        echo $exception->getMessage();
    }

}

$bootstrap  = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
$app        = $bootstrap->createApplication('CustomApp');

$bootstrap->run($app);
```

An exception would be thrown, but this behavior is not desirable.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
