### PR TITLE
[Backport] issue 18941

### DIFF
--- a/app/code/Magento/Store/Test/Unit/Url/Plugin/RouteParamsResolverTest.php
+++ b/app/code/Magento/Store/Test/Unit/Url/Plugin/RouteParamsResolverTest.php
@@ -80,7 +80,7 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
         $routeParamsResolverMock->expects($this->once())->method('setScope')->with($storeCode);
         $routeParamsResolverMock->expects($this->once())->method('getScope')->willReturn($storeCode);
 
-        $this->queryParamsResolverMock->expects($this->never())->method('setQueryParam');
+        $this->queryParamsResolverMock->expects($this->any())->method('setQueryParam');
 
         $this->model->beforeSetRouteParams(
             $routeParamsResolverMock,
@@ -113,7 +113,7 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
         $routeParamsResolverMock->expects($this->once())->method('setScope')->with($storeCode);
         $routeParamsResolverMock->expects($this->once())->method('getScope')->willReturn($storeCode);
 
-        $this->queryParamsResolverMock->expects($this->once())->method('setQueryParam')->with('___store', $storeCode);
+        $this->queryParamsResolverMock->expects($this->never())->method('setQueryParam')->with('___store', $storeCode);
 
         $this->model->beforeSetRouteParams(
             $routeParamsResolverMock,
@@ -178,7 +178,7 @@ class RouteParamsResolverTest extends \PHPUnit\Framework\TestCase
         $routeParamsResolverMock->expects($this->never())->method('setScope');
         $routeParamsResolverMock->expects($this->once())->method('getScope')->willReturn(false);
 
-        $this->queryParamsResolverMock->expects($this->once())->method('setQueryParam')->with('___store', $storeCode);
+        $this->queryParamsResolverMock->expects($this->never())->method('setQueryParam')->with('___store', $storeCode);
 
         $this->model->beforeSetRouteParams(
             $routeParamsResolverMock,

--- a/app/code/Magento/Store/Url/Plugin/RouteParamsResolver.php
+++ b/app/code/Magento/Store/Url/Plugin/RouteParamsResolver.php
@@ -78,7 +78,7 @@ class RouteParamsResolver
                 $storeCode
             );
 
-            if ($useStoreInUrl && !$this->storeManager->hasSingleStore()) {
+            if (!$useStoreInUrl && !$this->storeManager->hasSingleStore()) {
                 $this->queryParamsResolver->setQueryParam('___store', $storeCode);
             }
         }

--- a/dev/tests/integration/testsuite/Magento/Store/Model/StoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/Model/StoreTest.php
@@ -4,13 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Store\Model;
 
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Framework\App\Bootstrap;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\UrlInterface;
+use Magento\Store\Api\StoreRepositoryInterface;
 use Zend\Stdlib\Parameters;
 
 /**
@@ -200,7 +200,7 @@ class StoreTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetBaseUrlForCustomEntryPoint($type, $useCustomEntryPoint, $useStoreCode, $expected)
     {
-         /* config operations require store to be loaded */
+        /* config operations require store to be loaded */
         $this->model->load('default');
         \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
             ->get(\Magento\Framework\App\Config\MutableScopeConfigInterface::class)
@@ -269,12 +269,89 @@ class StoreTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->model->isCanDelete());
     }
 
+    /**
+     * @magentoDataFixture Magento/Store/_files/core_second_third_fixturestore.php
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoDbIsolation disabled
+     */
     public function testGetCurrentUrl()
     {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Framework\App\Config\MutableScopeConfigInterface::class)
+            ->setValue('web/url/use_store', true, ScopeInterface::SCOPE_STORE, 'secondstore');
+
         $this->model->load('admin');
-        $this->model->expects($this->any())->method('getUrl')->will($this->returnValue('http://localhost/index.php'));
+        $this->model
+            ->expects($this->any())->method('getUrl')
+            ->will($this->returnValue('http://localhost/index.php'));
         $this->assertStringEndsWith('default', $this->model->getCurrentUrl());
         $this->assertStringEndsNotWith('default', $this->model->getCurrentUrl(false));
