### PR TITLE
fixed issue #19925 Close button overlapping in shipping address label whenever any user adding new shipping address in mobile view in checkout

### DIFF
--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -82,7 +82,8 @@
 
     .modal-slide {
         .action-close {
-            padding: @modal-slide-action-close__padding;
+            padding: 0;
+            margin: 15px;
         }
 
         .page-main-actions {

--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -82,8 +82,8 @@
 
     .modal-slide {
         .action-close {
-            padding: 0;
             margin: 15px;
+            padding: 0;
         }
 
         .page-main-actions {


### PR DESCRIPTION
### Description (*)

Close button overlapping in shipping address label whenever any user adding new shipping address in mobile view in checkout

### Fixed Issues (if relevant)

1. magento/magento2#<19925>: Close button overlapping in shipping address label whenever any user adding new shipping address in mobile view in checkout

### Manual testing scenarios (*)

Note : testing should be in tab view or mobile view 
    Step 1: Go to frontend
    Step 2: login as customer 
    Step 3: now add any product to cart and go to checkout 
    Step 4: in shipping address steps, you will see an saved address
    Step 5: now click on add new address button or edit any saved address, then popup will open 
    (Now see actual result screenshot)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
