### PR TITLE
[Backport] Cancel expired orders using OrderManagementInterface

### DIFF
--- a/app/code/Magento/Sales/Model/CronJob/CleanExpiredOrders.php
+++ b/app/code/Magento/Sales/Model/CronJob/CleanExpiredOrders.php
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Sales\Model\CronJob;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Magento\Store\Model\StoresConfig;
 use Magento\Sales\Model\Order;
 
@@ -16,20 +21,28 @@ class CleanExpiredOrders
     protected $storesConfig;
 
     /**
-     * @var \Magento\Sales\Model\ResourceModel\Order\CollectionFactory
+     * @var CollectionFactory
      */
     protected $orderCollectionFactory;
 
     /**
+     * @var OrderManagementInterface
+     */
+    private $orderManagement;
+
+    /**
      * @param StoresConfig $storesConfig
-     * @param \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $collectionFactory
+     * @param CollectionFactory $collectionFactory
+     * @param OrderManagementInterface|null $orderManagement
      */
     public function __construct(
         StoresConfig $storesConfig,
-        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $collectionFactory
+        CollectionFactory $collectionFactory,
+        OrderManagementInterface $orderManagement = null
     ) {
         $this->storesConfig = $storesConfig;
         $this->orderCollectionFactory = $collectionFactory;
+        $this->orderManagement = $orderManagement ?: ObjectManager::getInstance()->get(OrderManagementInterface::class);
     }
 
     /**
@@ -48,8 +61,10 @@ class CleanExpiredOrders
             $orders->getSelect()->where(
                 new \Zend_Db_Expr('TIME_TO_SEC(TIMEDIFF(CURRENT_TIMESTAMP, `updated_at`)) >= ' . $lifetime * 60)
             );
-            $orders->walk('cancel');
-            $orders->walk('save');
+
+            foreach ($orders->getAllIds() as $entityId) {
+                $this->orderManagement->cancel((int) $entityId);
+            }
         }
     }
 }

--- a/app/code/Magento/Sales/Model/CronJob/CleanExpiredOrders.php
+++ b/app/code/Magento/Sales/Model/CronJob/CleanExpiredOrders.php
@@ -13,6 +13,9 @@ use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Magento\Store\Model\StoresConfig;
 use Magento\Sales\Model\Order;
 
+/**
+ * Class that provides functionality of cleaning expired quotes by cron
+ */
 class CleanExpiredOrders
 {
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18832

### Description (*)
Plugins are most likely be created in the `OrderManagementInterface` to do additional operations instead of the `cancel()` method of the order itself.

Regarding our use case: We create proforma invoices for an order with pending(_payment) status. When the cron cancels these orders it will call the `cancel()` method on the order instead of using the `OrderManagementInterface`. Result is our plugins are nog triggered.

### Fixed Issues (if relevant)-->
1. None I could find.

### Manual testing scenarios (*)
1. Create pending invoice for order with pending_payment status.
2. Set `sales/orders/delete_pending_after` to `0`.
3. Create before plugin on `OrderManagementInterface::cancel()` which cancel any open invoices.
4. Run the cron `sales_clean_orders` to cancel the order.
5. Invoices are not canceled while they should.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
