### PR TITLE
[Backport] fix: remove unused params in categorySubmit invocation

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/catalog/category/edit.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/catalog/category/edit.js
@@ -82,7 +82,7 @@ define([
     return function (config, element) {
         config = config || {};
         jQuery(element).on('click', function () {
-            categorySubmit(config.url, config.ajax);
+            categorySubmit();
         });
     };
 });


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19428
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes the unused params which were removed in https://github.com/magento/magento2/commit/e3bed3fc3319659d86f23454554d260480f32b6f#diff-7e0161ff9217ea5ad51d27fd7ac774c1

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
