### PR TITLE
Fix broken widget placeholders after upgrading from 2.2

### DIFF
--- a/app/code/Magento/Widget/Model/Widget.php
+++ b/app/code/Magento/Widget/Model/Widget.php
@@ -248,17 +248,13 @@ class Widget
         $result = $widgets;
 
         // filter widgets by params
-        if (is_array($filters) && count($filters) > 0) {
+        if (is_array($filters) && !empty($filters)) {
             foreach ($widgets as $code => $widget) {
-                try {
-                    foreach ($filters as $field => $value) {
-                        if (!isset($widget[$field]) || (string)$widget[$field] != $value) {
-                            throw new \Exception();
-                        }
+                foreach ($filters as $field => $value) {
+                    if (!isset($widget[$field]) || (string)$widget[$field] != $value) {
+                        unset($result[$code]);
+                        break;
                     }
-                } catch (\Exception $e) {
-                    unset($result[$code]);
-                    continue;
                 }
             }
         }

--- a/app/code/Magento/Widget/Model/Widget.php
+++ b/app/code/Magento/Widget/Model/Widget.php
@@ -323,8 +323,6 @@ class Widget
 
         $directive .= $this->getWidgetPageVarName($params);
 
-        $directive .= sprintf(' type_name="%s"', $widget['name']);
-
         $directive .= '}}';
 
         if ($asIs) {

--- a/app/code/Magento/Widget/Model/Widget/Config.php
+++ b/app/code/Magento/Widget/Model/Widget/Config.php
@@ -159,7 +159,7 @@ class Config implements \Magento\Framework\Data\Wysiwyg\ConfigProviderInterface
             }
         }
 
-        if (count($skipped) > 0) {
+        if (!empty($skipped)) {
             $params['skip_widgets'] = $this->encodeWidgetsToQuery($skipped);
         }
         return $this->_backendUrl->getUrl('adminhtml/widget/index', $params);

--- a/app/code/Magento/Widget/Model/Widget/Config.php
+++ b/app/code/Magento/Widget/Model/Widget/Config.php
@@ -202,7 +202,7 @@ class Config implements \Magento\Framework\Data\Wysiwyg\ConfigProviderInterface
                 if (is_array($skipped) && in_array($widget['type'], $skipped)) {
                     continue;
                 }
-                $result[] = $widget['name']->getText();
+                $result[$widget['type']] = $widget['name']->getText();
             }
         }
 

--- a/app/code/Magento/Widget/Model/Widget/Config.php
+++ b/app/code/Magento/Widget/Model/Widget/Config.php
@@ -120,6 +120,7 @@ class Config implements \Magento\Framework\Data\Wysiwyg\ConfigProviderInterface
 
     /**
      * Return url to error image
+     *
      * @return string
      */
     public function getErrorImageUrl()
@@ -129,6 +130,7 @@ class Config implements \Magento\Framework\Data\Wysiwyg\ConfigProviderInterface
 
     /**
      * Return url to wysiwyg plugin
+     *
      * @return string
      */
     public function getWysiwygJsPluginSrc()
@@ -189,6 +191,8 @@ class Config implements \Magento\Framework\Data\Wysiwyg\ConfigProviderInterface
     }
 
     /**
+     * Get available widgets.
+     *
      * @param \Magento\Framework\DataObject $config Editor element config
      * @return array
      */

--- a/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
@@ -224,7 +224,6 @@ class WidgetTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('title="my &quot;widget&quot;"', $result);
         $this->assertContains('conditions_encoded="encoded-conditions-string"', $result);
         $this->assertContains('page_var_name="pasdf"', $result);
-        $this->assertContains('type_name=""}}', $result);
     }
 
     /**
@@ -275,7 +274,6 @@ class WidgetTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertContains('{{widget type="Magento\CatalogWidget\Block\Product\ProductsList"', $result);
         $this->assertContains('page_var_name="pasdf"', $result);
-        $this->assertContains('type_name=""}}', $result);
         $this->assertContains('products_count=""', $result);
     }
 }

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -132,7 +132,7 @@ define([
                         attributes.type = attributes.type.replace(/\\\\/g, '\\');
                         imageSrc = config.placeholders[attributes.type];
 
-                        if (config.types.indexOf(attributes['type_name']) > -1) {
+                        if (imageSrc) {
                             imageHtml += '<span class="magento-placeholder magento-widget mceNonEditable" ' +
                                 'contenteditable="false">';
                         } else {

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -147,8 +147,8 @@ define([
                         imageHtml += ' src="' + imageSrc + '"';
                         imageHtml += ' />';
 
-                        if (attributes['type_name']) {
-                            imageHtml += attributes['type_name'];
+                        if (config.types[attributes.type]) {
+                            imageHtml += config.types[attributes.type];
                         }
 
                         imageHtml += '</span>';


### PR DESCRIPTION
Affects backend editor when WYSIWYG is enabled and widget declarations are from Magento < 2.3.

### Description (*)
This PR makes two things:
1. Makes visible widget placeholder when `type_name` is not available in widget declaration
2. Makes visible widget name when `type_name` is not available in widget declaration

### Manual testing scenarios (*)
1. Navigate to _Content > Pages_ and create a new page
2. Disable WYSIWYG editor
3. Fill content field with following value (It's a widget code from Magento < 2.3):

   ```
   <div>{{widget type="Magento\CatalogWidget\Block\Product\ProductsList" show_pager="0" products_count="10" template="Magento_CatalogWidget::product/widget/content/grid.phtml" }}</div>
   ```

4. Enable WYSIWYG editor
5. You will see an error icon instead of widget image

Without patch | With patch
--------------|-----------
![image](https://user-images.githubusercontent.com/306080/50474530-ea91a200-09c9-11e9-828f-c456251db2fd.png) | ![image](https://user-images.githubusercontent.com/306080/50474602-4825ee80-09ca-11e9-85bd-1089e43a1274.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
