### PR TITLE
Added htmlspecialchars_decode on the label to display correctly the l…

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ConfigurableAttributeData.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ConfigurableAttributeData.php
@@ -58,7 +58,7 @@ class ConfigurableAttributeData
             $optionId = $attributeOption['value_index'];
             $attributeOptionsData[] = [
                 'id' => $optionId,
-                'label' => $attributeOption['label'],
+                'label' => htmlspecialchars_decode($attributeOption['label']),
                 'products' => isset($config[$attribute->getAttributeId()][$optionId])
                     ? $config[$attribute->getAttributeId()][$optionId]
                     : [],


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the special characters problem for the attributes options on the front end
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/15404: &amp; bug on update to magento 2.1.12

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Connect to Admin
2. Add attribute options with special characters. ( ", ', & etc.)
3. Create product with these options.
4. On the frontend, the specials characters show up escaped.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
