### PR TITLE
[Backport] [Review] Integration tests for not allowed review submission

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Review/Controller/CaseCheckAddingProductReviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Review/Controller/CaseCheckAddingProductReviewTest.php
@@ -17,14 +17,14 @@ use Magento\TestFramework\TestCase\AbstractController;
  *
  * @magentoAppArea frontend
  */
-class CaseCheckUnsuccessfulAddingProductReviewTest extends AbstractController
+class CaseCheckAddingProductReviewTest extends AbstractController
 {
     /**
      * Test adding a review for allowed guests with incomplete data by a not logged in user
      *
      * @magentoDbIsolation enabled
      * @magentoAppIsolation enabled
-     * @magentoConfigFixture default_store catalog/review/allow_guest 1
+     * @magentoDataFixture Magento/Review/_files/config.php
      * @magentoDataFixture Magento/Catalog/_files/products.php
      */
     public function testAttemptForGuestToAddReviewsWithIncompleteData()
@@ -50,7 +50,7 @@ class CaseCheckUnsuccessfulAddingProductReviewTest extends AbstractController
      *
      * @magentoDbIsolation enabled
      * @magentoAppIsolation enabled
-     * @magentoConfigFixture default_store catalog/review/allow_guest 0
+     * @magentoDataFixture Magento/Review/_files/disable_config.php
      * @magentoDataFixture Magento/Catalog/_files/products.php
      */
     public function testAttemptForGuestToAddReview()
@@ -69,6 +69,35 @@ class CaseCheckUnsuccessfulAddingProductReviewTest extends AbstractController
         $this->dispatch('review/product/post/id/' . $product->getId());
 
         $this->assertRedirect($this->stringContains('customer/account/login'));
+    }
+
+    /**
+     * Test successfully adding a product review by a guest
+     *
+     * @magentoDbIsolation enabled
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture Magento/Review/_files/config.php
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     */
+    public function testSuccessfullyAddingProductReviewForGuest()
+    {
+        $product = $this->getProduct();
+        /** @var FormKey $formKey */
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $post = [
+            'nickname' => 'Test nick',
+            'title' => 'Summary',
+            'detail' => 'Test Details',
+            'form_key' => $formKey->getFormKey(),
+        ];
+
+        $this->prepareRequestData($post);
+        $this->dispatch('review/product/post/id/' . $product->getId());
+
+        $this->assertSessionMessages(
+            $this->equalTo(['You submitted your review for moderation.']),
+            MessageInterface::TYPE_SUCCESS
+        );
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Review/Controller/CaseCheckUnsuccessfulAddingProductReviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Review/Controller/CaseCheckUnsuccessfulAddingProductReviewTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Review\Controller;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Data\Form\FormKey;
+use Magento\Framework\Message\MessageInterface;
+use Magento\TestFramework\Request;
+use Magento\TestFramework\TestCase\AbstractController;
+
+/**
+ * Test review product controller behavior
+ *
+ * @magentoAppArea frontend
+ */
+class CaseCheckUnsuccessfulAddingProductReviewTest extends AbstractController
+{
+    /**
+     * Test adding a review for allowed guests with incomplete data by a not logged in user
+     *
+     * @magentoDbIsolation enabled
+     * @magentoAppIsolation enabled
+     * @magentoConfigFixture default_store catalog/review/allow_guest 1
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     */
+    public function testAttemptForGuestToAddReviewsWithIncompleteData()
+    {
+        $product = $this->getProduct();
+        /** @var FormKey $formKey */
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $post = [
+            'nickname' => 'Test nick',
+            'title' => 'Summary',
+            'form_key' => $formKey->getFormKey(),
+        ];
+        $this->prepareRequestData($post);
+        $this->dispatch('review/product/post/id/' . $product->getId());
+        $this->assertSessionMessages(
+            $this->equalTo(['Please enter a review.']),
+            MessageInterface::TYPE_ERROR
+        );
+    }
+
+    /**
+     * Test adding a review for not allowed guests by a guest
+     *
+     * @magentoDbIsolation enabled
+     * @magentoAppIsolation enabled
+     * @magentoConfigFixture default_store catalog/review/allow_guest 0
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     */
+    public function testAttemptForGuestToAddReview()
+    {
+        $product = $this->getProduct();
+        /** @var FormKey $formKey */
+        $formKey = $this->_objectManager->get(FormKey::class);
+        $post = [
+            'nickname' => 'Test nick',
+            'title' => 'Summary',
+            'detail' => 'Test Details',
+            'form_key' => $formKey->getFormKey(),
+        ];
+
+        $this->prepareRequestData($post);
+        $this->dispatch('review/product/post/id/' . $product->getId());
+
+        $this->assertRedirect($this->stringContains('customer/account/login'));
+    }
+
+    /**
+     * @return ProductInterface
+     */
+    private function getProduct()
+    {
+        return $this->_objectManager->get(ProductRepositoryInterface::class)->get('custom-design-simple-product');
+    }
+
+    /**
+     * @param array $postData
+     * @return void
+     */
+    private function prepareRequestData($postData)
+    {
+        $this->getRequest()->setMethod(Request::METHOD_POST);
+        $this->getRequest()->setPostValue($postData);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Review/_files/disable_config.php
+++ b/dev/tests/integration/testsuite/Magento/Review/_files/disable_config.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var Value $config */
+use Magento\Framework\App\Config\Value;
+
+$config = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(Value::class);
+$config->setPath('catalog/review/allow_guest');
+$config->setScope('default');
+$config->setScopeId(0);
+$config->setValue(0);
+$config->save();


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19736
### Description
This PR adds the integration tests for checking the not allowance to add a new product review by:
- a guest when `allow_guest` is `disabled`
- a guest when `allow_guest` is `enabled` and required fields aren't filled in

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)