### PR TITLE
Fixed issue related to Wrong implementation of interface

### DIFF
--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -339,6 +339,18 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      *
      * @param \Magento\Framework\DataObject $request
      * @return $this|bool|\Magento\Framework\DataObject
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function processAdditionalValidation(\Magento\Framework\DataObject $request)
+    {
+        return $this;
+    }
+
+    /**
+     * Processing additional validation to check is carrier applicable.
+     *
+     * @param \Magento\Framework\DataObject $request
+     * @return $this|bool|\Magento\Framework\DataObject
      * @deprecated
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -346,8 +346,6 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
         return $this;
     }
 
-    
-
     /**
      * Determine whether current carrier enabled for activity
      *

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -346,18 +346,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
         return $this;
     }
 
-    /**
-     * Processing additional validation to check is carrier applicable.
-     *
-     * @param \Magento\Framework\DataObject $request
-     * @return $this|bool|\Magento\Framework\DataObject
-     * @deprecated
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
-    {
-        return $this->processAdditionalValidation($request);
-    }
+    
 
     /**
      * Determine whether current carrier enabled for activity

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -329,7 +329,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      * @return $this|bool|\Magento\Framework\DataObject
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function processAdditionalValidation(\Magento\Framework\DataObject $request)
+    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
     {
         return $this;
     }


### PR DESCRIPTION
Fixed issue #19592 related to Wrong implementation of interface for Magento\Shipping\Model\Carrier\AbstractCarrier.

Preconditions (*)
1. 2.2.6
2. 2.2.7
Steps to reproduce (*)
1. Start with a version <= 2.2.5
2. Extend AbstractCarrier
3. Override proccessAdditionalValidation since that was the only method available at the time
4. Upgrade to 2.2.6 or 2.2.7

Expected result (*)

The caller should call proccessAdditionalValidation or AbstractCarrier should internally call proccessAdditionalValidation from processAdditionalValidation

Actual result (*)

Your class breaks because proccessAdditionalValidation never gets called. The caller calls the new, correctly named, method, processAdditionalValidation and never calls the old one.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
