### PR TITLE
[Backport] Fixed #19605 Don't static compile disabled modules

### DIFF
--- a/app/code/Magento/Deploy/Collector/Collector.php
+++ b/app/code/Magento/Deploy/Collector/Collector.php
@@ -5,9 +5,10 @@
  */
 namespace Magento\Deploy\Collector;
 
-use Magento\Deploy\Source\SourcePool;
 use Magento\Deploy\Package\Package;
 use Magento\Deploy\Package\PackageFactory;
+use Magento\Deploy\Source\SourcePool;
+use Magento\Deploy\Package\PackageFile;
 use Magento\Framework\Module\Manager;
 use Magento\Framework\View\Asset\PreProcessor\FileNameResolver;
 
@@ -44,7 +45,7 @@ class Collector implements CollectorInterface
      * @var PackageFactory
      */
     private $packageFactory;
-    
+
     /** @var \Magento\Framework\Module\Manager */
     private $moduleManager;
 
@@ -65,18 +66,19 @@ class Collector implements CollectorInterface
      * @param SourcePool $sourcePool
      * @param FileNameResolver $fileNameResolver
      * @param PackageFactory $packageFactory
+     * @param Manager $moduleManager
      */
     public function __construct(
         SourcePool $sourcePool,
         FileNameResolver $fileNameResolver,
         PackageFactory $packageFactory,
-        Manager $moduleManager  = null
+        Manager $moduleManager = null
     ) {
         $this->sourcePool = $sourcePool;
         $this->fileNameResolver = $fileNameResolver;
         $this->packageFactory = $packageFactory;
         $this->moduleManager = $moduleManager ?: \Magento\Framework\App\ObjectManager::getInstance()
-                              ->get(\Magento\Framework\Module\Manager::class);
+            ->get(Manager::class);
     }
 
     /**
@@ -92,18 +94,7 @@ class Collector implements CollectorInterface
                     continue;
                 }
                 $file->setDeployedFileName($this->fileNameResolver->resolve($file->getFileName()));
-                $params = [
-                    'area' => $file->getArea(),
-                    'theme' => $file->getTheme(),
-                    'locale' => $file->getLocale(),
-                    'module' => $file->getModule(),
-                    'isVirtual' => (!$file->getLocale() || !$file->getTheme() || !$file->getArea())
-                ];
-                foreach ($this->packageDefaultValues as $name => $value) {
-                    if (!isset($params[$name])) {
-                        $params[$name] = $value;
-                    }
-                }
+                $params = $this->getParams($file);
                 $packagePath = "{$params['area']}/{$params['theme']}/{$params['locale']}";
                 if (!isset($packages[$packagePath])) {
                     $packages[$packagePath] = $this->packageFactory->create($params);
@@ -114,5 +105,29 @@ class Collector implements CollectorInterface
             }
         }
         return $packages;
+    }
+
+    /**
+     * Retrieve package params.
+     *
+     * @param PackageFile $file
+     * @return array
+     */
+    private function getParams(PackageFile $file)
+    {
+        $params = [
+            'area' => $file->getArea(),
+            'theme' => $file->getTheme(),
+            'locale' => $file->getLocale(),
+            'module' => $file->getModule(),
+            'isVirtual' => (!$file->getLocale() || !$file->getTheme() || !$file->getArea())
+        ];
+        foreach ($this->packageDefaultValues as $name => $value) {
+            if (!isset($params[$name])) {
+                $params[$name] = $value;
+            }
+        }
+
+        return $params;
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19751
Fixed issue #19605 Don't static compile disabled modules

**Summary** 
 When running static-content:deploy, there are disabled module content in pub/static.

**Examples** 

Disable modules that have frontend resources.
Run bin/magento setup:static-content:deploy
Observe that pub/static/... contains the resources.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
