### PR TITLE
Fixes price index on partial update

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
@@ -217,11 +217,7 @@ class BaseFinalPrice
         $select->where("e.type_id = ?", $productType);
 
         if ($entityIds !== null) {
-            if (count($entityIds) > 1) {
-                $select->where(sprintf('e.entity_id BETWEEN %s AND %s', min($entityIds), max($entityIds)));
-            } else {
-                $select->where('e.entity_id = ?', $entityIds);
-            }
+            $select->where('e.entity_id IN (?)', $entityIds);
         }
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Backport to 2.2 of #19878

<!--- Please provide a general summary of the Pull Request in the Title above -->
When $entityIds is passed to the function, the where does a BETWEEN, but that's wrong because it will set to zero all the products between the min($entityIds) and max($entityIds).

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I have just replaced the "BETWEEN" SQL condition to "IN", like has been suggested by gavinlimely in https://github.com/magento/magento2/issues/7367#issuecomment-447921233 and tested and verified it.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19877: Wrong partial price reindex with two or more products 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. put two or more products to be re-indexed in the catalog_product_price_cl, without contiguous ids;
2. launch indexer_update_all_views;
3. all the products between min($entityIds) and max($entityIds) will be set with price, min_price and max_price to zero.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
