### PR TITLE
[Backport] Changed the mb_convert_encoding in order to allow unescaped ampersands

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -77,6 +77,7 @@ class Escaper
                         throw new \Exception($errorString, $errorNumber);
                     }
                 );
+                $data = $this->prepareUnescapedCharacters($data);
                 $string = mb_convert_encoding($data, 'HTML-ENTITIES', 'UTF-8');
                 try {
                     $domDocument->loadHTML(
@@ -103,6 +104,19 @@ class Escaper
             $result = $data;
         }
         return $result;
+    }
+
+    /**
+     * Used to replace characters, that mb_convert_encoding will not process
+     *
+     * @param string $data
+     * @return string|null
+     */
+    private function prepareUnescapedCharacters(string $data): ?string
+    {
+        $patterns = ['/\&/u'];
+        $replacements = ['&amp;'];
+        return \preg_replace($patterns, $replacements, $data);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -72,9 +72,9 @@ class EscaperTest extends \PHPUnit\Framework\TestCase
         // Exceptions to escaping ranges
         $immune = [',', '.', '_'];
         for ($chr = 0; $chr < 0xFF; $chr++) {
-            if ($chr >= 0x30 && $chr <= 0x39
-                || $chr >= 0x41 && $chr <= 0x5A
-                || $chr >= 0x61 && $chr <= 0x7A
+            if (($chr >= 0x30 && $chr <= 0x39)
+                || ($chr >= 0x41 && $chr <= 0x5A)
+                || ($chr >= 0x61 && $chr <= 0x7A)
             ) {
                 $literal = $this->codepointToUtf8($chr);
                 $this->assertEquals($literal, $this->escaper->escapeJs($literal));
@@ -173,6 +173,11 @@ class EscaperTest extends \PHPUnit\Framework\TestCase
             'text with special characters' => [
                 'data' => '&<>"\'&amp;&lt;&gt;&quot;&#039;&#9;',
                 'expected' => '&amp;&lt;&gt;&quot;&#039;&amp;&lt;&gt;&quot;&#039;&#9;'
+            ],
+            'text with special characters and allowed tag' => [
+                'data' => '&<br/>"\'&amp;&lt;&gt;&quot;&#039;&#9;',
+                'expected' => '&amp;<br>&quot;&#039;&amp;&lt;&gt;&quot;&#039;&#9;',
+                'allowedTags' => ['br'],
             ],
             'text with multiple allowed tags, includes self closing tag' => [
                 'data' => '<span>some text in tags<br /></span>',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This fix was discussed in the following issue : https://github.com/magento/magento2/issues/13269
The exception is thrown every time a string with an unescaped & is passed to the escapeHtml method. This exception is written to the exception.log file and floods the logs.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13269: Magento Framework Escaper - Critical log with special symbols

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an order comment with an &
2. On the page load an exception is written into the exception.log file
3. The exception is thrown every time a string with an unescaped & is passed to the escapeHtml method.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
