### PR TITLE
Prevent display of token when save for later is not selected

### DIFF
--- a/app/code/Magento/Vault/Observer/AfterPaymentSaveObserver.php
+++ b/app/code/Magento/Vault/Observer/AfterPaymentSaveObserver.php
@@ -77,11 +77,9 @@ class AfterPaymentSaveObserver implements ObserverInterface
         $paymentToken->setPaymentMethodCode($payment->getMethod());
 
         $additionalInformation = $payment->getAdditionalInformation();
-        if (isset($additionalInformation[VaultConfigProvider::IS_ACTIVE_CODE])) {
-            $paymentToken->setIsVisible(
-                (bool) (int) $additionalInformation[VaultConfigProvider::IS_ACTIVE_CODE]
-            );
-        }
+        $paymentToken->setIsVisible(
+            (bool) (int) ($additionalInformation[VaultConfigProvider::IS_ACTIVE_CODE] ?? 0)
+        );
 
         $paymentToken->setPublicHash($this->generatePublicHash($paymentToken));
 

--- a/app/code/Magento/Vault/Observer/AfterPaymentSaveObserver.php
+++ b/app/code/Magento/Vault/Observer/AfterPaymentSaveObserver.php
@@ -113,7 +113,7 @@ class AfterPaymentSaveObserver implements ObserverInterface
     /**
      * Reads Payment token from Order Payment
      *
-     * @param OrderPaymentExtensionInterface | null $extensionAttributes
+     * @param OrderPaymentExtensionInterface|null $extensionAttributes
      * @return PaymentTokenInterface | null
      */
     protected function getPaymentToken(OrderPaymentExtensionInterface $extensionAttributes = null)

--- a/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Vault\Test\Unit\Observer;
 
 use Magento\Framework\App\DeploymentConfig;
@@ -19,6 +20,9 @@ use Magento\Vault\Model\Ui\VaultConfigProvider;
 use Magento\Vault\Observer\AfterPaymentSaveObserver;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
+/**
+ * Tests for AfterPaymentSaveObserver.
+ */
 class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -162,7 +166,10 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
         static::assertEquals($token, $paymentToken->getGatewayToken());
         static::assertEquals($isActive, $paymentToken->getIsActive());
         static::assertEquals($createdAt, $paymentToken->getCreatedAt());
-        static::assertEquals($additionalInfo[VaultConfigProvider::IS_ACTIVE_CODE] ?? false, $paymentToken->getIsVisible());
+        static::assertEquals(
+            $additionalInfo[VaultConfigProvider::IS_ACTIVE_CODE] ?? false,
+            $paymentToken->getIsVisible()
+        );
     }
 
     /**

--- a/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
@@ -15,6 +15,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Vault\Model\PaymentToken;
 use Magento\Vault\Model\PaymentTokenManagement;
+use Magento\Vault\Model\Ui\VaultConfigProvider;
 use Magento\Vault\Observer\AfterPaymentSaveObserver;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
@@ -93,7 +94,7 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
 
         // Sales Order Payment Model
         $this->salesOrderPaymentMock = $this->getMockBuilder(Payment::class)
-            ->setMethods(null)
+            ->setMethods(['getAdditionalInformation'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->salesOrderPaymentMock->setOrder($this->salesOrderMock);
@@ -122,9 +123,10 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
      * @param string $token
      * @param bool $isActive
      * @param string $method
+     * @param array $additionalInformation
      * @dataProvider positiveCaseDataProvider
      */
-    public function testPositiveCase($customerId, $createdAt, $token, $isActive, $method)
+    public function testPositiveCase($customerId, $createdAt, $token, $isActive, $method, $additionalInformation)
     {
         $this->paymentTokenMock->setGatewayToken($token);
         $this->paymentTokenMock->setCustomerId($customerId);
@@ -135,6 +137,8 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
         $this->paymentExtension->expects($this->exactly(2))
             ->method('getVaultPaymentToken')
             ->willReturn($this->paymentTokenMock);
+
+        $this->salesOrderPaymentMock->method('getAdditionalInformation')->willReturn($additionalInformation);
 
         if (!empty($token)) {
             $this->paymentTokenManagementMock->expects($this->once())
@@ -158,6 +162,7 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
         static::assertEquals($token, $paymentToken->getGatewayToken());
         static::assertEquals($isActive, $paymentToken->getIsActive());
         static::assertEquals($createdAt, $paymentToken->getCreatedAt());
+        static::assertEquals($additionalInformation[VaultConfigProvider::IS_ACTIVE_CODE] ?? false, $paymentToken->getIsVisible());
     }
 
     /**
@@ -171,14 +176,32 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
                 '10\20\2015',
                 'asdfg',
                 true,
-                'paypal'
+                'paypal',
+                [],
+            ],
+            [
+                1,
+                '10\20\2015',
+                'asdfg',
+                true,
+                'paypal',
+                [VaultConfigProvider::IS_ACTIVE_CODE => true],
+            ],
+            [
+                1,
+                '10\20\2015',
+                'asdfg',
+                true,
+                'paypal',
+                [VaultConfigProvider::IS_ACTIVE_CODE => false],
             ],
             [
                 null,
                 null,
                 null,
                 false,
-                null
+                null,
+                [],
             ],
         ];
     }

--- a/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
@@ -123,10 +123,10 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
      * @param string $token
      * @param bool $isActive
      * @param string $method
-     * @param array $additionalInformation
+     * @param array $additionalInfo
      * @dataProvider positiveCaseDataProvider
      */
-    public function testPositiveCase($customerId, $createdAt, $token, $isActive, $method, $additionalInformation)
+    public function testPositiveCase($customerId, $createdAt, $token, $isActive, $method, $additionalInfo)
     {
         $this->paymentTokenMock->setGatewayToken($token);
         $this->paymentTokenMock->setCustomerId($customerId);
@@ -138,7 +138,7 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
             ->method('getVaultPaymentToken')
             ->willReturn($this->paymentTokenMock);
 
-        $this->salesOrderPaymentMock->method('getAdditionalInformation')->willReturn($additionalInformation);
+        $this->salesOrderPaymentMock->method('getAdditionalInformation')->willReturn($additionalInfo);
 
         if (!empty($token)) {
             $this->paymentTokenManagementMock->expects($this->once())
@@ -162,7 +162,7 @@ class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
         static::assertEquals($token, $paymentToken->getGatewayToken());
         static::assertEquals($isActive, $paymentToken->getIsActive());
         static::assertEquals($createdAt, $paymentToken->getCreatedAt());
-        static::assertEquals($additionalInformation[VaultConfigProvider::IS_ACTIVE_CODE] ?? false, $paymentToken->getIsVisible());
+        static::assertEquals($additionalInfo[VaultConfigProvider::IS_ACTIVE_CODE] ?? false, $paymentToken->getIsVisible());
     }
 
     /**


### PR DESCRIPTION
### Description
This sets the token `isVisible` value to false if
`VaultConfigProvider::IS_ACTIVE_CODE` is not set in the payment's
`additionalInformation` property. The value is not set when placing orders
through the admin panel, unless the save for later checkbox is selected. This
caused all admin order payment to be visible in the stored payment method
section in the storefront.

Testing on 2.3 depends on magento/magento2#19764

### Fixed Issues (if relevant)
1. magento/magento2#19515

### Manual testing scenarios
1. Enable PayFlow Pro payment method for credit card transactions with vault allowed.
2. Create orders in admin panel using PayFlow Pro 
3. After placing Admin order, new stored payment methods should only be visible to the customer if "Save for Later" option was selected during order placement.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
