### PR TITLE
Add useful debug info for which website has not been found

### DIFF
--- a/app/code/Magento/Store/Model/WebsiteRepository.php
+++ b/app/code/Magento/Store/Model/WebsiteRepository.php
@@ -79,7 +79,7 @@ class WebsiteRepository implements \Magento\Store\Api\WebsiteRepositoryInterface
 
         if ($website->getId() === null) {
             throw new NoSuchEntityException(
-                __(sprintf("The website %s that was requested wasn't found. Verify the website and try again.", $code))
+                __(sprintf("The website with code %s that was requested wasn't found. Verify the website and try again.", $code))
             );
         }
         $this->entities[$code] = $website;
@@ -103,7 +103,7 @@ class WebsiteRepository implements \Magento\Store\Api\WebsiteRepositoryInterface
 
         if ($website->getId() === null) {
             throw new NoSuchEntityException(
-                __(sprintf("The website %s that was requested wasn't found. Verify the website and try again.", $id))
+                __(sprintf("The website with id %s that was requested wasn't found. Verify the website and try again.", $id))
             );
         }
         $this->entities[$website->getCode()] = $website;

--- a/app/code/Magento/Store/Model/WebsiteRepository.php
+++ b/app/code/Magento/Store/Model/WebsiteRepository.php
@@ -78,7 +78,9 @@ class WebsiteRepository implements \Magento\Store\Api\WebsiteRepositoryInterface
         ]);
 
         if ($website->getId() === null) {
-            throw new NoSuchEntityException();
+            throw new NoSuchEntityException(
+                __(sprintf("The website %s that was requested wasn't found. Verify the website and try again.", $code))
+            );
         }
         $this->entities[$code] = $website;
         $this->entitiesById[$website->getId()] = $website;
@@ -100,7 +102,9 @@ class WebsiteRepository implements \Magento\Store\Api\WebsiteRepositoryInterface
         ]);
 
         if ($website->getId() === null) {
-            throw new NoSuchEntityException();
+            throw new NoSuchEntityException(
+                __(sprintf("The website %s that was requested wasn't found. Verify the website and try again.", $id))
+            );
         }
         $this->entities[$website->getCode()] = $website;
         $this->entitiesById[$id] = $website;


### PR DESCRIPTION
### Description (*)
After running Magento setup, with custom modules, you may have created settings for store and websites that do not exist yet.

This creates entries in core_config_data.

When running bin/magento to complete the settings and data migration, Magento will crash with the error message:

```
No such entity.
```

This code adds something useful to the user, informing them it is because the website Id requested does not exist.

### Manual testing scenarios (*)
1. Install Magento 2.3.0
2. Have any module insert data into core_config_data, with website scope values
3. Run bin/magento
4. It will crash with above message

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
