### PR TITLE
Set correct email message encoding

### DIFF
--- a/app/code/Magento/Email/Model/Transport.php
+++ b/app/code/Magento/Email/Model/Transport.php
@@ -87,7 +87,7 @@ class Transport implements TransportInterface
     public function sendMessage()
     {
         try {
-            $zendMessage = Message::fromString($this->message->getRawMessage());
+            $zendMessage = Message::fromString($this->message->getRawMessage())->setEncoding('utf-8');
             if (2 === $this->isSetReturnPath && $this->returnPathValue) {
                 $zendMessage->setSender($this->returnPathValue);
             } elseif (1 === $this->isSetReturnPath && $zendMessage->getFrom()->count()) {


### PR DESCRIPTION
### Description (*)
E-Mail subject not showing utf-8 characters.

I tried to investigate the problem and found that it happens because the **utf-8** encoding is reset during sending an email. This happens [here](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Email/Model/Transport.php#L90). The `Zend\Mail\Message::fromString` method recreates the `Zend\Mail\Message` object from the given string, but its default encoding is **ASCII**, so that the **utf-8** encoding set while [initializing the message](https://github.com/magento/magento2/blob/2.3-develop/lib/internal/Magento/Framework/Mail/Message.php#L30-L34) gets reset.
In order to eliminate the issue the encoding have to be explicitly set again, like this: `Message::fromString($this->message->getRawMessage())->setEncoding('utf-8')`.

### Fixed Issues (if relevant)
1. Fixed issue magento/magento2#19977: E-Mail subject not showing utf-8 characters

### Manual testing scenarios (*)
1. Create an e-mail template containing the "Ő" letter in the subject. For example, based on the Newsletter Subscription Success email template.
1. Change Success Email Template at the system Newsletter settings.
1. Subscribe for newsletter.
1. View the email in your email client. In my case, macOS Mail.app.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
