### PR TITLE
Fix for making subcategories appear in breadcrumbs (Backport)

### DIFF
--- a/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
@@ -107,7 +107,7 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
         return $this->escaper->escapeHtml($this->json->serialize([
             'breadcrumbs' => [
                 'categoryUrlSuffix' => $this->escaper->escapeHtml($this->getCategoryUrlSuffix()),
-                'userCategoryPathInUrl' => (int)$this->isCategoryUsedInProductUrl(),
+                'useCategoryPathInUrl' => (int)$this->isCategoryUsedInProductUrl(),
                 'product' => $this->getProductName()
             ]
         ]));


### PR DESCRIPTION
### Description (*)
The typo will break sub categories from appearing in the breadcrumbs

### Fixed Issues (if relevant)

1. magento/magento2#7967: Problems with breadcrumbs

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Backport for: https://github.com/magento/magento2/pull/19781