### PR TITLE
PUT, DELETE methods support added.

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Curl.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Curl.php
@@ -12,19 +12,4 @@ use Magento\Framework\HTTP\Client\Curl as CurlLibrary;
 
 class Curl extends CurlLibrary
 {
-    /**
-     * Make DELETE request
-     *
-     * String type was added to parameter $param in order to support sending JSON or XML requests.
-     * This feature was added base on Community Pull Request https://github.com/magento/magento2/pull/8373
-     *
-     * @param string $uri
-     * @return void
-     *
-     * @see \Magento\Framework\HTTP\Client#post($uri, $params)
-     */
-    public function delete($uri)
-    {
-        $this->makeRequest("DELETE", $uri);
-    }
 }

--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -230,6 +230,17 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     }
 
     /**
+     * Make DELETE request
+     *
+     * @param string $uri uri relative to host, ex. "/index.php"
+     * @return void
+     */
+    public function delete($uri)
+    {
+        $this->makeRequest("DELETE", $uri);
+    }
+
+    /**
      * Make POST request
      *
      * String type was added to parameter $param in order to support sending JSON or XML requests.
@@ -244,6 +255,20 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     public function post($uri, $params)
     {
         $this->makeRequest("POST", $uri, $params);
+    }
+
+    /**
+     * Make PUT request
+     *
+     * @param string $uri
+     * @param array|string $params
+     * @return void
+     *
+     * @see \Magento\Framework\HTTP\Client#put($uri, $params)
+     */
+    public function put($uri, $params)
+    {
+        $this->makeRequest("PUT", $uri, $params);
     }
 
     /**
@@ -363,6 +388,9 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
             $this->curlOption(CURLOPT_POSTFIELDS, is_array($params) ? http_build_query($params) : $params);
         } elseif ($method == "GET") {
             $this->curlOption(CURLOPT_HTTPGET, 1);
+        } elseif ($method == "PUT") {
+            $this->curlOption(CURLOPT_CUSTOMREQUEST, $method);
+            $this->curlOption(CURLOPT_POSTFIELDS, is_array($params) ? http_build_query($params) : $params);
         } else {
             $this->curlOption(CURLOPT_CUSTOMREQUEST, $method);
         }

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\HTTP\Test\Unit\Client;
+
+use \Magento\Framework\HTTP\Client\Curl;
+
+class CurlTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Curl
+     */
+    protected $model;
+
+    /**
+     * @var \Closure
+     */
+    public static $curlExectClosure;
+
+    protected function setUp()
+    {
+        require_once __DIR__ . '/_files/curl_exec_mock.php';
+        $this->model = new \Magento\Framework\HTTP\Client\Curl();
+    }
+
+    /**
+     * @param string $response
+     * @dataProvider readDataProvider
+     */
+    public function testGet($response)
+    {
+        self::$curlExectClosure = function () use ($response) {
+            return $response;
+        };
+
+        $this->model->get('test_url');
+        $this->assertEquals(file_get_contents(__DIR__ . '/_files/curl_response_expected.txt'), $this->model->getBody());
+    }
+
+    /**
+     * @param string $response
+     * @dataProvider readDataProvider
+     */
+    public function testPut($response)
+    {
+        self::$curlExectClosure = function () use ($response) {
+            return $response;
+        };
+
+        $this->model->put('test_url', []);
+        $this->assertEquals(file_get_contents(__DIR__ . '/_files/curl_response_expected.txt'), $this->model->getBody());
+    }
+
+    /**
+     * @param string $response
+     * @dataProvider readDataProvider
+     */
+    public function testPost($response)
+    {
+        self::$curlExectClosure = function () use ($response) {
+            return $response;
+        };
+
+        $this->model->post('test_url', []);
+        $this->assertEquals(file_get_contents(__DIR__ . '/_files/curl_response_expected.txt'), $this->model->getBody());
+    }
+
+    /**
+     * @param string $response
+     * @dataProvider readDataProvider
+     */
+    public function testDelete($response)
+    {
+        self::$curlExectClosure = function () use ($response) {
+            return $response;
+        };
+        $this->model->delete('test_url');
+        $this->assertEquals(file_get_contents(__DIR__ . '/_files/curl_response_expected.txt'), $this->model->getBody());
+    }
+
+    /**
+     * @return array
+     */
+    public function readDataProvider()
+    {
+        return [
+            [file_get_contents(__DIR__ . '/_files/curl_response.txt')],
+        ];
+    }
+}

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/_files/curl_exec_mock.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/_files/curl_exec_mock.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\HTTP\Client;
+
+/**
+ * Override global PHP function
+ *
+ * @SuppressWarnings("unused")
+ * @param mixed $resource
+ * @return string
+ */
+function curl_exec($resource)
+{
+    $response = call_user_func(\Magento\Framework\HTTP\Test\Unit\Client\CurlTest::$curlExectClosure);
+    return $response;
+}

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/_files/curl_response.txt
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/_files/curl_response.txt
@@ -1,0 +1,1 @@
+VERIFIED

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/_files/curl_response_expected.txt
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/_files/curl_response_expected.txt
@@ -1,0 +1,1 @@
+VERIFIED


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
PUT, DELETE methods support added in ` \Magento\Framework\HTTP\Client\Curl` class.
Same as the feature-request https://github.com/magento/community-features/issues/101

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
As by the coding standards it is preferred to use the `Curl` class instead of php curl lib directly, 
but the lib `Curl` class does not supports `PUT, DELETE` methods.
`phpcs: MEQP1.Security.DiscouragedFunction.Found: The use of function curl_init() is discouraged`


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use curl via Client Curl class

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
