### PR TITLE
Set free shipping to all items if address has free shipping

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
@@ -114,8 +114,8 @@ class FreeShipping implements FreeShippingInterface
     {
         /** @var AbstractItem $item */
         foreach ($items as $item) {
-            $item->getAddress()
-                ->setFreeShipping((int)$freeShipping);
+            $item->getAddress()->setFreeShipping((int) $freeShipping);
+            $item->setFreeShipping($freeShipping);
             $this->applyToChildren($item, $freeShipping);
         }
     }


### PR DESCRIPTION
### Description (*)
Set free shipping to all quote/order items when address has free shipping flag. In current situation no items will be marked if address has the free shipping flag.

This issue occurs when using FlatRate carrier. This carrier is only checking the free shipping flag for the items (https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/OfflineShipping/Model/Carrier/Flatrate.php#L114).

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios (*)
1. Create after plugin on `\Magento\OfflineShipping\Model\SalesRule\Calculator::processFreeShipping()`.
2. Set free shipping in that plugin: `$item->getAddress()->setFreeShipping(1);`
3. Items do not receive free shipping flag.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
