### PR TITLE
Changed the mb_convert_encoding in order to allow unescaped ampersands

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -91,7 +91,7 @@ class Escaper
                         throw new \Exception($errorString, $errorNumber);
                     }
                 );
-                $string = mb_convert_encoding($data, 'HTML-ENTITIES', 'UTF-8');
+                $string = mb_convert_encoding(preg_replace('/&/', '&amp;', html_entity_decode($data)), 'HTML-ENTITIES', 'UTF-8');
                 try {
                     $domDocument->loadHTML(
                         '<html><body id="' . $wrapperElementId . '">' . $string . '</body></html>'


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This fix was discussed in the following issue : https://github.com/magento/magento2/issues/13269
The exception is thrown every time a string with an unescaped & is passed to the escapeHtml method. This exception is written to the exception.log file and floods the logs.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13269: Magento Framework Escaper - Critical log with special symbols

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an order comment with an &
2. On the page load an exception is written into the exception.log file
3. The exception is thrown every time a string with an unescaped & is passed to the escapeHtml method.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
