### PR TITLE
Fixed issue of action button alignment in Customer Group Grid

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/_data-grid.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/_data-grid.less
@@ -421,9 +421,9 @@ body._in-resize {
     }
 
     .data-grid-actions-cell {
-        padding-left: @data-grid-cell__padding-horizontal * 2;
-        padding-right: @data-grid-cell__padding-horizontal * 2;
-        text-align: center;
+        padding-left: @data-grid-cell__padding-horizontal;
+        padding-right: @data-grid-cell__padding-horizontal;
+        text-align: left;
         width: 1%;
     }
 


### PR DESCRIPTION
**Preconditions:**
1. Magento 2.3.0
2. PHP 7.2

**Description (*)**
Customer Groups table grid action column values not aligned with <th>

**Steps to reproduce**
    Step 1: Go to admin url
    Step 2: login to admin panel
    Step 3: click on customer link from left side then click on customer groups link in sub menu 
    Step 4: then see customer Gruop table grid (ref screenshot) 

**Actual Result :** 
![issue](https://user-images.githubusercontent.com/26018716/50161504-fe6e4180-0301-11e9-9998-3f2458b1707a.png)

**Expected Result**
![sol](https://user-images.githubusercontent.com/26018716/50161513-04642280-0302-11e9-8837-3d3d6fa8c768.png)



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
