### PR TITLE
[Backport] Typo "customet_id" to  "customer_id" fixed.

### DIFF
--- a/app/code/Magento/SalesRule/Model/ResourceModel/Coupon/Usage.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Coupon/Usage.php
@@ -74,11 +74,11 @@ class Usage extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $select = $connection->select()->from(
                 $this->getMainTable()
             )->where(
-                'customer_id =:customet_id'
+                'customer_id =:customer_id'
             )->where(
                 'coupon_id = :coupon_id'
             );
-            $data = $connection->fetchRow($select, [':coupon_id' => $couponId, ':customet_id' => $customerId]);
+            $data = $connection->fetchRow($select, [':coupon_id' => $couponId, ':customer_id' => $customerId]);
             if ($data) {
                 $object->setData($data);
             }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19726
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Typo "customet_id" to  "customer_id" fixed.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19721: Typo in SalesRule/Model/ResourceModel/Coupon/Usage.php

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use a coupon

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
