### PR TITLE
Check repository label for possible non-string value

### DIFF
--- a/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
+++ b/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
@@ -148,7 +148,7 @@ try {
     }
     else {
         foreach ($composerData['repositories'] as $label => $repo) {
-            if (strpos(strtolower($label), 'mage') !== false || strpos($repo['url'], '.mage') !== false) {
+            if (is_string($label) && strpos(strtolower($label), 'mage') !== false || strpos($repo['url'], '.mage') !== false) {
                 $mageUrls[] = $repo['url'];
             }
         }


### PR DESCRIPTION
In my case the changed line of upgrade script was causing an error with an integer given to strtolower function, so I added the missing checking if $label is string.

This is a requested PR clone of #19526 