### PR TITLE
JSON Controlller implements HttpPostActionInterface

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Add.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Add.php
@@ -56,7 +56,7 @@ class Add extends \Magento\Backend\Block\Widget\Form\Container
                     },
                     loadProductData : function() {
                         jQuery.ajax({
-                            type: "POST",
+                            type: "GET",
                             url: review.productInfoUrl,
                             data: {
                                 form_key: FORM_KEY

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;;
 use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Registry;
@@ -18,7 +18,7 @@ use Magento\Framework\Controller\ResultFactory;
 /**
  * Represents product info in json
  */
-class JsonProductInfo extends ProductController implements HttpGetActionInterface
+class JsonProductInfo extends ProductController implements HttpPostActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Registry;
@@ -18,7 +18,7 @@ use Magento\Framework\Controller\ResultFactory;
 /**
  * Represents product info in json
  */
-class JsonProductInfo extends ProductController implements HttpPostActionInterface
+class JsonProductInfo extends ProductController implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When the admin trying to add the new reviews, its calling the post request to JsonProductInfo, and this class implemented HttpGetActionInterface hence it throws 404. I checked changed the implemented HttpGetActionInterface to HttpPostActionInterface





### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Admin Menu -> Marketing -> Review -> Add New Review -> Select Product it will redirect to review page form with product detail.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
