### PR TITLE
Allow Custom Translation (__) Function

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -28,6 +28,10 @@ HTML;
 }
 
 require_once __DIR__ . '/autoload.php';
+
+// Ensure that the translation function is defined
+\Magento\Framework\Phrase::defineTranslationFunction();
+
 // Sets default autoload mappings, may be overridden in Bootstrap::create
 \Magento\Framework\App\Bootstrap::populateAutoloader(BP, []);
 

--- a/lib/internal/Magento/Framework/Phrase.php
+++ b/lib/internal/Magento/Framework/Phrase.php
@@ -125,4 +125,13 @@ class Phrase implements \JsonSerializable
     {
         return $this->render();
     }
+    
+    /*
+	   * Register the translation function
+	   *
+	   */
+    public static function defineTranslationFunction()
+    {
+	    require_once __DIR__ . '/Phrase/__.php';
+    }
 }

--- a/lib/internal/Magento/Framework/Phrase/__.php
+++ b/lib/internal/Magento/Framework/Phrase/__.php
@@ -10,14 +10,16 @@ declare(strict_types=1);
  * @SuppressWarnings(PHPMD.ShortMethodName)
  * @return \Magento\Framework\Phrase
  */
-function __()
-{
-    $argc = func_get_args();
-
-    $text = array_shift($argc);
-    if (!empty($argc) && is_array($argc[0])) {
-        $argc = $argc[0];
-    }
-
-    return new \Magento\Framework\Phrase($text, $argc);
+if (!function_exists('__')) {
+	function __()
+	{
+	    $argc = func_get_args();
+	
+	    $text = array_shift($argc);
+	    if (!empty($argc) && is_array($argc[0])) {
+	        $argc = $argc[0];
+	    }
+	
+	    return new \Magento\Framework\Phrase($text, $argc);
+	}
 }

--- a/lib/internal/Magento/Framework/registration.php
+++ b/lib/internal/Magento/Framework/registration.php
@@ -7,7 +7,3 @@
 use \Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/framework', __DIR__);
-
-if (!function_exists('__')) {
-    require 'Phrase/__.php';
-}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This pull request allows the definition of a custom translation function. If a custom translation function is not set then the default Magento translation function is set.

This does this by removing the include for Phrase/\__.php in the Magento Framework registration.php file. This gives other registration.php files in other modules a chance to define the function.

After app/autoload.php is loaded in app/bootstrap.php, a call is made to \Magento\Framework\Phrase::defineTranslationFunction and this includes Phrase/__.php. The definition for the __ function is wrapped in a call to function_exists so that the function is not created more than once.

### Fixed Issues (if relevant)
This allows for integration with other online applications that define the __ translation function. This function is a common function in many popular online applications.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Apply pull request
2. Make a call to __('Any String Here');
3. String is translated as expected

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
