### PR TITLE
Fixes sorting by price after partial reindex

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
@@ -218,7 +218,7 @@ class BaseFinalPrice
 
         if ($entityIds !== null) {
             if (count($entityIds) > 1) {
-                $select->where(sprintf('e.entity_id BETWEEN %s AND %s', min($entityIds), max($entityIds)));
+                $select->where(sprintf('e.entity_id IN (%s)' , implode(',',$entityIds)));
             } else {
                 $select->where('e.entity_id = ?', $entityIds);
             }


### PR DESCRIPTION
This change should resolved problem with sorting by price.

Descriptions of problem

After run job indexer_update_all_views a lot of configurable products has got 0 as min_price and max_price in table _catalog_product_index_price_. This action causes problem with sorting by price.
After call reindex _catalog_product_price_, prices backs to normal and sorting by price works correct.

Reproduce problem:
- Preconditions
1. Magento 2.3.0
2. Php 7.1.13
3. Mysql 5.6

- Steps to reproduce:
1. Install Sample Data
2. Enable Magento cron
3. Save two configurable products with the biggest and smaller entity_id



The problem is that in class Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\Query\BaseFinalPrice in line 221 there is condition:

`$select->where(sprintf('e.entity_id BETWEEN %s AND %s', min($entityIds), max($entityIds)));`

and in class Magento\ConfigurableProduct\Model\ResourceModel\Product\Indexer\Price\Configurable line 220 there is condition 

`$select->where('le.entity_id IN (?)', $entityIds);`

So all configurable products with entity_id between min($entityIds) and max($entityIds) and which are not on list $entityIds has got 0 as min_price and max_price in table catalog_product_index_price_temp so then also in catalog_product_index_price.