### PR TITLE
Fix spelling in GraphQL schema comments

### DIFF
--- a/app/code/Magento/StoreGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/StoreGraphQl/etc/schema.graphqls
@@ -6,10 +6,10 @@ type Query {
 
 type Website @doc(description: "The type contains information about a website") {
     id : Int @doc(description: "The ID number assigned to the website")
-    name : String @doc(description: "The website name. Websites use this name to identify it easyer.")
+    name : String @doc(description: "The website name. Websites use this name to identify it easier.")
     code : String @doc(description: "A code assigned to the website to identify it")
     sort_order : Int @doc(description: "The attribute to use for sorting websites")
-    default_group_id : String @doc(description: "The default group id that the website has")
+    default_group_id : String @doc(description: "The default group ID that the website has")
     is_default : Boolean @doc(description: "Specifies if this is the default website")
 }
 


### PR DESCRIPTION
### Description (*)

Fixed spelling errors.

### Manual testing scenarios (*)

None, affects comments only.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
