### PR TITLE
Fix issue 19796 - Sales Order invoice Update Qty's Button is misaligned

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items.phtml
@@ -33,7 +33,7 @@
                     <tr>
                         <td colspan="3">&nbsp;</td>
                         <td><?= $block->getUpdateButtonHtml() ?></td>
-                        <td colspan="5">&nbsp;</td>
+                        <td colspan="4">&nbsp;</td>
                     </tr>
                 </tfoot>
                 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items.phtml
@@ -31,9 +31,9 @@
                 <?php if ($block->canEditQty()): ?>
                 <tfoot>
                     <tr>
-                        <td colspan="2">&nbsp;</td>
-                        <td colspan="3"><?= $block->getUpdateButtonHtml() ?></td>
                         <td colspan="3">&nbsp;</td>
+                        <td><?= $block->getUpdateButtonHtml() ?></td>
+                        <td colspan="5">&nbsp;</td>
                     </tr>
                 </tfoot>
                 <?php endif; ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Magento 2.3-develop
Sales Order invoice Update Qty's Button is misaligned 
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1.magento/magento2#19796: Sales Order invoice Update Qty's Button is misaligned

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Login to backend-> Order -> View order
2.Generate Invoice -> Items to Invoice -> Check Update Qty's Button

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
