### PR TITLE
issue resolved:Undefined Variable $itemsOrderItemId

### DIFF
--- a/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging.php
+++ b/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging.php
@@ -86,7 +86,7 @@ class Packaging extends \Magento\Backend\Block\Template
         $itemsName = [];
         $itemsWeight = [];
         $itemsProductId = [];
-
+        $itemsOrderItemId = [];
         if ($shipmentId) {
             $urlParams['shipment_id'] = $shipmentId;
             $createLabelUrl = $this->getUrl('adminhtml/order_shipment/createLabel', $urlParams);


### PR DESCRIPTION
Fixed Issue #19940 : Exceptio undefined variable itemsOrderItemId while creating shipment through MSI

### Description (*)

Fixed Issue #19940 : Exceptio undefined variable itemsOrderItemId while creating shipment through MSI

### Fixed Issues (if relevant)

1. magento/magento2#19940:  Exception undefined variable itemsOrderItemId while creating shipment through MSI

### Manual testing scenarios (*)

   1. Login to Admin Panel
  2. On left navigation goto Stores-> Inventory->sources
   3. Create two source
   4. Now goto left navigation Stores-> Inventory->stocks
   5. Create stock with Sales Channels : Main website , and add source created above to the stock
   6. Go to Catalog->products
   7. Click edit button of any products which is type of simple product , now assign two source and add quantity to them, at last save product.
   8. repeat step 7 for another product
   9. Now goto frontend and place order of above mentioned two products of single quantity each.
  10.  From admin panel select order and create shipment
   11. Ship only one products from first source.
   12. Now one product shipped from first source
   13. Try to ship that product again.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
