### PR TITLE
2.3 develop resolve wrong variable in parameter for phpDoc IN DataBuilder, closes #19974 

### DIFF
--- a/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
+++ b/app/code/Magento/Bundle/Model/Product/CopyConstructor/Bundle.php
@@ -27,6 +27,17 @@ class Bundle implements \Magento\Catalog\Model\Product\CopyConstructorInterface
         $bundleOptions = $product->getExtensionAttributes()->getBundleProductOptions() ?: [];
         $duplicatedBundleOptions = [];
         foreach ($bundleOptions as $key => $bundleOption) {
+            $productLinks = $bundleOption->getProductLinks();
+            if($productLinks)
+            {
+                foreach ($productLinks as $productLink)
+                {
+                    $productLink->setSelectionId(NULL);
+                    $productLink->setOptionId(NULL);
+                }
+            }
+            $bundleOption->setOptionId(null);
+            $bundleOption->setParentId(null);
             $duplicatedBundleOptions[$key] = clone $bundleOption;
         }
         $duplicate->getExtensionAttributes()->setBundleProductOptions($duplicatedBundleOptions);

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Item/DataBuilder.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Item/DataBuilder.php
@@ -29,7 +29,7 @@ class DataBuilder
      * Add Item Data
      *
      * @param string $label
-     * @param string $label
+     * @param string $value
      * @param int $count
      * @return void
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
### Fixed Issue #19974 (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19974: Wrong variable in parameter for phpDoc IN DataBuilder

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
