### PR TITLE
[Backport] [Framework] New Link is not correctly shown as Current if contains default parts

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -64,14 +64,15 @@ class Current extends Template
     private function getMca()
     {
         $routeParts = [
-            'module' => $this->_request->getModuleName(),
-            'controller' => $this->_request->getControllerName(),
-            'action' => $this->_request->getActionName(),
+            $this->_request->getModuleName(),
+            $this->_request->getControllerName(),
+            $this->_request->getActionName(),
         ];
 
         $parts = [];
+        $pathParts = explode('/', $this->getPath());
         foreach ($routeParts as $key => $value) {
-            if (!empty($value) && $value != $this->_defaultPath->getPart($key)) {
+            if (isset($pathParts[$key]) && $pathParts[$key] === $value) {
                 $parts[] = $value;
             }
         }
@@ -85,7 +86,7 @@ class Current extends Template
      */
     public function isCurrent()
     {
-        return $this->getCurrent() || $this->getUrl($this->getPath()) == $this->getUrl($this->getPathInfo());
+        return $this->getCurrent() || $this->getUrl($this->getPath()) == $this->getUrl($this->getMca());
     }
 
     /**
@@ -150,15 +151,5 @@ class Current extends Template
         }
 
         return $attributesHtml;
-    }
-
-    /**
-     * Get current page path info
-     *
-     * @return string
-     */
-    private function getPathInfo()
-    {
-        return trim($this->_request->getPathInfo(), '/');
     }
 }

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -71,7 +71,7 @@ class Current extends Template
         ];
 
         $parts = [];
