### PR TITLE
Subscribed to Fixed Issue #19905 Newsletter label and checkbox not aligned proper in admin panel while any customer editing

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -105,7 +105,7 @@ class Validate extends AttributeAction implements HttpGetActionInterface, HttpPo
             $attributeCode
         );
 
-        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type') {
+        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type' || $attributeCode === 'type_id') {
             $message = strlen($this->getRequest()->getParam('attribute_code'))
                 ? __('An attribute with this code already exists.')
                 : __('An attribute with the same code (%1) already exists.', $attributeCode);

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -105,7 +105,7 @@ class Validate extends AttributeAction implements HttpGetActionInterface, HttpPo
             $attributeCode
         );
 
-        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type' || $attributeCode === 'type_id') {
+        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type') {
             $message = strlen($this->getRequest()->getParam('attribute_code'))
                 ? __('An attribute with this code already exists.')
                 : __('An attribute with the same code (%1) already exists.', $attributeCode);

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -128,7 +128,13 @@
         }
 
         &:extend(.abs-field-sizes all);
-
+        
+        &.field-subscription{
+            > .admin__field-control{
+                line-height: 32px;
+            }
+        }
+        
         &.admin__field-no-label {
             > .admin__field-label {
                 display: none;

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -128,13 +128,6 @@
         }
 
         &:extend(.abs-field-sizes all);
-        
-        &.field-subscription{
-            > .admin__field-control{
-                line-height: 32px;
-            }
-        }
-        
         &.admin__field-no-label {
             > .admin__field-label {
                 display: none;

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -128,6 +128,13 @@
         }
 
         &:extend(.abs-field-sizes all);
+        
+        &.field-subscription{
+            > .admin__field-control{
+                line-height: 32px;
+            }
+        }
+        
         &.admin__field-no-label {
             > .admin__field-label {
                 display: none;


### PR DESCRIPTION
 Fixed Issue #19905 Newsletter label and checkbox not aligned proper in admin panel while any customer editing

### Description (*)

 Fixed Issue #19905 Newsletter label and checkbox not aligned proper in admin panel while any customer editing

### Fixed Issues (if relevant)

1. magento/magento2 #19905:  Newsletter label and checkbox not aligned proper in admin panel while any customer editing

### Manual testing scenarios (*)

Step 1: Go to admin url
Step 2: login to admin panel
Step 3: click on Customers link from left side and under customers click on all customers
Step 4: You see all registered customer grid now you edit any one of them.
Step 5: Now click on newsletter tab and check Newsletter checkbox is not aligned properly

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
