### PR TITLE
Page cache modifier added and getValue method broken into two methods…

### DIFF
--- a/lib/internal/Magento/Framework/App/PageCache/Identifier.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Identifier.php
@@ -29,7 +29,7 @@ class Identifier
     private $serializer;
 
     /**
-     * @var Identifier\Modifier[]
+     * @var Identifier\ModifierInterface[]
      */
     private $modifiers;
 
@@ -68,7 +68,7 @@ class Identifier
          * Add parameters appended through di
          */
         foreach ($this->modifiers as $modifier) {
-            if ($modifier instanceof Identifier\Modifier) {
+            if ($modifier instanceof Identifier\ModifierInterface) {
                 $data[] = $modifier->getData();
             }
         }

--- a/lib/internal/Magento/Framework/App/PageCache/Identifier/Modifier.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Identifier/Modifier.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\App\PageCache\Identifier;
+
+/**
+ * Page Cache Identifier Modifier Interface
+ */
+interface Modifier
+{
+    /**
+     * @return string
+     */
+    public function getData();
+}

--- a/lib/internal/Magento/Framework/App/PageCache/Identifier/ModifierInterface.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Identifier/ModifierInterface.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\App\PageCache\Identifier;
 /**
  * Page Cache Identifier Modifier Interface
  */
-interface Modifier
+interface ModifierInterface
 {
     /**
      * @return string


### PR DESCRIPTION
Page cache modifier added and getValue method broken into two methods to facilitate modifying it using plugins

### Description (*)
`Magento\Framework\App\PageCache\Identifier::getValue` method broken into two methods. The parameters are formed in the `Magento\Framework\App\PageCache\Identifier::getParameters` method so that writing plugins for it is easier. Also added a modifier parameter to the same class which can be populated using di to further help developers modify the page cache identifier

### Fixed Issues (if relevant)
1. magento/magento2#19676: Modifying Page cache parameters

### Manual testing scenarios (*)
1. Add an after plugin for the  `Magento\Framework\App\PageCache\Identifier::getParameters` method to modify the parameters
2. Add a modifier to the `Magento\Framework\App\PageCache\Identifier` class using di.xml to observe the same results as the first scenario

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
