### PR TITLE
magento2/magento:Non UTF-8/Unicode characters #19935

### DIFF
--- a/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/spellchecker/editor_plugin_src.js
+++ b/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/spellchecker/editor_plugin_src.js
@@ -167,7 +167,7 @@
 		},
 
 		_getSeparators : function() {
-			var re = '', i, str = this.editor.getParam('spellchecker_word_separator_chars', '\\s!"#$%&()*+,-./:;<=>?@[\]^_{|}����������������\u201d\u201c');
+			var re = '', i, str = this.editor.getParam('spellchecker_word_separator_chars', '\\s!"#$%&()*+,-./:;<=>?@[\]^_{|}\u599d\u57a3\u6377\u6ea2\u905e\u8768\u8b02\u9ad0\u201d\u201c');
 
 			// Build word separator regexp
 			for (i=0; i<str.length; i++)


### PR DESCRIPTION
### Preconditions
Magento 2.3

### Description (*)

### Fixed issues
1. magento/magento2#19935

### Steps to reproduce
Check file;
magento2/app/code/Magento/Tinymce3/view/base/web/tiny_mce/plugins/spellchecker/editor_plugin_src.js

Line 170 in f4c1d75

 var re = '', i, str = this.editor.getParam('spellchecker_word_separator_chars', '\\s!"#$%&()*+,-./:;<=>?@[\]^_{|}����������������\u201d\u201c'); 
### Expected result
UTF-8/unicode characters
### Actual result
var re = '', i, str = this.editor.getParam('spellchecker_word_separator_chars', '\\s!"#$%&()*+,-./:;<=>?@[\]^_{|}����������������\u201d\u201c');

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
