### PR TITLE
Fixed Issue #19891   product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id.

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -105,7 +105,7 @@ class Validate extends AttributeAction implements HttpGetActionInterface, HttpPo
             $attributeCode
         );
 
-        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type') {
+        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type' || $attributeCode === 'type_id') {
             $message = strlen($this->getRequest()->getParam('attribute_code'))
                 ? __('An attribute with this code already exists.')
                 : __('An attribute with the same code (%1) already exists.', $attributeCode);

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -128,7 +128,13 @@
         }
 
         &:extend(.abs-field-sizes all);
-
+        
+        &.field-subscription{
+            > .admin__field-control{
+                line-height: 32px;
+            }
+        }
+        
         &.admin__field-no-label {
             > .admin__field-label {
                 display: none;

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -128,13 +128,6 @@
         }
 
         &:extend(.abs-field-sizes all);
-        
-        &.field-subscription{
-            > .admin__field-control{
-                line-height: 32px;
-            }
-        }
-        
         &.admin__field-no-label {
             > .admin__field-label {
                 display: none;


### PR DESCRIPTION
Fixed Issue #19891 
product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id.

### Description (*)

Fixed Issue #19891 
product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id.


### Fixed Issues (if relevant)

1. magento/magento2 #19891  : product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id


### Manual testing scenarios (*)
 1. Create dropdown type product attribute with attribute code "type_id" and assign the product attribute to attribute set.

   2. Create new product using that attribute and save it.
   3. Export the product.
   4. Import using the same csv.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
