### PR TITLE
Fixed Issue #19891 ,Added checks of type_id

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -105,7 +105,7 @@ class Validate extends AttributeAction implements HttpGetActionInterface, HttpPo
             $attributeCode
         );
 
-        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type') {
+        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type' || $attributeCode === 'type_id') {
             $message = strlen($this->getRequest()->getParam('attribute_code'))
                 ? __('An attribute with this code already exists.')
                 : __('An attribute with the same code (%1) already exists.', $attributeCode);


### PR DESCRIPTION
Fixed Issue #19891 product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id.

### Description (*)
Fixed Issue #19891
product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id.

### Fixed Issues (if relevant)

1. magento/magento2 #19891 : product_type attribute contains incorrect value in mass import export csv after creating custom type_id attribute. actual type_id value in database gets change with newly created attribute type_id

### Manual testing scenarios (*)

1.Create dropdown type product attribute with attribute code "type_id" and assign the product attribute to attribute set.

   2.Create new product using that attribute and save it.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
