### PR TITLE
Added int as input type for loadByAttribute()

### DIFF
--- a/app/code/Magento/Catalog/Model/AbstractModel.php
+++ b/app/code/Magento/Catalog/Model/AbstractModel.php
@@ -235,7 +235,7 @@ abstract class AbstractModel extends \Magento\Framework\Model\AbstractExtensible
      * Load entity by attribute
      *
      * @param \Magento\Eav\Model\Entity\Attribute\AttributeInterface|integer|string|array $attribute
-     * @param null|string|array $value
+     * @param null|string|int|array $value
      * @param string $additionalAttributes
      * @return bool|\Magento\Catalog\Model\AbstractModel
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixes phpstan where 1st parameter is `entity_id` and 2nd `$product->getId()`

```
  115    Parameter #2 $value of method
         Magento\Catalog\Model\AbstractModel::loadByAttribute() expects
         array|string|null, int|null given.
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
