### PR TITLE
Additional Cache Management title

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/system/cache/additional.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/cache/additional.phtml
@@ -11,10 +11,10 @@ $permissions = $block->getData('permissions');
 ?>
 <?php if ($permissions && $permissions->hasAccessToAdditionalActions()): ?>
     <div class="additional-cache-management">
+        <h2>
+            <span><?= $block->escapeHtml(__('Additional Cache Management')); ?></span>
+        </h2>
         <?php if ($permissions->hasAccessToFlushCatalogImages()): ?>
-            <h2>
-                <span><?= $block->escapeHtml(__('Additional Cache Management')); ?></span>
-            </h2>
             <p>
                 <button onclick="setLocation('<?= $block->escapeJs($block->getCleanImagesUrl()); ?>')" type="button">
                     <?= $block->escapeHtml(__('Flush Catalog Images Cache')); ?>


### PR DESCRIPTION

### Description
Additional Cache Management title is shown only if the user is granted to flush catalog images cache.
It should be displayed if he is granted for any acl of additional cache actions.

### Manual testing scenarios
1. Disable acl "Flush Catalog Images Cache".
2. Go to System / Cache
3. "Additional Cache Management" is missing, even if the user has the rights for other additional cache management.

With and without "Flush Catalog Images Cache" acl:
![capture du 2018-12-07 14-53-46](https://user-images.githubusercontent.com/20971693/49651675-23c09d00-fa30-11e8-861f-487feaa093b8.png)
![capture du 2018-12-07 14-54-16](https://user-images.githubusercontent.com/20971693/49651676-23c09d00-fa30-11e8-8eb3-ccf347eced94.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