-        $pathParts = explode('/', $this->getPath());
+        $pathParts = explode('/', trim($this->_request->getPathInfo(), '/'));
         foreach ($routeParts as $key => $value) {
             if (isset($pathParts[$key]) && $pathParts[$key] === $value) {
                 $parts[] = $value;

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Framework\View\Element\Html\Link;
 
+use Magento\Framework\App\DefaultPathInterface;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+
 /**
  * Block representing link with two possible states.
  * "Current" state means link leads to URL equivalent to URL of currently displayed page.
@@ -17,25 +21,25 @@ namespace Magento\Framework\View\Element\Html\Link;
  * @method null|bool                       getCurrent()
  * @method \Magento\Framework\View\Element\Html\Link\Current setCurrent(bool $value)
  */
-class Current extends \Magento\Framework\View\Element\Template
+class Current extends Template
 {
     /**
      * Default path
      *
-     * @var \Magento\Framework\App\DefaultPathInterface
+     * @var DefaultPathInterface
      */
     protected $_defaultPath;
 
     /**
      * Constructor
      *
-     * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Magento\Framework\App\DefaultPathInterface $defaultPath
+     * @param Context $context
+     * @param DefaultPathInterface $defaultPath
      * @param array $data
      */
     public function __construct(
-        \Magento\Framework\View\Element\Template\Context $context,
-        \Magento\Framework\App\DefaultPathInterface $defaultPath,
+        Context $context,
+        DefaultPathInterface $defaultPath,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -81,7 +85,7 @@ class Current extends \Magento\Framework\View\Element\Template
      */
     public function isCurrent()
     {
-        return $this->getCurrent() || $this->getUrl($this->getPath()) == $this->getUrl($this->getMca());
+        return $this->getCurrent() || $this->getUrl($this->getPath()) == $this->getUrl($this->getPathInfo());
     }
 
     /**
@@ -146,5 +150,15 @@ class Current extends \Magento\Framework\View\Element\Template
         }
 
         return $attributesHtml;
+    }
+
+    /**
+     * Get current page path info
+     *
+     * @return string
+     */
+    private function getPathInfo()
+    {
+        return trim($this->_request->getPathInfo(), '/');
     }
 }

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -60,13 +60,14 @@ class Current extends Template
      * Get current mca
      *
      * @return string
+     * @SuppressWarnings(PHPMD.RequestAwareBlockMethod)
      */
     private function getMca()
     {
         $routeParts = [
-            $this->_request->getModuleName(),
-            $this->_request->getControllerName(),
-            $this->_request->getActionName(),
+            (string)$this->_request->getModuleName(),
+            (string)$this->_request->getControllerName(),
+            (string)$this->_request->getActionName(),
         ];
 
         $parts = [];

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
@@ -18,11 +18,6 @@ class CurrentTest extends \PHPUnit\Framework\TestCase
     protected $_requestMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $_defaultPathMock;
-
-    /**
      * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
      */
     protected $_objectManager;
@@ -32,7 +27,6 @@ class CurrentTest extends \PHPUnit\Framework\TestCase
         $this->_objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->_urlBuilderMock = $this->createMock(\Magento\Framework\UrlInterface::class);
         $this->_requestMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
-        $this->_defaultPathMock = $this->createMock(\Magento\Framework\App\DefaultPathInterface::class);
     }
 
     public function testGetUrl()
@@ -60,31 +54,54 @@ class CurrentTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($link->isCurrent());
     }
 
-    public function testIsCurrent()
+    /**
+     * Test if the current url is the same as link path
+     *
+     * @dataProvider linkPathProvider
+     * @param string $linkPath
+     * @param string $currentPathInfo
+     * @param bool $expected
+     * @return void
+     */
+    public function testIsCurrent($linkPath, $currentPathInfo, $expected)
     {
-        $path = 'test/path';
-        $url = 'http://example.com/a/b';
+        $baseUrl = 'http://example.com/';
+        $trimmed = trim($currentPathInfo, '/');
 
-        $this->_requestMock->expects($this->once())->method('getModuleName')->will($this->returnValue('a'));
-        $this->_requestMock->expects($this->once())->method('getControllerName')->will($this->returnValue('b'));
-        $this->_requestMock->expects($this->once())->method('getActionName')->will($this->returnValue('d'));
-        $this->_defaultPathMock->expects($this->atLeastOnce())->method('getPart')->will($this->returnValue('d'));
-
-        $this->_urlBuilderMock->expects($this->at(0))->method('getUrl')->with($path)->will($this->returnValue($url));
-        $this->_urlBuilderMock->expects($this->at(1))->method('getUrl')->with('a/b')->will($this->returnValue($url));
-
-        $this->_requestMock->expects($this->once())->method('getControllerName')->will($this->returnValue('b'));
+        $this->_requestMock->expects($this->any())->method('getPathInfo')->willReturn($currentPathInfo);
+        $this->_urlBuilderMock->expects($this->at(0))
+            ->method('getUrl')
+            ->with($linkPath)
+            ->will($this->returnValue($baseUrl . $linkPath));
+        $this->_urlBuilderMock->expects($this->at(1))
+            ->method('getUrl')
+            ->with($trimmed)
+            ->will($this->returnValue($baseUrl . $trimmed));
         /** @var \Magento\Framework\View\Element\Html\Link\Current $link */
         $link = $this->_objectManager->getObject(
             \Magento\Framework\View\Element\Html\Link\Current::class,
             [
                 'urlBuilder' => $this->_urlBuilderMock,
-                'request' => $this->_requestMock,
-                'defaultPath' => $this->_defaultPathMock
+                'request' => $this->_requestMock
             ]
         );
-        $link->setPath($path);
-        $this->assertTrue($link->isCurrent());
+
+        $link->setCurrent(false);
+        $link->setPath($linkPath);
+        $this->assertEquals($expected, $link->isCurrent());
+    }
+
+    /**
+     * @return array
+     */
+    public function linkPathProvider()
+    {
+        return [
+            ['test/index', '/test/index/', true],
+            ['test/index/index', '/test/index/index/', true],
+            ['test/route', '/test/index/', false],
+            ['test/index', '/test/', false]
+        ];
     }
 
     public function testIsCurrentFalse()

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
@@ -57,26 +57,31 @@ class CurrentTest extends \PHPUnit\Framework\TestCase
     /**
      * Test if the current url is the same as link path
      *
-     * @dataProvider linkPathProvider
-     * @param string $linkPath
-     * @param string $currentPathInfo
-     * @param bool $expected
      * @return void
      */
-    public function testIsCurrent($linkPath, $currentPathInfo, $expected)
+    public function testIsCurrent()
     {
-        $baseUrl = 'http://example.com/';
-        $trimmed = trim($currentPathInfo, '/');
+        $path = 'test/index';
+        $url = 'http://example.com/test/index';
 
-        $this->_requestMock->expects($this->any())->method('getPathInfo')->willReturn($currentPathInfo);
+        $this->_requestMock->expects($this->once())
+            ->method('getModuleName')
+            ->will($this->returnValue('test'));
+        $this->_requestMock->expects($this->once())
+            ->method('getControllerName')
+            ->will($this->returnValue('index'));
+        $this->_requestMock->expects($this->once())
+            ->method('getActionName')
+            ->will($this->returnValue('index'));
         $this->_urlBuilderMock->expects($this->at(0))
             ->method('getUrl')
-            ->with($linkPath)
-            ->will($this->returnValue($baseUrl . $linkPath));
+            ->with($path)
+            ->will($this->returnValue($url));
         $this->_urlBuilderMock->expects($this->at(1))
             ->method('getUrl')
-            ->with($trimmed)
-            ->will($this->returnValue($baseUrl . $trimmed));
+            ->with('test/index')
+            ->will($this->returnValue($url));
+
         /** @var \Magento\Framework\View\Element\Html\Link\Current $link */
         $link = $this->_objectManager->getObject(
             \Magento\Framework\View\Element\Html\Link\Current::class,
@@ -86,22 +91,8 @@ class CurrentTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $link->setCurrent(false);
-        $link->setPath($linkPath);
-        $this->assertEquals($expected, $link->isCurrent());
-    }
-
-    /**
-     * @return array
-     */
-    public function linkPathProvider()
-    {
-        return [
-            ['test/index', '/test/index/', true],
-            ['test/index/index', '/test/index/index/', true],
-            ['test/route', '/test/index/', false],
-            ['test/index', '/test/', false]
-        ];
+        $link->setPath($path);
+        $this->assertTrue($link->isCurrent());
     }
 
     public function testIsCurrentFalse()

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
@@ -65,6 +65,9 @@ class CurrentTest extends \PHPUnit\Framework\TestCase
         $url = 'http://example.com/test/index';
 
         $this->_requestMock->expects($this->once())
+            ->method('getPathInfo')
+            ->will($this->returnValue('/test/index/'));
+        $this->_requestMock->expects($this->once())
             ->method('getModuleName')
             ->will($this->returnValue('test'));
         $this->_requestMock->expects($this->once())


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19134
### Description (*)
This PR fixes the logic of `isCurrent` method by comparing the current requested url with the link path. This way we'll always know if the link is current, even it uses some `index` default parts. 

### Fixed Issues (if relevant)
1. magento/magento2#19099: New Link is not correctly shown as Current if contains default parts

### Manual testing scenarios (*)
1. Add a new link to customer account navigation menu
2. Navigate to the new added link
3. The link should have active state in the sidebar
![7bec67d2e5](https://user-images.githubusercontent.com/15868188/48267709-b6731980-e43b-11e8-8dae-e9517c0e3dd8.jpg)



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