+
+        /** @var \Magento\Store\Model\Store $secondStore */
+        $secondStore = $objectManager->get(StoreRepositoryInterface::class)->get('secondstore');
+
+        /** @var \Magento\Catalog\Model\ProductRepository $productRepository */
+        $productRepository = $objectManager->create(ProductRepository::class);
+        $product = $productRepository->get('simple');
+        $product->setStoreId($secondStore->getId());
+        $url = $product->getUrlInStore();
+
+        $this->assertEquals(
+            $secondStore->getBaseUrl().'catalog/product/view/id/1/s/simple-product/',
+            $url
+        );
+        $this->assertEquals(
+            $secondStore->getBaseUrl().'?___from_store=default',
+            $secondStore->getCurrentUrl()
+        );
+        $this->assertEquals(
+            $secondStore->getBaseUrl(),
+            $secondStore->getCurrentUrl(false)
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Store/_files/second_store.php
+     * @magentoDataFixture Magento/Catalog/_files/category_product.php
+     * @magentoDbIsolation disabled
+     */
+    public function testGetCurrentUrlWithUseStoreInUrlFalse()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $objectManager->get(\Magento\Framework\App\Config\ReinitableConfigInterface::class)
+            ->setValue('web/url/use_store', false, ScopeInterface::SCOPE_STORE, 'default');
+
+        /** @var \Magento\Store\Model\Store $secondStore */
+        $secondStore = $objectManager->get(StoreRepositoryInterface::class)->get('fixture_second_store');
+
+        /** @var \Magento\Catalog\Model\ProductRepository $productRepository */
+        $productRepository = $objectManager->create(ProductRepository::class);
+        $product = $productRepository->get('simple333');
+
+        $product->setStoreId($secondStore->getId());
+        $url = $product->getUrlInStore();
+
+        /** @var \Magento\Catalog\Model\CategoryRepository $categoryRepository */
+        $categoryRepository = $objectManager->get(\Magento\Catalog\Model\CategoryRepository::class);
+        $category = $categoryRepository->get(333, $secondStore->getStoreId());
+
+        $this->assertEquals(
+            $secondStore->getBaseUrl().'catalog/category/view/s/category-1/id/333/',
+            $category->getUrl()
+        );
+        $this->assertEquals(
+            $secondStore->getBaseUrl().
+            'catalog/product/view/id/333/s/simple-product-three/?___store=fixture_second_store',
+            $url
+        );
+        $this->assertEquals(
+            $secondStore->getBaseUrl().'?___store=fixture_second_store&___from_store=default',
+            $secondStore->getCurrentUrl()
+        );
+        $this->assertEquals(
+            $secondStore->getBaseUrl().'?___store=fixture_second_store',
+            $secondStore->getCurrentUrl(false)
+        );
     }
 
     /**
@@ -292,7 +369,11 @@ class StoreTest extends \PHPUnit\Framework\TestCase
             'sort_order' => 0,
             'is_active' => 1,
         ]);
-        $crud = new \Magento\TestFramework\Entity($this->model, ['name' => 'new name'], \Magento\Store\Model\Store::class);
+        $crud = new \Magento\TestFramework\Entity(
+            $this->model,
+            ['name' => 'new name'],
+            \Magento\Store\Model\Store::class
+        );
         $crud->testCrud();
     }
 


### PR DESCRIPTION
### Description (*)

I have the config "store code in URL" set to "yes" but when i use the method "getCurrentUrl" on a Store type variable i get the current URL but with the parameter "___store=[code]" in it, if the current store is not the one requested in the URL.
I want to use the getCurrentUrl method in order to redirect the user to the correct store based on some custom logic (like the browser language), but i don't want any additional parameters to be in the URL.
Form what i found out by looking around in the code, the parameter "___store" is mandatory when the config "use store code in URL" is set to "no" but not when it's set to "yes", as in my case. The store code is already in the URL (as set in system config) and it's not necessary to add any other parameters in the URL to remark this.

### Original PR https://github.com/magento/magento2/pull/19135
### Fixed Issues (if relevant)

1. magento/magento2#18941: Calling getCurrentUrl on Store will wrongly add "___store" parameter


### Manual testing scenarios (*)
```
<?php

namespace Fonderia\StoreAutoRedirect\Observer;

use Magento\Framework\Event\Observer;
use Magento\Framework\Event\ObserverInterface;
use Magento\Store\Model\Store;
use Magento\Store\Api\StoreRepositoryInterface;

class RedirectObserver implements ObserverInterface
{
    /**
     * @var StoreRepositoryInterface
     */
    private $storeRepository;

    public function __construct(StoreRepositoryInterface $storeRepository) {
        $this->storeRepository = $storeRepository;
    }

    public function execute(Observer $observer)
    {
        $storeCode = '[your store code]';

        /** @var Store $store */
        $store = $this->storeRepository->get($storeCode);
        $url = $store->getCurrentUrl(true, true);
        // ...
    }
}
```
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
