### PR TITLE
Fix Swatch Overflow issue

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
+++ b/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
@@ -149,6 +149,15 @@
     width: 50px;
 }
 
+.col-swatch, [class^=swatch-col] {
+  min-width: 150px;
+}
+
+#swatch-text-options-panel {
+  overflow: auto;
+  width: 100%;
+}
+
 .swatches-visual-col.unavailable:after {
     content: '';
     position: absolute;

--- a/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
+++ b/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
@@ -150,12 +150,12 @@
 }
 
 .col-swatch, [class^=swatch-col] {
-  min-width: 150px;
+    min-width: 150px;
 }
 
 #swatch-text-options-panel {
-  overflow: auto;
-  width: 100%;
+    overflow: auto;
+    width: 100%;
 }
 
 .swatches-visual-col.unavailable:after {


### PR DESCRIPTION
### Description (*)

   When dealing with multiple store views with different languages the swatch input fields become too small to use and they move off the screen with no way to get to them. This fix adds a min-width to the input fields and handles swatch overflow with a scrollbar.

### Manual testing scenarios (*)

1. Add multiple store views and languages to your store.
2. Open an attribute page within the Backend (Stores > Product > "Attribute").
3. Add more store views / languages until overflow happens.


