### PR TITLE
Move website_name column into columnSet

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_customer_block.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_create_customer_block.xml
@@ -80,13 +80,13 @@
                             <argument name="align" xsi:type="string">center</argument>
                         </arguments>
                     </block>
-                </block>
-                <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.website_name" as="website_name">
-                    <arguments>
-                        <argument name="header" xsi:type="string" translate="true">Website</argument>
-                        <argument name="index" xsi:type="string">website_name</argument>
-                        <argument name="align" xsi:type="string">center</argument>
-                    </arguments>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" name="adminhtml.customer.grid.columnSet.website_name" as="website_name">
+                        <arguments>
+                            <argument name="header" xsi:type="string" translate="true">Website</argument>
+                            <argument name="index" xsi:type="string">website_name</argument>
+                            <argument name="align" xsi:type="string">center</argument>
+                        </arguments>
+                    </block>
                 </block>
             </block>
         </referenceBlock>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
One column was outside the columnset in this layout, for some reason.  Moving this so the grid shows the user's website name.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In admin, go Sales > Orders, click the Create New Order button.
2. Ensure the customer grid's rightmost column is now a column with header Website, which should match up with the column set in this layout file.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
