### PR TITLE
Issue Fixed: #16806 Duplicate argument overwrites option language DeployStaticContentCommand 

### DIFF
--- a/app/code/Magento/Deploy/Console/InputValidator.php
+++ b/app/code/Magento/Deploy/Console/InputValidator.php
@@ -85,6 +85,10 @@ class InputValidator
             $input->getArgument(Options::LANGUAGES_ARGUMENT) ?: ['all'],
             $input->getOption(Options::EXCLUDE_LANGUAGE)
         );
+        $this->checkLanguagesInput(
+            $input->getOption(Options::LANGUAGE) ?: ['all'],
+            $input->getOption(Options::EXCLUDE_LANGUAGE)
+        );
     }
 
     /**

--- a/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
@@ -119,7 +119,9 @@ class DeployStaticContentCommand extends Command
         $this->inputValidator->validate($input);
 
         $options = $input->getOptions();
-        $options[Options::LANGUAGE] = $input->getArgument(Options::LANGUAGES_ARGUMENT) ?: ['all'];
+        $language = $input->getOption(Options::LANGUAGE) ?: ['all'];
+        $options[Options::LANGUAGE] = $input->getArgument(Options::LANGUAGES_ARGUMENT) ?
+            array_merge($input->getArgument(Options::LANGUAGES_ARGUMENT), $language): $language;
         $refreshOnly = isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
             && $options[Options::REFRESH_CONTENT_VERSION_ONLY];
 

--- a/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
@@ -60,12 +60,11 @@ class DeployStaticContentCommand extends Command
     private $appState;
 
     /**
-     * StaticContentCommand constructor
-     *
-     * @param InputValidator        $inputValidator
-     * @param ConsoleLoggerFactory  $consoleLoggerFactory
-     * @param Options               $options
+     * @param InputValidator $inputValidator
+     * @param ConsoleLoggerFactory $consoleLoggerFactory
+     * @param Options $options
      * @param ObjectManagerProvider $objectManagerProvider
+     * @throws \Magento\Setup\Exception
      */
     public function __construct(
         InputValidator $inputValidator,
@@ -82,7 +81,8 @@ class DeployStaticContentCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * Configures the current command.{@inheritdoc}
+     *
      * @throws \InvalidArgumentException
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -96,9 +96,13 @@ class DeployStaticContentCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * Executes static content deploy command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
      * @throws \InvalidArgumentException
      * @throws LocalizedException
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -119,9 +123,11 @@ class DeployStaticContentCommand extends Command
         $this->inputValidator->validate($input);
 
         $options = $input->getOptions();
-        $language = $input->getOption(Options::LANGUAGE) ?: ['all'];
-        $options[Options::LANGUAGE] = $input->getArgument(Options::LANGUAGES_ARGUMENT) ?
-            array_merge($input->getArgument(Options::LANGUAGES_ARGUMENT), $language): $language;
+        $language = $input->getOption(Options::LANGUAGE);
+        $languageArgs = $input->getArgument(Options::LANGUAGES_ARGUMENT);
+
+        $options[Options::LANGUAGE] = (empty($language) && empty($languageArgs)) ? ['all'] :
+            array_merge($language, $languageArgs);
         $refreshOnly = isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
             && $options[Options::REFRESH_CONTENT_VERSION_ONLY];
 
@@ -163,6 +169,8 @@ class DeployStaticContentCommand extends Command
     }
 
     /**
+     * Get App/State instance.
+     *
      * @return State
      */
     private function getAppState()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Duplicate argument overwrites option language DeployStaticContentCommand
+ Preconditions
    - Magento 2.3-alpha
    - Not installed: no env.php present, no database available, build environment `(Not Important as same issue occurs after installation too.)`
+ Static content was deployed for default `en_US` even if language parameters are provided.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#16806.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16806: Duplicate argument overwrites option language DeployStaticContentCommand

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. run `bin/magento setup:static-content:deploy -t Magento/blank -l nl_NL -f` and static content is deployed only for `nl_NL`.
2. run `bin/magento setup:static-content:deploy nl_NL`
3. run `bin/magento setup:static-content:deploy`
4. run `bin/magento deploy:mode:set production`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
