### PR TITLE
When creating a customer, prevent selection of store not relevant to chosen website

### DIFF
--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -292,8 +292,8 @@
                 <label translate="true">Send Welcome Email From</label>
                 <imports>
                     <link name="value">${ $.provider }:data.customer.store_id</link>
-	        </imports>
-	        <listens>
+                </imports>
+                <listens>
                     <link name="${ $.provider }:data.customer.website_id">websiteIdChanged</link>
                 </listens>
             </settings>

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -281,7 +281,7 @@
                 <visible>true</visible>
             </settings>
         </field>
-        <field name="sendemail_store_id" formElement="select">
+        <field name="sendemail_store_id" component="Magento_Ui/js/form/element/store" formElement="select">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">customer</item>
@@ -292,7 +292,10 @@
                 <label translate="true">Send Welcome Email From</label>
                 <imports>
                     <link name="value">${ $.provider }:data.customer.store_id</link>
-                </imports>
+	        </imports>
+	        <listens>
+                    <link name="${ $.provider }:data.customer.website_id">websiteIdChanged</link>
+                </listens>
             </settings>
             <formElements>
                 <select>

--- a/app/code/Magento/Store/Model/System/Store.php
+++ b/app/code/Magento/Store/Model/System/Store.php
@@ -118,36 +118,19 @@ class Store extends \Magento\Framework\DataObject implements OptionSourceInterfa
             $options[] = ['label' => __('All Store Views'), 'value' => 0];
         }
 
-        $nonEscapableNbspChar = html_entity_decode('&#160;', ENT_NOQUOTES, 'UTF-8');
-
         foreach ($this->_websiteCollection as $website) {
-            $websiteShow = false;
             foreach ($this->_groupCollection as $group) {
                 if ($website->getId() != $group->getWebsiteId()) {
                     continue;
                 }
-                $groupShow = false;
                 foreach ($this->_storeCollection as $store) {
                     if ($group->getId() != $store->getGroupId()) {
                         continue;
                     }
-                    if (!$websiteShow) {
-                        $options[] = ['label' => $website->getName(), 'value' => []];
-                        $websiteShow = true;
-                    }
-                    if (!$groupShow) {
-                        $groupShow = true;
-                        $values = [];
-                    }
-                    $values[] = [
-                        'label' => str_repeat($nonEscapableNbspChar, 4) . $store->getName(),
-                        'value' => $store->getId(),
-                    ];
-                }
-                if ($groupShow) {
                     $options[] = [
-                        'label' => str_repeat($nonEscapableNbspChar, 4) . $group->getName(),
-                        'value' => $values,
+                        'label' => sprintf('%s/%s/%s', $website->getName(), $group->getName(), $store->getName()),
+                        'value' => $store->getId(),
+                        'group' => $website->getId(),
                     ];
                 }
             }

--- a/app/code/Magento/Ui/view/base/web/js/form/element/store.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/store.js
@@ -17,7 +17,7 @@ define([
 
         /**
          * Store component constructor.
-	 *
+         *
          * @returns {exports}
          */
         initialize: function () {

--- a/app/code/Magento/Ui/view/base/web/js/form/element/store.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/store.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * @api
+ */
+define([
+    'underscore',
+    'uiRegistry',
+    './select'
+], function (_, registry, Select) {
+    'use strict';
+
+    return Select.extend({
+
+        initialize: function () {
+            this._super();
+
+            this.filterInitialStores();
+        },
+
+        filterInitialStores: function () {
+            var websiteId = registry.get(this.parentName + '.website_id');
+
+            if(websiteId) {
+                this.filter(websiteId.value(), 'group');
+            }
+        },
+
+        websiteIdChanged: function (data) {
+            this.filter(data, 'group');
+        }
+
+    });
+});

--- a/app/code/Magento/Ui/view/base/web/js/form/element/store.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/store.js
@@ -41,7 +41,7 @@ define([
         },
 
         /**
-         * @param {String} value
+         * @param {String} data
          */
         websiteIdChanged: function (data) {
             this.filter(data, 'group');

--- a/app/code/Magento/Ui/view/base/web/js/form/element/store.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/store.js
@@ -15,20 +15,34 @@ define([
 
     return Select.extend({
 
+        /**
+         * Store component constructor.
+	 *
+         * @returns {exports}
+         */
         initialize: function () {
-            this._super();
+            this._super()
+                .filterInitialStores();
 
-            this.filterInitialStores();
+            return this;
         },
 
+        /**
+         * Filter stores shown based on website selected initially
+         *
+         * @returns void
+         */
         filterInitialStores: function () {
             var websiteId = registry.get(this.parentName + '.website_id');
 
-            if(websiteId) {
+            if (websiteId) {
                 this.filter(websiteId.value(), 'group');
             }
         },
 
+        /**
+         * @param {String} value
+         */
         websiteIdChanged: function (data) {
             this.filter(data, 'group');
         }


### PR DESCRIPTION
When creating a customer, and with customers scope not set to Global, it is possible to select a store (in the "Send welcome email from" dropdown) that is not relevant to the website.

### Description (*)
While an improvement has been made to this process by the resolving of this issue - https://github.com/magento/magento2/issues/10411 . There is still a flaw in this process where it is possible to select a store that is not relevant to the selected website (the value in "Associate to Website"). The fix introduced in https://github.com/magento/magento2/issues/10411
 prevents an invalid store by providing an error, but the user should never be able to select an invalid store in the first place. This PR adds filtering to the select, only showing relevant stores to the selected website when customers can be scoped to websites (i.e. not global).

### Fixed Issues (if relevant)
None, but further enhances fix from https://github.com/magento/magento2/issues/10411

### Manual testing scenarios (*)
1. Magento 2.3 with fix from https://github.com/magento/magento2/issues/10411
2. Customer Configuration > Scope set to Website
3. Create a new customer, and change "Associate to Website"

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
