### PR TITLE
[Backport] Remove unneeded, also mistyped, saveHandler from CatalogSearch indexer declaration

### DIFF
--- a/app/code/Magento/CatalogSearch/etc/indexer.xml
+++ b/app/code/Magento/CatalogSearch/etc/indexer.xml
@@ -9,8 +9,6 @@
     <indexer id="catalogsearch_fulltext" view_id="catalogsearch_fulltext" class="Magento\CatalogSearch\Model\Indexer\Fulltext">
         <title translate="true">Catalog Search</title>
         <description translate="true">Rebuild Catalog product fulltext search index</description>
-
-        <saveHandler class="Magento\CatalogSearch\Model\Indexer\IndexHandler" />
         <structure class="Magento\CatalogSearch\Model\Indexer\IndexStructure" />
     </indexer>
 </config>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/11626
Remove unneeded, also mistyped, saveHandler from CatalogSearch indexer declaration.

### Description
This PR removes unneeded from Magento/CatalogSearch/etc/indexer.xml:
<img width="940" alt="captura de pantalla 2017-10-22 a las 3 21 29" src="https://user-images.githubusercontent.com/17545750/31857194-3441dfc8-b6d8-11e7-8903-4e277e03ea69.png">

It's not used, and it is mistyped: no such class `Magento\CatalogSearch\Model\Indexer\IndexHandler` exists; it refers instead to `Magento\CatalogSearch\Model\Indexer\IndexerHandler`. Even it is mistyped, it works due to `Magento\CatalogSearch\Model\Indexer\IndexerHandlerFactory`handling the save handlers, and correct class name is injected into IndexerHandlerFactory via Magento/CatalogSearch/etc/di.xml:
<img width="756" alt="captura de pantalla 2017-10-22 a las 3 27 03" src="https://user-images.githubusercontent.com/17545750/31857219-061f63d0-b6d9-11e7-898f-7cd37a651758.png">

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/19982

### Manual testing scenarios
After removing that line, everything should work as before.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
