### PR TITLE
19482 increase product quantity with disabled manage stock when place order is failed

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockManagement.php
+++ b/app/code/Magento/CatalogInventory/Model/StockManagement.php
@@ -142,8 +142,9 @@ class StockManagement implements StockManagementInterface, RegisterProductSaleIn
 
     /**
      * @param string[] $items
-     * @param int $websiteId
-     * @return bool
+     * @param int|null $websiteId
+     *
+     * @return array|bool
      */
     public function revertProductsSale($items, $websiteId = null)
     {
@@ -161,7 +162,7 @@ class StockManagement implements StockManagementInterface, RegisterProductSaleIn
         }
         $this->qtyCounter->correctItemsQty($revertItems, $websiteId, '+');
 
-        return true;
+        return $revertItems;
     }
 
     /**

--- a/app/code/Magento/CatalogInventory/Model/StockManagement.php
+++ b/app/code/Magento/CatalogInventory/Model/StockManagement.php
@@ -150,7 +150,17 @@ class StockManagement implements StockManagementInterface, RegisterProductSaleIn
         //if (!$websiteId) {
         $websiteId = $this->stockConfiguration->getDefaultScopeId();
         //}
-        $this->qtyCounter->correctItemsQty($items, $websiteId, '+');
+        $revertItems = [];
+        foreach ($items as $productId => $qty) {
+            $stockItem = $this->stockRegistryProvider->getStockItem($productId, $websiteId);
+            $canSubtractQty = $stockItem->getItemId() && $this->canSubtractQty($stockItem);
+            if (!$canSubtractQty || !$this->stockConfiguration->isQty($stockItem->getTypeId())) {
+                continue;
+            }
+            $revertItems[$productId] = $qty;
+        }
+        $this->qtyCounter->correctItemsQty($revertItems, $websiteId, '+');
+
         return true;
     }
 

--- a/app/code/Magento/CatalogInventory/Model/StockManagement.php
+++ b/app/code/Magento/CatalogInventory/Model/StockManagement.php
@@ -85,6 +85,7 @@ class StockManagement implements StockManagementInterface, RegisterProductSaleIn
 
     /**
      * Subtract product qtys from stock.
+     *
      * Return array of items that require full save.
      *
      * @param string[] $items
@@ -141,10 +142,7 @@ class StockManagement implements StockManagementInterface, RegisterProductSaleIn
     }
 
     /**
-     * @param string[] $items
-     * @param int|null $websiteId
-     *
-     * @return array|bool
+     * @inheritdoc
      */
     public function revertProductsSale($items, $websiteId = null)
     {
@@ -206,6 +204,8 @@ class StockManagement implements StockManagementInterface, RegisterProductSaleIn
     }
 
     /**
+     * Get stock resource.
+     *
      * @return ResourceStock
      */
     protected function getResource()

--- a/app/code/Magento/CatalogInventory/Observer/RevertQuoteInventoryObserver.php
+++ b/app/code/Magento/CatalogInventory/Observer/RevertQuoteInventoryObserver.php
@@ -64,8 +64,8 @@ class RevertQuoteInventoryObserver implements ObserverInterface
     {
         $quote = $observer->getEvent()->getQuote();
         $items = $this->productQty->getProductQty($quote->getAllItems());
-        $this->stockManagement->revertProductsSale($items, $quote->getStore()->getWebsiteId());
-        $productIds = array_keys($items);
+        $revertedItems = $this->stockManagement->revertProductsSale($items, $quote->getStore()->getWebsiteId());
+        $productIds = array_keys($revertedItems);
         if (!empty($productIds)) {
             $this->stockIndexerProcessor->reindexList($productIds);
             $this->priceIndexer->reindexList($productIds);


### PR DESCRIPTION
Magento increments stock for products for which stock managing is disabled in case, when restore stock qty after failed placing order

### Fixed Issues (if relevant)
1. magento/magento2#19482: Increase product quantity with disabled Manage Stock when place order is failed

### Manual testing scenarios (*)
1. In the admin panel set for a product Manage Stock: No and Quantity: 100
2. Place an order with this product via PayPal, but with a card that does not have enough money to pay for the order
Expected result:
Product Quantity is 100

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
